### PR TITLE
feat: add telemetry client

### DIFF
--- a/src/deadline/client/api/__init__.py
+++ b/src/deadline/client/api/__init__.py
@@ -9,6 +9,7 @@ __all__ = [
     "get_boto3_client",
     "AwsCredentialsStatus",
     "AwsCredentialsType",
+    "TelemetryClient",
     "check_credentials_status",
     "check_deadline_api_available",
     "get_credentials_type",
@@ -18,6 +19,7 @@ __all__ = [
     "list_fleets",
     "list_storage_profiles_for_queue",
     "get_queue_boto3_session",
+    "get_telemetry_client",
 ]
 
 from configparser import ConfigParser
@@ -37,6 +39,7 @@ from ._session import (
     get_studio_id,
 )
 from ._submit_job_bundle import create_job_from_job_bundle, wait_for_create_job_to_complete
+from ._telemetry import get_telemetry_client, TelemetryClient
 
 logger = getLogger(__name__)
 

--- a/src/deadline/client/api/_submit_job_bundle.py
+++ b/src/deadline/client/api/_submit_job_bundle.py
@@ -247,6 +247,7 @@ def _hash_attachments(
     output_paths: Set[str],
     storage_profile_id: Optional[str] = None,
     hashing_progress_callback: Optional[Callable] = None,
+    config: Optional[ConfigParser] = None,
 ) -> List[AssetRootManifest]:
     """
     Starts the job attachments hashing and handles the progress reporting
@@ -266,6 +267,7 @@ def _hash_attachments(
         hash_cache_dir=os.path.expanduser(os.path.join("~", ".deadline", "cache")),
         on_preparing_to_submit=hashing_progress_callback,
     )
+    api.get_telemetry_client(config=config).record_hashing_summary(hashing_summary)
 
     return manifests
 
@@ -274,6 +276,7 @@ def _upload_attachments(
     asset_manager: S3AssetManager,
     manifests: List[AssetRootManifest],
     upload_progress_callback: Optional[Callable] = None,
+    config: Optional[ConfigParser] = None,
 ) -> Dict[str, Any]:
     """
     Starts the job attachments upload and handles the progress reporting callback.
@@ -289,5 +292,6 @@ def _upload_attachments(
     upload_summary, attachment_settings = upload_job_attachments(
         asset_manager, manifests, upload_progress_callback
     )
+    api.get_telemetry_client(config=config).record_upload_summary(upload_summary)
 
     return attachment_settings

--- a/src/deadline/client/api/_telemetry.py
+++ b/src/deadline/client/api/_telemetry.py
@@ -1,0 +1,182 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import atexit
+import json
+import logging
+import platform
+import uuid
+
+from configparser import ConfigParser
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from queue import Queue
+from threading import Thread
+from typing import Any, Dict, Optional
+from urllib import request, error
+
+from ...job_attachments.progress_tracker import SummaryStatistics
+
+from ._session import get_studio_id, get_user_and_identity_store_id
+from ..config import config_file
+from .. import version
+
+__cached_telemetry_client = None
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TelemetryEvent:
+    """Base class for telemetry events"""
+
+    event_type: str = "com.amazon.rum.uncategorized"
+    event_body: Dict[str, Any] = field(default_factory=dict)
+
+
+class TelemetryClient:
+    """
+    Sends telemetry events periodically to the Deadline Cloud telemetry service.
+
+    This client holds a queue of events which is written to synchronously, and processed
+    asynchronously, where events are sent in the background, so that it does not slow
+    down user interactivity.
+
+    Telemetry events contain non-personally-identifiable information that helps us
+    understand how users interact with our software so we know what features our
+    customers use, and/or what existing pain points are.
+
+    Data is aggregated across a session ID (a UUID created at runtime), used to mark every
+    telemetry event for the lifetime of the application), and a 'telemetry identifier' (a
+    UUID recorded in the configuration file), to aggregate data across multiple application
+    lifetimes on the same machine.
+
+    Telemetry collection can be opted-out of by running:
+    'deadline config set "telemetry.opt_out" true'
+    """
+
+    def __init__(self, config: Optional[ConfigParser] = None):
+        self.telemetry_opted_out = config_file.str2bool(
+            config_file.get_setting("telemetry.opt_out", config=config)
+        )
+        if self.telemetry_opted_out:
+            return
+        self.endpoint: str = f"{config_file.get_setting('settings.deadline_endpoint_url', config=config)}/2023-10-12/telemetry"
+
+        # IDs for this session
+        self.session_id: str = str(uuid.uuid4())
+        self.telemetry_id: str = self._get_telemetry_identifier(config=config)
+        # Get common data we'll include in each request
+        self.studio_id: Optional[str] = get_studio_id(config=config)
+        self.user_id, _ = get_user_and_identity_store_id(config=config)
+        self.env_info: Dict[str, Any] = self._get_env_summary()
+        self.system_info: Dict[str, Any] = self._get_system_info()
+
+        self._start_threads()
+
+    def _get_telemetry_identifier(self, config: Optional[ConfigParser] = None):
+        identifier = config_file.get_setting("telemetry.identifier", config=config)
+        try:
+            uuid.UUID(identifier, version=4)
+        except ValueError:  # Thrown if the user_id isn't in UUID4 format
+            identifier = str(uuid.uuid4())
+            config_file.set_setting("telemetry.identifier", identifier)
+        return identifier
+
+    def _start_threads(self) -> None:
+        """Set up background threads for shutdown checking and request sending"""
+        self.event_queue: Queue[Optional[TelemetryEvent]] = Queue()
+        atexit.register(self._exit_cleanly)
+        self.processing_thread: Thread = Thread(
+            target=self._process_event_queue_thread, daemon=True
+        )
+        self.processing_thread.start()
+
+    def _get_env_summary(self) -> Dict[str, Any]:
+        """Builds up a dict of non-identifiable information the environment."""
+        return {
+            "service": "deadline-cloud-library",
+            "version": ".".join(version.split(".")[:3]),
+            "pythonVersion": platform.python_version(),
+        }
+
+    def _get_system_info(self) -> Dict[str, Any]:
+        """Builds up a dict of non-identifiable information about this machine."""
+        platform_info = platform.uname()
+        return {
+            "osName": "macOS" if platform_info.system == "Darwin" else platform_info.system,
+            "osVersion": platform_info.release,
+            "cpuType": platform_info.machine,
+            "cpuName": platform_info.processor,
+        }
+
+    def _exit_cleanly(self):
+        self.event_queue.put(None)
+        self.processing_thread.join()
+
+    def _process_event_queue_thread(self):
+        """Background thread for processing the telemetry event data queue and sending telemetry requests."""
+        while True:
+            # Blocks until we get a new entry in the queue
+            event_data: Optional[TelemetryEvent] = self.event_queue.get()
+            # We've received the shutdown signal
+            if event_data is None:
+                return
+
+            headers = {"Accept": "application-json", "Content-Type": "application-json"}
+            request_body = {
+                "BatchId": str(uuid.uuid4()),
+                "RumEvents": [
+                    {
+                        "details": "{}",
+                        "id": str(uuid.uuid4()),
+                        "metadata": str(json.dumps(event_data.event_body)),
+                        "timestamp": int(datetime.now().timestamp()),
+                        "type": event_data.event_type,
+                    },
+                ],
+                "UserDetails": {"sessionId": self.session_id, "userId": self.telemetry_id},
+            }
+            request_body_encoded = str(json.dumps(request_body)).encode("utf-8")
+            req = request.Request(url=self.endpoint, data=request_body_encoded, headers=headers)
+            try:
+                logger.debug(f"Sending telemetry data: {request_body}")
+                with request.urlopen(req):
+                    logger.debug("Successfully sent telemetry.")
+            except error.HTTPError as httpe:
+                logger.debug(f"HTTPError sending telemetry: {str(httpe)}")
+            except Exception as ex:
+                logger.debug(f"Exception sending telemetry: {str(ex)}")
+            self.event_queue.task_done()
+
+    def _record_summary_statistics(
+        self, event_type: str, summary: SummaryStatistics, from_gui: bool
+    ):
+        if self.telemetry_opted_out:
+            return
+        data_body: Dict[str, Any] = asdict(summary)
+        data_body.update(self.env_info)
+        data_body.update(self.system_info)
+        if self.user_id:
+            data_body["userId"] = self.user_id
+        if self.studio_id:
+            data_body["studioId"] = self.studio_id
+        data_body["usageMode"] = "GUI" if from_gui else "CLI"
+        self.event_queue.put_nowait(TelemetryEvent(event_type=event_type, event_body=data_body))
+
+    def record_hashing_summary(self, summary: SummaryStatistics, from_gui: bool = False):
+        self._record_summary_statistics(
+            "com.amazon.rum.job_attachments.hashing_summary", summary, from_gui
+        )
+
+    def record_upload_summary(self, summary: SummaryStatistics, from_gui: bool = False):
+        self._record_summary_statistics(
+            "com.amazon.rum.job_attachments.upload_summary", summary, from_gui
+        )
+
+
+def get_telemetry_client(config: Optional[ConfigParser] = None) -> TelemetryClient:
+    global __cached_telemetry_client
+    if not __cached_telemetry_client:
+        __cached_telemetry_client = TelemetryClient(config)
+
+    return __cached_telemetry_client

--- a/src/deadline/client/config/config_file.py
+++ b/src/deadline/client/config/config_file.py
@@ -96,6 +96,8 @@ SETTINGS: Dict[str, Dict[str, Any]] = {
     "settings.log_level": {
         "default": "INFO",
     },
+    "telemetry.opt_out": {"default": "false"},
+    "telemetry.identifier": {"default": ""},
 }
 
 

--- a/src/deadline/client/ui/dialogs/submit_job_progress_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_progress_dialog.py
@@ -425,6 +425,9 @@ class SubmitJobProgressDialog(QDialog):
         Handles the signal sent from the background hashing thread when the
         hashing process has completed.
         """
+        api.get_telemetry_client(config=self._config).record_hashing_summary(
+            hashing_summary, from_gui=True
+        )
         self.summary_edit.setText(
             f"\nHashing Summary:\n"
             f"    Hashed {hashing_summary.processed_files} files totaling"
@@ -456,6 +459,9 @@ class SubmitJobProgressDialog(QDialog):
         if attachment_settings:
             self._create_job_args["attachments"] = attachment_settings
 
+        api.get_telemetry_client(config=self._config).record_upload_summary(
+            upload_summary, from_gui=True
+        )
         self.summary_edit.setText(
             f"{self.summary_edit.toPlainText()}"
             f"\nUpload Summary:\n"

--- a/test/unit/deadline_client/api/test_api_telemetry.py
+++ b/test/unit/deadline_client/api/test_api_telemetry.py
@@ -1,0 +1,153 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import pytest
+import uuid
+
+from unittest.mock import patch, MagicMock
+from dataclasses import asdict
+from urllib import request
+
+from deadline.client import api, config
+from deadline.client.api._telemetry import TelemetryClient, TelemetryEvent
+from deadline.job_attachments.progress_tracker import SummaryStatistics
+
+
+@pytest.fixture(scope="function", name="telemetry_client")
+def fixture_telemetry_client(fresh_deadline_config):
+    config.set_setting("defaults.aws_profile_name", "SomeRandomProfileName")
+    with patch.object(api.TelemetryClient, "_start_threads"), patch.object(
+        api._telemetry, "get_studio_id", side_effect=["studio-id"]
+    ), patch.object(
+        api._telemetry,
+        "get_user_and_identity_store_id",
+        side_effect=[("user-id", "identity-store-id")],
+    ):
+        return TelemetryClient(config=config.config_file.read_config())
+
+
+def test_opt_out(fresh_deadline_config):
+    """Ensures the telemetry client doesn't fully initialize if the opt out config setting is set"""
+    # GIVEN
+    config.set_setting("defaults.aws_profile_name", "SomeRandomProfileName")
+    config.set_setting("telemetry.opt_out", "true")
+    # WHEN
+    client = TelemetryClient(config=config.config_file.read_config())
+    # THEN
+    assert not hasattr(client, "endpoint")
+    assert not hasattr(client, "session_id")
+    assert not hasattr(client, "telemetry_id")
+    assert not hasattr(client, "studio_id")
+    assert not hasattr(client, "user_id")
+    assert not hasattr(client, "env_info")
+    assert not hasattr(client, "event_queue")
+    assert not hasattr(client, "processing_thread")
+    # Ensure nothing blows up if we try recording telemetry after we've opted out
+    client.record_hashing_summary(SummaryStatistics(), True)
+    client.record_upload_summary(SummaryStatistics(), False)
+
+
+def test_get_telemetry_identifier(telemetry_client):
+    """Ensures that getting the local-user-id handles empty/malformed strings"""
+    # Confirm that we generate a new UUID if the setting doesn't exist, and write to config
+    uuid.UUID(telemetry_client.telemetry_id, version=4)  # Should not raise ValueError
+    assert config.get_setting("telemetry.identifier") == telemetry_client.telemetry_id
+
+    # Confirm we generate a new UUID if the local_user_id is not a valid UUID
+    config.set_setting("telemetry.identifier", "bad-id")
+    telemetry_id = telemetry_client._get_telemetry_identifier()
+    assert telemetry_id != "bad-id"
+    uuid.UUID(telemetry_id, version=4)  # Should not raise ValueError
+
+    # Confirm the new user id was saved and is retrieved properly
+    assert config.get_setting("telemetry.identifier") == telemetry_id
+    assert telemetry_client._get_telemetry_identifier() == telemetry_id
+
+
+@pytest.mark.timeout(5)  # Timeout in case we don't exit the while loop
+def test_process_event_queue_thread(telemetry_client):
+    """Test that the queue processing thread function exits cleanly after getting None"""
+    # GIVEN
+    queue_mock = MagicMock()
+    queue_mock.get.side_effect = [TelemetryEvent(), None]
+    telemetry_client.event_queue = queue_mock
+    # WHEN
+    with patch.object(request, "urlopen") as urlopen_mock:
+        telemetry_client._process_event_queue_thread()
+        urlopen_mock.assert_called_once()
+    # THEN
+    assert queue_mock.get.call_count == 2
+
+
+@pytest.mark.timeout(5)  # Timeout in case we don't exit the while loop
+def test_process_event_queue_thread_handles_errors(telemetry_client):
+    """Test that the thread continues after getting exceptions"""
+    # GIVEN
+    queue_mock = MagicMock()
+    queue_mock.get.side_effect = [TelemetryEvent(), None]
+    telemetry_client.event_queue = queue_mock
+    # WHEN
+    with patch.object(request, "urlopen", side_effect=Exception("Some error")) as urlopen_mock:
+        telemetry_client._process_event_queue_thread()
+        urlopen_mock.assert_called_once()
+    # THEN
+    assert queue_mock.get.call_count == 2
+
+
+def test_record_hashing_summary(telemetry_client):
+    """Tests that recording a hashing summary sends the expected TelemetryEvent to the thread queue"""
+    # GIVEN
+    queue_mock = MagicMock()
+    expected_env_info = {"test_env": "test_val"}
+    expected_machine_info = {"test_machine": "test_val2"}
+    test_summary = SummaryStatistics(total_bytes=123, total_files=12, total_time=12345)
+
+    expected_summary = asdict(test_summary)
+    expected_summary["usageMode"] = "CLI"
+    expected_summary["userId"] = "user-id"
+    expected_summary["studioId"] = "studio-id"
+    expected_summary.update(expected_env_info)
+    expected_summary.update(expected_machine_info)
+
+    expected_event = TelemetryEvent(
+        event_type="com.amazon.rum.job_attachments.hashing_summary", event_body=expected_summary
+    )
+
+    telemetry_client.event_queue = queue_mock
+    telemetry_client.env_info = expected_env_info
+    telemetry_client.system_info = expected_machine_info
+
+    # WHEN
+    telemetry_client.record_hashing_summary(test_summary)
+
+    # THEN
+    queue_mock.put_nowait.assert_called_once_with(expected_event)
+
+
+def test_record_upload_summary(telemetry_client):
+    """Tests that recording an upload summary sends the expected TelemetryEvent to the thread queue"""
+    # GIVEN
+    queue_mock = MagicMock()
+    expected_env_info = {"test_env": "test_val"}
+    expected_machine_info = {"test_machine": "test_val2"}
+    test_summary = SummaryStatistics(total_bytes=123, total_files=12, total_time=12345)
+
+    expected_summary = asdict(test_summary)
+    expected_summary["usageMode"] = "GUI"
+    expected_summary["userId"] = "user-id"
+    expected_summary["studioId"] = "studio-id"
+    expected_summary.update(expected_env_info)
+    expected_summary.update(expected_machine_info)
+
+    expected_event = TelemetryEvent(
+        event_type="com.amazon.rum.job_attachments.upload_summary", event_body=expected_summary
+    )
+
+    telemetry_client.event_queue = queue_mock
+    telemetry_client.env_info = expected_env_info
+    telemetry_client.system_info = expected_machine_info
+
+    # WHEN
+    telemetry_client.record_upload_summary(test_summary, from_gui=True)
+
+    # THEN
+    queue_mock.put_nowait.assert_called_once_with(expected_event)

--- a/test/unit/deadline_client/api/test_job_bundle_submission.py
+++ b/test/unit/deadline_client/api/test_job_bundle_submission.py
@@ -431,7 +431,9 @@ def test_create_job_from_job_bundle_job_attachments(
         api._submit_job_bundle, "_hash_attachments"
     ) as mock_hash_attachments, patch.object(
         submission.S3AssetManager, "upload_assets"
-    ) as mock_upload_assets:
+    ) as mock_upload_assets, patch.object(
+        _submit_job_bundle.api, "get_telemetry_client"
+    ):
         client_mock().get_queue.side_effect = [MOCK_GET_QUEUE_RESPONSE]
         client_mock().create_job.side_effect = [MOCK_CREATE_JOB_RESPONSE]
         client_mock().get_job.side_effect = [MOCK_GET_JOB_RESPONSE]
@@ -574,12 +576,14 @@ def test_create_job_from_job_bundle_with_single_asset_file(
         api._submit_job_bundle, "_hash_attachments"
     ) as mock_hash_attachments, patch.object(
         submission.S3AssetManager, "upload_assets"
-    ) as mock_upload_assets:
+    ) as mock_upload_assets, patch.object(
+        _submit_job_bundle.api, "get_telemetry_client"
+    ):
         client_mock().create_job.side_effect = [MOCK_CREATE_JOB_RESPONSE]
         client_mock().get_queue.side_effect = [MOCK_GET_QUEUE_RESPONSE]
         client_mock().get_job.side_effect = [MOCK_GET_JOB_RESPONSE]
         mock_upload_assets.return_value = [
-            SummaryStatistics,
+            SummaryStatistics(),
             Attachments(
                 [
                     ManifestProperties(

--- a/test/unit/deadline_client/api/test_job_bundle_submission_asset_refs.py
+++ b/test/unit/deadline_client/api/test_job_bundle_submission_asset_refs.py
@@ -134,7 +134,9 @@ def test_create_job_from_job_bundle_with_all_asset_ref_variants(
         submission.S3AssetManager, "hash_assets_and_create_manifest"
     ) as mock_hash_assets, patch.object(
         submission.S3AssetManager, "upload_assets"
-    ) as mock_upload_assets:
+    ) as mock_upload_assets, patch.object(
+        _submit_job_bundle.api, "get_telemetry_client"
+    ):
         client_mock().create_job.side_effect = [MOCK_CREATE_JOB_RESPONSE]
         client_mock().get_queue.side_effect = [MOCK_GET_QUEUE_RESPONSE]
         client_mock().get_job.side_effect = [MOCK_GET_JOB_RESPONSE]

--- a/test/unit/deadline_client/cli/test_cli_bundle.py
+++ b/test/unit/deadline_client/cli/test_cli_bundle.py
@@ -53,6 +53,8 @@ def test_cli_bundle_submit(fresh_deadline_config, temp_job_bundle_dir):
         bundle_group, "_hash_attachments", return_value=[]
     ), patch.object(bundle_group, "get_queue_boto3_session"), patch.object(
         bundle_group, "_upload_attachments"
+    ), patch.object(
+        bundle_group.api, "get_telemetry_client"
     ):
         get_boto3_client_mock().create_job.return_value = MOCK_CREATE_JOB_RESPONSE
         get_boto3_client_mock().get_job.return_value = MOCK_GET_JOB_RESPONSE
@@ -172,6 +174,8 @@ def test_cli_bundle_asset_load_method(fresh_deadline_config, temp_job_bundle_dir
         bundle_group.api, "get_boto3_session"
     ), patch.object(
         bundle_group, "get_queue_boto3_session"
+    ), patch.object(
+        bundle_group.api, "get_telemetry_client"
     ):
         get_boto3_client_mock().create_job.return_value = MOCK_CREATE_JOB_RESPONSE
         get_boto3_client_mock().get_job.return_value = MOCK_GET_JOB_RESPONSE
@@ -327,6 +331,8 @@ def test_cli_bundle_accept_upload_confirmation(fresh_deadline_config, temp_job_b
         bundle_group.api, "get_boto3_session"
     ), patch.object(
         bundle_group, "get_queue_boto3_session"
+    ), patch.object(
+        bundle_group.api, "get_telemetry_client"
     ):
         get_boto3_client_mock().create_job.return_value = MOCK_CREATE_JOB_RESPONSE
         get_boto3_client_mock().get_job.return_value = MOCK_GET_JOB_RESPONSE
@@ -394,6 +400,8 @@ def test_cli_bundle_reject_upload_confirmation(fresh_deadline_config, temp_job_b
         bundle_group.api, "get_boto3_session"
     ), patch.object(
         bundle_group, "get_queue_boto3_session"
+    ), patch.object(
+        bundle_group.api, "get_telemetry_client"
     ):
         get_boto3_client_mock().get_queue.return_value = {
             "displayName": "Test Queue",

--- a/test/unit/deadline_client/cli/test_cli_config.py
+++ b/test/unit/deadline_client/cli/test_cli_config.py
@@ -34,7 +34,7 @@ def test_cli_config_show_defaults(fresh_deadline_config):
     assert fresh_deadline_config in result.output
 
     # Assert the expected number of settings
-    assert len(settings.keys()) == 10
+    assert len(settings.keys()) == 12
 
     for setting_name in settings.keys():
         assert setting_name in result.output
@@ -98,6 +98,8 @@ def test_cli_config_show_modified_config(fresh_deadline_config):
     config.set_setting("defaults.job_id", "job-239u40234jkl234nkl23")
     config.set_setting("settings.auto_accept", "False")
     config.set_setting("settings.log_level", "DEBUG")
+    config.set_setting("telemetry.opt_out", "True")
+    config.set_setting("telemetry.identifier", "user-id-123abc-456def")
 
     runner = CliRunner()
     result = runner.invoke(deadline_cli.cli, ["config", "show"])
@@ -110,13 +112,15 @@ def test_cli_config_show_modified_config(fresh_deadline_config):
     assert "EnvVarOverrideProfile" in result.output
     assert "~/alternate/job_history" in result.output
     assert result.output.count("False") == 1
+    assert result.output.count("True") == 1
     assert "https://some-url-value" in result.output
     assert "farm-82934h23k4j23kjh" in result.output
     assert "queue-389348u234jhk34" in result.output
     assert "job-239u40234jkl234nkl23" in result.output
+    assert "settings.log_level:\n   DEBUG" in result.output
+    assert "user-id-123abc-456def" in result.output
     # It shouldn't say anywhere that there is a default setting
     assert "(default)" not in result.output
-    assert "settings.log_level:\n   DEBUG" in result.output
 
 
 @pytest.mark.parametrize("setting_name,default_value,alternate_value", CONFIG_SETTING_ROUND_TRIP)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We need to add client-side code to collect diagnostic / usage information, in order to gain insights of how customers use our software.

### What was the solution? (How)
Add an initial Telemetry Client class to the Client Lib. It currently accepts two kinds of telemetry events, the Job Attachments Hashing and Upload progress summary statistics. I used the existing pattern we use for our cached boto3 session in order to cache the TelemetryClient so we can reuse it during the lifecycle of the application. We use the AWS Rum format for data, so I have to specifically craft a request to fit the format ([see docs](https://docs.aws.amazon.com/cloudwatchrum/latest/APIReference/API_PutRumEvents.html))

We spin up two background threads for the client: (1) that processes a queue of telemetry events and (2) a thread that checks for application shutdown so we can signal to the telemetry thread that we need to shut down. 
We use this pattern instead of a daemon thread as a daemon thread would be killed before sending last data when the client lib exits.

Added configuration for the telemetry endpoint, so developers can test against their own backend.

### What is the impact of this change?
Now we can get insights into Job Attachments usage statistics, and easily build off of the telemetry client to collect other kinds of data.

### How was this change tested?
- Manually submitted a job using the Client Lib, confirming it showed up in our reporting backend.
- Confirmed the debug logs showed up when setting the log level to debug
- Confirmed the new config settings worked as expected

### Was this change documented?
No

### Is this a breaking change?
No, the telemetry client runs in a background thread and is intended to have no impact on main execution