### PR TITLE
fix: Change default client aws profile setting to the default provide…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,7 @@ looponfailroots = [
 ]
 markers = [
     "no_setup: mark that test shouldn't use default setups",
+    "integ: tests that run against AWS resources",
 ]
 # looponfailroots is deprecated, this removes the deprecation from the test output
 filterwarnings = [

--- a/src/deadline/client/api/_session.py
+++ b/src/deadline/client/api/_session.py
@@ -48,7 +48,8 @@ def get_boto3_session(
     force_refresh: bool = False, config: Optional[ConfigParser] = None
 ) -> boto3.Session:
     """
-    Gets a boto3 session for the configured Amazon Deadline Cloud aws profile
+    Gets a boto3 session for the configured Amazon Deadline Cloud aws profile. This may
+    either use a named profile or the default credentials provider chain.
 
     This implementation caches the session object for use across the CLI code,
     so that we can use the following code pattern without repeated calls to
@@ -61,7 +62,12 @@ def get_boto3_session(
     global __cached_boto3_session
     global __cached_boto3_session_profile_name
 
-    profile_name = get_setting("defaults.aws_profile_name", config)
+    profile_name: Optional[str] = get_setting("defaults.aws_profile_name", config)
+
+    # If the default AWS profile name is either not set, or set to "default",
+    # use the default credentials provider chain instead of a named profile.
+    if profile_name in ("", "default"):
+        profile_name = None
 
     # If a config was provided, don't use the Session caching mechanism.
     if config:

--- a/src/deadline/client/config/__init__.py
+++ b/src/deadline/client/config/__init__.py
@@ -14,11 +14,9 @@ __all__ = [
     "get_best_profile_for_farm",
     "str2bool",
     "DEFAULT_DEADLINE_ENDPOINT_URL",
-    "DEFAULT_DEADLINE_AWS_PROFILE_NAME",
 ]
 
 from .config_file import (
-    DEFAULT_DEADLINE_AWS_PROFILE_NAME,
     DEFAULT_DEADLINE_ENDPOINT_URL,
     get_best_profile_for_farm,
     get_setting,

--- a/src/deadline/client/config/config_file.py
+++ b/src/deadline/client/config/config_file.py
@@ -10,7 +10,6 @@ __all__ = [
     "get_best_profile_for_farm",
     "str2bool",
     "DEFAULT_DEADLINE_ENDPOINT_URL",
-    "DEFAULT_DEADLINE_AWS_PROFILE_NAME",
 ]
 
 import os
@@ -26,8 +25,6 @@ from ..exceptions import DeadlineOperationError
 CONFIG_FILE_PATH = os.path.join("~", ".deadline", "config")
 # Environment variable that, if set, overrides the value of CONFIG_FILE_PATH
 CONFIG_FILE_PATH_ENV_VAR = "DEADLINE_CONFIG_FILE_PATH"
-# The default Amazon Deadline Cloud SDK AWS profile
-DEFAULT_DEADLINE_AWS_PROFILE_NAME = "AmazonDeadlineCliAccess"
 # The default Amazon Deadline Cloud endpoint URL
 # TODO: This is currently set to our closed-beta endpoint. We need to update this for GA.
 DEFAULT_DEADLINE_ENDPOINT_URL = "https://btpdb6qczg.execute-api.us-west-2.amazonaws.com"
@@ -55,7 +52,7 @@ SETTINGS: Dict[str, Dict[str, Any]] = {
         "default": "",
     },
     "defaults.aws_profile_name": {
-        "default": DEFAULT_DEADLINE_AWS_PROFILE_NAME,
+        "default": "",
         "section_format": "profile-{}",
     },
     "settings.job_history_dir": {

--- a/test/deadline_client/unit/api/test_api_session.py
+++ b/test/deadline_client/unit/api/test_api_session.py
@@ -37,7 +37,7 @@ def test_get_boto3_session_caching_behavior(fresh_deadline_config):
         # This is a session with the default profile name
         session0 = api.get_boto3_session()
 
-        assert session0 == f"session for {config.DEFAULT_DEADLINE_AWS_PROFILE_NAME}"  # type: ignore
+        assert session0 == "session for None"  # type: ignore
 
         # This should return the cached object, and not call boto3.Session
         session1 = api.get_boto3_session()
@@ -65,7 +65,7 @@ def test_get_boto3_session_caching_behavior(fresh_deadline_config):
         # value of AWS profile name that was configured.
         boto3_session.assert_has_calls(
             [
-                call(profile_name=config.DEFAULT_DEADLINE_AWS_PROFILE_NAME),
+                call(profile_name=None),
                 call(profile_name="SomeRandomProfileName"),
             ]
         )

--- a/test/deadline_client/unit/config/test_config_file.py
+++ b/test/deadline_client/unit/config/test_config_file.py
@@ -12,7 +12,6 @@ import pytest
 
 from deadline.client import config
 from deadline.client.config import (
-    DEFAULT_DEADLINE_AWS_PROFILE_NAME,
     DEFAULT_DEADLINE_ENDPOINT_URL,
     config_file,
 )
@@ -20,7 +19,7 @@ from deadline.client.exceptions import DeadlineOperationError
 
 # This is imported by `test_cli_config.py` for a matching CLI test
 CONFIG_SETTING_ROUND_TRIP = [
-    ("defaults.aws_profile_name", DEFAULT_DEADLINE_AWS_PROFILE_NAME, "AnotherProfileName"),
+    ("defaults.aws_profile_name", "", "AnotherProfileName"),
     (
         "settings.deadline_endpoint_url",
         DEFAULT_DEADLINE_ENDPOINT_URL,
@@ -59,7 +58,7 @@ def test_config_settings_hierarchy(fresh_deadline_config):
     assert config.get_setting("defaults.queue_id") == ""
 
     # Switch back to the default profile, and check the next layer of the onion
-    config.set_setting("defaults.aws_profile_name", DEFAULT_DEADLINE_AWS_PROFILE_NAME)
+    config.set_setting("defaults.aws_profile_name", "")
     assert config.get_setting("settings.deadline_endpoint_url") == "nondefault-endpoint-url"
     assert config.get_setting("defaults.farm_id") == "farm-for-profile-default"
     # The queue id is still default
@@ -126,7 +125,7 @@ def test_config_file_env_var(fresh_deadline_config):
         os.environ["DEADLINE_CONFIG_FILE_PATH"] = alternate_deadline_config_file
 
         # Confirm that we see the default settings again
-        assert config.get_setting("defaults.aws_profile_name") == DEFAULT_DEADLINE_AWS_PROFILE_NAME
+        assert config.get_setting("defaults.aws_profile_name") == ""
 
         # Change the settings in this new file
         config.set_setting("defaults.aws_profile_name", "AlternateProfileName")

--- a/test/deadline_job_attachments/integ/test_job_attachments.py
+++ b/test/deadline_job_attachments/integ/test_job_attachments.py
@@ -237,6 +237,7 @@ def upload_input_files_one_asset_in_cas(
     return UploadInputFilesOneAssetInCasOutputs(attachments)
 
 
+@pytest.mark.integ
 def test_upload_input_files_all_assets_in_cas(
     job_attachment_test: JobAttachmentTest,
     upload_input_files_one_asset_in_cas: UploadInputFilesOneAssetInCasOutputs,
@@ -506,6 +507,7 @@ def sync_inputs_no_job_attachment_settings_in_job(
     )
 
 
+@pytest.mark.integ
 def test_sync_outputs_no_job_attachment_settings_in_job(
     job_attachment_test: JobAttachmentTest,
     sync_inputs_no_job_attachment_settings_in_job: SyncInputsNoJobAttachmentSettingsInJobOutput,
@@ -564,6 +566,7 @@ def test_sync_outputs_no_job_attachment_settings_in_job(
     )
 
 
+@pytest.mark.integ
 def test_sync_outputs_no_job_attachment_s3_settings(
     job_attachment_test: JobAttachmentTest,
     sync_inputs_no_job_attachment_s3_settings: SyncInputsNoJobAttachmentS3SettingsOutput,
@@ -812,6 +815,7 @@ def sync_outputs(
     )
 
 
+@pytest.mark.integ
 def test_sync_inputs_with_step_dependencies(
     job_attachment_test: JobAttachmentTest,
     tmp_path_factory: TempPathFactory,
@@ -868,6 +872,7 @@ def test_sync_inputs_with_step_dependencies(
     assert not Path(session_dir / dest_dir / job_attachment_test.MOV_FILE_OUTPUT_PATH).exists()
 
 
+@pytest.mark.integ
 def test_download_outputs_with_job_id_step_id_task_id_and_download_directory(
     job_attachment_test: JobAttachmentTest, tmp_path: Path, sync_outputs: SyncOutputsOutput
 ):
@@ -902,6 +907,7 @@ def test_download_outputs_with_job_id_step_id_task_id_and_download_directory(
         shutil.rmtree(job_attachment_test.OUTPUT_PATH)
 
 
+@pytest.mark.integ
 def test_download_outputs_with_job_id_step_id_and_download_directory(
     job_attachment_test: JobAttachmentTest, tmp_path: Path, sync_outputs: SyncOutputsOutput
 ):
@@ -937,6 +943,7 @@ def test_download_outputs_with_job_id_step_id_and_download_directory(
         shutil.rmtree(job_attachment_test.OUTPUT_PATH)
 
 
+@pytest.mark.integ
 def test_download_outputs_with_job_id_and_download_directory(
     job_attachment_test: JobAttachmentTest, tmp_path: Path, sync_outputs: SyncOutputsOutput
 ):
@@ -1043,6 +1050,7 @@ def upload_input_files_no_input_paths(
     return UploadInputFilesNoInputPathsOutput(attachments=attachments)
 
 
+@pytest.mark.integ
 def test_upload_input_files_no_download_paths(job_attachment_test: JobAttachmentTest) -> None:
     """
     Test that if there are no output directories, when upload_assets is called,
@@ -1111,6 +1119,7 @@ def test_upload_input_files_no_download_paths(job_attachment_test: JobAttachment
     assert attachments.manifests[0].inputManifestHash == manifest_hash
 
 
+@pytest.mark.integ
 def test_sync_inputs_no_inputs(
     job_attachment_test: JobAttachmentTest,
     upload_input_files_no_input_paths: UploadInputFilesNoInputPathsOutput,
@@ -1158,6 +1167,7 @@ def test_sync_inputs_no_inputs(
     assert not any(Path(session_dir).iterdir())
 
 
+@pytest.mark.integ
 def test_upload_bucket_wrong_account(external_bucket: str, job_attachment_test: JobAttachmentTest):
     """
     Test that if trying to upload to a bucket that isn't in the farm's AWS account, the correct error is thrown.
@@ -1191,6 +1201,7 @@ def test_upload_bucket_wrong_account(external_bucket: str, job_attachment_test: 
         asset_manager.upload_assets(manifests, on_uploading_assets=mock_on_uploading_files)
 
 
+@pytest.mark.integ
 def test_sync_inputs_bucket_wrong_account(
     external_bucket: str,
     job_attachment_test: JobAttachmentTest,
@@ -1237,6 +1248,7 @@ def test_sync_inputs_bucket_wrong_account(
     assert excinfo.value.response["ResponseMetadata"]["HTTPStatusCode"] == 403
 
 
+@pytest.mark.integ
 def test_sync_outputs_bucket_wrong_account(
     job_attachment_test: JobAttachmentTest,
     sync_inputs: SyncInputsOutputs,
@@ -1321,6 +1333,7 @@ def test_sync_outputs_bucket_wrong_account(
         )
 
 
+@pytest.mark.integ
 def test_download_outputs_bucket_wrong_account(
     job_attachment_test: JobAttachmentTest,
     tmp_path: Path,

--- a/test/deadline_job_attachments/integ/test_manifest_files.py
+++ b/test/deadline_job_attachments/integ/test_manifest_files.py
@@ -1,1 +1,0 @@
-# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The default setting was using a hardcoded AWS profile name, not following normal AWS conventions. This meant you couldn't use environment variables to set the credentials to use.

### What was the solution? (How)

- Change default client aws profile setting to the default provider chain
- Make a setting of "" or "default" as the profile name use the default provider chain.
- Also added pytest markers to the integration tests, to try to get something working on Windows.

### What is the impact of this change?

Customers can use copy/pasted credential env vars, the creds from an instance profile, etc.

### How was this change tested?

- Confirmed a named profile still worked.
- Set the profile name to '', confirmed it failed.
- Set env vars for teh creds, confirmed it succeeded.

### Was this change documented?

No

### Is this a breaking change?

I don't believe there is remaining behavior depending on the hardcoded profile name.