### PR TITLE
feat: Submitter Dialog: Add worker requirements UI

### DIFF
--- a/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
@@ -35,6 +35,7 @@ from ...job_bundle import create_job_history_bundle_dir
 from ..widgets.deadline_credentials_status_widget import DeadlineCredentialsStatusWidget
 from ..widgets.job_attachments_tab import JobAttachmentsWidget
 from ..widgets.shared_job_settings_tab import SharedJobSettingsWidget
+from ..widgets.host_requirements_tab import HostRequirementsWidget
 from . import DeadlineConfigDialog, DeadlineLoginDialog
 from ...job_bundle.submission import AssetReferences
 
@@ -60,6 +61,10 @@ class SubmitJobToDeadlineDialog(QDialog):
         attachments: (FlatAssetReferences): The job attachments that have been added to the job by the user.
         on_create_job_bundle_callback: A function to call when the dialog needs to create a Job Bundle. It
             is called with arguments (widget, job_bundle_dir, settings, queue_parameters, asset_references)
+        parent: parent of the widget
+        f: Qt Window Flags
+        show_host_requirements_tab: Display the host requirements tab in dialog if set to True. Default
+            to False.
     """
 
     def __init__(
@@ -73,6 +78,7 @@ class SubmitJobToDeadlineDialog(QDialog):
         on_create_job_bundle_callback,
         parent=None,
         f=Qt.WindowFlags(),
+        show_host_requirements_tab=False,
     ):
         # The Qt.Tool flag makes sure our widget stays in front of the main application window
         super().__init__(parent=parent, f=f)
@@ -89,6 +95,7 @@ class SubmitJobToDeadlineDialog(QDialog):
             initial_shared_parameter_values,
             auto_detected_attachments,
             attachments,
+            show_host_requirements_tab,
         )
 
         self.gui_update_counter: Any = None
@@ -147,6 +154,7 @@ class SubmitJobToDeadlineDialog(QDialog):
         initial_shared_parameter_values,
         auto_detected_attachments: AssetReferences,
         attachments: AssetReferences,
+        show_host_requirements_tab: bool,
     ):
         self.lyt = QVBoxLayout(self)
         self.lyt.setContentsMargins(5, 5, 5, 5)
@@ -159,6 +167,10 @@ class SubmitJobToDeadlineDialog(QDialog):
         self._build_shared_job_settings_tab(initial_job_settings, initial_shared_parameter_values)
         self._build_job_settings_tab(job_setup_widget_type, initial_job_settings)
         self._build_job_attachments_tab(auto_detected_attachments, attachments)
+
+        # Show host requirements only if requested by the constructor
+        if show_host_requirements_tab:
+            self._build_host_requirements_tab(HostRequirementsWidget())
 
         self.creds_status_box = DeadlineCredentialsStatusWidget()
         self.lyt.addWidget(self.creds_status_box)
@@ -227,6 +239,12 @@ class SubmitJobToDeadlineDialog(QDialog):
         )
         self.job_attachments_tab.setWidget(self.job_attachments)
         self.job_attachments_tab.setWidgetResizable(True)
+
+    def _build_host_requirements_tab(self, worker_requirements_widget: QWidget):
+        self.host_requirements_tab = QScrollArea()
+        self.tabs.addTab(self.host_requirements_tab, "Host Requirements")
+        self.host_requirements_tab.setWidget(worker_requirements_widget)
+        self.host_requirements_tab.setWidgetResizable(True)
 
     def on_shared_job_parameter_changed(self, parameter: dict[str, Any]):
         """

