### PR TITLE
refactor(job_attachments)!: Move class definitions from `_utils` to `models.py`

### DIFF
--- a/src/deadline/client/cli/_groups/bundle_group.py
+++ b/src/deadline/client/cli/_groups/bundle_group.py
@@ -29,12 +29,13 @@ from deadline.client.job_bundle.submission import (
 )
 from deadline.job_attachments.exceptions import AssetSyncError, AssetSyncCancelledError
 from deadline.job_attachments.models import (
+    AssetLoadingMethod,
     AssetRootManifest,
     JobAttachmentS3Settings,
 )
 from deadline.job_attachments.progress_tracker import ProgressReportMetadata, SummaryStatistics
 from deadline.job_attachments.upload import S3AssetManager
-from deadline.job_attachments._utils import _human_readable_file_size, AssetLoadingMethod
+from deadline.job_attachments._utils import _human_readable_file_size
 
 from ...exceptions import DeadlineOperationError, CreateJobWaiterCanceled
 from .._common import _apply_cli_options_to_config, _handle_error

--- a/src/deadline/client/cli/_groups/job_group.py
+++ b/src/deadline/client/cli/_groups/job_group.py
@@ -17,14 +17,16 @@ from botocore.exceptions import ClientError  # type: ignore[import]
 
 from deadline.client.api._session import _modified_logging_level
 from deadline.job_attachments.download import OutputDownloader
-from deadline.job_attachments.models import JobAttachmentS3Settings
+from deadline.job_attachments.models import (
+    FileConflictResolution,
+    JobAttachmentS3Settings,
+    OperatingSystemFamily,
+)
 from deadline.job_attachments.progress_tracker import (
     DownloadSummaryStatistics,
     ProgressReportMetadata,
 )
-from deadline.job_attachments._utils import FileConflictResolution, _human_readable_file_size
-
-from deadline.job_attachments._utils import OperatingSystemFamily, _get_deadline_formatted_os
+from deadline.job_attachments._utils import _human_readable_file_size, _get_deadline_formatted_os
 
 from ... import api
 from ...config import config_file
