### PR TITLE
feat: Add a new option for user to select FileSystem parameter from Config UI.

### DIFF
--- a/src/deadline/client/cli/groups/bundle_group.py
+++ b/src/deadline/client/cli/groups/bundle_group.py
@@ -88,9 +88,8 @@ def validate_parameters(ctx, param, value):
 @click.option("--queue-id", help="The Amazon Deadline Cloud Queue to use.")
 @click.option(
     "--asset-loading-method",
-    help="The method to use for loading assets on the server.  Options are PRELOAD (load assets onto server first then run the job) or ON_DEMAND (load assets as requested).",
+    help="The method to use for loading assets on the server (Overrides the default set in config file).  Options are PRELOAD (load assets onto server first then run the job) or ON_DEMAND (load assets as requested).",
     type=click.Choice([e.value for e in AssetLoadingMethod]),
-    default=AssetLoadingMethod.PRELOAD.value,
 )
 @click.option(
     "--yes",
@@ -116,6 +115,10 @@ def bundle_submit(job_bundle_dir, asset_loading_method, parameter, yes, **args):
         deadline = get_boto3_client("deadline", config=config)
         farm_id = get_setting("defaults.farm_id", config=config)
         queue_id = get_setting("defaults.queue_id", config=config)
+        if asset_loading_method is None:
+            asset_loading_method = get_setting(
+                "defaults.job_attachments_file_system", config=config
+            )
 
         queue = deadline.get_queue(farmId=farm_id, queueId=queue_id)
         click.echo(f"Submitting to Queue: {queue['displayName']}")

--- a/src/deadline/client/cli/groups/config_group.py
+++ b/src/deadline/client/cli/groups/config_group.py
@@ -44,6 +44,10 @@ def cli_config():
 
     settings.log_level:
         Setting to change the log level. Must be one of ["ERROR", "WARNING", "INFO", "DEBUG"]
+
+    defaults.job_attachments_file_system:
+        Setting to determine if attachments are preloaded on to workers before a job executes
+        or fetched in realtime. Must be one of ["PRELOAD", "ON_DEMAND"]
     """
 
 

--- a/src/deadline/client/config/config_file.py
+++ b/src/deadline/client/config/config_file.py
@@ -98,6 +98,7 @@ SETTINGS: Dict[str, Dict[str, Any]] = {
     },
     "telemetry.opt_out": {"default": "false"},
     "telemetry.identifier": {"default": ""},
+    "defaults.job_attachments_file_system": {"default": "PRELOAD", "depend": "defaults.farm_id"},
 }
 
 

--- a/src/deadline/client/ui/dialogs/deadline_config_dialog.py
+++ b/src/deadline/client/ui/dialogs/deadline_config_dialog.py
@@ -253,6 +253,13 @@ class DeadlineWorkstationConfigWidget(QWidget):
             self.handle_background_exception
         )
         layout.addRow(default_storage_profile_box_label, self.default_storage_profile_box)
+        self.file_system_box = self._init_combobox_setting(
+            group,
+            layout,
+            "defaults.job_attachments_file_system",
+            "Job Attachments FileSystem Options",
+            ["PRELOAD", "ON_DEMAND"],
+        )
 
     def _build_general_settings_ui(self, group, layout):
         self.auto_accept = self._init_checkbox_setting(

--- a/src/deadline/client/ui/dialogs/submit_job_progress_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_progress_dialog.py
@@ -12,6 +12,8 @@ import os
 import threading
 from typing import Any, Dict, List, Optional, Set
 
+from deadline.client.config import config_file
+
 from botocore.client import BaseClient  # type: ignore[import]
 from PySide2.QtCore import Qt, Signal
 from PySide2.QtGui import QCloseEvent
@@ -456,6 +458,9 @@ class SubmitJobProgressDialog(QDialog):
         """
         if attachment_settings:
             self._create_job_args["attachments"] = attachment_settings
+            self._create_job_args["attachments"]["assetLoadingMethod"] = config_file.get_setting(
+                "defaults.job_attachments_file_system"
+            )
 
         api.get_telemetry_client().record_upload_summary(upload_summary, from_gui=True)
         self.summary_edit.setText(

--- a/test/unit/deadline_client/cli/test_cli_bundle.py
+++ b/test/unit/deadline_client/cli/test_cli_bundle.py
@@ -194,7 +194,9 @@ def test_cli_bundle_asset_load_method(fresh_deadline_config, temp_job_bundle_dir
         result = runner.invoke(deadline_cli.cli, params)
 
         expected_loading_method = (
-            loading_method if loading_method is not None else AssetLoadingMethod.PRELOAD
+            loading_method
+            if loading_method is not None
+            else config.get_setting("defaults.job_attachments_file_system")
         )
 
         get_boto3_client_mock().create_job.assert_called_with(

--- a/test/unit/deadline_client/cli/test_cli_config.py
+++ b/test/unit/deadline_client/cli/test_cli_config.py
@@ -34,7 +34,7 @@ def test_cli_config_show_defaults(fresh_deadline_config):
     assert fresh_deadline_config in result.output
 
     # Assert the expected number of settings
-    assert len(settings.keys()) == 12
+    assert len(settings.keys()) == 13
 
     for setting_name in settings.keys():
         assert setting_name in result.output
@@ -97,6 +97,7 @@ def test_cli_config_show_modified_config(fresh_deadline_config):
     config.set_setting("defaults.queue_id", "queue-389348u234jhk34")
     config.set_setting("defaults.job_id", "job-239u40234jkl234nkl23")
     config.set_setting("settings.auto_accept", "False")
+    config.set_setting("defaults.job_attachments_file_system", "ON_DEMAND")
     config.set_setting("settings.log_level", "DEBUG")
     config.set_setting("telemetry.opt_out", "True")
     config.set_setting("telemetry.identifier", "user-id-123abc-456def")

--- a/test/unit/deadline_client/config/test_config_file.py
+++ b/test/unit/deadline_client/config/test_config_file.py
@@ -26,6 +26,7 @@ CONFIG_SETTING_ROUND_TRIP = [
         "https://some-other-url",
     ),
     ("defaults.farm_id", "", "farm-82934h23k4j23kjh"),
+    ("defaults.job_attachments_file_system", "PRELOAD", "ON_DEMAND"),
 ]
 
 


### PR DESCRIPTION
The options for the parameter are:
PRELOAD - Preload all attachments described in the job manifest before starting a job. 
ON_DEMAND - Load attachments using VFS when requested by a task.


### What was the problem/requirement? (What/Why)
Provide an option via the Submitter UI for users to select how assets are accessed during a job execution. The options are to copy all assets on to the worker before hand or access them via a Virtual file system as and when needed. 

### What was the solution? (How)
Modify the Deadline Config UI to add the options to select.

### What is the impact of this change?

### How was this change tested?
Added New Unit Tests, Submitted Jobs via Maya and Nuke Submitters and made sure the selected options reflected in job submission parameters.

### Was this change documented?
N/A

### Is this a breaking change?
No