### PR TITLE
fix: Remove log_and_reraise_exception decorator

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -24,7 +24,7 @@ lint = [
 python = ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
 [envs.default.env-vars]
-# PIP_INDEX_URL="https://aws:{env:CODEARTIFACT_AUTH_TOKEN}@{env:CODEARTIFACT_DOMAIN}-{env:CODEARTIFACT_ACCOUNT_ID}.d.codeartifact.{env:CODEARTIFACT_REGION}.amazonaws.com/pypi/{env:CODEARTIFACT_REPOSITORY}/simple/"
+PIP_INDEX_URL="https://aws:{env:CODEARTIFACT_AUTH_TOKEN}@{env:CODEARTIFACT_DOMAIN}-{env:CODEARTIFACT_ACCOUNT_ID}.d.codeartifact.{env:CODEARTIFACT_REGION}.amazonaws.com/pypi/{env:CODEARTIFACT_REPOSITORY}/simple/"
 SKIP_BOOTSTRAP_TEST_RESOURCES="True"
 
 [envs.codebuild.scripts]

--- a/src/deadline/job_attachments/asset_sync.py
+++ b/src/deadline/job_attachments/asset_sync.py
@@ -49,11 +49,10 @@ from .utils import (
     hash_data,
     hash_file,
     join_s3_paths,
-    log_and_reraise_exception,
     map_source_path_to_dest_path,
 )
 
-logger = getLogger(__name__)
+logger = getLogger("deadline.job_attachments")
 
 
 class AssetSync:
@@ -252,7 +251,6 @@ class AssetSync:
         )
         return job.attachments if job and job.attachments else None
 
-    @log_and_reraise_exception(prefix_mssage="Error syncing inputs for Job.")
     def sync_inputs(
         self,
         s3_settings: Optional[JobAttachmentS3Settings],
@@ -393,7 +391,6 @@ class AssetSync:
             summary_statistics = download_summary_statistics.convert_to_summary_statistics()
         return (summary_statistics, list(pathmapping_rules.values()))
 
-    @log_and_reraise_exception(prefix_mssage="Error syncing outputs for Job.")
     def sync_outputs(
         self,
         s3_settings: Optional[JobAttachmentS3Settings],

--- a/src/deadline/job_attachments/utils.py
+++ b/src/deadline/job_attachments/utils.py
@@ -1,14 +1,13 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 import datetime
-from functools import wraps
 import io
 import os
 import sys
 from enum import Enum
 from hashlib import shake_256
 from pathlib import Path, PurePath, PurePosixPath, PureWindowsPath
-from typing import Callable, Optional, Tuple, Union
+from typing import Optional, Tuple, Union
 import uuid
 import yaml
 
@@ -228,43 +227,3 @@ class FileConflictResolution(Enum):
     @classmethod
     def from_index(cls, index: int):
         return cls(index)
-
-
-def log_and_reraise_exception(prefix_mssage: Optional[str] = None) -> Callable:
-    """
-    A decorator for logging exceptions and re-raising them in instance methods.
-    This decorator expects the class to have a 'logger' attribute. If not,
-    an AttributeError will be raised.
-
-    Usage:
-        class MyClass:
-            def __init__(self):
-                self.logger = ...
-
-            @log_and_reraise_exception("Error in some_methid: ")
-            def some_method(self):
-                ...
-
-        my_instance = MyClass()
-        my_instance.some_method() # Logs the exception and re-raises it.
-
-    Args:
-        prefix_mssage: A message to prefix the exception message with.
-    """
-
-    def decorator(func: Callable):
-        @wraps(func)
-        def wrapper(instance, *args, **kwargs):
-            if not hasattr(instance, "logger"):
-                raise AttributeError(
-                    "The class using log_and_reraise_exception must have a 'logger' attribute."
-                )
-            try:
-                return func(instance, *args, **kwargs)
-            except Exception as e:
-                instance.logger.exception(f"{prefix_mssage} - {str(e)}")
-                raise e
-
-        return wrapper
-
-    return decorator


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Due to the recent fix made in Worker Agent [PR#12](https://github.com/casillas2/deadline-cloud-worker-agent/pull/12), the decorator which logs and re-raises exceptions from AssetSync is no longer necessary. 

### What was the solution? (How)
All its usages have been removed. The decorator itself is not used anywhere, so it was also removed.

### What is the impact of this change?
Cleaning up unnecessary lines

### How was this change tested?
- `hatch run lint` and `hatch run test`
- Performed end-to-end tests (job submission --> running CMF worker), and confirmed that (intentionally thrown) exceptions are caught and logged into Session log, (not in Worker log.)

### Was this change documented?
No.

### Is this a breaking change?
No.