@@ -351,7 +353,7 @@ def _download_job_output(
                 return
             else:
                 resolution_choice_int = int(user_choice)
-                file_conflict_resolution = FileConflictResolution.from_index(resolution_choice_int)
+                file_conflict_resolution = FileConflictResolution(resolution_choice_int)
 
     # TODO: remove logging level setting when the max number connections for boto3 client
     # in Job Attachments library can be increased (currently using default number, 10, which

--- a/src/deadline/job_attachments/_aws/deadline.py
+++ b/src/deadline/job_attachments/_aws/deadline.py
@@ -9,14 +9,16 @@ from botocore.exceptions import ClientError
 from ..exceptions import JobAttachmentsError
 from ..models import (
     Attachments,
+    AssetLoadingMethod,
     FileSystemLocation,
+    FileSystemLocationType,
     Job,
     JobAttachmentS3Settings,
     ManifestProperties,
+    OperatingSystemFamily,
     Queue,
-    StorageProfileForQueue,
+    StorageProfile,
 )
-from .._utils import AssetLoadingMethod, FileSystemLocationType, OperatingSystemFamily
 from .aws_clients import get_deadline_client
 
 
@@ -85,7 +87,7 @@ def get_job(
                 ManifestProperties(
                     fileSystemLocationName=manifest_properties.get("fileSystemLocationName", None),
                     rootPath=manifest_properties["rootPath"],
-                    osType=OperatingSystemFamily.get_os_family(manifest_properties["osType"]),
+                    osType=OperatingSystemFamily(manifest_properties["osType"]),
                     outputRelativeDirectories=manifest_properties["outputRelativeDirectories"],
                     inputManifestPath=manifest_properties.get("inputManifestPath", None),
                 )
@@ -106,7 +108,7 @@ def get_storage_profile_for_queue(
     storage_profile_id: str,
     session: Optional[boto3.Session] = None,
     deadline_endpoint_url: Optional[str] = None,
-) -> StorageProfileForQueue:
+) -> StorageProfile:
     """
     Retrieves a specific storage profile for queue from Amazon Deadline Cloud.
     """
@@ -120,15 +122,15 @@ def get_storage_profile_for_queue(
         raise JobAttachmentsError(
             f'Failed to get Storage profile "{storage_profile_id}" from Deadline'
         ) from exc
-    return StorageProfileForQueue(
+    return StorageProfile(
         storageProfileId=response["storageProfileId"],
         displayName=response["displayName"],
-        osFamily=OperatingSystemFamily.get_os_family(response["osFamily"]),
+        osFamily=OperatingSystemFamily(response["osFamily"]),
         fileSystemLocations=[
             FileSystemLocation(
                 name=file_system_location["name"],
                 path=file_system_location["path"],
-                type=FileSystemLocationType.get_type(file_system_location["type"]),
+                type=FileSystemLocationType(file_system_location["type"]),
             )
             for file_system_location in response.get("fileSystemLocations", [])
         ],

--- a/src/deadline/job_attachments/asset_sync.py
+++ b/src/deadline/job_attachments/asset_sync.py
@@ -41,15 +41,15 @@ from .download import (
 from .fus3 import Fus3ProcessManager
 from .exceptions import AssetSyncError, Fus3ExecutableMissingError
 from .models import (
-    ManifestProperties,
+    AssetLoadingMethod,
     Attachments,
+    FileSystemPermissionSettings,
     JobAttachmentS3Settings,
+    ManifestProperties,
     OutputFile,
 )
 from .upload import S3AssetUploader
 from ._utils import (
-    AssetLoadingMethod,
-    FileSystemPermissionSettings,
     _float_to_iso_datetime_string,
     _get_unique_dest_dir_name,
     _hash_data,
@@ -333,7 +333,7 @@ class AssetSync:
                 dir_name: str = _get_unique_dest_dir_name(manifest_properties.rootPath)
                 local_root = str(session_dir.joinpath(dir_name))
                 pathmapping_rules[dir_name] = {
-                    "source_os": manifest_properties.osType.to_path_mapping_os(),
+                    "source_os": manifest_properties.osType.to_path_format(),
                     "source_path": manifest_properties.rootPath,
                     "destination_path": local_root,
                 }

--- a/src/deadline/job_attachments/download.py
+++ b/src/deadline/job_attachments/download.py
@@ -39,13 +39,13 @@ from .exceptions import (
     MissingAssetRootError,
 )
 from .fus3 import Fus3ProcessManager
-from .models import JobAttachmentS3Settings, Attachments
-from ._utils import (
+from .models import (
+    Attachments,
     FileConflictResolution,
     FileSystemPermissionSettings,
-    _is_relative_to,
-    _join_s3_paths,
+    JobAttachmentS3Settings,
 )
+from ._utils import _is_relative_to, _join_s3_paths
 
 download_logger = getLogger("deadline.job_attachments.download")
 

--- a/src/deadline/job_attachments/progress_tracker.py
+++ b/src/deadline/job_attachments/progress_tracker.py
@@ -135,6 +135,7 @@ class ProgressReportMetadata:
 
     status: ProgressStatus
     progress: float  # percentage with one decimal place
+    transferRate: float  # bytes/second
     progressMessage: str  # pylint: disable=invalid-name
 
 
@@ -288,7 +289,7 @@ class ProgressTracker:
         seconds_since_last_report = round(
             time.perf_counter() - self.last_report_time if self.last_report_time else 0, 2
         )
-        transfer_rate = int(
+        transfer_rate = (
             (self.processed_bytes - self.last_report_processed_bytes) / seconds_since_last_report
             if seconds_since_last_report > 0
             else 0
@@ -301,12 +302,13 @@ class ProgressTracker:
             f"{self.status.verb_in_message}"
             f" {_human_readable_file_size(completed_bytes)} / {_human_readable_file_size(self.total_bytes)}"
             f" of {self.total_files} file{'' if self.total_files == 1 else 's'}"
-            f" ({transfer_rate_name}: {_human_readable_file_size(transfer_rate)}/s)"
+            f" ({transfer_rate_name}: {_human_readable_file_size(int(transfer_rate))}/s)"
         )
 
         return ProgressReportMetadata(
             status=self.status,
             progress=percentage,
+            transferRate=transfer_rate,
             progressMessage=progress_message,
         )
 

--- a/src/deadline/job_attachments/upload.py
+++ b/src/deadline/job_attachments/upload.py
@@ -40,10 +40,12 @@ from .hash_cache import HashCache
 from .models import (
     AssetRootGroup,
     AssetRootManifest,
-    ManifestProperties,
+    Attachments,
+    FileSystemLocationType,
     HashCacheEntry,
     JobAttachmentS3Settings,
-    Attachments,
+    ManifestProperties,
+    OperatingSystemFamily,
 )
 from .progress_tracker import (
     ProgressStatus,
@@ -51,8 +53,6 @@ from .progress_tracker import (
     SummaryStatistics,
 )
 from ._utils import (
-    FileSystemLocationType,
-    OperatingSystemFamily,
     _get_deadline_formatted_os,
     _hash_data,
     _hash_file,
@@ -842,7 +842,7 @@ class S3AssetManager:
             manifest_properties = ManifestProperties(
                 fileSystemLocationName=asset_root_manifest.file_system_location_name,
                 rootPath=asset_root_manifest.root_path,
-                osType=OperatingSystemFamily.get_os_family(_get_deadline_formatted_os()),
+                osType=OperatingSystemFamily(_get_deadline_formatted_os()),
                 outputRelativeDirectories=output_rel_paths,
             )
 

--- a/test/integ/deadline_job_attachments/test_job_attachments.py
+++ b/test/integ/deadline_job_attachments/test_job_attachments.py
@@ -20,10 +20,9 @@ from deadline.job_attachments import asset_sync, download, upload
 from deadline.job_attachments.asset_manifests import ManifestVersion
 from deadline.job_attachments._aws.deadline import get_queue
 from deadline.job_attachments.exceptions import AssetSyncError, JobAttachmentsS3ClientError
-from deadline.job_attachments.models import ManifestProperties, Attachments
+from deadline.job_attachments.models import Attachments, ManifestProperties, OperatingSystemFamily
 from deadline.job_attachments.progress_tracker import SummaryStatistics
 from deadline.job_attachments._utils import (
-    OperatingSystemFamily,
     _get_deadline_formatted_os,
     _get_unique_dest_dir_name,
     _hash_data,
@@ -1041,7 +1040,7 @@ def upload_input_files_no_input_paths(
     assert attachments.manifests == [
         ManifestProperties(
             rootPath=str(job_attachment_test.OUTPUT_PATH),
-            osType=OperatingSystemFamily.get_os_family(mock_submission_profile_name),
+            osType=OperatingSystemFamily(mock_submission_profile_name),
             outputRelativeDirectories=["."],
         )
     ]
@@ -1106,9 +1105,7 @@ def test_upload_input_files_no_download_paths(job_attachment_test: JobAttachment
     assert len(attachments.manifests) == 1
     assert attachments.manifests[0].fileSystemLocationName is None
     assert attachments.manifests[0].rootPath == str(job_attachment_test.INPUT_PATH)
-    assert attachments.manifests[0].osType == OperatingSystemFamily.get_os_family(
-        mock_submission_profile_name
-    )
+    assert attachments.manifests[0].osType == OperatingSystemFamily(mock_submission_profile_name)
     assert attachments.manifests[0].outputRelativeDirectories == []
     assert attachments.manifests[0].inputManifestPath is not None
     assert attachments.manifests[0].inputManifestPath.startswith(

--- a/test/unit/deadline_client/api/test_job_bundle_submission.py
+++ b/test/unit/deadline_client/api/test_job_bundle_submission.py
@@ -16,9 +16,13 @@ import time
 from deadline.client import api, config
 from deadline.client.api import _submit_job_bundle
 from deadline.client.job_bundle import submission
-from deadline.job_attachments.models import ManifestProperties, Attachments
+from deadline.job_attachments.models import (
+    AssetLoadingMethod,
+    Attachments,
+    ManifestProperties,
+    OperatingSystemFamily,
+)
 from deadline.job_attachments.progress_tracker import SummaryStatistics
-from deadline.job_attachments._utils import AssetLoadingMethod, OperatingSystemFamily
 
 from ..shared_constants import (
     MOCK_BUCKET_NAME,

--- a/test/unit/deadline_client/api/test_job_bundle_submission_asset_refs.py
+++ b/test/unit/deadline_client/api/test_job_bundle_submission_asset_refs.py
@@ -11,9 +11,14 @@ from unittest.mock import ANY, patch
 from deadline.client import api, config
 from deadline.client.api import _submit_job_bundle
 from deadline.client.job_bundle import submission
-from deadline.job_attachments.models import ManifestProperties, AssetRootManifest, Attachments
+from deadline.job_attachments.models import (
+    Attachments,
+    AssetLoadingMethod,
+    AssetRootManifest,
+    ManifestProperties,
+    OperatingSystemFamily,
+)
 from deadline.job_attachments.progress_tracker import SummaryStatistics
-from deadline.job_attachments._utils import AssetLoadingMethod, OperatingSystemFamily
 
 from ..shared_constants import MOCK_FARM_ID, MOCK_QUEUE_ID
 from .test_job_bundle_submission import (

--- a/test/unit/deadline_client/cli/test_cli_bundle.py
+++ b/test/unit/deadline_client/cli/test_cli_bundle.py
@@ -16,7 +16,7 @@ from deadline.client import config
 from deadline.client.cli import main
 from deadline.client.cli._groups import bundle_group
 from deadline.client.config.config_file import set_setting
-from deadline.job_attachments._utils import AssetLoadingMethod
+from deadline.job_attachments.models import AssetLoadingMethod
 from deadline.job_attachments.progress_tracker import SummaryStatistics
 
 from ..api.test_job_bundle_submission import (

--- a/test/unit/deadline_client/cli/test_cli_handle_web_url.py
+++ b/test/unit/deadline_client/cli/test_cli_handle_web_url.py
@@ -7,11 +7,6 @@ import os
 import sys
 from typing import Dict, List
 from unittest.mock import ANY, MagicMock, call, patch
-from deadline.job_attachments._utils import (
-    FileConflictResolution,
-    OperatingSystemFamily,
-    _get_deadline_formatted_os,
-)
 
 import pytest
 from click.testing import CliRunner
@@ -25,7 +20,12 @@ from deadline.client.cli._deadline_web_url import (
 )
 from deadline.client.cli._groups import handle_web_url_command, job_group
 from deadline.client.exceptions import DeadlineOperationError
-from deadline.job_attachments.models import JobAttachmentS3Settings
+from deadline.job_attachments.models import (
+    FileConflictResolution,
+    JobAttachmentS3Settings,
+    OperatingSystemFamily,
+)
+from deadline.job_attachments._utils import _get_deadline_formatted_os
 
 from ..api.test_job_bundle_submission import (
     MOCK_GET_QUEUE_RESPONSE,
@@ -260,7 +260,7 @@ def test_cli_handle_web_url_download_output_only_required_input(fresh_deadline_c
                 "manifests": [
                     {
                         "rootPath": "/root/path",
-                        "osType": OperatingSystemFamily.get_os_family(mock_submission_profile_name),
+                        "osType": OperatingSystemFamily(mock_submission_profile_name),
                         "outputRelativeDirectories": ["."],
                     }
                 ],
@@ -310,7 +310,7 @@ def test_cli_handle_web_url_download_output_with_optional_input(fresh_deadline_c
                 "manifests": [
                     {
                         "rootPath": "/root/path",
-                        "osType": OperatingSystemFamily.get_os_family(mock_submission_profile_name),
+                        "osType": OperatingSystemFamily(mock_submission_profile_name),
                         "outputRelativeDirectories": ["."],
                     }
                 ],

--- a/test/unit/deadline_client/cli/test_cli_job.py
+++ b/test/unit/deadline_client/cli/test_cli_job.py
@@ -10,11 +10,6 @@ import sys
 from unittest.mock import ANY, MagicMock, patch
 
 import boto3  # type: ignore[import]
-from deadline.job_attachments._utils import (
-    FileConflictResolution,
-    OperatingSystemFamily,
-    _get_deadline_formatted_os,
-)
 from botocore.exceptions import ClientError  # type: ignore[import]
 from click.testing import CliRunner
 from dateutil.tz import tzutc  # type: ignore[import]
@@ -22,7 +17,12 @@ from dateutil.tz import tzutc  # type: ignore[import]
 from deadline.client import api, config
 from deadline.client.cli import main
 from deadline.client.cli._groups import job_group
-from deadline.job_attachments.models import JobAttachmentS3Settings
+from deadline.job_attachments.models import (
+    FileConflictResolution,
+    JobAttachmentS3Settings,
+    OperatingSystemFamily,
+)
+from deadline.job_attachments._utils import _get_deadline_formatted_os
 
 from ..api.test_job_bundle_submission import (
     MOCK_GET_QUEUE_RESPONSE,
@@ -310,7 +310,7 @@ def test_cli_job_download_output_stdout_with_only_required_input(
                 "manifests": [
                     {
                         "rootPath": "/root/path",
-                        "osType": OperatingSystemFamily.get_os_family(mock_submission_profile_name),
+                        "osType": OperatingSystemFamily(mock_submission_profile_name),
                         "outputRelativeDirectories": ["."],
                     }
                 ],
@@ -401,7 +401,7 @@ def test_cli_job_dowuload_output_stdout_with_json_format(
                 "manifests": [
                     {
                         "rootPath": "/root/path",
-                        "osType": OperatingSystemFamily.get_os_family(mock_submission_profile_name),
+                        "osType": OperatingSystemFamily(mock_submission_profile_name),
                         "outputRelativeDirectories": ["."],
                     }
                 ],
@@ -465,7 +465,7 @@ def test_cli_job_download_output_handle_web_url_with_optional_input(fresh_deadli
                 "manifests": [
                     {
                         "rootPath": "/root/path",
-                        "osType": OperatingSystemFamily.get_os_family(mock_submission_profile_name),
+                        "osType": OperatingSystemFamily(mock_submission_profile_name),
                         "outputRelativeDirectories": ["."],
                     },
                 ],

--- a/test/unit/deadline_client/job_bundle/test_job_submission.py
+++ b/test/unit/deadline_client/job_bundle/test_job_submission.py
@@ -11,9 +11,8 @@ from unittest.mock import Mock
 import pytest
 
 from deadline.client.job_bundle import submission
-from deadline.job_attachments.models import Attachments
+from deadline.job_attachments.models import AssetLoadingMethod, Attachments
 from deadline.job_attachments.progress_tracker import SummaryStatistics
-from deadline.job_attachments._utils import AssetLoadingMethod
 
 MOCK_FARM_ID = "farm-0123456789abcdef0123456789abcdef"
 MOCK_QUEUE_ID = "queue-0123456789abcdef0123456789abcdef"

--- a/test/unit/deadline_job_attachments/conftest.py
+++ b/test/unit/deadline_job_attachments/conftest.py
@@ -31,15 +31,13 @@ import deadline  # noqa: E402 isort:skip
 from deadline.job_attachments._aws import aws_clients  # noqa: E402 isort:skip
 from deadline.job_attachments.asset_sync import AssetSync  # noqa: E402 isort:skip
 from deadline.job_attachments.models import (  # noqa: E402 isort:skip
+    AssetLoadingMethod,
     Attachments,
     ManifestProperties,
     Job,
     JobAttachmentS3Settings,
-    Queue,
-)
-from deadline.job_attachments._utils import (  # noqa: E402 isort:skip
-    AssetLoadingMethod,
     OperatingSystemFamily,
+    Queue,
 )
 
 

--- a/test/unit/deadline_job_attachments/test_asset_sync.py
+++ b/test/unit/deadline_job_attachments/test_asset_sync.py
@@ -24,13 +24,14 @@ from deadline.job_attachments.models import (
     Job,
     JobAttachmentS3Settings,
     ManifestProperties,
+    OperatingSystemFamily,
     Queue,
 )
 from deadline.job_attachments.progress_tracker import (
     DownloadSummaryStatistics,
     SummaryStatistics,
 )
-from deadline.job_attachments._utils import OperatingSystemFamily, _human_readable_file_size
+from deadline.job_attachments._utils import _human_readable_file_size
 
 from deadline.job_attachments.asset_manifests.decode import decode_manifest
 

--- a/test/unit/deadline_job_attachments/test_download.py
+++ b/test/unit/deadline_job_attachments/test_download.py
@@ -51,18 +51,21 @@ from deadline.job_attachments.exceptions import (
     MissingAssetRootError,
     PathOutsideDirectoryError,
 )
-from deadline.job_attachments.models import Job, JobAttachmentS3Settings, Attachments, Queue
+from deadline.job_attachments.models import (
+    Attachments,
+    FileConflictResolution,
+    FileSystemPermissionSettings,
+    Job,
+    JobAttachmentS3Settings,
+    Queue,
+)
 from deadline.job_attachments.progress_tracker import (
     DownloadSummaryStatistics,
     ProgressReportMetadata,
     ProgressStatus,
 )
-from deadline.job_attachments._utils import (
-    FileConflictResolution,
-    FileSystemPermissionSettings,
-    _human_readable_file_size,
-)
 from deadline.job_attachments.asset_manifests.decode import decode_manifest
+from deadline.job_attachments._utils import _human_readable_file_size
 
 from .conftest import has_posix_target_user, has_posix_disjoint_user
 

--- a/test/unit/deadline_job_attachments/test_upload.py
+++ b/test/unit/deadline_job_attachments/test_upload.py
@@ -31,24 +31,22 @@ from deadline.job_attachments.exceptions import (
     MissingS3RootPrefixError,
 )
 from deadline.job_attachments.models import (
-    Attachments,
     AssetRootGroup,
+    Attachments,
     FileSystemLocation,
+    FileSystemLocationType,
     ManifestProperties,
     HashCacheEntry,
     JobAttachmentS3Settings,
-    StorageProfileForQueue,
+    OperatingSystemFamily,
+    StorageProfile,
 )
 from deadline.job_attachments.progress_tracker import (
     ProgressStatus,
     SummaryStatistics,
 )
 from deadline.job_attachments.upload import S3AssetManager, S3AssetUploader
-from deadline.job_attachments._utils import (
-    FileSystemLocationType,
-    OperatingSystemFamily,
-    _human_readable_file_size,
-)
+from deadline.job_attachments._utils import _human_readable_file_size
 
 
 class TestUpload:
@@ -128,7 +126,7 @@ class TestUpload:
 
         with patch(
             f"{deadline.__package__}.job_attachments.upload._get_deadline_formatted_os",
-            return_value="Linux",
+            return_value="linux",
         ), patch(
             f"{deadline.__package__}.job_attachments.upload._hash_data",
             side_effect=["e", "manifesthash"],
@@ -208,7 +206,7 @@ class TestUpload:
                 "manifests": [
                     {
                         "rootPath": f"{asset_root}",
-                        "osType": OperatingSystemFamily.get_os_family("linux").value,
+                        "osType": OperatingSystemFamily("linux").value,
                         "inputManifestPath": f"{farm_id}/{queue_id}/Inputs/0000/e_input.xxh128",
                         "inputManifestHash": "manifesthash",
                         "outputRelativeDirectories": [
@@ -371,13 +369,13 @@ class TestUpload:
                 "manifests": [
                     {
                         "rootPath": f"{root_c}",
-                        "osType": OperatingSystemFamily.get_os_family("windows").value,
+                        "osType": OperatingSystemFamily("windows").value,
                         "inputManifestPath": f"{farm_id}/{queue_id}/Inputs/0000/b_input.xxh128",
                         "inputManifestHash": "manifesthash",
                     },
                     {
                         "rootPath": f"{output_d}",
-                        "osType": OperatingSystemFamily.get_os_family("windows").value,
+                        "osType": OperatingSystemFamily("windows").value,
                         "outputRelativeDirectories": [
                             ".",
                         ],
@@ -467,7 +465,7 @@ class TestUpload:
 
         with patch(
             f"{deadline.__package__}.job_attachments.upload._get_deadline_formatted_os",
-            return_value="Linux",
+            return_value="linux",
         ), patch(
             f"{deadline.__package__}.job_attachments.upload._hash_data",
             side_effect=["c", "manifesthash"],
@@ -536,7 +534,7 @@ class TestUpload:
                 "manifests": [
                     {
                         "rootPath": f"{asset_root}",
-                        "osType": OperatingSystemFamily.get_os_family("linux").value,
+                        "osType": OperatingSystemFamily("linux").value,
                         "inputManifestPath": f"{farm_id}/{queue_id}/Inputs/0000/c_input.xxh128",
                         "inputManifestHash": "manifesthash",
                         "outputRelativeDirectories": ["outputs"],
@@ -621,7 +619,7 @@ class TestUpload:
         # Given
         with patch(
             f"{deadline.__package__}.job_attachments.upload._get_deadline_formatted_os",
-            return_value="Linux",
+            return_value="linux",
         ), patch(
             f"{deadline.__package__}.job_attachments.upload._hash_data",
             side_effect=["c", "manifesthash"],
@@ -729,13 +727,13 @@ class TestUpload:
         # Given
         with patch(
             f"{deadline.__package__}.job_attachments.upload._get_deadline_formatted_os",
-            return_value="Linux",
+            return_value="linux",
         ), patch(
             f"{deadline.__package__}.job_attachments.upload._hash_data",
             side_effect=["manifest", "manifesthash"],
         ), patch(
             f"{deadline.__package__}.job_attachments.upload._get_deadline_formatted_os",
-            return_value="Linux",
+            return_value="linux",
         ), patch(
             f"{deadline.__package__}.job_attachments.upload._hash_file", side_effect=mock_hash_file
         ), patch(
@@ -853,13 +851,13 @@ class TestUpload:
         # Given
         with patch(
             f"{deadline.__package__}.job_attachments.upload._get_deadline_formatted_os",
-            return_value="Linux",
+            return_value="linux",
         ), patch(
             f"{deadline.__package__}.job_attachments.upload._hash_data",
             side_effect=["manifesto", "manifesthash"],
         ), patch(
             f"{deadline.__package__}.job_attachments.upload._get_deadline_formatted_os",
-            return_value="Linux",
+            return_value="linux",
         ), patch(
             f"{deadline.__package__}.job_attachments.upload._hash_file",
             side_effect=[str(i) for i in range(num_input_files)],
@@ -985,7 +983,7 @@ class TestUpload:
         # Given
         with patch(
             f"{deadline.__package__}.job_attachments.upload._get_deadline_formatted_os",
-            return_value="Linux",
+            return_value="linux",
         ), patch(
             f"{deadline.__package__}.job_attachments.upload._hash_data",
             side_effect=["a", "manifesthash"],
@@ -1038,7 +1036,7 @@ class TestUpload:
                 "manifests": [
                     {
                         "rootPath": f"{output_dir}",
-                        "osType": OperatingSystemFamily.get_os_family("linux").value,
+                        "osType": OperatingSystemFamily("linux").value,
                         "outputRelativeDirectories": ["."],
                     }
                 ],
@@ -1422,7 +1420,7 @@ class TestUpload:
 
         with patch(
             f"{deadline.__package__}.job_attachments.upload._get_deadline_formatted_os",
-            return_value="Linux",
+            return_value="linux",
         ), patch(
             f"{deadline.__package__}.job_attachments.upload._hash_data",
             side_effect=["c", "manifesthash"],
@@ -1698,7 +1696,7 @@ class TestUpload:
         mock_file_system_locations: List[FileSystemLocation],
         expected_result: Tuple[Dict[str, str], Dict[str, str]],
     ):
-        mock_storage_profile_for_queue = StorageProfileForQueue(
+        mock_storage_profile_for_queue = StorageProfile(
             storageProfileId="sp-0123456789",
             displayName="Storage profile 1",
             osFamily=OperatingSystemFamily.WINDOWS,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The `_utils.py` is no longer considered a public interface due to the leading underscore (`_`) in its name. However, certain items, especially classes defined in it, (e.g., `OperatingSystemFamily`, `AssetLoadingMethod`, …) were being imported and used from external code (i.e., Worker Agent.) Although those are in `__all__` public exports, the `_utils` wasn't the best place for these classes. To address this, we need a refactoring to move these classes from `_utils` to somewhere else.

### What was the solution? (How)
- Relocated the classes from `_utils` to `models.py`, as `models.py` serves as a place for data classes, and some of them are using the classes that we need to move.
  - **Note**: While some private methods still exist in `_utils`, I plan to further refactor them in future iterations with the goal of eventually emptying and removing `_utils`.
- Not related to this specific requirement, but I also add a `transferRate` attribute to the `ProgressReportMetadata` class, that I missed in the [previous PR](https://github.com/casillas2/deadline-cloud/pull/33), making it easier for the progress report callback during file download/upload to use this data.

### What is the impact of this change?
- Refactoring our code and adhering to the intended public interface structure.
  - Those moved classes should be now imported from `models.py` rather than `_utils`.
  - **Note**: Additional refactoring may be needed in the future, but for this PR, I simply focused on moving those classes out of the `_utils`.

### How was this change tested?
- Run unit tests by `hatch run test`
- Run integration tests by `hatch run integ:test`
- Run docker-based tests by `hatch run test_docker`
- Run a manual end-to-end test (submitting a non-rendering job bundle --> running my local CMF against my local backend) ensuring that there were no issues/errors in the flow.

### Was this change documented?
No.

### Is this a breaking change?
Yes!