### PR TITLE
!refactor: renaming cloud companion to deadline cloud monitor

### DIFF
--- a/src/deadline/client/api/_session.py
+++ b/src/deadline/client/api/_session.py
@@ -35,7 +35,7 @@ __cached_queue_id_for_queue_session = None
 class AwsCredentialsType(Enum):
     NOT_VALID = 0
     HOST_PROVIDED = 2
-    CLOUD_COMPANION_LOGIN = 3
+    DEADLINE_CLOUD_MONITOR_LOGIN = 3
 
 
 class AwsCredentialsStatus(Enum):
@@ -118,7 +118,7 @@ def get_boto3_client(service_name: str, config: Optional[ConfigParser] = None) -
 
 def get_credentials_type(config: Optional[ConfigParser] = None) -> AwsCredentialsType:
     """
-    Returns CLOUD_COMPANION_LOGIN if Cloud Companion wrote the credentials, HOST_PROVIDED otherwise.
+    Returns DEADLINE_CLOUD_MONITOR_LOGIN if Deadline Cloud Monitor wrote the credentials, HOST_PROVIDED otherwise.
 
     Args:
         config (ConfigParser, optional): The Amazon Deadline Cloud configuration
@@ -131,7 +131,7 @@ def get_credentials_type(config: Optional[ConfigParser] = None) -> AwsCredential
         return AwsCredentialsType.NOT_VALID
     if "studio_id" in profile_config:
         # CTDX adds some Nimble-specific keys here which we can use to know that this came from CTDX
-        return AwsCredentialsType.CLOUD_COMPANION_LOGIN
+        return AwsCredentialsType.DEADLINE_CLOUD_MONITOR_LOGIN
     else:
         return AwsCredentialsType.HOST_PROVIDED
 
@@ -140,7 +140,7 @@ def get_user_and_identity_store_id(
     config: Optional[ConfigParser] = None,
 ) -> tuple[Optional[str], Optional[str]]:
     """
-    If logged in with Nimble Studio Cloud Companion, returns a tuple
+    If logged in with Nimble Studio Deadline Cloud Monitor, returns a tuple
     (user_id, identity_store_id), otherwise returns None.
     """
     session = get_boto3_session(config=config)
@@ -156,7 +156,7 @@ def get_studio_id(
     config: Optional[ConfigParser] = None,
 ) -> Optional[str]:
     """
-    If logged in with Nimble Studio Cloud Companion, returns Studio Id, otherwise returns None.
+    If logged in with Nimble Studio Deadline Cloud Monitor, returns Studio Id, otherwise returns None.
     """
     session = get_boto3_session(config=config)
     profile_config = session._session.get_scoped_config()
@@ -279,7 +279,7 @@ def check_credentials_status(config: Optional[ConfigParser] = None) -> AwsCreden
     Returns AwsCredentialsStatus enum value:
       - CONFIGURATION_ERROR if there is an unexpected error accessing credentials
       - AUTHENTICATED if they are fine
-      - NEEDS_LOGIN if a Cloud Companion login is required.
+      - NEEDS_LOGIN if a Deadline Cloud Monitor login is required.
     """
 
     with _modified_logging_level(logging.getLogger("botocore.credentials"), logging.ERROR):
@@ -287,10 +287,10 @@ def check_credentials_status(config: Optional[ConfigParser] = None) -> AwsCreden
             get_boto3_session(config=config).client("sts").get_caller_identity()
             return AwsCredentialsStatus.AUTHENTICATED
         except Exception:
-            # We assume that the presence of a CloudCompanion profile
+            # We assume that the presence of a Deadline Cloud Monitor profile
             # means we will know everything necessary to start it and login.
 
-            if get_credentials_type(config) == AwsCredentialsType.CLOUD_COMPANION_LOGIN:
+            if get_credentials_type(config) == AwsCredentialsType.DEADLINE_CLOUD_MONITOR_LOGIN:
                 return AwsCredentialsStatus.NEEDS_LOGIN
             return AwsCredentialsStatus.CONFIGURATION_ERROR
 

