### PR TITLE
feat(job-attachment): Add transfer rate in progress message

### DIFF
--- a/src/deadline/job_attachments/asset_sync.py
+++ b/src/deadline/job_attachments/asset_sync.py
@@ -101,10 +101,15 @@ class AssetSync:
         Uploads the given output files to the given S3 bucket.
         Sets up `progress_tracker` to report upload progress back to the caller (i.e. worker.)
         """
-        progress_tracker = ProgressTracker(ProgressStatus.UPLOAD_IN_PROGRESS, on_uploading_files)
-
+        # Sets up progress tracker to report upload progress back to the caller.
         total_file_size = sum([file.file_size for file in output_files])
-        progress_tracker.set_total_files(len(output_files), total_file_size)
+        progress_tracker = ProgressTracker(
+            status=ProgressStatus.UPLOAD_IN_PROGRESS,
+            total_files=len(output_files),
+            total_bytes=total_file_size,
+            on_progress_callback=on_uploading_files,
+            logger=self.logger,
+        )
 
         start_time = time.perf_counter()
 
@@ -389,6 +394,7 @@ class AssetSync:
                 fs_permission_settings=fs_permission_settings,
                 session=self.session,
                 on_downloading_files=on_downloading_files,
+                logger=self.logger,
             )
 
             summary_statistics = download_summary_statistics.convert_to_summary_statistics()


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
During the 'Sync Input Job Attachments' session action is running, we should provide clearer logs in the Session log to indicate that the action is still running and there is progress being made. So, the Job Attachments should periodically log cumulative stats to the Session log as syncing inputs is happening. (e.g., "Download rate: 54Mb/s")

### What was the solution? (How)
The ProgressTracker in Job Attachments library is modified:
- It provides transfer rate info within its progress message.
- It takes an optional `logger` when instantiated. During the progress is running, it calls the new `log_progress_message()` method to log progress messages to its logger (if exists) on specific conditions:
  1. The percentage since the last logged message has increased by >= 10%.
  2. The percentage has reached 100%.
  3. The time elapsed since the last logged message is >= 5 minutes.

### What is the impact of this change?
Job Attachments lib can log progress messages into the Session log while syncing inputs/outputs.

### How was this change tested?
- `hatch run lint && hatch run test && hatch run integ:test`
- Manually run an end-to-end test by submitting a job --> running a CMF worker. Confirmed that the Session log had additional log lines as shown below:

![Screenshot 2023-09-12 at 8 54 55 AM](https://github.com/casillas2/deadline-cloud/assets/132245153/0787344b-f975-4ff8-bb91-bf8ce032c33e)


### Was this change documented?
No.

### Is this a breaking change?
No.
