### PR TITLE
feat(job_attachments)!: Add OS-specific FileSystemPermissionSettings classes

### DIFF
--- a/src/deadline/job_attachments/_aws/deadline.py
+++ b/src/deadline/job_attachments/_aws/deadline.py
@@ -40,7 +40,9 @@ def get_queue(
 
     # The API returns empty fields instead of an empty dict if there are no job attachment settings. So we need to
     # double check if the s3BucketName is set.
-    if response["jobAttachmentSettings"] and response["jobAttachmentSettings"].get("s3BucketName"):
+    if response.get("jobAttachmentSettings") and response["jobAttachmentSettings"].get(
+        "s3BucketName"
+    ):
         job_attachment_settings = JobAttachmentS3Settings(
             s3BucketName=response["jobAttachmentSettings"].get("s3BucketName", ""),
             rootPrefix=response["jobAttachmentSettings"].get("rootPrefix", ""),

--- a/src/deadline/job_attachments/models.py
+++ b/src/deadline/job_attachments/models.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import List, Optional, Set, Any
+from typing import List, Optional, Set, Any, Union
 
 from deadline.job_attachments.asset_manifests.base_manifest import BaseAssetManifest
 
@@ -266,11 +266,11 @@ class FileConflictResolution(Enum):
 
 
 @dataclass
-class FileSystemPermissionSettings:
+class PosixFileSystemPermissionSettings:
     """
-    A data class representing file system permission-related information.
-    The specified permission modes will be bitwise-OR'ed with the directory
-    or file's existing permissions.
+    A dataclass representing file system permission-related information
+    for Posix. The specified permission modes will be bitwise-OR'ed with
+    the directory or file's existing permissions.
 
     Attributes:
         os_group (str): The target operating system group for ownership.
@@ -281,3 +281,19 @@ class FileSystemPermissionSettings:
     os_group: str
     dir_mode: int
     file_mode: int
+
+
+@dataclass
+class WindowsFileSystemPermissionSettings:
+    """
+    A dataclass representing file system permission-related information
+    for Windows.
+    """
+
+    # TODO: Implement this
+
+
+# A union of different file system permission settings that are based on the underlying OS.
+FileSystemPermissionSettings = Union[
+    PosixFileSystemPermissionSettings, WindowsFileSystemPermissionSettings
+]

--- a/test/unit/deadline_job_attachments/test_download.py
+++ b/test/unit/deadline_job_attachments/test_download.py
@@ -54,7 +54,7 @@ from deadline.job_attachments.exceptions import (
 from deadline.job_attachments.models import (
     Attachments,
     FileConflictResolution,
-    FileSystemPermissionSettings,
+    PosixFileSystemPermissionSettings,
     Job,
     JobAttachmentS3Settings,
     Queue,
@@ -696,7 +696,11 @@ class TestFullDownload:
         )
 
     @mock_sts
-    def test_download_files_from_manifests_with_fs_permission_settings(
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="This test is for testing file permission changes in Posix-based OS.",
+    )
+    def test_download_files_from_manifests_with_posix_fs_permission_settings(
         self,
         tmp_path: Path,
         manifest_version: ManifestVersion,
@@ -713,7 +717,7 @@ class TestFullDownload:
         manifest = decode_manifest(mannifest_str)
 
         manifests_by_root = {str(tmp_path): manifest}
-        fs_permission_settings = FileSystemPermissionSettings(
+        fs_permission_settings = PosixFileSystemPermissionSettings(
             os_group="test-group",
             dir_mode=0o20,
             file_mode=0o20,
@@ -773,7 +777,7 @@ class TestFullDownload:
         not (has_posix_target_user() and has_posix_disjoint_user()),
         reason="Must be running inside of the sudo_environment testing container.",
     )
-    def test_download_files_from_manifests_have_correct_group(
+    def test_download_files_from_manifests_have_correct_group_posix(
         self,
         tmp_path: Path,
         manifest_version: ManifestVersion,
@@ -803,7 +807,7 @@ class TestFullDownload:
         manifest = decode_manifest(mannifest_str)
         manifests_by_root = {str(tmp_path): manifest}
 
-        fs_permission_settings = FileSystemPermissionSettings(
+        fs_permission_settings = PosixFileSystemPermissionSettings(
             os_group=posix_target_group,
             dir_mode=0o20,
             file_mode=0o20,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
In the PR from the worker-agent side: https://github.com/casillas2/deadline-cloud-worker-agent/pull/26, there was a concern raised about the lack of consideration for Windows compatibility when handling file ownership/permissions for job attachment-owned files. To address this, we need to introduce OS-specific FileSystemPermissionSettings classes to accommodate Windows support.

### What was the solution? (How)
- Separates the `FileSystemPermissionSettings` class into two distinct types - one for Posix, and one for Windows to better accommodate OS-specific permission handling. So, added two new classes:
  - `PosixFileSystemPermissionSettings`: it is actually identical to the previous FileSystemPermissionSettings class, with the name being the only change to explicitly indicate the OS, Posix.
  - `WindowsFileSystemPermissionSettings`: A placeholder class for Windows. Will be implemented in a follow-up PR.
- The `FileSystemPermissionSettings` is now the Union type of those two classes.
- When changing the file ownership/permissions, internally checks what kind of permission settings it is using `isinstance()` checks.

### What is the impact of this change?
Better accommodation for OS-specific (file) permission handling

### How was this change tested?
- Ran unit tests: `hatch run lint && hatch run test`
- Ran integ tests: `hatch run integ:test`
- Ran docker-based tests: `hatch run test_docker`
- Run an end-to-end test (submitting a non-rendering job bundle --> running a CMF against my local backend) ensuring that there were no issues/errors in the flow.

### Was this change documented?
No.

### Is this a breaking change?
Yes!
