### PR TITLE
feat: Create a CLI command to output a job schedule trace

### DIFF
--- a/src/deadline/client/cli/_common.py
+++ b/src/deadline/client/cli/_common.py
@@ -137,7 +137,7 @@ def _apply_cli_options_to_config(
 
     if args:
         raise RuntimeError(
-            f"Option names {args.keys()} are not standard Amazon Deadline Cloud CLI options, they need special handling"
+            f"Option names {tuple(args.keys())} are not standard Amazon Deadline Cloud CLI options, they need special handling"
         )
 
     return config

--- a/src/deadline/client/cli/_groups/bundle_group.py
+++ b/src/deadline/client/cli/_groups/bundle_group.py
@@ -81,9 +81,22 @@ def validate_parameters(ctx, param, value):
 @click.option("--profile", help="The AWS profile to use.")
 @click.option("--farm-id", help="The Amazon Deadline Cloud Farm to use.")
 @click.option("--queue-id", help="The Amazon Deadline Cloud Queue to use.")
+@click.option("--priority", type=int, help="The priority of the job.")
+@click.option(
+    "--max-failed-tasks-count",
+    type=int,
+    help="The maximum number of failed tasks before the job is marked as failed.",
+)
+@click.option(
+    "--max-retries-per-task",
+    type=int,
+    help="The maximum number of times to retry a task before it is marked as failed.",
+)
 @click.option(
     "--job-attachments-file-system",
-    help="The method to use for loading assets on the server (Overrides the default set in config file).  Options are COPIED (load assets onto server first then run the job) or VIRTUAL (load assets as requested).",
+    help="The method for accessing files from job attachments. "
+    + "COPIED means to copy files to the host and "
+    + "VIRTUAL means to load files when needed with a virtual file system.",
     type=click.Choice([e.value for e in JobAttachmentsFileSystem]),
 )
 @click.option(
@@ -93,7 +106,16 @@ def validate_parameters(ctx, param, value):
 )
 @click.argument("job_bundle_dir")
 @_handle_error
-def bundle_submit(job_bundle_dir, job_attachments_file_system, parameter, yes, **args):
+def bundle_submit(
+    job_bundle_dir,
+    job_attachments_file_system,
+    parameter,
+    yes,
+    priority,
+    max_failed_tasks_count,
+    max_retries_per_task,
+    **args,
+):
     """
     Submits an Open Job Description job bundle to Amazon Deadline Cloud.
     """
@@ -219,6 +241,13 @@ def bundle_submit(job_bundle_dir, job_attachments_file_system, parameter, yes, *
 
         if job_parameters_formatted:
             create_job_args["parameters"] = job_parameters_formatted
+
+        if priority is not None:
+            create_job_args["priority"] = priority
+        if max_failed_tasks_count is not None:
+            create_job_args["maxFailedTasksCount"] = max_failed_tasks_count
+        if max_retries_per_task is not None:
+            create_job_args["maxRetriesPerTask"] = max_retries_per_task
 
         if logging.DEBUG >= logger.getEffectiveLevel():
             logger.debug(json.dumps(create_job_args, indent=1))

--- a/src/deadline/client/job_bundle/parameters.py
+++ b/src/deadline/client/job_bundle/parameters.py
@@ -40,6 +40,7 @@ _VALID_UI_CONTROLS = (
     "LINE_EDIT",
     "MULTILINE_EDIT",
     "SPIN_BOX",
+    "HIDDEN",
 )
 
 

--- a/src/deadline/job_attachments/_aws/deadline.py
+++ b/src/deadline/job_attachments/_aws/deadline.py
@@ -63,6 +63,7 @@ def get_queue(
         queueId=response["queueId"],
         farmId=response["farmId"],
         status=response[status_key],
+        defaultBudgetAction=response["defaultBudgetAction"],
         jobAttachmentSettings=job_attachment_settings,
     )
 

--- a/src/deadline/job_attachments/models.py
+++ b/src/deadline/job_attachments/models.py
@@ -240,6 +240,7 @@ class Queue:
     displayName: str
     farmId: str  # pylint: disable=invalid-name
     status: str
+    defaultBudgetAction: str
     jobAttachmentSettings: Optional[JobAttachmentS3Settings] = None  # pylint: disable=invalid-name
 
 

--- a/test/unit/deadline_client/shared_constants.py
+++ b/test/unit/deadline_client/shared_constants.py
@@ -2,6 +2,8 @@
 
 MOCK_FARM_ID = "farm-0123456789abcdefabcdefabcdefabcd"
 MOCK_QUEUE_ID = "queue-0123456789abcdefabcdefabcdefabcd"
+MOCK_FLEET_ID = "fleet-7371eafb4bc74c7485c1138947bbe4e6"
+MOCK_WORKER_ID = "worker-aaca38a11996485f81d7f819c4f41f2b"
 MOCK_BUCKET_NAME = "deadline-job-attachments-mock-bucket"
 MOCK_STORAGE_PROFILE_ID = "sp-0123456789abcdefabcdefabcdefabcd"
 MOCK_JOB_ID = "job-0123456789abcdefabcdefabcdefabcd"

--- a/test/unit/deadline_job_attachments/conftest.py
+++ b/test/unit/deadline_job_attachments/conftest.py
@@ -299,6 +299,7 @@ def fixture_default_queue(farm_id, queue_id, default_job_attachment_s3_settings)
         queueId=queue_id,
         farmId=farm_id,
         status="ENABLED",
+        defaultBudgetAction="None",
         jobAttachmentSettings=default_job_attachment_s3_settings,
     )
 

--- a/test/unit/deadline_job_attachments/test_asset_sync.py
+++ b/test/unit/deadline_job_attachments/test_asset_sync.py
@@ -619,6 +619,7 @@ class TestAssetSync:
                     displayName="test-queue",
                     farmId="test-farm",
                     status="test",
+                    defaultBudgetAction="NONE",
                 ),
                 None,
             ),


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Understanding the behavior of the Deadline Cloud scheduler is important to help guide its development and to help customers understand how effectively it is working on their behalf. Something that could visualize the entire schedule produced for a job would help.

### What was the solution? (How)

* Write a new CLI command that queries all the session and session action data from runing a job, and writes both a high level summary and optionally a trace json file that can be opened with the https://ui.perfetto.dev tracing UI.
* While at it, added the --priority option to `deadline bundle submit`

### What is the impact of this change?

Using this tool, we can evaluate how well the scheduler is working.

### How was this change tested?

Ran it on some jobs, inspected the output.

### Was this change documented?

Yes, it's in the CLI help. I marked it as EXPERIMENTAL, as we'll likely want to modify this over time.

### Is this a breaking change?

No