### PR TITLE
feat(job-attachment): allow changing group ownership and permissions of transferred files

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -91,3 +91,8 @@ class MyCustomWidget(QWidget):
 ```
 
 **We recommend you set up your runtimes via `asdf`.**
+
+## Running Docker-based Unit Tests
+
+- Some of the unit tests in this package require a docker environment to run. These tests are marked with `@pytest.mark.docker`. In order to execute these tests, please run the `run_sudo_tests.sh` script located in the `scripts` directory. For detailed instructions, please refer to [scripts/README.md](./scripts/README.md).
+- If you make changes to the `download` or `asset_sync` modules, it's hightly recommended to run an ensure these tests pass.

--- a/hatch.toml
+++ b/hatch.toml
@@ -6,6 +6,7 @@ pre-install-commands = [
 [envs.default.scripts]
 sync = "pip install -r requirements-testing.txt"
 test = "pytest --cov-config pyproject.toml {args:test/unit}"
+test_docker = "./scripts/run_sudo_tests.sh --build"
 typing = "mypy {args:src test}"
 style = [
   "ruff {args:.}",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,7 @@ looponfailroots = [
 markers = [
     "no_setup: mark that test shouldn't use default setups",
     "integ: tests that run against AWS resources",
+    "docker: marks tests to be run only in a Docker environment",
 ]
 # looponfailroots is deprecated, this removes the deprecation from the test output
 filterwarnings = [

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,18 @@
+## Scripts
+
+### Running Tests with Docker for File and Directory Permissions
+
+We have some unit tests that require being run in a specific docker container that is set up for testing with different users. Those unit tests are marked with `docker`, and the `run_sudo_tests.sh` script is provided to facilitate this testing. The script builds the Docker iamge using the Dockerfile located in `testing_containers/localuser_sudo_environment/`, and then runs the container.
+
+#### Usage
+Execute the script from the root of the repository.
+```
+./scripts/run_sudo_tests.sh --build
+```
+
+Or, you can run the hatch script:
+```
+hatch run test_docker
+```
+
+Please make sure that you have the necessary permissions to execute the script.

--- a/scripts/run_sudo_tests.sh
+++ b/scripts/run_sudo_tests.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+set -eu
+
+# Run this from the root of the repository
+if ! test -d scripts
+then
+    echo "Must run from the root of the repository"
+    exit 1
+fi
+
+DO_BUILD="False"
+BUILD_ONLY="False"
+while [[ "${1:-}" != "" ]]; do
+    case $1 in
+        -h|--help)
+            echo "Usage: run_sudo_tests.sh [--build]"
+            exit 1
+            ;;
+        --build)
+            DO_BUILD="True"
+            ;;
+        --build-only)
+            BUILD_ONLY="True"
+            ;;
+        *)
+            echo "Unrecognized parameter: $1"
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+# Copying the dist/ dir can cause permission issues, so just nuke it.
+hatch clean 2> /dev/null || true
+
+ARGS=""
+
+if test "${PIP_INDEX_URL:-}" != ""; then
+    # If PIP_INDEX_URL is set, then export that in to the container
+    # so that `pip install` run in the container will fetch packages
+    # from the correct repository.
+    ARGS="${ARGS} -e  PIP_INDEX_URL=${PIP_INDEX_URL}"
+fi
+
+ARGS="${ARGS} -h localuser.environment.internal"
+CONTAINER_IMAGE_TAG="job_attachment_localuser_test"
+CONTAINER_IMAGE_DIR="localuser_sudo_environment"
+
+if test "${DO_BUILD}" == "True"; then
+    docker build testing_containers/"${CONTAINER_IMAGE_DIR}" -t "${CONTAINER_IMAGE_TAG}"
+fi
+
+if test "${BUILD_ONLY}" == "True"; then
+    exit 0
+fi
+
+docker run --name test_sudo --rm -v $(pwd):/code:ro ${ARGS} "${CONTAINER_IMAGE_TAG}":latest 

--- a/src/deadline/job_attachments/_utils.py
+++ b/src/deadline/job_attachments/_utils.py
@@ -1,5 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
+from dataclasses import dataclass
 import datetime
 import io
 import os
@@ -201,3 +202,21 @@ class FileConflictResolution(Enum):
     @classmethod
     def from_index(cls, index: int):
         return cls(index)
+
+
+@dataclass
+class FileSystemPermissionSettings:
+    """
+    A data class representing file system permission-related information.
+    The specified permission modes will be bitwise-OR'ed with the directory
+    or file's existing permissions.
+
+    Attributes:
+        os_group (str): The target operating system group for ownership.
+        dir_mode (int): The permission mode to be applied to directories.
+        file_mode (int): The permission mode to be applied to files.
+    """
+
+    os_group: str
+    dir_mode: int
+    file_mode: int

--- a/test/unit/deadline_job_attachments/conftest.py
+++ b/test/unit/deadline_job_attachments/conftest.py
@@ -455,3 +455,35 @@ def fixture_merged_manifest():
         ],
         "totalSize": 70,
     }
+
+
+def has_posix_target_user() -> bool:
+    """Returns if the testing environment exported the env variables for doing
+    cross-account posix target-user tests.
+    """
+    return (
+        os.environ.get("DEADLINE_JOB_ATTACHMENT_TEST_SUDO_TARGET_USER") is not None
+        and os.environ.get("DEADLINE_JOB_ATTACHMENT_TEST_SUDO_TARGET_GROUP") is not None
+    )
+
+
+def has_posix_disjoint_user() -> bool:
+    """Returns if the testing environment exported the env variables for doing
+    cross-account posix disjoint-user tests.
+    """
+    return (
+        os.environ.get("DEADLINE_JOB_ATTACHMENT_TEST_SUDO_DISJOINT_USER") is not None
+        and os.environ.get("DEADLINE_JOB_ATTACHMENT_TEST_SUDO_DISJOINT_GROUP") is not None
+    )
+
+
+@pytest.fixture(scope="function")
+def posix_target_group() -> str:
+    # Intentionally fail if the var is not defined.
+    return os.environ["DEADLINE_JOB_ATTACHMENT_TEST_SUDO_TARGET_GROUP"]
+
+
+@pytest.fixture(scope="function")
+def posix_disjoint_group() -> str:
+    # Intentionally fail if the var is not defined.
+    return os.environ["DEADLINE_JOB_ATTACHMENT_TEST_SUDO_DISJOINT_GROUP"]

--- a/test/unit/deadline_job_attachments/test_asset_sync.py
+++ b/test/unit/deadline_job_attachments/test_asset_sync.py
@@ -687,12 +687,12 @@ class TestAssetSync:
             mock_on_downloading_files = MagicMock(return_value=True)
 
             (summary_statistics, result_pathmap_rules) = self.default_asset_sync.sync_inputs(
-                default_queue.jobAttachmentSettings,
-                default_job.attachments,
-                default_queue.queueId,
-                default_job.jobId,
-                tmp_path,
-                storage_profiles_path_mapping_rules,
+                s3_settings=default_queue.jobAttachmentSettings,
+                attachments=default_job.attachments,
+                queue_id=default_queue.queueId,
+                job_id=default_job.jobId,
+                session_dir=tmp_path,
+                storage_profiles_path_mapping_rules=storage_profiles_path_mapping_rules,
                 on_downloading_files=mock_on_downloading_files,
             )
 
@@ -712,6 +712,7 @@ class TestAssetSync:
                     "/tmp/movie1": "test_manifest_data",
                 },
                 cas_prefix="assetRoot/Data",
+                fs_permission_settings=None,
                 session=ANY,
                 on_downloading_files=mock_on_downloading_files,
             )

--- a/testing_containers/localuser_sudo_environment/Dockerfile
+++ b/testing_containers/localuser_sudo_environment/Dockerfile
@@ -1,0 +1,39 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+FROM python:3.9-buster
+
+# Let our tests know that we"re in an environment that can run the sudo
+# tests
+ENV DEADLINE_JOB_ATTACHMENT_TEST_SUDO_TARGET_USER=targetuser
+ENV DEADLINE_JOB_ATTACHMENT_TEST_SUDO_TARGET_GROUP=targetgroup
+ENV DEADLINE_JOB_ATTACHMENT_TEST_SUDO_DISJOINT_USER=disjointuser
+ENV DEADLINE_JOB_ATTACHMENT_TEST_SUDO_DISJOINT_GROUP=disjointgroup
+
+# Use a docker volume to mount the root of the repo to this directory
+WORKDIR /code
+
+# We set up three users for our tests:
+#  1) hostuser -- the user that will be running the pytests.
+#  2) targetuser -- the user assumed to be running the job in the tests.
+#  3) disjointuser -- a user to be used in cross-account testing.
+# These accounts belong to the following groups:
+#   hostuser: hostuser, targetgroup
+#   targetuser: targetuser, targetgroup
+#   disjointuser: disjointuser, disjointgroup
+RUN apt-get update && apt-get install sudo && \
+    rm -rf /var/lib/apt/lists/* && \
+    addgroup ${DEADLINE_JOB_ATTACHMENT_TEST_SUDO_TARGET_GROUP} &&  \
+    useradd -ms /bin/bash -G ${DEADLINE_JOB_ATTACHMENT_TEST_SUDO_TARGET_GROUP} ${DEADLINE_JOB_ATTACHMENT_TEST_SUDO_TARGET_USER} && \
+    useradd -ms /bin/bash -G ${DEADLINE_JOB_ATTACHMENT_TEST_SUDO_TARGET_GROUP} hostuser && \
+    echo "hostuser ALL=(${DEADLINE_JOB_ATTACHMENT_TEST_SUDO_TARGET_USER},hostuser) NOPASSWD: ALL" > /etc/sudoers.d/hostuser && \
+    addgroup ${DEADLINE_JOB_ATTACHMENT_TEST_SUDO_DISJOINT_GROUP} && \
+    useradd -ms /bin/bash -G ${DEADLINE_JOB_ATTACHMENT_TEST_SUDO_DISJOINT_GROUP} ${DEADLINE_JOB_ATTACHMENT_TEST_SUDO_DISJOINT_USER} && \
+    chmod 777 /code
+
+WORKDIR /home/hostuser
+
+COPY --chown=hostuser:hostuser run_tests.sh /home/hostuser/
+
+USER hostuser
+
+CMD ["/bin/sh", "-c", "./run_tests.sh"]

--- a/testing_containers/localuser_sudo_environment/README.md
+++ b/testing_containers/localuser_sudo_environment/README.md
@@ -1,0 +1,6 @@
+## Docker Environment for Testing File and Directory Permissions
+
+This Docker environment is set up to test code related to modifying OS group ownership and permissions of files and directories. It adds two different OS groups (and a user in each group,) allowing us to manipulate system-level settings of files and directories. When the container starts, it executes the test script `run_tests.sh`, which only runs unit tests marked with `docker`.
+
+### Usage
+To use this Docker environment and run the related tests, navigate to the parent directory and run the `./scripts/run_sudo_tests.sh` script.

--- a/testing_containers/localuser_sudo_environment/run_tests.sh
+++ b/testing_containers/localuser_sudo_environment/run_tests.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+set -eux
+
+mkdir -p /home/hostuser/code/
+cp -r /code/* /home/hostuser/code/
+cp -r /code/.git /home/hostuser/code/
+
+cd code
+python -m venv .venv
+source .venv/bin/activate
+pip install hatch
+# Use the codebuild env so that PIP_INDEX_URL isn't set in the hatch config files.
+hatch run codebuild:test -m docker


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Currently as part of the sync job action, the worker agent runs some code to change the group ownership on files in the session directory:
- [Definition](https://github.com/casillas2/deadline-cloud-worker-agent/blob/044f0fa5ce28e9764589373f09c2e07195492764/src/deadline_worker_agent/sessions/session.py#L862)
- Usages: [Usage 1](https://github.com/casillas2/deadline-cloud-worker-agent/blob/044f0fa5ce28e9764589373f09c2e07195492764/src/deadline_worker_agent/sessions/session.py#L860C29-L860C29), [Usage 2](https://github.com/casillas2/deadline-cloud-worker-agent/blob/044f0fa5ce28e9764589373f09c2e07195492764/src/deadline_worker_agent/sessions/session.py#L769)

This was originally only meant to be run against the job attachment owned files/folders (ie. asset roots and all the files within them), however, it's running against all files/folders within the session directory. This used to be good/safe enough when the job attachments sync always happened before all other actions, however there is now the possibility of other actions running before the sync input job attachments action (queue/job level environments vs. step input sync).

### What was the solution? (How)
- Fix AssetSync.sync_asset_inputs(), (which is used by the worker agent,) to accept an argument for os_group: str, dir_mode: int, file_mode: int. If set, then perform `chown` and `chmod` with the given ownership/permissions on all newly created files. 
- To test these changes, new docker-based tests have been added.
  - Added new tests that run inside the docker container that are built with necessary users and groups added.
  - The tests are triggered by a script `scripts/run_sudo_tests.sh` that builds the container image and runs tests within it

### What is the impact of this change?
This will allow the worker agent to remove the custom job attachments specific code and let job attachments handle it.

### How was this change tested?
- `hatch run lint && hatch run test`
- Run a script `./scripts/run_sudo_tests.sh` to run a new unit test that require a specific docker container that is set up with different users and groups.
- Perform end-to-end test (via CLI) to ensure that job submission was successful.

### Was this change documented?
No.

### Is this a breaking change?
No.
