### PR TITLE
chore(job-attachment): upgrade test-scaffolding version

### DIFF
--- a/requirements-integ-testing.txt
+++ b/requirements-integ-testing.txt
@@ -1,1 +1,1 @@
-deadline-cloud-test-fixtures ~= 0.2.0
+deadline-cloud-test-fixtures ~= 0.3.0


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
With the recent release of a new version `0.3.0` of test-scaffolding, and additional changes from a [PR#10 in test-scaffolding](https://github.com/casillas2/deadline-cloud-test-fixtures/pull/10), the integration tests were out of sync and needed updates to pass successfully.

### What was the solution? (How)
Updates the Job Attachment's `integ` tests to be compatible with the newest test-scaffolding version and new changes in PR#10.

### What is the impact of this change?
The integration tests will now pass with the updated test-scaffolding version.

### How was this change tested?
- Ran `hatch run lint && hatch run test`
- Ran `hatch run integ:test` with the changes of [PR#10 in test-scaffolding](https://github.com/casillas2/deadline-cloud-test-fixtures/pull/10) (Needed to manually install the locally-built whl file.)

### Was this change documented?
No.

### Is this a breaking change?
No.
