### PR TITLE
feat!: Update the Job Submit GUI to display Queue Parameters

### DIFF
--- a/examples/submit_job.py
+++ b/examples/submit_job.py
@@ -40,7 +40,7 @@ def process_job_attachments(farm_id, queue_id, inputs, outputDir, deadline_clien
         queue_id=queue_id,
         job_attachment_settings=JobAttachmentS3Settings(**queue["jobAttachmentSettings"]),
     )
-    (_, manifests) = asset_manager.hash_assets_and_create_manifest(inputs, [outputDir])
+    (_, manifests) = asset_manager.hash_assets_and_create_manifest(inputs, [outputDir], [])
     (_, attachments) = asset_manager.upload_assets(manifests)
     attachments = attachments.to_dict()
     total = time.perf_counter() - start

--- a/examples/upload_cancel_test.py
+++ b/examples/upload_cancel_test.py
@@ -87,6 +87,7 @@ def run():
         (summary_statistics_hashing, manifests) = asset_manager.hash_assets_and_create_manifest(
             files,
             [root_path / "outputs"],
+            [],
             on_preparing_to_submit=mock_on_preparing_to_submit,
         )
         print(f"Hashing Summary Statistics:\n{summary_statistics_hashing}")

--- a/examples/upload_scale_test.py
+++ b/examples/upload_scale_test.py
@@ -106,7 +106,7 @@ if __name__ == "__main__":
     start = time.perf_counter()
 
     (summary_statistics_hashing, manifests) = asset_manager.hash_assets_and_create_manifest(
-        files, [root_path / "outputs"]
+        files, [root_path / "outputs"], []
     )
     print(f"Summary Statistics for file hashing:\n{summary_statistics_hashing}")
 

--- a/src/deadline/client/api/_list_apis.py
+++ b/src/deadline/client/api/_list_apis.py
@@ -1,0 +1,111 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from ._session import (
+    get_boto3_client,
+    get_user_and_identity_store_id,
+    get_studio_id,
+)
+
+
+def _call_paginated_deadline_list_api(list_api, list_property_name, **kwargs):
+    """
+    Calls a deadline:List* API repeatedly to concatenate all pages.
+
+    Example:
+        deadline = get_boto3_client("deadline")
+        return _call_paginated_deadline_list_api(deadline.list_farms, "farms", **kwargs)
+
+    Args:
+      list_api (callable): The List* API function to call, from the boto3 client.
+      list_property_name (str): The name of the property in the response that contains
+                                the list.
+    """
+    response = list_api(**kwargs)
+    if kwargs.get("dryRun", False):
+        return response
+    else:
+        result = {list_property_name: response[list_property_name]}
+
+        while "nextToken" in response:
+            response = list_api(nextToken=response["nextToken"], **kwargs)
+            result[list_property_name].extend(response[list_property_name])
+
+        return result
+
+
+def list_farms(config=None, **kwargs):
+    """
+    Calls the deadline:ListFarms API call, applying the filter for user membership
+    depending on the configuration. If the response is paginated, it repeated
+    calls the API to get all the farms.
+    """
+    if "principalId" not in kwargs:
+        user_id, _ = get_user_and_identity_store_id(config=config)
+        if user_id:
+            kwargs["principalId"] = user_id
+
+    if "studioId" not in kwargs:
+        studio_id = get_studio_id(config=config)
+        if studio_id:
+            kwargs["studioId"] = studio_id
+
+    deadline = get_boto3_client("deadline", config=config)
+    return _call_paginated_deadline_list_api(deadline.list_farms, "farms", **kwargs)
+
+
+def list_queues(config=None, **kwargs):
+    """
+    Calls the deadline:ListQueues API call, applying the filter for user membership
+    depending on the configuration. If the response is paginated, it repeated
+    calls the API to get all the queues.
+    """
+    if "principalId" not in kwargs:
+        user_id, _ = get_user_and_identity_store_id(config=config)
+        if user_id:
+            kwargs["principalId"] = user_id
+
+    deadline = get_boto3_client("deadline", config=config)
+    return _call_paginated_deadline_list_api(deadline.list_queues, "queues", **kwargs)
+
+
+def list_jobs(config=None, **kwargs):
+    """
+    Calls the deadline:ListJobs API call, applying the filter for user membership
+    depending on the configuration. If the response is paginated, it repeated
+    calls the API to get all the jobs.
+    """
+    if "principalId" not in kwargs:
+        user_id, _ = get_user_and_identity_store_id(config=config)
+        if user_id:
+            kwargs["principalId"] = user_id
+
+    deadline = get_boto3_client("deadline", config=config)
+    return _call_paginated_deadline_list_api(deadline.list_jobs, "jobs", **kwargs)
+
+
+def list_fleets(config=None, **kwargs):
+    """
+    Calls the deadline:ListFleets API call, applying the filter for user membership
+    depending on the configuration. If the response is paginated, it repeated
+    calls the API to get all the fleets.
+    """
+    if "principalId" not in kwargs:
+        user_id, _ = get_user_and_identity_store_id(config=config)
+        if user_id:
+            kwargs["principalId"] = user_id
+
+    deadline = get_boto3_client("deadline", config=config)
+    return _call_paginated_deadline_list_api(deadline.list_fleets, "fleets", **kwargs)
+
+
+def list_storage_profiles_for_queue(config=None, **kwargs):
+    """
+    Calls the deadline:ListStorageProfilesForQueue API call, applying the filter for user membership
+    depending on the configuration. If the response is paginated, it repeated
+    calls the API to get all the storage profiles.
+    """
+    deadline = get_boto3_client("deadline", config=config)
+
+    return _call_paginated_deadline_list_api(
+        deadline.list_storage_profiles_for_queue, "storageProfiles", **kwargs
+    )

