### PR TITLE
feat: Add a CLI 'deadline job cancel' command

### DIFF
--- a/src/deadline/client/api/__init__.py
+++ b/src/deadline/client/api/__init__.py
@@ -60,7 +60,7 @@ def check_deadline_api_available(config: Optional[ConfigParser] = None) -> bool:
 
     with _modified_logging_level(logging.getLogger("botocore.credentials"), logging.ERROR):
         try:
-            list_farms(config=config, dryRun=True)
+            list_farms(config=config, maxResults=1)
             return True
         except Exception:
             logger.exception("Error invoking ListFarms")

--- a/src/deadline/client/cli/groups/bundle_group.py
+++ b/src/deadline/client/cli/groups/bundle_group.py
@@ -99,7 +99,7 @@ def validate_parameters(ctx, param, value):
 )
 @click.argument("job_bundle_dir")
 @handle_error
-def bundle_submit(job_bundle_dir, asset_loading_method, parameter, **args):
+def bundle_submit(job_bundle_dir, asset_loading_method, parameter, yes, **args):
     """
     Submits an OpenJobIO job bundle to Amazon Deadline Cloud.
     """
@@ -181,7 +181,9 @@ def bundle_submit(job_bundle_dir, asset_loading_method, parameter, **args):
             )
 
             if (
-                not config_file.str2bool(get_setting("settings.auto_accept", config=config))
+                not (
+                    yes or config_file.str2bool(get_setting("settings.auto_accept", config=config))
+                )
                 and len(asset_references.input_filenames) > 0
                 and not click.confirm(
                     f"Job submission contains {hash_summary.total_files} files "

--- a/test/unit/deadline_client/api/test_api_session.py
+++ b/test/unit/deadline_client/api/test_api_session.py
@@ -128,7 +128,7 @@ def test_get_queue_boto3_session_cache(fresh_deadline_config):
 
 def test_check_deadline_api_available(fresh_deadline_config):
     with patch.object(api._session, "get_boto3_session") as session_mock:
-        session_mock().client("deadline").list_farms.return_value = {}
+        session_mock().client("deadline").list_farms.return_value = {"farms": []}
         session_mock()._session.get_scoped_config().get.return_value = "some-studio-id"
 
         # Call the function under test
@@ -137,7 +137,7 @@ def test_check_deadline_api_available(fresh_deadline_config):
         assert result is True
         # It should have called list_farms with dry-run to check the API
         session_mock().client("deadline").list_farms.assert_called_once_with(
-            dryRun=True, studioId="some-studio-id"
+            maxResults=1, studioId="some-studio-id"
         )
 
 
@@ -152,7 +152,7 @@ def test_check_deadline_api_available_fails(fresh_deadline_config):
         assert result is False
         # It should have called list_farms with dry-run to check the API
         session_mock().client("deadline").list_farms.assert_called_once_with(
-            dryRun=True, studioId="some-studio-id"
+            maxResults=1, studioId="some-studio-id"
         )
 
 

--- a/test/unit/deadline_client/cli/test_cli_job.py
+++ b/test/unit/deadline_client/cli/test_cli_job.py
@@ -82,7 +82,6 @@ def test_cli_job_list(fresh_deadline_config):
   taskRunStatus: RUNNING
   startedAt: 2023-01-27 07:37:53+00:00
   endedAt: 2023-01-27 07:39:17+00:00
-  lifecycleStatus: SUCCEEDED
   createdBy: b801f3c0-c071-70bc-b869-6804bc732408
   createdAt: 2023-01-27 07:34:41+00:00
 - displayName: CLI Job
@@ -90,7 +89,6 @@ def test_cli_job_list(fresh_deadline_config):
   taskRunStatus: COMPLETED
   startedAt: 2023-01-27 07:27:06+00:00
   endedAt: 2023-01-27 07:29:51+00:00
-  lifecycleStatus: SUCCEEDED
   createdBy: b801f3c0-c071-70bc-b869-6804bc732408
   createdAt: 2023-01-27 07:24:22+00:00
 
@@ -126,7 +124,6 @@ def test_cli_job_list_explicit_farm_and_queue_id(fresh_deadline_config):
   taskRunStatus: RUNNING
   startedAt: 2023-01-27 07:37:53+00:00
   endedAt: 2023-01-27 07:39:17+00:00
-  lifecycleStatus: SUCCEEDED
   createdBy: b801f3c0-c071-70bc-b869-6804bc732408
   createdAt: 2023-01-27 07:34:41+00:00
 - displayName: CLI Job
@@ -134,7 +131,6 @@ def test_cli_job_list_explicit_farm_and_queue_id(fresh_deadline_config):
   taskRunStatus: COMPLETED
   startedAt: 2023-01-27 07:27:06+00:00
   endedAt: 2023-01-27 07:29:51+00:00
-  lifecycleStatus: SUCCEEDED
   createdBy: b801f3c0-c071-70bc-b869-6804bc732408
   createdAt: 2023-01-27 07:24:22+00:00
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

I'm testing on Alpha, and don't have a portal set up to use. So, I'm using the CLI to work with the queue and my jobs. One missing feature was job cancelation.

### What was the solution? (How)

Add a CLI 'deadline job cancel' command.

- By default, the cancel command asks for confirmation. It has a --mark-as option to set the taskRunStatus to FAILED or SUCCEEDED instead.

Other changes:

- When copying the --yes option, found it was not being used where I copied from, so fixed it there.
- Removed lifeCycleStatus from the job list output, because it does not provide meaningful information about the job itself, and was just distracting to look at.

### What is the impact of this change?

The Deadline CLI is slightly more useful.

### How was this change tested?

Canceled a number of jobs, including with the --mark-as option.

### Was this change documented?

Yes, it's in the CLI help output.

### Is this a breaking change?

No