### PR TITLE
feat!: Add Storage Profiles support to Job Attachment

### DIFF
--- a/src/deadline/client/api/_submit_job_bundle.py
+++ b/src/deadline/client/api/_submit_job_bundle.py
@@ -149,6 +149,7 @@ def create_job_from_job_bundle(
             asset_manager,
             asset_references.input_filenames,
             asset_references.output_directories,
+            storage_profile_id,
             hashing_progress_callback,
         )
 
@@ -244,6 +245,7 @@ def _hash_attachments(
     asset_manager: S3AssetManager,
     input_paths: Set[str],
     output_paths: Set[str],
+    storage_profile_id: Optional[str] = None,
     hashing_progress_callback: Optional[Callable] = None,
 ) -> List[AssetRootManifest]:
     """
@@ -260,6 +262,7 @@ def _hash_attachments(
     hashing_summary, manifests = asset_manager.hash_assets_and_create_manifest(
         input_paths=sorted(input_paths),
         output_paths=sorted(output_paths),
+        storage_profile_id=storage_profile_id,
         hash_cache_dir=os.path.expanduser(os.path.join("~", ".deadline", "cache")),
         on_preparing_to_submit=hashing_progress_callback,
     )

--- a/src/deadline/client/cli/groups/bundle_group.py
+++ b/src/deadline/client/cli/groups/bundle_group.py
@@ -9,7 +9,7 @@ import logging
 import os
 import re
 import signal
-from typing import Any, Dict, List, Set, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 import click
 from botocore.exceptions import ClientError  # type: ignore[import]
@@ -175,6 +175,7 @@ def bundle_submit(job_bundle_dir, asset_loading_method, parameter, **args):
                 asset_manager,
                 asset_references.input_filenames,
                 asset_references.output_directories,
+                storage_profile_id=storage_profile_id,
             )
 
             if (
@@ -288,7 +289,10 @@ def bundle_gui_submit(job_bundle_dir, **args):
 
 
 def _hash_attachments(
-    asset_manager: S3AssetManager, input_paths: Set[str], output_paths: Set[str]
+    asset_manager: S3AssetManager,
+    input_paths: Set[str],
+    output_paths: Set[str],
+    storage_profile_id: Optional[str] = None,
 ) -> Tuple[SummaryStatistics, List[AssetRootManifest]]:
     """
     Starts the job attachments hashing and handles the progress reporting
