### PR TITLE
feat!: update to the 2023-09 job template schema

### DIFF
--- a/examples/submit_job.py
+++ b/examples/submit_job.py
@@ -17,7 +17,7 @@ import time
 from pathlib import Path
 
 import boto3
-from openjobio.model.template import SchemaVersion, TemplateModelRegistry
+from openjd.model.template import SchemaVersion, TemplateModelRegistry
 
 from deadline.job_attachments.aws.deadline import get_queue
 from deadline.job_attachments.upload import S3AssetManager

--- a/hatch_version_hook.py
+++ b/hatch_version_hook.py
@@ -45,9 +45,7 @@ class CustomBuildHook(BuildHookInterface):
       "_version.py",
     ]
     destinations = [
-      "src/openjobio",
-      "src/openjobio_adaptor_runtime",
-      "src/openjobio_adaptor_runtime_client",
+      "src/deadline",
     ]
     [[tool.hatch.build.hooks.custom.copy_map]]
     sources = [
@@ -55,9 +53,7 @@ class CustomBuildHook(BuildHookInterface):
       "something_else_the_tests_need.ini",
     ]
     destinations = [
-      "test/openjobio",
-      "test/openjobio_adaptor_runtime",
-      "test/openjobio_adaptor_runtime_client",
+      "test/deadline",
     ]
     ```
     """

--- a/src/deadline/client/api/_submit_job_bundle.py
+++ b/src/deadline/client/api/_submit_job_bundle.py
@@ -45,7 +45,7 @@ def create_job_from_job_bundle(
 
     A job bundle has the following directory structure:
 
-    /template.json|yaml (required): An OpenJobIO job template that specifies the work to be done. Job parameters
+    /template.json|yaml (required): An Open Job Description job template that specifies the work to be done. Job parameters
             are embedded here.
     /parameter_values.yson|yaml (optional): If provided, these are parameter values for the job template and for
             the render farm. Amazon Deadline Cloud-specific parameters are like "deadline:priority".

--- a/src/deadline/client/cli/groups/bundle_group.py
+++ b/src/deadline/client/cli/groups/bundle_group.py
@@ -56,7 +56,7 @@ signal.signal(signal.SIGINT, _handle_sigint)
 @handle_error
 def cli_bundle():
     """
-    Commands to work with OpenJobIO job bundles.
+    Commands to work with Open Job Description job bundles.
     """
 
 
@@ -100,7 +100,7 @@ def validate_parameters(ctx, param, value):
 @handle_error
 def bundle_submit(job_bundle_dir, asset_loading_method, parameter, yes, **args):
     """
-    Submits an OpenJobIO job bundle to Amazon Deadline Cloud.
+    Submits an Open Job Description job bundle to Amazon Deadline Cloud.
     """
     # Check Whether the CLI options are modifying any of the default settings that affect
     # the job id. If not, we'll save the job id submitted as the default job id.
@@ -270,7 +270,7 @@ def bundle_submit(job_bundle_dir, asset_loading_method, parameter, yes, **args):
 @handle_error
 def bundle_gui_submit(job_bundle_dir, **args):
     """
-    Opens GUI to submit an OpenJobIO job bundle to Amazon Deadline Cloud.
+    Opens GUI to submit an Open Job Description job bundle to Amazon Deadline Cloud.
     """
     from ...ui import gui_context_for_cli
 

--- a/src/deadline/client/job_bundle/adaptors.py
+++ b/src/deadline/client/job_bundle/adaptors.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import re
 from typing import Any
 
-from deadline.job_attachments.utils import OJIOToken
+from deadline.job_attachments.utils import OPENJDToken
 
 
 def parse_frame_range(frame_string: str) -> list[int]:
@@ -90,9 +90,9 @@ delete = {k for k in before if k not in after}
 
 for k, v in put.items():
     print(f"updating {k}={v}")
-    print(f"openjobio_env: {k}={v}")
+    print(f"openjd_env: {k}={v}")
 for k in delete:
-    print(f"openjobio_unset_env: {k}")
+    print(f"openjd_unset_env: {k}")
 """
 
 
@@ -104,10 +104,10 @@ def get_rez_environment() -> dict[str, Any]:
         "script": {
             "actions": {
                 "onEnter": {
-                    "command": str(OJIOToken("Env.File.Enter")),
+                    "command": str(OPENJDToken("Env.File.Enter")),
                 },
                 "onExit": {
-                    "command": str(OJIOToken("Env.File.Exit")),
+                    "command": str(OPENJDToken("Env.File.Exit")),
                 },
             },
             "embeddedFiles": [

--- a/src/deadline/client/job_bundle/job_template.py
+++ b/src/deadline/client/job_bundle/job_template.py
@@ -6,7 +6,7 @@ import enum
 
 class ControlType(enum.Enum):
     """
-    Defines all the valid GUI control types that are supported in an OpenJobIO
+    Defines all the valid GUI control types that are supported in an Open Job Description
     job template parameter's "userInterface" property.
     """
 

--- a/src/deadline/client/job_bundle/parameters.py
+++ b/src/deadline/client/job_bundle/parameters.py
@@ -123,7 +123,7 @@ def read_job_bundle_parameters(bundle_dir: str) -> list[dict[str, Any]]:
         if not isinstance(version, str):
             raise DeadlineOperationError("Job Template's 'specificationVersion' must be a string.")
         schema_version = version
-        if schema_version not in ["2022-09-01"]:
+        if schema_version not in ["jobtemplate-2023-09"]:
             raise DeadlineOperationError(
                 f"The Job Bundle's Job Template has an unsupported specificationVersion: {schema_version}"
             )
@@ -131,7 +131,7 @@ def read_job_bundle_parameters(bundle_dir: str) -> list[dict[str, Any]]:
     # Start with the template parameters
     template_parameters = {}
     if isinstance(template, dict):
-        template_parameters = template.get("parameters", {})
+        template_parameters = template.get("parameterDefinitions", {})
 
     if template_parameters:
         # parameters are a list of objects. Convert it to a map

--- a/src/deadline/client/ui/cli_job_submitter.py
+++ b/src/deadline/client/ui/cli_job_submitter.py
@@ -62,9 +62,9 @@ def show_cli_job_submitter(parent=None, f=Qt.WindowFlags()) -> None:
             )
 
         job_template: Dict[str, Any] = {
-            "specificationVersion": "2022-09-01",
+            "specificationVersion": "jobtemplate-2023-09",
             "name": settings.name,
-            "parameters": [
+            "parameterDefinitions": [
                 {
                     "name": "DataDir",
                     "type": "PATH",
@@ -95,7 +95,7 @@ def show_cli_job_submitter(parent=None, f=Qt.WindowFlags()) -> None:
         job_template["steps"] = [step]
         if settings.use_array_parameter:
             job_array_parameter_name = f"{settings.array_parameter_name}Values"
-            job_template["parameters"].append(
+            job_template["parameterDefinitions"].append(
                 {
                     "name": job_array_parameter_name,
                     "type": "STRING",
@@ -103,7 +103,7 @@ def show_cli_job_submitter(parent=None, f=Qt.WindowFlags()) -> None:
                 }
             )
             step["parameterSpace"] = {
-                "parameters": [
+                "taskParameterDefinitions": [
                     {
                         "name": settings.array_parameter_name,
                         "type": "INT",

--- a/src/deadline/client/ui/resources/blender_example_bundle/template.yaml
+++ b/src/deadline/client/ui/resources/blender_example_bundle/template.yaml
@@ -1,4 +1,4 @@
-specificationVersion: '2022-09-01'
+specificationVersion: 'jobtemplate-2023-09'
 name: Blender scene submission
 parameters:
   - name: Frames

--- a/src/deadline/client/ui/resources/cli_job_bundle/template.yaml
+++ b/src/deadline/client/ui/resources/cli_job_bundle/template.yaml
@@ -1,4 +1,4 @@
-specificationVersion: '2022-09-01'
+specificationVersion: 'jobtemplate-2023-09'
 name: Job Bundle - CLI Job Example
 parameters:
   - name: BashScript

--- a/src/deadline/client/ui/resources/controls_demo_job_bundle/template.yaml
+++ b/src/deadline/client/ui/resources/controls_demo_job_bundle/template.yaml
@@ -1,4 +1,4 @@
-specificationVersion: '2022-09-01'
+specificationVersion: 'jobtemplate-2023-09'
 name: Job Template GUI Control Showcase
 parameters:
   - name: LineEditControl

--- a/src/deadline/client/ui/widgets/job_template_parameters_widget.py
+++ b/src/deadline/client/ui/widgets/job_template_parameters_widget.py
@@ -38,10 +38,10 @@ class JobTemplateParametersWidget(QWidget):
     Widget that takes the set of parameters from a job template, and generated
     a UI form to edit them with.
 
-    OpenJobIO has optional UI metadata for each parameter specified under "userInterface".
+    Open Job Description has optional UI metadata for each parameter specified under "userInterface".
 
     Args:
-        initial_job_parameters (Dict[str, Any]): OpenJobIO parameters block.
+        initial_job_parameters (Dict[str, Any]): Open Job Description parameters block.
         parent: The parent Qt Widget.
     """
 
@@ -80,7 +80,7 @@ class JobTemplateParametersWidget(QWidget):
                 if "userInterface" in parameter:
                     control_type_name = parameter["userInterface"].get("control", "")
 
-                # If not explicitly provided, determine the default control type name based on the OJIO specification
+                # If not explicitly provided, determine the default control type name based on the OPENJD specification
                 if not control_type_name:
                     if parameter.get("allowedValues"):
                         control_type_name = "DROPDOWN_LIST"
@@ -189,46 +189,46 @@ class _JobTemplateWidget(QWidget):
         self.job_template_parameter = parameter
 
         # Validate that the template parameter has the right type and fields
-        if parameter["type"] not in self.OJIO_TYPES:
-            if len(self.OJIO_TYPES) == 1:
+        if parameter["type"] not in self.OPENJD_TYPES:
+            if len(self.OPENJD_TYPES) == 1:
                 raise RuntimeError(
                     f"Job Template parameter {parameter['name']} with control "
-                    + f"{self.OJIO_CONTROL_TYPE} has type {parameter['type']} but "
-                    + f"must have type {self.OJIO_TYPES[0]}."
+                    + f"{self.OPENJD_CONTROL_TYPE} has type {parameter['type']} but "
+                    + f"must have type {self.OPENJD_TYPES[0]}."
                 )
             else:
                 raise RuntimeError(
                     f"Job Template parameter {parameter['name']} with control "
-                    + f"{self.OJIO_CONTROL_TYPE} has type {parameter['type']} but "
-                    + f"must have one of type: {[v[0] for v in self.OJIO_TYPES]}"
+                    + f"{self.OPENJD_CONTROL_TYPE} has type {parameter['type']} but "
+                    + f"must have one of type: {[v[0] for v in self.OPENJD_TYPES]}"
                 )
 
-        for field in self.OJIO_REQUIRED_PARAMETER_FIELDS:
+        for field in self.OPENJD_REQUIRED_PARAMETER_FIELDS:
             if field not in parameter:
                 raise RuntimeError(
                     f"Job Template parameter {parameter['name']} with control "
-                    + f"{self.OJIO_CONTROL_TYPE} is missing required field '{field}'."
+                    + f"{self.OPENJD_CONTROL_TYPE} is missing required field '{field}'."
                 )
-        for field in self.OJIO_DISALLOWED_PARAMETER_FIELDS:
+        for field in self.OPENJD_DISALLOWED_PARAMETER_FIELDS:
             if field in parameter:
                 raise RuntimeError(
                     f"Job Template parameter {parameter['name']} with control "
-                    + f"{self.OJIO_CONTROL_TYPE} must not provide field '{field}'."
+                    + f"{self.OPENJD_CONTROL_TYPE} must not provide field '{field}'."
                 )
 
         self._build_ui(parameter)
 
         # Set the initial value to the first of the value, default or a type default
-        value = parameter.get("value", parameter.get("default", self.OJIO_DEFAULT_VALUE))
+        value = parameter.get("value", parameter.get("default", self.OPENJD_DEFAULT_VALUE))
         self.set_value(value)
 
 
 class _JobTemplateLineEditWidget(_JobTemplateWidget):
-    OJIO_CONTROL_TYPE: ControlType = ControlType.LINE_EDIT
-    OJIO_TYPES: List[str] = ["STRING"]
-    OJIO_DEFAULT_VALUE: str = ""
-    OJIO_REQUIRED_PARAMETER_FIELDS: List[str] = []
-    OJIO_DISALLOWED_PARAMETER_FIELDS: List[str] = ["allowedValues"]
+    OPENJD_CONTROL_TYPE: ControlType = ControlType.LINE_EDIT
+    OPENJD_TYPES: List[str] = ["STRING"]
+    OPENJD_DEFAULT_VALUE: str = ""
+    OPENJD_REQUIRED_PARAMETER_FIELDS: List[str] = []
+    OPENJD_DISALLOWED_PARAMETER_FIELDS: List[str] = ["allowedValues"]
 
     def _build_ui(self, parameter):
         # Create the edit widget
@@ -268,11 +268,11 @@ class _JobTemplateLineEditWidget(_JobTemplateWidget):
 
 
 class _JobTemplateMultiLineEditWidget(_JobTemplateWidget):
-    OJIO_CONTROL_TYPE: ControlType = ControlType.MULTILINE_EDIT
-    OJIO_TYPES: List[str] = ["STRING"]
-    OJIO_DEFAULT_VALUE: str = ""
-    OJIO_REQUIRED_PARAMETER_FIELDS: List[str] = []
-    OJIO_DISALLOWED_PARAMETER_FIELDS: List[str] = ["allowedValues"]
+    OPENJD_CONTROL_TYPE: ControlType = ControlType.MULTILINE_EDIT
+    OPENJD_TYPES: List[str] = ["STRING"]
+    OPENJD_DEFAULT_VALUE: str = ""
+    OPENJD_REQUIRED_PARAMETER_FIELDS: List[str] = []
+    OPENJD_DISALLOWED_PARAMETER_FIELDS: List[str] = ["allowedValues"]
     IS_VERTICAL_EXPANDING: bool = True
 
     def _build_ui(self, parameter):
@@ -314,11 +314,11 @@ class _JobTemplateMultiLineEditWidget(_JobTemplateWidget):
 
 
 class _JobTemplateIntSpinBoxWidget(_JobTemplateWidget):
-    OJIO_CONTROL_TYPE: ControlType = ControlType.INT_SPIN_BOX
-    OJIO_TYPES: List[str] = ["INT"]
-    OJIO_DEFAULT_VALUE: int = 0
-    OJIO_REQUIRED_PARAMETER_FIELDS: List[str] = []
-    OJIO_DISALLOWED_PARAMETER_FIELDS: List[str] = ["allowedValues"]
+    OPENJD_CONTROL_TYPE: ControlType = ControlType.INT_SPIN_BOX
+    OPENJD_TYPES: List[str] = ["INT"]
+    OPENJD_DEFAULT_VALUE: int = 0
+    OPENJD_REQUIRED_PARAMETER_FIELDS: List[str] = []
+    OPENJD_DISALLOWED_PARAMETER_FIELDS: List[str] = ["allowedValues"]
 
     def _build_ui(self, parameter):
         # Create the edit widget
@@ -385,11 +385,11 @@ class _JobTemplateIntSpinBoxWidget(_JobTemplateWidget):
 
 
 class _JobTemplateFloatSpinBoxWidget(_JobTemplateWidget):
-    OJIO_CONTROL_TYPE: ControlType = ControlType.FLOAT_SPIN_BOX
-    OJIO_TYPES: List[str] = ["FLOAT"]
-    OJIO_DEFAULT_VALUE: float = 0.0
-    OJIO_REQUIRED_PARAMETER_FIELDS: List[str] = []
-    OJIO_DISALLOWED_PARAMETER_FIELDS: List[str] = ["allowedValues"]
+    OPENJD_CONTROL_TYPE: ControlType = ControlType.FLOAT_SPIN_BOX
+    OPENJD_TYPES: List[str] = ["FLOAT"]
+    OPENJD_DEFAULT_VALUE: float = 0.0
+    OPENJD_REQUIRED_PARAMETER_FIELDS: List[str] = []
+    OPENJD_DISALLOWED_PARAMETER_FIELDS: List[str] = ["allowedValues"]
 
     def _build_ui(self, parameter):
         # Create the edit widget
@@ -463,15 +463,15 @@ class _JobTemplateFloatSpinBoxWidget(_JobTemplateWidget):
 
 
 class _JobTemplateDropdownListWidget(_JobTemplateWidget):
-    OJIO_CONTROL_TYPE: ControlType = ControlType.DROPDOWN_LIST
-    OJIO_TYPES: List[str] = [
+    OPENJD_CONTROL_TYPE: ControlType = ControlType.DROPDOWN_LIST
+    OPENJD_TYPES: List[str] = [
         "STRING",
         "INT",
         "FLOAT",
         "PATH",
     ]
-    OJIO_REQUIRED_PARAMETER_FIELDS: List[str] = ["allowedValues"]
-    OJIO_DISALLOWED_PARAMETER_FIELDS: List[str] = ["minValue", "maxValue", "allowedPattern"]
+    OPENJD_REQUIRED_PARAMETER_FIELDS: List[str] = ["allowedValues"]
+    OPENJD_DISALLOWED_PARAMETER_FIELDS: List[str] = ["minValue", "maxValue", "allowedPattern"]
 
     def _build_ui(self, parameter):
         # Create the edit widget
@@ -489,7 +489,7 @@ class _JobTemplateDropdownListWidget(_JobTemplateWidget):
             self.edit_control.addItem(str(value), value)
 
         # Default to the first item in the list
-        self.OJIO_DEFAULT_VALUE = parameter["allowedValues"][0]
+        self.OPENJD_DEFAULT_VALUE = parameter["allowedValues"][0]
 
         # Add the decription as a tooltip if provided
         if "description" in parameter:
@@ -509,10 +509,10 @@ class _JobTemplateDropdownListWidget(_JobTemplateWidget):
 
 
 class _JobTemplateBaseFileWidget(_JobTemplateWidget):
-    OJIO_TYPES: List[str] = ["PATH"]
-    OJIO_DEFAULT_VALUE: str = ""
-    OJIO_REQUIRED_PARAMETER_FIELDS: List[str] = []
-    OJIO_DISALLOWED_PARAMETER_FIELDS: List[str] = ["allowedValues"]
+    OPENJD_TYPES: List[str] = ["PATH"]
+    OPENJD_DEFAULT_VALUE: str = ""
+    OPENJD_REQUIRED_PARAMETER_FIELDS: List[str] = []
+    OPENJD_DISALLOWED_PARAMETER_FIELDS: List[str] = ["allowedValues"]
 
     def _build_ui(self, parameter):
         # Get the filters
@@ -566,21 +566,21 @@ class _JobTemplateBaseFileWidget(_JobTemplateWidget):
 
 
 class _JobTemplateInputFileWidget(_JobTemplateBaseFileWidget):
-    OJIO_CONTROL_TYPE: ControlType = ControlType.CHOOSE_INPUT_FILE
+    OPENJD_CONTROL_TYPE: ControlType = ControlType.CHOOSE_INPUT_FILE
     FILE_PICKER_WIDGET = InputFilePickerWidget
 
 
 class _JobTemplateOutputFileWidget(_JobTemplateBaseFileWidget):
-    OJIO_CONTROL_TYPE: ControlType = ControlType.CHOOSE_OUTPUT_FILE
+    OPENJD_CONTROL_TYPE: ControlType = ControlType.CHOOSE_OUTPUT_FILE
     FILE_PICKER_WIDGET = OutputFilePickerWidget
 
 
 class _JobTemplateDirectoryWidget(_JobTemplateWidget):
-    OJIO_CONTROL_TYPE: ControlType = ControlType.CHOOSE_DIRECTORY
-    OJIO_TYPES: List[str] = ["PATH"]
-    OJIO_DEFAULT_VALUE: str = ""
-    OJIO_REQUIRED_PARAMETER_FIELDS: List[str] = []
-    OJIO_DISALLOWED_PARAMETER_FIELDS: List[str] = ["allowedValues"]
+    OPENJD_CONTROL_TYPE: ControlType = ControlType.CHOOSE_DIRECTORY
+    OPENJD_TYPES: List[str] = ["PATH"]
+    OPENJD_DEFAULT_VALUE: str = ""
+    OPENJD_REQUIRED_PARAMETER_FIELDS: List[str] = []
+    OPENJD_DISALLOWED_PARAMETER_FIELDS: List[str] = ["allowedValues"]
 
     def _build_ui(self, parameter):
         # Create the edit widget
@@ -616,11 +616,11 @@ ALLOWED_VALUES_FOR_CHECK_BOX = (["TRUE", "FALSE"], ["YES", "NO"], ["ON", "OFF"],
 
 
 class _JobTemplateCheckBoxWidget(_JobTemplateWidget):
-    OJIO_CONTROL_TYPE: ControlType = ControlType.CHECK_BOX
-    OJIO_TYPES: List[str] = ["STRING"]
-    OJIO_DEFAULT_VALUE: str = "false"
-    OJIO_REQUIRED_PARAMETER_FIELDS: List[str] = ["allowedValues"]
-    OJIO_DISALLOWED_PARAMETER_FIELDS: List[str] = [
+    OPENJD_CONTROL_TYPE: ControlType = ControlType.CHECK_BOX
+    OPENJD_TYPES: List[str] = ["STRING"]
+    OPENJD_DEFAULT_VALUE: str = "false"
+    OPENJD_REQUIRED_PARAMETER_FIELDS: List[str] = ["allowedValues"]
+    OPENJD_DISALLOWED_PARAMETER_FIELDS: List[str] = [
         "maxValue",
         "minValue",
     ]
@@ -675,16 +675,16 @@ class _JobTemplateCheckBoxWidget(_JobTemplateWidget):
 
 
 class _JobTemplateHiddenWidget(_JobTemplateWidget):
-    OJIO_CONTROL_TYPE: ControlType = ControlType.HIDDEN
-    OJIO_TYPES: List[str] = [
+    OPENJD_CONTROL_TYPE: ControlType = ControlType.HIDDEN
+    OPENJD_TYPES: List[str] = [
         "PATH",
         "INT",
         "FLOAT",
         "STRING",
     ]
-    OJIO_DEFAULT_VALUE: str = ""  # All hidden fields require a default value to be provided
-    OJIO_REQUIRED_PARAMETER_FIELDS: List[str] = ["default"]
-    OJIO_DISALLOWED_PARAMETER_FIELDS: List[str] = []
+    OPENJD_DEFAULT_VALUE: str = ""  # All hidden fields require a default value to be provided
+    OPENJD_REQUIRED_PARAMETER_FIELDS: List[str] = ["default"]
+    OPENJD_DISALLOWED_PARAMETER_FIELDS: List[str] = []
 
     def __init__(self, parent: QWidget, parameter: Dict[str, Any]):
         super().__init__(parent, parameter)

--- a/src/deadline/job_attachments/utils.py
+++ b/src/deadline/job_attachments/utils.py
@@ -195,7 +195,7 @@ def is_relative_to(path1: Union[Path, str], path2: Union[Path, str]) -> bool:
         return False
 
 
-class OJIOToken:
+class OPENJDToken:
     def __init__(self, token: str) -> None:
         self.token = token
 
@@ -203,12 +203,12 @@ class OJIOToken:
         return "{{ " + self.token + " }}"
 
 
-# add OJIOToken to the YAML representer
-def ojio_token_representer(dumper: yaml.Dumper, token: OJIOToken) -> yaml.Node:
+# add OPENJDToken to the YAML representer
+def openjd_token_representer(dumper: yaml.Dumper, token: OPENJDToken) -> yaml.Node:
     return dumper.represent_data(str(token))
 
 
-yaml.add_representer(OJIOToken, ojio_token_representer)
+yaml.add_representer(OPENJDToken, openjd_token_representer)
 
 
 # Behavior to adopt when loading job assets

--- a/test/integ/deadline_job_attachments/conftest.py
+++ b/test/integ/deadline_job_attachments/conftest.py
@@ -13,12 +13,14 @@ def default_job_template() -> str:
     return json.dumps(
         {
             "name": "custom-job",
-            "specificationVersion": "2022-09-01",
+            "specificationVersion": "jobtemplate-2023-09",
             "steps": [
                 {
                     "name": "custom-step",
                     "parameterSpace": {
-                        "parameters": [{"name": "frame", "type": "INT", "range": ["0", "1"]}]
+                        "taskParameterDefinitions": [
+                            {"name": "frame", "type": "INT", "range": ["0", "1"]}
+                        ]
                     },
                     "script": {
                         "actions": {"onRun": {"command": "{{ Task.File.run }}"}},
@@ -35,7 +37,9 @@ def default_job_template() -> str:
                 {
                     "name": "custom-step-2",
                     "parameterSpace": {
-                        "parameters": [{"name": "frame", "type": "INT", "range": ["0"]}]
+                        "taskParameterDefinitions": [
+                            {"name": "frame", "type": "INT", "range": ["0"]}
+                        ]
                     },
                     "script": {
                         "actions": {"onRun": {"command": "{{ Task.File.run }}"}},
@@ -62,12 +66,14 @@ def default_job_template_one_task_one_step() -> str:
     return json.dumps(
         {
             "name": "custom-job",
-            "specificationVersion": "2022-09-01",
+            "specificationVersion": "jobtemplate-2023-09",
             "steps": [
                 {
                     "name": "custom-step",
                     "parameterSpace": {
-                        "parameters": [{"name": "frame", "type": "INT", "range": ["0"]}]
+                        "taskParameterDefinitions": [
+                            {"name": "frame", "type": "INT", "range": ["0"]}
+                        ]
                     },
                     "script": {
                         "actions": {"onRun": {"command": "{{ Task.File.run }}"}},

--- a/test/unit/deadline_client/api/test_job_bundle_submission.py
+++ b/test/unit/deadline_client/api/test_job_bundle_submission.py
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 """
-Tests the deadline.client.api functions for submitting OpenJobIO job bundles.
+Tests the deadline.client.api functions for submitting Open Job Description job bundles.
 """
 
 import json
@@ -60,9 +60,9 @@ MOCK_JOB_TEMPLATE_CASES = {
         "JSON",
         """
 {
- "specificationVersion": "2022-09-01",
+ "specificationVersion": "jobtemplate-2023-09",
  "name": "CLI Job",
- "parameters": [
+ "parameterDefinitions": [
   {
     "name": "priority",
     "type": "INT",
@@ -100,9 +100,9 @@ MOCK_JOB_TEMPLATE_CASES = {
     "MINIMAL_YAML": (
         "YAML",
         """
-specificationVersion: '2022-09-01'
+specificationVersion: 'jobtemplate-2023-09'
 name: CLI Job
-parameters:
+parameterDefinitions:
 - name: priority
   type: INT
   default: 10

--- a/test/unit/deadline_client/api/test_job_bundle_submission_asset_refs.py
+++ b/test/unit/deadline_client/api/test_job_bundle_submission_asset_refs.py
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 """
-Tests the deadline.client.api functions for submitting OpenJobIO job bundles,
+Tests the deadline.client.api functions for submitting Open Job Description job bundles,
 where there are PATH parameters that carry assetReference IN/OUT metadata.
 """
 
@@ -27,9 +27,9 @@ from .test_job_bundle_submission import (
 JOB_BUNDLE_RELATIVE_FILE_PATH = "./file/inside/job_bundle.txt"
 JOB_BUNDLE_RELATIVE_DIR_PATH = "./dir/inside/job_bundle"
 JOB_TEMPLATE_ALL_ASSET_REF_VARIANTS = f"""
-specificationVersion: '2022-09-01'
+specificationVersion: 'jobtemplate-2023-09'
 name: Job Template to test all assetReference variants.
-parameters:
+parameterDefinitions:
 - name: FileNoneDefault
   type: PATH
   objectType: FILE

--- a/test/unit/deadline_client/job_bundle/test_adaptors.py
+++ b/test/unit/deadline_client/job_bundle/test_adaptors.py
@@ -12,9 +12,11 @@ FAKE_ENVIRONMENT = {"fake": "environment"}
 STEP = {
     "name": "MyStep",
     "parameterSpace": {
-        "parameters": [{"name": "Frame", "range": "{{ Param.Frames }}", "type": "INT"}]
+        "taskParameterDefinitions": [
+            {"name": "Frame", "range": "{{ Param.Frames }}", "type": "INT"}
+        ]
     },
-    "environments": [FAKE_ENVIRONMENT],
+    "jobEnvironments": [FAKE_ENVIRONMENT],
     "script": {
         "embeddedFiles": [
             {"name": "runData", "type": "TEXT", "data": "frame: {{ Task.Param.Frame }}"},

--- a/test/unit/deadline_client/job_bundle/test_job_bundle_loader.py
+++ b/test/unit/deadline_client/job_bundle/test_job_bundle_loader.py
@@ -16,10 +16,10 @@ from deadline.client.exceptions import DeadlineOperationError
 from deadline.client.job_bundle.loader import parse_yaml_or_json_content
 from deadline.client.job_bundle.parameters import read_job_bundle_parameters
 
-JOB_TEMPLATE_WITH_PARAMETERS_2022_09_01 = """
-specificationVersion: '2022-09-01'
+JOB_TEMPLATE_WITH_PARAMETERS_2023_09 = """
+specificationVersion: 'jobtemplate-2023-09'
 name: CLI Job
-parameters:
+parameterDefinitions:
 - name: LineEditControl
   type: STRING
   userInterface:
@@ -125,10 +125,10 @@ READ_JOB_BUNDLE_PARAMETERS_RESULT = """
     "template_data,parameter_values,expected_result",
     [
         pytest.param(
-            JOB_TEMPLATE_WITH_PARAMETERS_2022_09_01,
+            JOB_TEMPLATE_WITH_PARAMETERS_2023_09,
             PARAMETER_VALUES,
             READ_JOB_BUNDLE_PARAMETERS_RESULT,
-            id="2022-09-01",
+            id="jobtemplate-2023-09",
         ),
     ],
 )

--- a/test/unit/deadline_job_attachments/test_utils.py
+++ b/test/unit/deadline_job_attachments/test_utils.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 import pytest
 
 from deadline.job_attachments.utils import (
-    OJIOToken,
+    OPENJDToken,
     get_deadline_formatted_os,
     get_default_hash_cache_db_file_dir,
     is_relative_to,
@@ -57,11 +57,11 @@ class TestUtils:
         ("test_token", "serialized_token"),
         [("mytoken", "{{ mytoken }}")],
     )
-    def test_OJIOToken_serializer(self, test_token: str, serialized_token: str):
+    def test_OPENJDToken_serializer(self, test_token: str, serialized_token: str):
         """
         Tests that the serializer works
         """
-        token = OJIOToken(test_token)
+        token = OPENJDToken(test_token)
         assert str(token) == serialized_token
 
     @pytest.mark.skipif(


### PR DESCRIPTION
This reverts commit a734e771e6cd89b978a7b0d4a30af44349df5bbd -- i.e. revert a revert. This reapplies the change:

### What was the problem/requirement? (What/Why)

The job template schema is being updated for service release. With it, the implementation library is being updated in a breaking way and so this code needs to be updated to that revision. This includes a rename of the job template's specification name from the codename openjobio to Open Job Description.

### What was the solution? (How)

This is exactly the same commit as in https://github.com/casillas2/deadline-cloud/pull/11
Please see that PR for additional information.

### Is this a breaking change?

Yes