### PR TITLE
fix: remove unused search workers filter

### DIFF
--- a/src/deadline/client/cli/groups/worker_group.py
+++ b/src/deadline/client/cli/groups/worker_group.py
@@ -40,22 +40,7 @@ def worker_list(page_size, item_offset, fleet_id, **args):
     deadline = api.get_boto3_client("deadline", config=config)
     try:
         response = deadline.search_workers(
-            farmId=farm_id,
-            fleetIds=[fleet_id],
-            itemOffset=item_offset,
-            pageSize=page_size,
-            filterExpressions={
-                "filters": [
-                    {
-                        "stringFilter": {
-                            "name": "STATUS",
-                            "value": "DELETED",
-                            "operator": "NOT_EQUAL",
-                        }
-                    },
-                ],
-                "operator": "AND",
-            },
+            farmId=farm_id, fleetIds=[fleet_id], itemOffset=item_offset, pageSize=page_size
         )
     except ClientError as exc:
         raise DeadlineOperationError(f"Failed to get Workers from Deadline:\n{exc}") from exc


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The filter for `DELETED` workers is no longer needed when calling `SearchWorkers`
### What was the solution? (How)
Removed the filter on the API call
### What is the impact of this change?
No impact
### How was this change tested?
Ran `deadline worker list` before and after the change with the same result
### Was this change documented?
No
### Is this a breaking change?
No