@@ -306,6 +310,7 @@ def _hash_attachments(
         hashing_summary, manifests = asset_manager.hash_assets_and_create_manifest(
             input_paths=sorted(input_paths),
             output_paths=sorted(output_paths),
+            storage_profile_id=storage_profile_id,
             hash_cache_dir=os.path.expanduser(os.path.join("~", ".deadline", "cache")),
             on_preparing_to_submit=_update_hash_progress,
         )

--- a/src/deadline/client/ui/dialogs/submit_job_progress_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_progress_dialog.py
@@ -265,6 +265,7 @@ class SubmitJobProgressDialog(QDialog):
             hashing_summary, manifests = self._asset_manager.hash_assets_and_create_manifest(
                 input_paths=sorted(input_paths),
                 output_paths=sorted(output_paths),
+                storage_profile_id=self._storage_profile_id,
                 hash_cache_dir=os.path.expanduser(os.path.join("~", ".deadline", "cache")),
                 on_preparing_to_submit=_update_hash_progress,
             )

--- a/src/deadline/job_attachments/download.py
+++ b/src/deadline/job_attachments/download.py
@@ -40,7 +40,7 @@ from .errors import (
 )
 from .fus3 import Fus3ProcessManager
 from .models import JobAttachmentS3Settings, Attachments
-from .utils import FileConflictResolution, join_s3_paths
+from .utils import FileConflictResolution, is_relative_to, join_s3_paths
 
 logger = getLogger("deadline.job_attachments.download")
 
@@ -581,7 +581,7 @@ def get_output_manifests_by_asset_root(
     session: Optional[boto3.Session] = None,
 ) -> dict[str, list[tuple[AssetManifest, str]]]:
     """
-    For a given job/step/task, Gets a map from each root path to a corresponding list of
+    For a given job/step/task, gets a map from each root path to a corresponding list of
     output manifests.
     """
     outputs: DefaultDict[str, list[tuple[AssetManifest, str]]] = DefaultDict(list)
@@ -772,9 +772,7 @@ def _ensure_paths_within_directory(root_path: str, paths_relative_to_root: list[
 
     for path in paths_relative_to_root:
         resolved_path = Path(root_path, path).resolve()
-        try:
-            resolved_path.relative_to(Path(root_path).resolve())
-        except ValueError:
+        if not is_relative_to(resolved_path, Path(root_path).resolve()):
             raise PathOutsideDirectoryError(
                 f"The provided path is not under the root directory: {path}"
             )

--- a/src/deadline/job_attachments/models.py
+++ b/src/deadline/job_attachments/models.py
@@ -13,7 +13,13 @@ from deadline.job_attachments.asset_manifests.base_manifest import AssetManifest
 
 from deadline.job_attachments.errors import MissingS3RootPrefixError
 
-from .utils import AssetLoadingMethod, OperatingSystemFamily, generate_random_guid, join_s3_paths
+from .utils import (
+    AssetLoadingMethod,
+    FileSystemLocationType,
+    OperatingSystemFamily,
+    generate_random_guid,
+    join_s3_paths,
+)
 
 S3_DATA_FOLDER_NAME = "Data"
 S3_MANIFEST_FOLDER_NAME = "Manifests"
@@ -34,6 +40,7 @@ class AssetRootManifest:
 class AssetRootGroup:
     """Represents lists of input and output files grouped under the same root"""
 
+    file_system_location_name: Optional[str] = None
     root_path: str = ""
     inputs: Set[Path] = field(default_factory=set)
     outputs: Set[Path] = field(default_factory=set)
@@ -187,3 +194,22 @@ class Job:
 
     jobId: str
     attachments: Optional[Attachments] = None  # pylint: disable=invalid-name
+
+
+@dataclass
+class FileSystemLocation:
+    """DataClass to store File System Location objects"""
+
+    name: str
+    path: str
+    type: FileSystemLocationType
+
+
+@dataclass
+class StorageProfileForQueue:
+    """DataClass to store Storage Profile For Queue objects"""
+
+    storageProfileId: str
+    displayName: str
+    osFamily: OperatingSystemFamily = OperatingSystemFamily.WINDOWS
+    fileSystemLocations: List[FileSystemLocation] = field(default_factory=list)  # type: ignore

--- a/src/deadline/job_attachments/utils.py
+++ b/src/deadline/job_attachments/utils.py
@@ -8,7 +8,7 @@ import sys
 from enum import Enum
 from hashlib import shake_256
 from pathlib import Path, PurePath, PurePosixPath, PureWindowsPath
-from typing import Callable, Optional, Tuple
+from typing import Callable, Optional, Tuple, Union
 import uuid
 import yaml
 
@@ -16,6 +16,21 @@ import xxhash
 
 CONFIG_ROOT = ".deadline"
 COMPONENT_NAME = "job_attachments"
+
+
+class FileSystemLocationType(str, Enum):
+    SHARED = "SHARED"
+    LOCAL = "LOCAL"
+
+    @classmethod
+    def get_type(cls, type_string):
+        """
+        Returns the OperatingSystemFamily enum value from the (case-insensitive) OS string.
+        """
+        try:
+            return cls(type_string.upper())
+        except ValueError:
+            raise ValueError(f"Invalid type string: {type_string}")
 
 
 class OperatingSystemFamily(str, Enum):
@@ -167,6 +182,18 @@ def get_default_hash_cache_db_file_dir() -> Optional[str]:
     if default_path:
         default_path = os.path.join(default_path, CONFIG_ROOT, COMPONENT_NAME)
     return default_path
+
+
+def is_relative_to(path1: Union[Path, str], path2: Union[Path, str]) -> bool:
+    """
+    Determines if path1 is relative to path2. This function is to support
+    Python versions that do not have the built-in `Path.is_relative_to()` method.
+    """
+    try:
+        Path(path1).relative_to(Path(path2))
+        return True
+    except ValueError:
+        return False
 
 
 class OJIOToken:

--- a/test/unit/deadline_client/api/test_job_bundle_submission.py
+++ b/test/unit/deadline_client/api/test_job_bundle_submission.py
@@ -492,6 +492,7 @@ def test_create_job_from_job_bundle_job_attachments(
                 ]
             ),
             set([os.path.join(temp_assets_dir, "somedir")]),
+            MOCK_STORAGE_PROFILE_ID,
             fake_hashing_callback,
         )
         client_mock().create_job.assert_called_once_with(
@@ -631,7 +632,11 @@ def test_create_job_from_job_bundle_with_single_asset_file(
         )
 
         mock_hash_attachments.assert_called_once_with(
-            ANY, set([os.path.join(temp_assets_dir, "asset-1.txt")]), set(), fake_hashing_callback
+            ANY,
+            set([os.path.join(temp_assets_dir, "asset-1.txt")]),
+            set(),
+            MOCK_STORAGE_PROFILE_ID,
+            fake_hashing_callback,
         )
         client_mock().create_job.assert_called_once_with(
             farmId=MOCK_FARM_ID,

--- a/test/unit/deadline_client/api/test_job_bundle_submission_asset_refs.py
+++ b/test/unit/deadline_client/api/test_job_bundle_submission_asset_refs.py
@@ -264,6 +264,7 @@ def test_create_job_from_job_bundle_with_all_asset_ref_variants(
         mock_hash_assets.assert_called_once_with(
             input_paths=input_paths,
             output_paths=output_paths,
+            storage_profile_id="",
             hash_cache_dir=os.path.expanduser(os.path.join("~", ".deadline", "cache")),
             on_preparing_to_submit=ANY,
         )

--- a/test/unit/deadline_job_attachments/test_utils.py
+++ b/test/unit/deadline_job_attachments/test_utils.py
@@ -1,14 +1,17 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
+from pathlib import Path
+import sys
 from unittest.mock import patch
 
 import pytest
 
 from deadline.job_attachments.utils import (
+    OJIOToken,
     get_deadline_formatted_os,
     get_default_hash_cache_db_file_dir,
+    is_relative_to,
     map_source_path_to_dest_path,
-    OJIOToken,
 )
 
 
@@ -60,3 +63,51 @@ class TestUtils:
         """
         token = OJIOToken(test_token)
         assert str(token) == serialized_token
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="This test is for paths in POSIX path format and will be skipped on Windows.",
+    )
+    @pytest.mark.parametrize(
+        ("path1", "path2", "expected"),
+        [
+            ("/a/b/c", "/a/b", True),
+            (Path("/a/b/c.txt"), "/a", True),
+            ("a/b/c", "a/b", True),
+            (Path("a/b/c.txt"), "a", True),
+            ("/a/b/c", "a/b", False),
+            ("a/b/c", "/a/b", False),
+            ("/a/b/c", "/d", False),
+            ("a/b/c", "b", False),
+            ("a/b/c", "d", False),
+        ],
+    )
+    def test_is_relative_to_on_posix(self, path1, path2, expected):
+        """
+        Tests if the is_relative_to() works correctly when using Posix paths.
+        """
+        assert is_relative_to(path1, path2) == expected
+
+    @pytest.mark.skipif(
+        sys.platform != "win32",
+        reason="This test is for paths in Windows path format and will be skipped on non-Windows.",
+    )
+    @pytest.mark.parametrize(
+        ("path1", "path2", "expected"),
+        [
+            ("C:/a/b/c", "C:/a/b", True),
+            (Path("C:/a/b/c.txt"), "C:/a", True),
+            ("a/b/c", "a/b", True),
+            (Path("a/b/c.txt"), "a", True),
+            ("C:/a/b/c", "a/b", False),
+            ("a/b/c", "C:/a/b", False),
+            ("C:/a/b/c", "C:/d", False),
+            ("a/b/c", "b", False),
+            ("a/b/c", "d", False),
+        ],
+    )
+    def test_is_relative_to_on_windows(self, path1, path2, expected):
+        """
+        Tests if the is_relative_to() works correctly when using Windows paths.
+        """
+        assert is_relative_to(path1, path2) == expected


### PR DESCRIPTION
```
BREAKING CHANGE:
- Add `storage_profile_id` to AssetManager.hash_assets_and_create_manifest() to enable Storage Profiles support.
- AssetManager.hash_assets_and_create_manifest() now takes `storage_profile_id`.
- sync_inputs(), sync_outputs() now takes `storage_profiles_path_mapping_rules`.
- Add a new method get_storage_profile_for_queue() in job_attachments/aws/deadline.py.
- Add a new data class `FileSystemLocation`, `StorageProfileForQueue`
```

### What was the problem/requirement? (What/Why)
The Job Attachment needs to support Storage Profile feature. Specifically,
- File uploads in Submitter:
  - If the input path is relative to a File System Location (FSL) or the `SHARED` type, the upload is skipped.
  - For other uploads, if the input path is relative to an FSL of `LOCAL` type, the `fileSystemLocationName` is set in the manifest's properties.
- Input Syncing in Worker Agent:
  - Worker Agent can now send path mapping rules related to Storage Profiles received from the service API to Job Attachment. This allows `sync_inputs()` function to download input files to the correct locations.
- Output Syncing in Worker Agent:
  - When uploading the output manifest to an S3 bucket, if `fileSystemLocationName` is set, metadata with a key of `file-system-location-name` is also added.
- File Downloads in Submitter: No special changes are required for this PR.

### What was the solution? (How)
Implement the requirements.

### What is the impact of this change?
Implement the Storage Profiles support in Job Attachments.

### How was this change tested?
- `hatch run lint && hatch run test`
- End-to-end test
  - Created a Farm, a Queue, a Fleet (CMF), and two Storage Profiles (SP) - one for Linux, the other for Windows - on my local backend.
    - For each SP, added two FileSystemLocation (FSL) - one for LOCAL type, the other for SHARED type.
    - Make those two SPs available to the Farm and the Queue. For the Fleet, the Linux SP was connected.
  - Specification of the sample job bundle that I used:
    - Defines a few input job attachments. Half of the inputs are relative to the LOCAL-type FSL path, another half is not relative to any of the FSLs’ paths (so that they are grouped with their own dynamic root path.)
    - An output directory is relative to the LOCAL-type FSL path.
    - A simple non-rendering script that has 2 Steps which has 2 Tasks each, and generates one output file per Task.
  - Tested below cases, and confirmed that a flow of job submission via CLI/GUI - worker execution - job donwload via CLI was working.
    1. Submitted a Job from Linux, (so that the job has Linux SP,) and ran a CMF Worker from Linux
    2. Submitted a Job from Windows, (so that the job has Windows SP,) and ran a CMF Worker from Linux
    3. Also, tested the same flow on a Farm, Fleet and Queue that have no involvement with SP, and it worked fine.

### Was this change documented?
Yes.

### Is this a breaking change?
Yes.