--- a/src/deadline/client/api/_queue_parameters.py
+++ b/src/deadline/client/api/_queue_parameters.py
@@ -1,0 +1,71 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+from __future__ import annotations
+
+__all__ = ["get_queue_parameter_definitions"]
+
+import yaml
+from typing import Any
+
+from ._list_apis import _call_paginated_deadline_list_api
+from ._session import get_boto3_client
+from ..exceptions import DeadlineOperationError
+from ..job_bundle.parameters import (
+    get_ui_control_for_parameter_definition,
+    parameter_definition_difference,
+)
+
+
+def get_queue_parameter_definitions(
+    *, farmId: str, queueId: str, config=None
+) -> list[dict[str, Any]]:
+    """
+    This gets all the queue parameters definitions from the specified Queue. It does so
+    by getting all the full templates for queue environments, and then combining
+    them equivalently to the Deadline Cloud service logic.
+    """
+    deadline = get_boto3_client("deadline", config=config)
+    response = _call_paginated_deadline_list_api(
+        deadline.list_queue_environments,
+        "environments",
+        farmId=farmId,
+        queueId=queueId,
+    )
+    queue_environments = sorted(
+        (
+            deadline.get_queue_environment(
+                farmId=farmId,
+                queueId=queueId,
+                queueEnvironmentId=queue_env["queueEnvironmentId"],
+            )
+            for queue_env in response["environments"]
+        ),
+        key=lambda queue_env: queue_env["priority"],
+    )
+    queue_environment_templates = [
+        yaml.safe_load(queue_env["template"]) for queue_env in queue_environments
+    ]
+
+    queue_parameters_definitions: dict[str, dict[str, Any]] = {}
+    for template in queue_environment_templates:
+        for parameter in template["parameters"]:  # TODO: change to parameterDefinitions
+            # If there is no group label, set it to the name of the Queue Environment
+            if not parameter.get("userInterface", {}).get("groupLabel"):
+                if "userInterface" not in parameter:
+                    parameter["userInterface"] = {
+                        "control": get_ui_control_for_parameter_definition(parameter)
+                    }
+                parameter["userInterface"][
+                    "groupLabel"
+                ] = f"Queue Environment: {template['environment']['name']}"
+            existing_parameter = queue_parameters_definitions.get(parameter["name"])
+            if existing_parameter:
+                differences = parameter_definition_difference(existing_parameter, parameter)
+                if differences:
+                    raise DeadlineOperationError(
+                        f"Job template parameter {parameter['name']} is duplicated across queue environments with mismatched fields:\n"
+                        + " ".join(differences)
+                    )
+            else:
+                queue_parameters_definitions[parameter["name"]] = parameter
+
+    return list(queue_parameters_definitions.values())

--- a/src/deadline/client/api/_submit_job_bundle.py
+++ b/src/deadline/client/api/_submit_job_bundle.py
@@ -3,13 +3,14 @@
 """
 Provides the function to submit a job bundle to Amazon Deadline Cloud.
 """
+from __future__ import annotations
 
 import json
 import logging
 import time
 import os
 from configparser import ConfigParser
-from typing import Any, Callable, Dict, List, Optional, Tuple, Set
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from deadline.client import api
 from deadline.client.exceptions import DeadlineOperationError, CreateJobWaiterCanceled