--- a/src/deadline/client/ui/widgets/host_requirements_tab.py
+++ b/src/deadline/client/ui/widgets/host_requirements_tab.py
@@ -1,0 +1,368 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+UI widgets for the Host Requirements tab.
+"""
+from typing import List
+
+from PySide2.QtCore import Qt  # type: ignore
+from PySide2.QtGui import QFont, QValidator, QIntValidator, QBrush, QPalette
+from PySide2.QtWidgets import (  # type: ignore
+    QComboBox,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QRadioButton,
+    QSizePolicy,
+    QSpacerItem,
+    QSpinBox,
+    QVBoxLayout,
+    QWidget,
+    QPushButton,
+)
+
+LABLE_FIXED_WIDTH: int = 150
+BUTTON_FIXED_WIDTH: int = 150
+PLACEHOLDER_TEXT = "-"
+
+
+class HostRequirementsWidget(QWidget):  # pylint: disable=too-few-public-methods
+    """
+    UI Elements that hold host requirements settings across all job types.
+
+    Args:
+        parent: The parent Qt Widget.
+    """
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+
+        self.mode_selection_box = OverrideRequirementsWidget(self)
+        layout.addWidget(self.mode_selection_box)
+
+        self.os_requirements_box = OSRequirementsWidget(self)
+        self.os_requirements_box.setEnabled(False)
+        layout.addWidget(self.os_requirements_box)
+
+        self.hardware_requirements_box = HardwareRequirementsWidget(self)
+        self.hardware_requirements_box.setEnabled(False)
+        layout.addWidget(self.hardware_requirements_box)
+
+        self.custom_requirements_box = CustomRequirementsWidget(self)
+        self.custom_requirements_box.setEnabled(False)
+        layout.addWidget(self.custom_requirements_box)
+
+        layout.addItem(QSpacerItem(0, 0, QSizePolicy.Minimum, QSizePolicy.Expanding))
+
+        self.mode_selection_box.use_custom_button.toggled.connect(
+            self._on_mode_selection_use_custom_button_toggled
+        )
+
+    def _on_mode_selection_use_custom_button_toggled(self, state):
+        """
+        Enable all settings when use_custom_button is selected. Otherwise disable all settings.
+        """
+        self.os_requirements_box.setEnabled(state)
+        self.hardware_requirements_box.setEnabled(state)
+        self.custom_requirements_box.setEnabled(state)
+
+
+class OverrideRequirementsWidget(QGroupBox):  # pylint: disable=too-few-public-methods
+    """
+    UI elements to hold top level selection between using all workers or selected workers that meet requirements.
+
+    Args:
+        parent: The parent Qt Widget.
+    """
+
+    def __init__(self, parent=None):
+        super().__init__("", parent)
+        self.layout = QVBoxLayout(self)
+        self._build_ui()
+
+    def _build_ui(self):
+        # Use Fleet Default button
+        self.use_default_button = QRadioButton("Run on all available worker hosts")
+        self.use_default_button.setChecked(True)
+
+        # Use customized settings button + tip
+        self.use_custom_button = QRadioButton(
+            "Run on worker hosts that meet the following requirements"
+        )
+        self.use_custom_button_tip = QHBoxLayout()
+        self.custom_button_tip_text = QLabel("All fields below are optional")
+        custom_button_label_font = self.custom_button_tip_text.font()
+        custom_button_label_font.setPointSize(10)
+        custom_button_label_font.setItalic(True)
+        custom_button_label_font.setWeight(QFont.Light)
+        self.custom_button_tip_text.setFont(custom_button_label_font)
+        self.custom_button_tip_text.setWordWrap(True)
+        self.custom_button_tip_text.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Minimum)
+        self.custom_button_tip_text.setAlignment(Qt.AlignTop)
+
+        # account for 2pt spacing left/right of radio button
+        self.use_custom_button_tip.addSpacing(self.use_custom_button.iconSize().width() + 4)
+        self.use_custom_button_tip.addWidget(self.custom_button_tip_text)
+
+        # Stack the components
+        self.layout.addWidget(self.use_default_button)
+        self.layout.addSpacing(6)
+        self.layout.addWidget(self.use_custom_button)
+        self.layout.addLayout(self.use_custom_button_tip)
+
+
+class OSRequirementsWidget(QGroupBox):
+    """
+    UI elements to hold OS settings.
+
+    Args:
+        parent: The parent Qt Widget.
+    """
+
+    def __init__(self, parent=None):
+        super().__init__("", parent=parent)
+        self.layout = QVBoxLayout(self)
+        self._build_ui()
+
+    def _build_ui(self):
+        self.os_row = OSRequirementRowWidget("Operating System", ["Linux", "MacOS", "Windows"])
+        self.cpu_row = OSRequirementRowWidget("CPU Architecture", ["x86_64", "arm64"])
+
+        self.layout.addWidget(self.os_row)
+        self.layout.addWidget(self.cpu_row)
+
+
+class HardwareRequirementsWidget(QGroupBox):  # pylint: disable=too-few-public-methods
+    """
+    UI elements to hold list of hardware requirements.
+
+    Args:
+        parent: The parent Qt Widget.
+    """
+
+    def __init__(self, parent=None):
+        super().__init__("Hardware requirements", parent)
+        self.layout = QVBoxLayout(self)
+        self._build_ui()
+
+    def _build_ui(self):
+        # Build a custom row widget for each selectable option
+        self.cpu_row = HardwareRequirementsRowWidget("vCPUs", self)
+        self.memory_row = HardwareRequirementsRowWidget("Memory (GiB)", self)
+        self.gpu_row = HardwareRequirementsRowWidget("GPUs", self)
+        self.gpu_memory_row = HardwareRequirementsRowWidget("GPU Memory (GiB)", self)
+        self.scratch_space_row = HardwareRequirementsRowWidget("Scratch Space", self)
+
+        # Add all rows to layout
+        self.layout.addWidget(self.cpu_row)
+        self.layout.addWidget(self.memory_row)
+        self.layout.addWidget(self.gpu_row)
+        self.layout.addWidget(self.gpu_memory_row)
+        self.layout.addWidget(self.scratch_space_row)
+
+
+class CustomRequirementsWidget(QGroupBox):
+    """
+    UI elements to hold custom host requirements.
+
+    Args:
+        parent: The parent Qt Widget.
+    """
+
+    def __init__(self, parent=None):
+        super().__init__("Custom host requirements", parent)
+        self.layout = QVBoxLayout(self)
+        self._build_ui()
+
+    def _build_ui(self):
+        # TODO: make the "More Info" text open a pop-up or tool tip
+        # self.info_icon = QIcon(QStyle.SP_MessageBoxInformation)
+        # self.info_label = QLabel("More info")
+
+        # Add a row with two buttons
+        self.add_amount_button = QPushButton("Add amount")
+        self.add_amount_button.setFixedWidth(BUTTON_FIXED_WIDTH)
+
+        self.add_attr_button = QPushButton("Add attribute")
+        self.add_attr_button.setFixedWidth(BUTTON_FIXED_WIDTH)
+
+        self.buttons_row = QHBoxLayout(self)
+        self.buttons_row.setAlignment(Qt.AlignLeft)
+        self.buttons_row.addWidget(self.add_amount_button)
+        self.buttons_row.addWidget(self.add_attr_button)
+
+        self.add_amount_button.clicked.connect(self._add_new_custom_amount)
+        self.add_attr_button.clicked.connect(self._add_new_custom_attr)
+
+        self.layout.addLayout(self.buttons_row)
+
+    def _add_new_custom_amount(self):
+        print("Feature not yet supported!")
+        # TODO: insert widget once UI design is finalized
+        # self.layout.insertWidget(0, CustomAmountWidget())
+
+    def _add_new_custom_attr(self):
+        print("Feature not yet supported!")
+        # TODO: insert widget once UI design is finalized
+        # self.layout.insertWidget(0, CustomAttributeWidget())
+
+
+class CustomAmountWidget(QWidget):
+    """
+    UI element to hold a single custom attribute.
+    """
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.layout = QHBoxLayout(self)
+        # remove default spaces around BoxLayout
+        self.layout.setContentsMargins(0, 0, 0, 0)
+        # TODO: build widget once UI design is finalized
+
+
+class CustomAttributeWidget(QWidget):
+    """
+    UI element to hold a single custom attribute.
+    """
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.layout = QHBoxLayout(self)
+        # remove default spaces around BoxLayout
+        self.layout.setContentsMargins(0, 0, 0, 0)
+        # TODO: build widget once UI design is finalized
+
+
+class OSRequirementRowWidget(QWidget):
+    """
+    UI element to hold a single row of OS requirement components.
+
+    Args:
+        label: the name of the requirement
+        items: selectable options to display inside a comboBox
+        parent: The parent Qt Widget
+    """
+
+    def __init__(self, label: str, items: List[str], parent=None):
+        super().__init__(parent)
+        self.layout = QHBoxLayout(self)
+        # remove default spaces around BoxLayout
+        self.layout.setContentsMargins(0, 0, 0, 0)
+        self._build_ui(label, items)
+
+    def _build_ui(self, label: str, items: List[str]):
+        self.label = QLabel(label)
+        self.label.setFixedWidth(LABLE_FIXED_WIDTH)
+        self.combo_box = OptionalComboBox(items, parent=self)
+        self.layout.addWidget(self.label)
+        self.layout.addWidget(self.combo_box)
+
+
+class HardwareRequirementsRowWidget(QWidget):
+    """
+    UI element to hold a single row of hardware requirement components.
+
+    Args:
+        label: the name of the requirement
+        parent: The parent Qt Widget
+    """
+
+    def __init__(self, label: str, parent=None):
+        super().__init__(parent)
+        self.layout = QHBoxLayout(self)
+        # remove default spaces around BoxLayout
+        self.layout.setContentsMargins(0, 0, 0, 0)
+        self._build_ui(label)
+
+    def _build_ui(self, label: str):
+        self.label = QLabel(label)
+        self.label.setFixedWidth(LABLE_FIXED_WIDTH)
+
+        # Create "Min" label, and set label to fixed width
+        self.min_label = QLabel("Min")
+        self.min_label.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+
+        # Create "Max" label, and set label to fixed width
+        self.max_label = QLabel("Max")
+        self.max_label.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+
+        # Create spin box for "Min"
+        self.min_spin_box = OptionalSpinBox(min=0, max=100000, parent=self)
+
+        # Create spin box for "Max"
+        self.max_spin_box = OptionalSpinBox(min=0, max=100000, parent=self)
+
+        self.layout.addWidget(self.label)
+        self.layout.addWidget(self.min_label)
+        self.layout.addWidget(self.min_spin_box)
+        self.layout.addWidget(self.max_label)
+        self.layout.addWidget(self.max_spin_box)
+
+
+class OptionalComboBox(QComboBox):
+    """
+    A custom QComboBox that always have a grayed out placeholder option.
+    """
+
+    def __init__(self, items: List[str], parent=None):
+        super().__init__(parent)
+        self.addItem(PLACEHOLDER_TEXT)
+        self.setItemData(0, QBrush(Qt.gray), Qt.TextColorRole)
+        self.addItems(items)
+
+
+class OptionalSpinBox(QSpinBox):
+    """
+    A custom QSpinBox that set min - 1 value as "-" to represent value not set.
+    """
+
+    NAN_VALUE = -(2**31)
+    MAX_INT_VALUE = (2**31) - 1
+    MIN_INT_VALUE = -(2**31) + 1
+    palette = QPalette()
+
+    def __init__(self, min: int = MIN_INT_VALUE, max: int = MAX_INT_VALUE, parent=None) -> None:
+        super().__init__(parent)
+        self.min = min
+        self.max = max
+        # Set the range to include NaN as a valid value
+        self.setRange(self.NAN_VALUE, self.MAX_INT_VALUE)
+        self.setValue(self.NAN_VALUE)
+
+    def validate(self, input: str, pos: int) -> QValidator.State:
+        """
+        Override validate function to treat empty string "" as acceptable.
+        """
+        if input == "" or input == PLACEHOLDER_TEXT:
+            return QValidator.Acceptable
+        else:
+            # Override the range that can be accepted by the validator by actual min/max values.
+            validator = QIntValidator()
+            validator.setBottom(self.min)
+            validator.setTop(self.max)
+            return validator.validate(input, pos)
+
+    def valueFromText(self, text: str) -> int:
+        """
+        Override valueFromText function to return NaN if input string is empty or placeholder.
+        """
+        if text == "" or text == PLACEHOLDER_TEXT:
+            return self.NAN_VALUE
+        else:
+            return super().valueFromText(text)
+
+    def textFromValue(self, val: int) -> str:
+        """
+        Override textFromValue function to return placeholder text if value is NaN.
+        """
+        if val == self.NAN_VALUE:
+            return PLACEHOLDER_TEXT
+        else:
+            return super().textFromValue(val)
+
+    def has_input(self) -> bool:
+        """
+        Custom function to indicate whether the SpinBox has received input.
+        """
+        return self.NAN_VALUE != self.value()


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
- Submitter dialog need a new tab to support hardware requirements (capabilities)

### What was the solution? (How)
- Add a main worker requirements UI. 
    - This PR only contains the UI and not yet wiring up the input to job submission
    - "Custom Requirements" is not yet fully functioning

### What is the impact of this change?

By default the worker capabilities tab is NOT added to the dialog. To see the UI in DCC submitter packages, set `show_host_requirements_tab` to True. When ready, the host requirements tab will be enabled by default for DCC submitters, but remain off for gui-bundle and CLI submitters.
```
    submitter_dialog = SubmitJobToDeadlineDialog(
        job_setup_widget_type=JobBundleSettingsWidget,
        initial_job_settings=initial_settings,
        initial_shared_parameter_values=initial_shared_parameter_values,
        auto_detected_attachments=asset_references,
        attachments=AssetReferences(),
        on_create_job_bundle_callback=on_create_job_bundle_callback,
        parent=parent,
        f=f,
        show_host_requirements_tab=True,
    )
```

### How was this change tested?

<img width="540" alt="Screenshot 2023-09-22 at 2 00 01 PM" src="https://github.com/casillas2/deadline-cloud/assets/36546476/96043ed5-4ea0-43af-a4dd-f00c791a7095">

<img width="541" alt="Screenshot 2023-09-22 at 2 01 21 PM" src="https://github.com/casillas2/deadline-cloud/assets/36546476/5632c97e-5eb2-4b79-86b9-11dc303d68fd">


### Was this change documented?
N/A

### Is this a breaking change?
No, since the worker requirements tab is not enabled by default at the moment.