### PR TITLE
refactor: Adjust the github actions for more flexible release

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -1,8 +1,8 @@
-name: Release Publish
+name: "Release Publish: run pipeline/publish.sh in CodeBuild"
 on:
   workflow_dispatch:
 
-jobs:  
+jobs:
   Publish:
       runs-on: ubuntu-latest
       environment: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,18 +1,32 @@
-name: Release
+name: "Release: create version tag, push to release branch and CodeArtifact"
 
 on:
   workflow_dispatch:
     inputs:
+      release_source:
+        type: choice
+        description: "Source for the release (mainline or mainline-<version chosen>)"
+        required: true
+        options:
+        - mainline
+        - v0.22.x
       version_to_publish:
-        description: "Version to be release"
+        description: "Version to be released"
         required: false
 
+env:
+  # Note: These values can't be used in the "with: ref: ..." clauses, so this code is duplicated there.
+  mainline_branch: ${{ inputs.release_source == 'mainline' && 'mainline' || format('mainline-{}', inputs.release_source) }}
+  release_branch: ${{ inputs.release_source == 'mainline' && 'release' || format('release-{}', inputs.release_source) }}
+
 jobs:
+
   TestMainline:
-    name: Test Mainline
+    name: Test Mainline/Source Branch
     uses: ./.github/workflows/reuse_python_build.yml
     with:
-      branch: mainline
+      # This is either mainline or mainline-v<version>
+      ref: ${{ inputs.release_source == 'mainline' && 'mainline' || format('mainline-{}', inputs.release_source) }}
     secrets: inherit
 
   Merge:
@@ -23,7 +37,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: release
+          # This is either release or release-v<version>
+          ref: ${{ inputs.release_source == 'mainline' && 'release' || format('release-{}', inputs.release_source) }}
           fetch-depth: 0
           token: ${{ secrets.CI_TOKEN }}
       - name: Set Git config
@@ -31,22 +46,23 @@ jobs:
           git config --local user.email "client-software-ci@amazon.com"
           git config --local user.name "client-software-ci"
       - name: Update Release
-        run: git merge --ff-only origin/mainline -v
+        run: git merge --ff-only origin/${{ env.mainline_branch }} -v
       - name: Push new release
         if: ${{ inputs.version_to_publish}}
         run: |
           git tag -a ${{ inputs.version_to_publish }} -m "Release ${{ inputs.version_to_publish }}"
-          git push origin release ${{ inputs.version_to_publish }}
+          git push origin ${{ env.release_branch }} ${{ inputs.version_to_publish }}
       - name: Push post release
         if: ${{ !inputs.version_to_publish}}
-        run: git push origin release
+        run: git push origin ${{ env.release_branch }}
 
   TestRelease:
     needs: Merge
     name: Test Release
     uses: ./.github/workflows/reuse_python_build.yml
     with:
-      branch: release
+      # This is either release or release-v<version>
+      ref: ${{ inputs.release_source == 'mainline' && 'release' || format('release-{}', inputs.release_source) }}
     secrets: inherit
 
   PublishMirror:
@@ -65,7 +81,8 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@v3
         with:
-          ref: release
+          # This is either release or release-v<version>
+          ref: ${{ inputs.release_source == 'mainline' && 'release' || format('release-{}', inputs.release_source) }}
           fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/reuse_python_build.yml
+++ b/.github/workflows/reuse_python_build.yml
@@ -3,7 +3,8 @@ name: Python Build
 on:
   workflow_call:
     inputs:
-      branch:
+      ref:
+        description: "If provided, the branch or tag to build. Otherwise, uses the event's default."
         required: false
         type: string
 
@@ -25,12 +26,12 @@ jobs:
       CODEARTIFACT_REPOSITORY: ${{ secrets.CODEARTIFACT_REPOSITORY }}
     steps:
     - uses: actions/checkout@v3
-      if: ${{ !inputs.branch }}
+      if: ${{ !inputs.ref }}
 
     - uses: actions/checkout@v3
-      if: ${{ inputs.branch }}
+      if: ${{ inputs.ref }}
       with:
-        ref: ${{ inputs.branch }}
+        ref: ${{ inputs.ref }}
         fetch-depth: 0
 
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

We should be able to publish point releases on older versions. Charles is doing refactoring work elsewhere, but it seems useful to learn how this works, and adjust it to have that flexibility.

To actually use the non-mainline publish, will likely require a configuration update and other tweaks for the github secrets interactions.

### What was the solution? (How)

- Rename the "branch" parameter to "ref" matching the actions/checkout action used, and document it as either a branch or tag.
- Update the names of Release and Release Publish to be more descriptive.
- Modify the Release action to also accept the source of the release, either mainline or a mainline-<version> branch, so it publishes to the corresponding release or release-<version> branch.

### What is the impact of this change?

Will be able to release point releases for older versions.

### How was this change tested?

Not tested yet, hopefully can test it while this PR is up.

### Was this change documented?

Attempted to improve some names for clarity.

### Is this a breaking change?

No