@@ -17,9 +18,8 @@ from deadline.client.config import get_setting, set_setting
 from deadline.client.job_bundle.loader import read_yaml_or_json, read_yaml_or_json_object
 from deadline.client.job_bundle.parameters import apply_job_parameters, read_job_bundle_parameters
 from deadline.client.job_bundle.submission import (
-    FlatAssetReferences,
+    AssetReferences,
     split_parameter_args,
-    upload_job_attachments,
 )
 from deadline.job_attachments.models import (
     AssetRootManifest,
@@ -33,7 +33,8 @@ logger = logging.getLogger(__name__)
 
 def create_job_from_job_bundle(
     job_bundle_dir: str,
-    job_parameters: List[Dict[str, Any]] = [],
+    job_parameters: list[dict[str, Any]] = [],
+    queue_parameter_definitions: list[dict[str, Any]] = [],
     config: Optional[ConfigParser] = None,
     hashing_progress_callback: Optional[Callable] = None,
     upload_progress_callback: Optional[Callable] = None,
@@ -109,9 +110,15 @@ def create_job_from_job_bundle(
     asset_references_obj = read_yaml_or_json_object(
         job_bundle_dir, "asset_references", required=False
     )
-    asset_references = FlatAssetReferences.from_dict(asset_references_obj)
+    asset_references = AssetReferences.from_dict(asset_references_obj)
 
-    apply_job_parameters(job_parameters, job_bundle_dir, job_bundle_parameters, asset_references)
+    apply_job_parameters(
+        job_parameters,
+        job_bundle_dir,
+        job_bundle_parameters,
+        queue_parameter_definitions,
+        asset_references,
+    )
     app_parameters_formatted, job_parameters_formatted = split_parameter_args(
         job_bundle_parameters, job_bundle_dir
     )
@@ -147,8 +154,7 @@ def create_job_from_job_bundle(
 
         asset_manifests = _hash_attachments(
             asset_manager,
-            asset_references.input_filenames,
-            asset_references.output_directories,
+            asset_references,
             storage_profile_id,
             hashing_progress_callback,
         )
@@ -243,8 +249,7 @@ def wait_for_create_job_to_complete(
 
 def _hash_attachments(
     asset_manager: S3AssetManager,
-    input_paths: Set[str],
-    output_paths: Set[str],
+    asset_references: AssetReferences,
     storage_profile_id: Optional[str] = None,
     hashing_progress_callback: Optional[Callable] = None,
     config: Optional[ConfigParser] = None,
@@ -261,8 +266,9 @@ def _hash_attachments(
         hashing_progress_callback = _default_update_hash_progress
 
     hashing_summary, manifests = asset_manager.hash_assets_and_create_manifest(
-        input_paths=sorted(input_paths),
-        output_paths=sorted(output_paths),
+        input_paths=sorted(asset_references.input_filenames),
+        output_paths=sorted(asset_references.output_directories),
+        referenced_paths=sorted(asset_references.referenced_paths),
         storage_profile_id=storage_profile_id,
         hash_cache_dir=os.path.expanduser(os.path.join("~", ".deadline", "cache")),
         on_preparing_to_submit=hashing_progress_callback,
@@ -289,9 +295,9 @@ def _upload_attachments(
     if not upload_progress_callback:
         upload_progress_callback = _default_update_upload_progress
 
-    upload_summary, attachment_settings = upload_job_attachments(
-        asset_manager, manifests, upload_progress_callback
+    upload_summary, attachment_settings = asset_manager.upload_assets(
+        manifests, upload_progress_callback
     )
     api.get_telemetry_client(config=config).record_upload_summary(upload_summary)
 
-    return attachment_settings
+    return attachment_settings.to_dict()

--- a/src/deadline/client/cli/_groups/fleet_group.py
+++ b/src/deadline/client/cli/_groups/fleet_group.py
@@ -85,7 +85,7 @@ def fleet_get(fleet_id, queue_id, **args):
         response = deadline.get_queue(farmId=farm_id, queueId=queue_id)
         queue_name = response["displayName"]
 
-        response = api._call_paginated_deadline_list_api(
+        response = api._list_apis._call_paginated_deadline_list_api(
             deadline.list_queue_fleet_associations,
             "queueFleetAssociations",
             farmId=farm_id,

--- a/src/deadline/client/cli/_groups/queue_group.py
+++ b/src/deadline/client/cli/_groups/queue_group.py
@@ -17,7 +17,7 @@ from .._common import _apply_cli_options_to_config, _cli_object_repr, _handle_er
 @_handle_error
 def cli_queue():
     """
-    Commands to work with Amazon Deadline Cloud Queue resources.
+    Commands for Amazon Deadline Cloud Queues.
     """
 
 
@@ -46,6 +46,31 @@ def queue_list(**args):
     ]
 
     click.echo(_cli_object_repr(structured_queue_list))
+
+
+@cli_queue.command(name="paramdefs")
+@click.option("--profile", help="The AWS profile to use.")
+@click.option("--farm-id", help="The Amazon Deadline Cloud Farm to use.")
+@click.option("--queue-id", help="The Amazon Deadline Cloud Queue to use.")
+@_handle_error
+def queue_paramdefs(**args):
+    """
+    Lists a Queue's Parameters Definitions.
+    """
+    # Get a temporary config object with the standard options handled
+    config = _apply_cli_options_to_config(required_options={"farm_id", "queue_id"}, **args)
+
+    farm_id = config_file.get_setting("defaults.farm_id", config=config)
+    queue_id = config_file.get_setting("defaults.queue_id", config=config)
+
+    try:
+        response = api.get_queue_parameter_definitions(farmId=farm_id, queueId=queue_id)
+    except ClientError as exc:
+        raise DeadlineOperationError(
+            f"Failed to get Queue Parameter Definitions from Deadline:\n{exc}"
+        ) from exc
+
+    click.echo(_cli_object_repr(response))
 
 
 @cli_queue.command(name="get")

--- a/src/deadline/client/ui/dataclasses/__init__.py
+++ b/src/deadline/client/ui/dataclasses/__init__.py
@@ -3,10 +3,11 @@
 """
 Contains dataclasses for holding UI parameter values, used by the widgets.
 """
+from __future__ import annotations
 
 import os
 from dataclasses import dataclass, field
-from typing import Any, Dict, List
+from typing import Any
 
 
 @dataclass
@@ -21,16 +22,10 @@ class JobBundleSettings:  # pylint: disable=too-many-instance-attributes
     # Shared settings
     name: str = field(default="Job Bundle")
     description: str = field(default="")
-    initial_status: str = field(default="READY")
-    max_failed_tasks_count: int = field(default=100)
-    max_retries_per_task: int = field(default=5)
-    priority: int = field(default=50)
-    override_rez_packages: bool = field(default=False)
-    rez_packages: str = field(default="")
 
     # Job Bundle settings
     input_job_bundle_dir: str = field(default="")
-    parameter_values: List[Dict[str, Any]] = field(default_factory=list)
+    parameters: list[dict[str, Any]] = field(default_factory=list)
 
 
 @dataclass
@@ -45,12 +40,6 @@ class CliJobSettings:  # pylint: disable=too-many-instance-attributes
     # Shared settings
     name: str = field(default="CLI Job")
     description: str = field(default="")
-    initial_status: str = field(default="READY")
-    max_failed_tasks_count: int = field(default=20)
-    max_retries_per_task: int = field(default=5)
-    priority: int = field(default=50)
-    override_rez_packages: bool = field(default=False)
-    rez_packages: str = field(default="")
 
     # CLI job settings
     bash_script_contents: str = field(

--- a/src/deadline/client/ui/job_bundle_submitter.py
+++ b/src/deadline/client/ui/job_bundle_submitter.py
@@ -1,9 +1,10 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+from __future__ import annotations
 
 import json
 import os
 from logging import getLogger
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from PySide2.QtCore import Qt  # pylint: disable=import-error
 from PySide2.QtWidgets import (  # pylint: disable=import-error; type: ignore
@@ -12,17 +13,18 @@ from PySide2.QtWidgets import (  # pylint: disable=import-error; type: ignore
     QMainWindow,
 )
 
+from ..exceptions import DeadlineOperationError
 from ..job_bundle import deadline_yaml_dump
 from ..job_bundle.loader import (
     parse_yaml_or_json_content,
     read_yaml_or_json,
     read_yaml_or_json_object,
 )
-from ..job_bundle.parameters import apply_job_parameters
+from ..job_bundle.parameters import apply_job_parameters, read_job_bundle_parameters
 from .dataclasses import JobBundleSettings
 from .dialogs.submit_job_to_deadline_dialog import SubmitJobToDeadlineDialog
 from .widgets.job_bundle_settings_tab import JobBundleSettingsWidget
-from ..job_bundle.submission import FlatAssetReferences
+from ..job_bundle.submission import AssetReferences
 
 logger = getLogger(__name__)
 
@@ -55,9 +57,10 @@ def show_job_bundle_submitter(
 
     def on_create_job_bundle_callback(
         widget: SubmitJobToDeadlineDialog,
-        settings: JobBundleSettings,
         job_bundle_dir: str,
-        asset_references: FlatAssetReferences,
+        settings: JobBundleSettings,
+        queue_parameters: list[dict[str, Any]],
+        asset_references: AssetReferences,
     ) -> None:
         """
         Perform a submission when the submit button is pressed
@@ -87,25 +90,30 @@ def show_job_bundle_submitter(
             elif file_type == "JSON":
                 json.dump(template, f, indent=1)
 
-        parameters_values: List[Dict[str, Any]] = [
-            {"name": "deadline:priority", "value": settings.priority},
-            {"name": "deadline:targetTaskRunStatus", "value": settings.initial_status},
-            {"name": "deadline:maxFailedTasksCount", "value": settings.max_failed_tasks_count},
-            {"name": "deadline:maxRetriesPerTask", "value": settings.max_retries_per_task},
-        ]
-
         if asset_references:
             with open(
                 os.path.join(job_bundle_dir, "asset_references.yaml"), "w", encoding="utf8"
             ) as f:
                 deadline_yaml_dump(asset_references.to_dict(), f)
 
-        job_bundle_parameters = widget.job_settings.job_bundle_parameters
-
-        parameters_values.extend(settings.parameter_values)
+        # First filter the queue parameters to exclude any from the job template,
+        # then extend it with the job template parameters.
+        job_parameter_names = {param["name"] for param in settings.parameters}
+        parameters_values: list[dict[str, Any]] = [
+            {"name": param["name"], "value": param["value"]}
+            for param in queue_parameters
+            if param["name"] not in job_parameter_names
+        ]
+        parameters_values.extend(
+            {"name": param["name"], "value": param["value"]} for param in settings.parameters
+        )
 
         apply_job_parameters(
-            parameters_values, job_bundle_dir, job_bundle_parameters, FlatAssetReferences()
+            parameters_values,
+            job_bundle_dir,
+            settings.parameters,
+            queue_parameters,
+            AssetReferences(),
         )
 
         with open(os.path.join(job_bundle_dir, "parameter_values.yaml"), "w", encoding="utf8") as f:
@@ -117,18 +125,32 @@ def show_job_bundle_submitter(
     asset_references_obj = (
         read_yaml_or_json_object(input_job_bundle_dir, "asset_references", False) or {}
     )
-    asset_references = FlatAssetReferences.from_dict(asset_references_obj)
+    asset_references = AssetReferences.from_dict(asset_references_obj)
 
     name = "Job Bundle Submission"
     if template:
         name = template.get("name", name)
 
+    if not os.path.isdir(input_job_bundle_dir):
+        raise DeadlineOperationError(f"Input Job Bundle Dir is not valid: {input_job_bundle_dir}")
+    initial_settings = JobBundleSettings(input_job_bundle_dir=input_job_bundle_dir, name=name)
+    initial_settings.parameters = read_job_bundle_parameters(input_job_bundle_dir)
+
+    # Populate the initial queue parameter values based on the job template parameter values
+    initial_shared_parameter_values = {}
+    for parameter in initial_settings.parameters:
+        if "default" in parameter or "value" in parameter:
+            initial_shared_parameter_values[parameter["name"]] = parameter.get(
+                "value", parameter.get("default")
+            )
+
     submitter_dialog = SubmitJobToDeadlineDialog(
-        JobBundleSettingsWidget,
-        JobBundleSettings(input_job_bundle_dir=input_job_bundle_dir, name=name),
-        asset_references,
-        FlatAssetReferences(),
-        on_create_job_bundle_callback,
+        job_setup_widget_type=JobBundleSettingsWidget,
+        initial_job_settings=initial_settings,
+        initial_shared_parameter_values=initial_shared_parameter_values,
+        auto_detected_attachments=asset_references,
+        attachments=AssetReferences(),
+        on_create_job_bundle_callback=on_create_job_bundle_callback,
         parent=parent,
         f=f,
     )

--- a/src/deadline/client/ui/widgets/job_attachments_tab.py
+++ b/src/deadline/client/ui/widgets/job_attachments_tab.py
@@ -23,7 +23,7 @@ from PySide2.QtWidgets import (  # type: ignore
     QMessageBox,
 )
 
-from ...job_bundle.submission import FlatAssetReferences
+from ...job_bundle.submission import AssetReferences
 from .. import block_signals
 
 logger = getLogger(__name__)
@@ -43,8 +43,8 @@ class JobAttachmentsWidget(QWidget):
 
     def __init__(
         self,
-        auto_detected_attachments: FlatAssetReferences,
-        attachments: FlatAssetReferences,
+        auto_detected_attachments: AssetReferences,
+        attachments: AssetReferences,
         parent: QWidget = None,
     ) -> None:
         super().__init__(parent=parent)
@@ -284,7 +284,7 @@ class JobAttachmentsWidget(QWidget):
                 f"The selected directories from the auto-detected list ({len(unremoved_dirs)} items) were not removed.",
             )
 
-    def get_asset_references(self) -> FlatAssetReferences:
+    def get_asset_references(self) -> AssetReferences:
         """
         Creates an asset_references object that can be saved as the
         asset_references.json|yaml file in a Job Bundle.

--- a/src/deadline/client/ui/widgets/job_bundle_settings_tab.py
+++ b/src/deadline/client/ui/widgets/job_bundle_settings_tab.py
@@ -3,23 +3,31 @@
 """
 UI widgets for the Scene Settings tab.
 """
-import os
+from __future__ import annotations
 
+from typing import Any
+
+from PySide2.QtCore import Signal  # type: ignore
 from PySide2.QtWidgets import QVBoxLayout, QWidget  # type: ignore
 
-from ...job_bundle import read_job_bundle_parameters
 from ..dataclasses import JobBundleSettings
-from .job_template_parameters_widget import JobTemplateParametersWidget
+from .openjd_parameters_widget import OpenJDParametersWidget
 
 
 class JobBundleSettingsWidget(QWidget):
     """
     Widget containing job setup specific to CLI jobs.
 
+    Signals:
+        parameter_changed: This is sent whenever a parameter value in the widget changes. The message
+            is a copy of the parameter definition with the "value" key containing the new value.
+
     Args:
         initial_settings (CliJobSettings): dataclass containing the job-specific settings.
         parent: The parent Qt Widget.
     """
+
+    parameter_changed = Signal(dict)
 
     def __init__(self, initial_settings: JobBundleSettings, parent=None):
         super().__init__(parent=parent)
@@ -29,24 +37,35 @@ class JobBundleSettingsWidget(QWidget):
     def _build_ui(self, initial_settings: JobBundleSettings):
         layout = QVBoxLayout(self)
 
-        if not os.path.isdir(initial_settings.input_job_bundle_dir):
-            raise RuntimeError(
-                f"Input Job Bundle Dir is not valid: {initial_settings.input_job_bundle_dir}"
-            )
-
         self.input_job_bundle_dir = initial_settings.input_job_bundle_dir
-        self.job_bundle_parameters = read_job_bundle_parameters(
-            initial_settings.input_job_bundle_dir
-        )
 
-        self.job_template_parameters_widget = JobTemplateParametersWidget(
-            self.job_bundle_parameters, parent=self
+        self.parameters_widget = OpenJDParametersWidget(
+            parameter_definitions=initial_settings.parameters, parent=self
         )
-        layout.addWidget(self.job_template_parameters_widget)
+        layout.addWidget(self.parameters_widget)
+        self.parameters_widget.parameter_changed.connect(
+            lambda message: self.parameter_changed.emit(message)
+        )
 
     def update_settings(self, settings: JobBundleSettings):
         """
         Update a settings object with the latest values.
         """
         settings.input_job_bundle_dir = self.input_job_bundle_dir
-        settings.parameter_values = self.job_template_parameters_widget.get_parameter_values()
+        settings.parameters = self.parameters_widget.get_parameters()
+
+    def get_parameters(self):
+        """
+        Returns a list of OpenJD parameter definition dicts with
+        a "value" key filled from the widget.
+        """
+        return self.parameters_widget.get_parameters()
+
+    def set_parameter_value(self, parameter: dict[str, Any]):
+        """
+        Given an OpenJD parameter definition with a "value" key,
+        set the parameter value in the widget.
+
+        If the parameter value cannot be set, raises a KeyError.
+        """
+        self.parameters_widget.set_parameter_value(parameter)

--- a/src/deadline/client/ui/widgets/path_widgets.py
+++ b/src/deadline/client/ui/widgets/path_widgets.py
@@ -17,7 +17,7 @@ from .. import block_signals
 
 
 class _FileWidget(QWidget):
-    # Emitted when the directory changes
+    # Emitted when the file changes
     path_changed = Signal(str)
 
     def __init__(

--- a/src/deadline/job_attachments/models.py
+++ b/src/deadline/job_attachments/models.py
@@ -36,12 +36,13 @@ class AssetRootManifest:
 
 @dataclass
 class AssetRootGroup:
-    """Represents lists of input and output files grouped under the same root"""
+    """Represents lists of input files, output files and path references grouped under the same root"""
 
     file_system_location_name: Optional[str] = None
     root_path: str = ""
     inputs: Set[Path] = field(default_factory=set)
     outputs: Set[Path] = field(default_factory=set)
+    references: Set[Path] = field(default_factory=set)
 
 
 @dataclass

--- a/test/integ/deadline_job_attachments/test_job_attachments.py
+++ b/test/integ/deadline_job_attachments/test_job_attachments.py
@@ -136,6 +136,7 @@ def upload_input_files_assets_not_in_cas(job_attachment_test: JobAttachmentTest)
     (_, manifests) = asset_manager.hash_assets_and_create_manifest(
         input_paths=[str(job_attachment_test.SCENE_MA_PATH)],
         output_paths=[str(job_attachment_test.OUTPUT_PATH)],
+        referenced_paths=[],
         hash_cache_dir=str(job_attachment_test.hash_cache_dir),
         on_preparing_to_submit=mock_on_preparing_to_submit,
     )
@@ -202,6 +203,7 @@ def upload_input_files_one_asset_in_cas(
     (_, manifests) = asset_manager.hash_assets_and_create_manifest(
         input_paths=input_paths,
         output_paths=[str(job_attachment_test.OUTPUT_PATH)],
+        referenced_paths=[],
         hash_cache_dir=str(job_attachment_test.hash_cache_dir),
         on_preparing_to_submit=mock_on_preparing_to_submit,
     )
@@ -281,6 +283,7 @@ def test_upload_input_files_all_assets_in_cas(
     (_, manifests) = asset_manager.hash_assets_and_create_manifest(
         input_paths=input_paths,
         output_paths=[str(job_attachment_test.OUTPUT_PATH)],
+        referenced_paths=[],
         hash_cache_dir=str(job_attachment_test.hash_cache_dir),
         on_preparing_to_submit=mock_on_preparing_to_submit,
     )
@@ -1028,6 +1031,7 @@ def upload_input_files_no_input_paths(
     (_, manifests) = asset_manager.hash_assets_and_create_manifest(
         input_paths=[],
         output_paths=[str(job_attachment_test.OUTPUT_PATH)],
+        referenced_paths=[],
         hash_cache_dir=str(job_attachment_test.hash_cache_dir),
         on_preparing_to_submit=mock_on_preparing_to_submit,
     )
@@ -1087,6 +1091,7 @@ def test_upload_input_files_no_download_paths(job_attachment_test: JobAttachment
     (_, manifests) = asset_manager.hash_assets_and_create_manifest(
         input_paths=[str(job_attachment_test.SCENE_MA_PATH)],
         output_paths=[],
+        referenced_paths=[],
         hash_cache_dir=str(job_attachment_test.hash_cache_dir),
         on_preparing_to_submit=mock_on_preparing_to_submit,
     )
@@ -1191,6 +1196,7 @@ def test_upload_bucket_wrong_account(external_bucket: str, job_attachment_test: 
         (_, manifests) = asset_manager.hash_assets_and_create_manifest(
             input_paths=[str(job_attachment_test.SCENE_MA_PATH)],
             output_paths=[str(job_attachment_test.OUTPUT_PATH)],
+            referenced_paths=[],
             hash_cache_dir=str(job_attachment_test.hash_cache_dir),
             on_preparing_to_submit=mock_on_preparing_to_submit,
         )

--- a/test/unit/deadline_client/api/test_job_bundle_submission.py
+++ b/test/unit/deadline_client/api/test_job_bundle_submission.py
@@ -15,13 +15,14 @@ import time
 
 from deadline.client import api, config
 from deadline.client.api import _submit_job_bundle
-from deadline.client.job_bundle import submission
+from deadline.client.job_bundle.submission import AssetReferences
 from deadline.job_attachments.models import (
     AssetLoadingMethod,
     Attachments,
     ManifestProperties,
     OperatingSystemFamily,
 )
+from deadline.job_attachments.upload import S3AssetManager
 from deadline.job_attachments.progress_tracker import SummaryStatistics
 
 from ..shared_constants import (
@@ -434,7 +435,7 @@ def test_create_job_from_job_bundle_job_attachments(
     ) as client_mock, patch.object(_submit_job_bundle.api, "get_queue_boto3_session"), patch.object(
         api._submit_job_bundle, "_hash_attachments"
     ) as mock_hash_attachments, patch.object(
-        submission.S3AssetManager, "upload_assets"
+        S3AssetManager, "upload_assets"
     ) as mock_upload_assets, patch.object(
         _submit_job_bundle.api, "get_telemetry_client"
     ):
@@ -490,14 +491,17 @@ def test_create_job_from_job_bundle_job_attachments(
 
         mock_hash_attachments.assert_called_once_with(
             ANY,
-            set(
-                [
-                    os.path.join(temp_assets_dir, "asset-1.txt"),
-                    os.path.join(temp_assets_dir, os.path.normpath("somedir/asset-2.txt")),
-                    os.path.join(temp_assets_dir, os.path.normpath("somedir/asset-3.bat")),
-                ]
+            AssetReferences(
+                input_filenames=set(
+                    [
+                        os.path.join(temp_assets_dir, "asset-1.txt"),
+                        os.path.join(temp_assets_dir, os.path.normpath("somedir/asset-2.txt")),
+                        os.path.join(temp_assets_dir, os.path.normpath("somedir/asset-3.bat")),
+                    ]
+                ),
+                output_directories=set([os.path.join(temp_assets_dir, "somedir")]),
+                referenced_paths=set(),
             ),
-            set([os.path.join(temp_assets_dir, "somedir")]),
             MOCK_STORAGE_PROFILE_ID,
             fake_hashing_callback,
         )
@@ -579,7 +583,7 @@ def test_create_job_from_job_bundle_with_single_asset_file(
     ) as client_mock, patch.object(_submit_job_bundle.api, "get_queue_boto3_session"), patch.object(
         api._submit_job_bundle, "_hash_attachments"
     ) as mock_hash_attachments, patch.object(
-        submission.S3AssetManager, "upload_assets"
+        S3AssetManager, "upload_assets"
     ) as mock_upload_assets, patch.object(
         _submit_job_bundle.api, "get_telemetry_client"
     ):
@@ -641,8 +645,7 @@ def test_create_job_from_job_bundle_with_single_asset_file(
 
         mock_hash_attachments.assert_called_once_with(
             ANY,
-            set([os.path.join(temp_assets_dir, "asset-1.txt")]),
-            set(),
+            AssetReferences(input_filenames=set([os.path.join(temp_assets_dir, "asset-1.txt")])),
             MOCK_STORAGE_PROFILE_ID,
             fake_hashing_callback,
         )

--- a/test/unit/deadline_client/api/test_job_bundle_submission_asset_refs.py
+++ b/test/unit/deadline_client/api/test_job_bundle_submission_asset_refs.py
@@ -10,7 +10,6 @@ from unittest.mock import ANY, patch
 
 from deadline.client import api, config
 from deadline.client.api import _submit_job_bundle
-from deadline.client.job_bundle import submission
 from deadline.job_attachments.models import (
     Attachments,
     AssetLoadingMethod,
@@ -18,6 +17,7 @@ from deadline.job_attachments.models import (
     ManifestProperties,
     OperatingSystemFamily,
 )
+from deadline.job_attachments.upload import S3AssetManager
 from deadline.job_attachments.progress_tracker import SummaryStatistics
 
 from ..shared_constants import MOCK_FARM_ID, MOCK_QUEUE_ID
@@ -136,9 +136,9 @@ def test_create_job_from_job_bundle_with_all_asset_ref_variants(
     with patch.object(_submit_job_bundle.api, "get_boto3_session"), patch.object(
         _submit_job_bundle.api, "get_boto3_client"
     ) as client_mock, patch.object(_submit_job_bundle.api, "get_queue_boto3_session"), patch.object(
-        submission.S3AssetManager, "hash_assets_and_create_manifest"
+        S3AssetManager, "hash_assets_and_create_manifest"
     ) as mock_hash_assets, patch.object(
-        submission.S3AssetManager, "upload_assets"
+        S3AssetManager, "upload_assets"
     ) as mock_upload_assets, patch.object(
         _submit_job_bundle.api, "get_telemetry_client"
     ):
@@ -268,9 +268,19 @@ def test_create_job_from_job_bundle_with_all_asset_ref_variants(
                 "./file/inside",
             ]
         )
+        referenced_paths = sorted(
+            os.path.normpath(os.path.abspath(p))
+            for p in [
+                os.path.join(temp_assets_dir, "./dir/inside/asset-dir-dirnone"),
+                os.path.join(temp_assets_dir, "./dir/inside/asset-dir-dirnonedefault"),
+                os.path.join(temp_assets_dir, "file/inside/asset-dir-filenonedefault.txt"),
+                os.path.join(temp_assets_dir, "file/inside/asset-dir-filenone.txt"),
+            ]
+        )
         mock_hash_assets.assert_called_once_with(
             input_paths=input_paths,
             output_paths=output_paths,
+            referenced_paths=referenced_paths,
             storage_profile_id="",
             hash_cache_dir=os.path.expanduser(os.path.join("~", ".deadline", "cache")),
             on_preparing_to_submit=ANY,

--- a/test/unit/deadline_client/job_bundle/test_job_parameters.py
+++ b/test/unit/deadline_client/job_bundle/test_job_parameters.py
@@ -85,8 +85,336 @@ def test_apply_job_parameters_parameter_without_value(
     """
     with pytest.raises(exceptions.DeadlineOperationError) as excinfo:
         parameters.apply_job_parameters(
-            job_parameters, job_bundle_dir, job_bundle_parameters, asset_references
+            job_parameters, job_bundle_dir, job_bundle_parameters, [], asset_references
         )
     assert "TestParameterName" in str(excinfo)
     assert "no default value" in str(excinfo).lower()
     assert "no parameter value" in str(excinfo).lower()
+
+
+@pytest.mark.parametrize(
+    "parameter_def, expected_control",
+    [
+        # All the defaults
+        ({"name": "X", "type": "STRING"}, "LINE_EDIT"),
+        ({"name": "X", "type": "PATH"}, "CHOOSE_DIRECTORY"),
+        ({"name": "X", "type": "INT"}, "SPIN_BOX"),
+        ({"name": "X", "type": "FLOAT"}, "SPIN_BOX"),
+        # When there is an allowedValues list
+        ({"name": "X", "type": "STRING", "allowedValues": ["A", "B"]}, "DROPDOWN_LIST"),
+        ({"name": "X", "type": "PATH", "allowedValues": ["/A", "/B"]}, "DROPDOWN_LIST"),
+        ({"name": "X", "type": "INT", "allowedValues": [1, 2]}, "DROPDOWN_LIST"),
+        ({"name": "X", "type": "FLOAT", "allowedValues": [1.0, 2.5]}, "DROPDOWN_LIST"),
+        # Variations for PATH parameters
+        ({"name": "X", "type": "PATH", "objectType": "FILE"}, "CHOOSE_INPUT_FILE"),
+        (
+            {"name": "X", "type": "PATH", "objectType": "FILE", "dataFlow": "NONE"},
+            "CHOOSE_INPUT_FILE",
+        ),
+        (
+            {"name": "X", "type": "PATH", "objectType": "FILE", "dataFlow": "IN"},
+            "CHOOSE_INPUT_FILE",
+        ),
+        (
+            {"name": "X", "type": "PATH", "objectType": "FILE", "dataFlow": "INOUT"},
+            "CHOOSE_INPUT_FILE",
+        ),
+        (
+            {"name": "X", "type": "PATH", "objectType": "FILE", "dataFlow": "OUT"},
+            "CHOOSE_OUTPUT_FILE",
+        ),
+        ({"name": "X", "type": "PATH", "objectType": "DIRECTORY"}, "CHOOSE_DIRECTORY"),
+        # When the control is specified explicitly for STRING
+        ({"name": "X", "type": "STRING", "userInterface": {"control": "LINE_EDIT"}}, "LINE_EDIT"),
+        (
+            {"name": "X", "type": "STRING", "userInterface": {"control": "MULTILINE_EDIT"}},
+            "MULTILINE_EDIT",
+        ),
+        (
+            {
+                "name": "X",
+                "type": "STRING",
+                "userInterface": {"control": "DROPDOWN_LIST"},
+                "allowedValues": ["A", "B"],
+            },
+            "DROPDOWN_LIST",
+        ),
+        (
+            {
+                "name": "X",
+                "type": "STRING",
+                "userInterface": {"control": "CHECK_BOX"},
+                "allowedValues": ["true", "false"],
+            },
+            "CHECK_BOX",
+        ),
+        ({"name": "X", "type": "STRING", "userInterface": {"control": "HIDDEN"}}, "HIDDEN"),
+        # When the control is specified explicitly for PATH
+        (
+            {"name": "X", "type": "PATH", "userInterface": {"control": "CHOOSE_INPUT_FILE"}},
+            "CHOOSE_INPUT_FILE",
+        ),
+        (
+            {
+                "name": "X",
+                "type": "PATH",
+                "objectType": "FILE",
+                "dataFlow": "NONE",
+                "userInterface": {"control": "CHOOSE_INPUT_FILE"},
+            },
+            "CHOOSE_INPUT_FILE",
+        ),
+        (
+            {
+                "name": "X",
+                "type": "PATH",
+                "objectType": "FILE",
+                "dataFlow": "NONE",
+                "userInterface": {"control": "CHOOSE_OUTPUT_FILE"},
+            },
+            "CHOOSE_OUTPUT_FILE",
+        ),
+        (
+            {
+                "name": "X",
+                "type": "PATH",
+                "objectType": "FILE",
+                "dataFlow": "IN",
+                "userInterface": {"control": "CHOOSE_INPUT_FILE"},
+            },
+            "CHOOSE_INPUT_FILE",
+        ),
+        (
+            {
+                "name": "X",
+                "type": "PATH",
+                "objectType": "FILE",
+                "dataFlow": "INOUT",
+                "userInterface": {"control": "CHOOSE_INPUT_FILE"},
+            },
+            "CHOOSE_INPUT_FILE",
+        ),
+        (
+            {
+                "name": "X",
+                "type": "PATH",
+                "objectType": "FILE",
+                "dataFlow": "INOUT",
+                "userInterface": {"control": "CHOOSE_OUTPUT_FILE"},
+            },
+            "CHOOSE_OUTPUT_FILE",
+        ),
+        (
+            {
+                "name": "X",
+                "type": "PATH",
+                "objectType": "FILE",
+                "dataFlow": "OUT",
+                "userInterface": {"control": "CHOOSE_OUTPUT_FILE"},
+            },
+            "CHOOSE_OUTPUT_FILE",
+        ),
+        (
+            {
+                "name": "X",
+                "type": "PATH",
+                "objectType": "DIRECTORY",
+                "userInterface": {"control": "CHOOSE_DIRECTORY"},
+            },
+            "CHOOSE_DIRECTORY",
+        ),
+        (
+            {
+                "name": "X",
+                "type": "PATH",
+                "userInterface": {"control": "DROPDOWN_LIST"},
+                "allowedValues": ["/A", "/B"],
+            },
+            "DROPDOWN_LIST",
+        ),
+        ({"name": "X", "type": "PATH", "userInterface": {"control": "HIDDEN"}}, "HIDDEN"),
+        # When the control is specified explicitly for INT
+        ({"name": "X", "type": "INT", "userInterface": {"control": "SPIN_BOX"}}, "SPIN_BOX"),
+        (
+            {
+                "name": "X",
+                "type": "INT",
+                "userInterface": {"control": "DROPDOWN_LIST"},
+                "allowedValues": [1, 2],
+            },
+            "DROPDOWN_LIST",
+        ),
+        ({"name": "X", "type": "INT", "userInterface": {"control": "HIDDEN"}}, "HIDDEN"),
+        # When the control is specified explicitly for FLOAT
+        ({"name": "X", "type": "FLOAT", "userInterface": {"control": "SPIN_BOX"}}, "SPIN_BOX"),
+        (
+            {
+                "name": "X",
+                "type": "FLOAT",
+                "userInterface": {"control": "DROPDOWN_LIST"},
+                "allowedValues": [1, 2],
+            },
+            "DROPDOWN_LIST",
+        ),
+        ({"name": "X", "type": "FLOAT", "userInterface": {"control": "HIDDEN"}}, "HIDDEN"),
+    ],
+)
+def test_ui_control_for_parameter_definition(parameter_def, expected_control):
+    """Test that the correct UI control for a parameter definition is returned."""
+    assert parameters.get_ui_control_for_parameter_definition(parameter_def) == expected_control
+
+
+@pytest.mark.parametrize(
+    "parameter_def",
+    [
+        # Unsupported type
+        ({"name": "X", "type": "UNSUPPORTED"}),
+        # Dropdown list requires allowedValues
+        ({"name": "X", "type": "STRING", "userInterface": {"control": "DROPDOWN_LIST"}}),
+        ({"name": "X", "type": "PATH", "userInterface": {"control": "DROPDOWN_LIST"}}),
+        ({"name": "X", "type": "INT", "userInterface": {"control": "DROPDOWN_LIST"}}),
+        ({"name": "X", "type": "FLOAT", "userInterface": {"control": "DROPDOWN_LIST"}}),
+        # Supported controls, but not for the STRING type
+        ({"name": "X", "type": "STRING", "userInterface": {"control": "CHOOSE_INPUT_FILE"}}),
+        ({"name": "X", "type": "STRING", "userInterface": {"control": "CHOOSE_OUTPUT_FILE"}}),
+        ({"name": "X", "type": "STRING", "userInterface": {"control": "CHOOSE_DIRECTORY"}}),
+        ({"name": "X", "type": "STRING", "userInterface": {"control": "SPIN_BOX"}}),
+        # Supported controls, but not for the PATH type
+        ({"name": "X", "type": "PATH", "userInterface": {"control": "LINE_EDIT"}}),
+        ({"name": "X", "type": "PATH", "userInterface": {"control": "MULTILINE_EDIT"}}),
+        ({"name": "X", "type": "PATH", "userInterface": {"control": "CHECK_BOX"}}),
+        ({"name": "X", "type": "PATH", "userInterface": {"control": "SPIN_BOX"}}),
+        # Supported controls, but not for the INT type
+        ({"name": "X", "type": "INT", "userInterface": {"control": "LINE_EDIT"}}),
+        ({"name": "X", "type": "INT", "userInterface": {"control": "MULTILINE_EDIT"}}),
+        ({"name": "X", "type": "INT", "userInterface": {"control": "CHECK_BOX"}}),
+        ({"name": "X", "type": "INT", "userInterface": {"control": "CHOOSE_INPUT_FILE"}}),
+        ({"name": "X", "type": "INT", "userInterface": {"control": "CHOOSE_OUTPUT_FILE"}}),
+        ({"name": "X", "type": "INT", "userInterface": {"control": "CHOOSE_DIRECTORY"}}),
+        # Supported controls, but not for the FLOAT type
+        ({"name": "X", "type": "FLOAT", "userInterface": {"control": "LINE_EDIT"}}),
+        ({"name": "X", "type": "FLOAT", "userInterface": {"control": "MULTILINE_EDIT"}}),
+        ({"name": "X", "type": "FLOAT", "userInterface": {"control": "CHECK_BOX"}}),
+        ({"name": "X", "type": "FLOAT", "userInterface": {"control": "CHOOSE_INPUT_FILE"}}),
+        ({"name": "X", "type": "FLOAT", "userInterface": {"control": "CHOOSE_OUTPUT_FILE"}}),
+        ({"name": "X", "type": "FLOAT", "userInterface": {"control": "CHOOSE_DIRECTORY"}}),
+    ],
+)
+def test_ui_control_for_parameter_definition_errors(parameter_def):
+    """Test that an error is raised with incorrect parameter definition controls."""
+    with pytest.raises(exceptions.DeadlineOperationError):
+        parameters.get_ui_control_for_parameter_definition(parameter_def)
+
+
+@pytest.mark.parametrize(
+    "parameter1, parameter2, expected_difference",
+    [
+        # Cases where they match
+        ({"name": "X", "type": "STRING"}, {"name": "X", "type": "STRING"}, []),
+        (
+            {"name": "X", "type": "STRING"},
+            {"name": "X", "type": "STRING", "userInterface": {"control": "HIDDEN"}},
+            [],
+        ),
+        (
+            {"name": "X", "type": "STRING", "allowedValues": ["A", "B"]},
+            {"name": "X", "type": "STRING", "allowedValues": ["B", "A"]},
+            [],
+        ),
+        # Different name
+        ({"name": "X", "type": "STRING"}, {"name": "Y", "type": "STRING"}, ["name"]),
+        # Different type
+        ({"name": "X", "type": "STRING"}, {"name": "X", "type": "PATH"}, ["type"]),
+        # Different minValue
+        (
+            {"name": "X", "type": "INT", "minValue": 3},
+            {"name": "X", "type": "INT", "minValue": 2},
+            ["minValue"],
+        ),
+        # Different maxValue
+        (
+            {"name": "X", "type": "INT", "maxValue": 3},
+            {"name": "X", "type": "INT", "maxValue": 2},
+            ["maxValue"],
+        ),
+        # Different minLength
+        (
+            {"name": "X", "type": "STRING", "minLength": 3},
+            {"name": "X", "type": "STRING", "minLength": 2},
+            ["minLength"],
+        ),
+        # Different maxLength
+        (
+            {"name": "X", "type": "STRING", "maxLength": 3},
+            {"name": "X", "type": "STRING", "maxLength": 2},
+            ["maxLength"],
+        ),
+        # Different dataFlow
+        (
+            {
+                "name": "X",
+                "type": "PATH",
+                "dataFlow": "NONE",
+            },
+            {
+                "name": "X",
+                "type": "PATH",
+                "dataFlow": "IN",
+            },
+            ["dataFlow"],
+        ),
+        (
+            {
+                "name": "X",
+                "type": "PATH",
+                "dataFlow": "IN",
+            },
+            {
+                "name": "X",
+                "type": "PATH",
+            },
+            ["dataFlow"],
+        ),
+        # Different objectType
+        (
+            {
+                "name": "X",
+                "type": "PATH",
+                "objectType": "FILE",
+            },
+            {
+                "name": "X",
+                "type": "PATH",
+                "objectType": "DIRECTORY",
+            },
+            ["objectType"],
+        ),
+        # Different allowedValues
+        (
+            {"name": "X", "type": "STRING", "allowedValues": ["A", "B"]},
+            {"name": "X", "type": "STRING", "allowedValues": ["B", "C"]},
+            ["allowedValues"],
+        ),
+        # Many differences
+        (
+            {
+                "name": "X",
+                "type": "PATH",
+                "dataFlow": "IN",
+                "objectType": "FILE",
+                "minLength": 3,
+                "maxLength": 5,
+            },
+            {
+                "name": "Y",
+                "type": "STRING",
+                "allowedValues": ["B", "C"],
+                "minLength": 2,
+            },
+            ["name", "type", "minLength", "maxLength", "dataFlow", "objectType", "allowedValues"],
+        ),
+    ],
+)
+def test_parameter_definition_difference(parameter1, parameter2, expected_difference):
+    """Test that parameter_definition_difference returns expected differences."""
+    assert parameters.parameter_definition_difference(parameter1, parameter2) == expected_difference


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

BREAKING-CHANGE: This changes the interface that consumers of the deadline cloud client UI library use.

Queues can contain Queue Environments that accept parameters in addition to those defined in the job template. Currently, the submitter GUIs do not provide a way to set these parameters.

### What was the solution? (How)

- Added an implementation of get_queue_parameter_definitions to
  deadline.client.api
- Set the default group label to queue parameters to be the queue
  environment name. Created a function in
  deadline.client.job_bundle.parameters to get the control type, so that
  this could be implemented by adding the 'userInterface' property.
  Modified the job template parameters widget to use the function
  instead of duplicating the code.
- Rename the job_template_parameters_widget to openjd_parameters_widget
  so it's a name applicable to both job and queue parameters. Add a
  signal called parameter_changed to the widget that gets emitted
  whenever a parameter value changed, with a deep copy of the parameter
  definition and the new value in its "value" key.
- Update the shared_job_settings_tab to move properties of the job out
  of the "Deadline Settings" into the top group. Rename that top group
  from "Description" to "Job Settings", and rename "Deadline Settings"
  to "Deadline Cloud Settings".
- Add get_parameter_values and set_parameter_value functions to the
  shared job settings tab and the job settings tab, so that they can be
  queried and set using general interface functions.
- Connect the parameter_changed signals from the shared job settings
  tab to set the job settings, and vice versa so that when a queue
  parameter and a job parameter are the same, the values between the two
  tabs are always up to date.
- Load the Queue parameters in a background thread so that the
  submission dialog opens sooner and shows the loading state.
- Wire up the deadline settings refresh to reload the queue parameters
  if the default queue id has changed in the settings.
- Move the 'deadline:*' parameters from the settings dataclasses into
  the queue parameters dictionaries. This makes their parameter values
  more consistent with the job bundle handling of them end-to-end.
- Rename FlatAssetReferences to AssetReferences, and add the ability to
  reference paths without making them input or output data flow. This
  affects job attachments, as any PATH parameter with NONE dataflow will
  become an asset reference that should have path mapping applied, and
  therefore needs to be in one of the AssetRootGroup objects that the
  job attachment library deduces.
- Update the tests for the reference paths ability. The job bundle
  submission asset refs tests pick up this case, because they include
  all the variations of data flow.

### What is the impact of this change?

When a user submits a job using the deadline-cloud submission GUIs, they
can see the queue environment parameters, and set their values. Also, if a
job template has a matching parameter name, the GUI keeps the value in
the shared job settings and the job-specific settings the same.

Where job templates have path references that don't have data flow, it
now ensures that these paths occur under a job attachments root, so
that path mapping applies to them correctly.

### How was this change tested?

Created unit tests for many of the components added. Updated unit tests where
applicable.

Submitted every job bundle in our job bundles library repo using `deadline bundle gui-submit`

### Was this change documented?

No

### Is this a breaking change?

Yes

### Screenshots:

![image](https://github.com/casillas2/deadline-cloud/assets/399551/1a581ef0-26df-4bf3-a111-921c95064da4)

![image](https://github.com/casillas2/deadline-cloud/assets/399551/f58e687b-a2a2-4637-b7b8-03ec7eda686d)

![image](https://github.com/casillas2/deadline-cloud/assets/399551/7464076b-1262-43e6-bf3c-df73944a8908)