--- a/src/deadline/client/cli/groups/handle_web_url_command.py
+++ b/src/deadline/client/cli/groups/handle_web_url_command.py
@@ -113,7 +113,7 @@ def cli_handle_web_url(
             step_id = url_queries.pop("step_id", None)
             task_id = url_queries.pop("task_id", None)
 
-            # Add the standard option "profile", using the one provided by the url (set by Cloud Companion)
+            # Add the standard option "profile", using the one provided by the url (set by Deadline Cloud Monitor)
             # or choosing a best guess based on farm and queue IDs
             aws_profile_name = url_queries.pop(
                 "profile",

--- a/src/deadline/client/cli/groups/loginout_commands.py
+++ b/src/deadline/client/cli/groups/loginout_commands.py
@@ -15,11 +15,11 @@ from .._common import handle_error
 
 def _cli_on_pending_authorization(**kwargs):
     """
-    Callback for `login`, to tell the user that Cloud Companion is opening
+    Callback for `login`, to tell the user that Deadline Cloud Monitor is opening
     """
 
-    if kwargs["credential_type"] == AwsCredentialsType.CLOUD_COMPANION_LOGIN:
-        click.echo("Opening Cloud Companion. Please login before returning here.")
+    if kwargs["credential_type"] == AwsCredentialsType.DEADLINE_CLOUD_MONITOR_LOGIN:
+        click.echo("Opening Deadline Cloud Monitor. Please login before returning here.")
 
 
 @click.command(name="login")
@@ -29,7 +29,7 @@ def cli_login():
     Logs in to the Amazon Deadline Cloud configured AWS profile.
 
     This is for any profile type that Amazon Deadline Cloud knows how to login to
-    Currently only supports Nimble Cloud Companion
+    Currently only supports Deadline Cloud Monitor
     """
     click.echo(
         f"Logging into AWS Profile {config_file.get_setting('defaults.aws_profile_name')!r} for Amazon Deadline Cloud"

--- a/src/deadline/client/config/config_file.py
+++ b/src/deadline/client/config/config_file.py
@@ -47,9 +47,9 @@ __config_mtime = None
 #             section [profile-{profileName} default]
 # "section_format" - How its value gets formatted into config file sections.
 SETTINGS: Dict[str, Dict[str, Any]] = {
-    "cloud-companion.path": {
+    "deadline-cloud-monitor.path": {
         "default": "",
-        "description": "The filesystem path to Cloud Companion, set during login process.",
+        "description": "The filesystem path to Deadline Cloud Monitor, set during login process.",
     },
     "defaults.aws_profile_name": {
         "default": "",

--- a/src/deadline/client/ui/dialogs/deadline_login_dialog.py
+++ b/src/deadline/client/ui/dialogs/deadline_login_dialog.py
@@ -105,9 +105,9 @@ class DeadlineLoginDialog(QMessageBox):
         try:
 
             def on_pending_authorization(**kwargs):
-                if kwargs["credential_type"] == AwsCredentialsType.CLOUD_COMPANION_LOGIN:
+                if kwargs["credential_type"] == AwsCredentialsType.DEADLINE_CLOUD_MONITOR_LOGIN:
                     self.login_thread_message.emit(
-                        "Opening Cloud Companion. Please login before returning here."
+                        "Opening Deadline Cloud Monitor. Please login before returning here."
                     )
 
             def on_cancellation_check():

--- a/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
@@ -87,12 +87,12 @@ class SubmitJobToDeadlineDialog(QDialog):
 
     def refresh_deadline_settings(self):
         # Enable/disable the Login and Logout buttons based on whether
-        # the configured profile is for Cloud Companion
+        # the configured profile is for Deadline Cloud Monitor
         self.login_button.setEnabled(
-            self.creds_status_box.creds_type == api.AwsCredentialsType.CLOUD_COMPANION_LOGIN
+            self.creds_status_box.creds_type == api.AwsCredentialsType.DEADLINE_CLOUD_MONITOR_LOGIN
         )
         self.logout_button.setEnabled(
-            self.creds_status_box.creds_type == api.AwsCredentialsType.CLOUD_COMPANION_LOGIN
+            self.creds_status_box.creds_type == api.AwsCredentialsType.DEADLINE_CLOUD_MONITOR_LOGIN
         )
         # Enable/disable the Submit button based on whether the
         # Amazon Deadline Cloud API is accessible and the farm+queue are configured.

--- a/src/deadline/client/ui/widgets/deadline_credentials_status_widget.py
+++ b/src/deadline/client/ui/widgets/deadline_credentials_status_widget.py
@@ -15,7 +15,7 @@ The status includes three parts:
      This is checked with an sts:GetCallerIdentity AWS API call.
   2. Do the credentials grant access to Amazon Deadline Cloud APIs?
      This is checked with a dry-run deadline:ListFarms AWS API call.
-  3. Do the credentials use Cloud Companion?
+  3. Do the credentials use Deadline Cloud Monitor?
      This is checked by looking for the relevant properties
      in the AWS profile configuration.
 """

--- a/test/unit/deadline_client/cli/test_cli_config.py
+++ b/test/unit/deadline_client/cli/test_cli_config.py
@@ -88,7 +88,7 @@ def test_cli_config_show_modified_config(fresh_deadline_config):
     Confirm that the CLI interface prints out all the configuration
     file data, when the configuration is default
     """
-    config.set_setting("cloud-companion.path", "/User/auser/bin/CloudCompanion")
+    config.set_setting("deadline-cloud-monitor.path", "/User/auser/bin/DeadlineCloudMonitor")
     config.set_setting("defaults.aws_profile_name", "EnvVarOverrideProfile")
     config.set_setting("settings.job_history_dir", "~/alternate/job_history")
     config.set_setting("settings.deadline_endpoint_url", "https://some-url-value")

--- a/test/unit/deadline_client/cli/test_cli_loginout.py
+++ b/test/unit/deadline_client/cli/test_cli_loginout.py
@@ -15,18 +15,18 @@ from deadline.client import api, config
 from deadline.client.cli import deadline_cli
 
 
-def test_cli_cloud_companion_login(fresh_deadline_config):
+def test_cli_deadline_cloud_monitor_login(fresh_deadline_config):
     """
-    Confirm that the CLI login/logout command invokes Cloud Companion as expected
+    Confirm that the CLI login/logout command invokes Deadline Cloud Monitor as expected
     """
     scoped_config = {
-        "credential_process": "/bin/NimbleCloudCompanion get-credentials --profile sandbox-us-west-2",
+        "credential_process": "/bin/DeadlineCloudMonitor get-credentials --profile sandbox-us-west-2",
         "studio_id": "us-west-2:stid-1g9neezauta8ease",
         "region": "us-west-2",
     }
 
     profile_name = "sandbox-us-west-2"
-    config.set_setting("cloud-companion.path", "/bin/NimbleCloudCompanion")
+    config.set_setting("deadline-cloud-monitor.path", "/bin/DeadlineCloudMonitor")
     config.set_setting("defaults.aws_profile_name", profile_name)
 
     with patch.object(api._session, "get_boto3_session") as session_mock, patch.object(
@@ -47,7 +47,7 @@ def test_cli_cloud_companion_login(fresh_deadline_config):
         assert result.exit_code == 0, result.output
 
         popen_mock.assert_called_once_with(
-            ["/bin/NimbleCloudCompanion", "login", "--profile", "sandbox-us-west-2"],
+            ["/bin/DeadlineCloudMonitor", "login", "--profile", "sandbox-us-west-2"],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             stdin=subprocess.PIPE,
@@ -55,7 +55,10 @@ def test_cli_cloud_companion_login(fresh_deadline_config):
 
         assert result.exit_code == 0
 
-        assert "Successfully logged in: Cloud Companion Profile: sandbox-us-west-2" in result.output
+        assert (
+            "Successfully logged in: Deadline Cloud Monitor Profile: sandbox-us-west-2"
+            in result.output
+        )
         assert result.exit_code == 0
 
         # Now lets logout
@@ -63,7 +66,7 @@ def test_cli_cloud_companion_login(fresh_deadline_config):
         result = runner.invoke(deadline_cli.cli, ["logout"])
 
         check_output_mock.assert_called_once_with(
-            ["/bin/NimbleCloudCompanion", "logout", "--profile", "sandbox-us-west-2"]
+            ["/bin/DeadlineCloudMonitor", "logout", "--profile", "sandbox-us-west-2"]
         )
 
         assert "Successfully logged out" in result.output


### PR DESCRIPTION
format

### What was the problem/requirement? (What/Why)
`Nimble Cloud Companion` is now renamed as `Deadline Cloud Monitor`

### What was the solution? (How)
Renaming all Cloud Companion related to Deadline Cloud Monitor

### What is the impact of this change?
Reflect renaming of DCM in Deadline Cloud codebase

### How was this change tested?
`hatch run test`

### Was this change documented?
N/A

### Is this a breaking change?
N/A