### PR TITLE
fix(job_attachment)!: Change osType and source_os names

### DIFF
--- a/src/deadline/client/cli/_groups/job_group.py
+++ b/src/deadline/client/cli/_groups/job_group.py
@@ -20,13 +20,12 @@ from deadline.job_attachments.download import OutputDownloader
 from deadline.job_attachments.models import (
     FileConflictResolution,
     JobAttachmentS3Settings,
-    OperatingSystemFamily,
 )
 from deadline.job_attachments.progress_tracker import (
     DownloadSummaryStatistics,
     ProgressReportMetadata,
 )
-from deadline.job_attachments._utils import _human_readable_file_size, _get_deadline_formatted_os
+from deadline.job_attachments._utils import _human_readable_file_size
 
 from ... import api
 from ...config import config_file
@@ -505,7 +504,7 @@ def _is_current_os_windows() -> bool:
     """
     Checks whether the current OS is Windows.
     """
-    return _get_deadline_formatted_os() == OperatingSystemFamily.WINDOWS.value
+    return sys.platform.startswith("win")
 
 
 def _is_path_in_windows_format(path_str: str) -> bool:

--- a/src/deadline/job_attachments/_aws/deadline.py
+++ b/src/deadline/job_attachments/_aws/deadline.py
@@ -16,6 +16,7 @@ from ..models import (
     JobAttachmentS3Settings,
     ManifestProperties,
     OperatingSystemFamily,
+    PathFormat,
     Queue,
     StorageProfile,
 )
@@ -89,7 +90,7 @@ def get_job(
                 ManifestProperties(
                     fileSystemLocationName=manifest_properties.get("fileSystemLocationName", None),
                     rootPath=manifest_properties["rootPath"],
-                    osType=OperatingSystemFamily(manifest_properties["osType"]),
+                    rootPathFormat=PathFormat(manifest_properties["rootPathFormat"]),
                     outputRelativeDirectories=manifest_properties["outputRelativeDirectories"],
                     inputManifestPath=manifest_properties.get("inputManifestPath", None),
                 )

--- a/src/deadline/job_attachments/_utils.py
+++ b/src/deadline/job_attachments/_utils.py
@@ -3,7 +3,6 @@
 import datetime
 import io
 import os
-import sys
 from hashlib import shake_256
 from pathlib import Path
 from typing import Optional, Tuple, Union
@@ -17,7 +16,6 @@ __all__ = [
     "_generate_random_guid",
     "_float_to_iso_datetime_string",
     "_human_readable_file_size",
-    "_get_deadline_formatted_os",
     "_get_unique_dest_dir_name",
     "_get_bucket_and_object_key",
     "_get_default_hash_cache_db_file_dir",
@@ -87,25 +85,6 @@ def _human_readable_file_size(size_in_bytes: int) -> str:
     # If we go higher than the provided postfix,
     # then return as a large amount of the highest postfix we've specified.
     return f"{rounded} {postfixes[-1]}"
-
-
-def _get_deadline_formatted_os() -> str:
-    """
-    Get a string specifying what the OS is, following the format the Deadline API expects.
-    """
-    # Avoiding circular imports here
-    from .models import OperatingSystemFamily
-
-    if sys.platform.startswith("linux"):
-        return OperatingSystemFamily.LINUX.value
-
-    if sys.platform.startswith("darwin"):
-        return OperatingSystemFamily.MACOS.value
-
-    if sys.platform.startswith("win"):
-        return OperatingSystemFamily.WINDOWS.value
-
-    return "Unknown"
 
 
 def _get_unique_dest_dir_name(source_root: str) -> str:

--- a/src/deadline/job_attachments/asset_sync.py
+++ b/src/deadline/job_attachments/asset_sync.py
@@ -333,7 +333,7 @@ class AssetSync:
                 dir_name: str = _get_unique_dest_dir_name(manifest_properties.rootPath)
                 local_root = str(session_dir.joinpath(dir_name))
                 pathmapping_rules[dir_name] = {
-                    "source_os": manifest_properties.osType.to_path_format(),
+                    "source_path_format": manifest_properties.rootPathFormat.value,
                     "source_path": manifest_properties.rootPath,
                     "destination_path": local_root,
                 }
@@ -461,7 +461,7 @@ class AssetSync:
                     local_root = session_dir.joinpath(dir_name)
 
                 output_files: List[OutputFile] = self._get_output_files(
-                    manifest_properties.osType.value,
+                    manifest_properties.rootPathFormat.value,
                     manifest_properties,
                     s3_settings,
                     local_root,

--- a/src/deadline/job_attachments/upload.py
+++ b/src/deadline/job_attachments/upload.py
@@ -45,7 +45,7 @@ from .models import (
     HashCacheEntry,
     JobAttachmentS3Settings,
     ManifestProperties,
-    OperatingSystemFamily,
+    PathFormat,
 )
 from .progress_tracker import (
     ProgressStatus,
@@ -53,7 +53,6 @@ from .progress_tracker import (
     SummaryStatistics,
 )
 from ._utils import (
-    _get_deadline_formatted_os,
     _hash_data,
     _hash_file,
     _is_relative_to,
@@ -866,7 +865,7 @@ class S3AssetManager:
             manifest_properties = ManifestProperties(
                 fileSystemLocationName=asset_root_manifest.file_system_location_name,
                 rootPath=asset_root_manifest.root_path,
-                osType=OperatingSystemFamily(_get_deadline_formatted_os()),
+                rootPathFormat=PathFormat.get_host_path_format(),
                 outputRelativeDirectories=output_rel_paths,
             )
 

--- a/test/integ/deadline_job_attachments/test_job_attachments.py
+++ b/test/integ/deadline_job_attachments/test_job_attachments.py
@@ -20,10 +20,13 @@ from deadline.job_attachments import asset_sync, download, upload
 from deadline.job_attachments.asset_manifests import ManifestVersion
 from deadline.job_attachments._aws.deadline import get_queue
 from deadline.job_attachments.exceptions import AssetSyncError, JobAttachmentsS3ClientError
-from deadline.job_attachments.models import Attachments, ManifestProperties, OperatingSystemFamily
+from deadline.job_attachments.models import (
+    Attachments,
+    ManifestProperties,
+    PathFormat,
+)
 from deadline.job_attachments.progress_tracker import SummaryStatistics
 from deadline.job_attachments._utils import (
-    _get_deadline_formatted_os,
     _get_unique_dest_dir_name,
     _hash_data,
     _hash_file,
@@ -1040,11 +1043,11 @@ def upload_input_files_no_input_paths(
     )
 
     # THEN
-    mock_submission_profile_name = _get_deadline_formatted_os()
+    mock_host_path_format_name = PathFormat.get_host_path_format_string()
     assert attachments.manifests == [
         ManifestProperties(
             rootPath=str(job_attachment_test.OUTPUT_PATH),
-            osType=OperatingSystemFamily(mock_submission_profile_name),
+            rootPathFormat=PathFormat(mock_host_path_format_name),
             outputRelativeDirectories=["."],
         )
     ]
@@ -1103,14 +1106,14 @@ def test_upload_input_files_no_download_paths(job_attachment_test: JobAttachment
     if manifests[0].asset_manifest is None:
         raise TypeError("Asset manifest must be set for this test.")
 
-    mock_submission_profile_name = _get_deadline_formatted_os()
+    mock_host_path_format_name = PathFormat.get_host_path_format_string()
     asset_root_hash = _hash_data(str(job_attachment_test.INPUT_PATH).encode())
     manifest_hash = _hash_data(bytes(manifests[0].asset_manifest.encode(), "utf-8"))
 
     assert len(attachments.manifests) == 1
     assert attachments.manifests[0].fileSystemLocationName is None
     assert attachments.manifests[0].rootPath == str(job_attachment_test.INPUT_PATH)
-    assert attachments.manifests[0].osType == OperatingSystemFamily(mock_submission_profile_name)
+    assert attachments.manifests[0].rootPathFormat == PathFormat(mock_host_path_format_name)
     assert attachments.manifests[0].outputRelativeDirectories == []
     assert attachments.manifests[0].inputManifestPath is not None
     assert attachments.manifests[0].inputManifestPath.startswith(

--- a/test/unit/deadline_client/api/test_job_bundle_submission.py
+++ b/test/unit/deadline_client/api/test_job_bundle_submission.py
@@ -20,7 +20,7 @@ from deadline.job_attachments.models import (
     AssetLoadingMethod,
     Attachments,
     ManifestProperties,
-    OperatingSystemFamily,
+    PathFormat,
 )
 from deadline.job_attachments.upload import S3AssetManager
 from deadline.job_attachments.progress_tracker import SummaryStatistics
@@ -596,7 +596,7 @@ def test_create_job_from_job_bundle_with_single_asset_file(
                 [
                     ManifestProperties(
                         rootPath="/mnt/root/path1",
-                        osType=OperatingSystemFamily.LINUX,
+                        rootPathFormat=PathFormat.POSIX,
                         inputManifestPath="mock-manifest",
                         inputManifestHash="mock-manifest-hash",
                         outputRelativeDirectories=["."],
@@ -659,7 +659,7 @@ def test_create_job_from_job_bundle_with_single_asset_file(
                 "manifests": [
                     {
                         "rootPath": "/mnt/root/path1",
-                        "osType": OperatingSystemFamily.LINUX,
+                        "rootPathFormat": PathFormat.POSIX,
                         "inputManifestPath": "mock-manifest",
                         "inputManifestHash": "mock-manifest-hash",
                         "outputRelativeDirectories": ["."],

--- a/test/unit/deadline_client/api/test_job_bundle_submission_asset_refs.py
+++ b/test/unit/deadline_client/api/test_job_bundle_submission_asset_refs.py
@@ -15,7 +15,7 @@ from deadline.job_attachments.models import (
     AssetLoadingMethod,
     AssetRootManifest,
     ManifestProperties,
-    OperatingSystemFamily,
+    PathFormat,
 )
 from deadline.job_attachments.upload import S3AssetManager
 from deadline.job_attachments.progress_tracker import SummaryStatistics
@@ -152,7 +152,7 @@ def test_create_job_from_job_bundle_with_all_asset_ref_variants(
                 [
                     ManifestProperties(
                         rootPath="/mnt/root/path1",
-                        osType=OperatingSystemFamily.LINUX,
+                        rootPathFormat=PathFormat.POSIX,
                         inputManifestPath="mock-manifest",
                         inputManifestHash="mock-manifest-hash",
                         outputRelativeDirectories=["."],
@@ -294,7 +294,7 @@ def test_create_job_from_job_bundle_with_all_asset_ref_variants(
                 "manifests": [
                     {
                         "rootPath": "/mnt/root/path1",
-                        "osType": OperatingSystemFamily.LINUX,
+                        "rootPathFormat": PathFormat.POSIX,
                         "inputManifestPath": "mock-manifest",
                         "inputManifestHash": "mock-manifest-hash",
                         "outputRelativeDirectories": ["."],

--- a/test/unit/deadline_client/cli/test_cli_handle_web_url.py
+++ b/test/unit/deadline_client/cli/test_cli_handle_web_url.py
@@ -23,9 +23,8 @@ from deadline.client.exceptions import DeadlineOperationError
 from deadline.job_attachments.models import (
     FileConflictResolution,
     JobAttachmentS3Settings,
-    OperatingSystemFamily,
+    PathFormat,
 )
-from deadline.job_attachments._utils import _get_deadline_formatted_os
 
 from ..api.test_job_bundle_submission import (
     MOCK_GET_QUEUE_RESPONSE,
@@ -252,7 +251,7 @@ def test_cli_handle_web_url_download_output_only_required_input(fresh_deadline_c
     ):
         mock_download = MagicMock()
         MockOutputDownloader.return_value.download_job_output = mock_download
-        mock_submission_profile_name = _get_deadline_formatted_os()
+        mock_host_path_format_name = PathFormat.get_host_path_format_string()
 
         boto3_client_mock().get_job.return_value = {
             "name": "Mock Job",
@@ -260,7 +259,7 @@ def test_cli_handle_web_url_download_output_only_required_input(fresh_deadline_c
                 "manifests": [
                     {
                         "rootPath": "/root/path",
-                        "osType": OperatingSystemFamily(mock_submission_profile_name),
+                        "rootPathFormat": PathFormat(mock_host_path_format_name),
                         "outputRelativeDirectories": ["."],
                     }
                 ],
@@ -302,7 +301,7 @@ def test_cli_handle_web_url_download_output_with_optional_input(fresh_deadline_c
     ):
         mock_download = MagicMock()
         MockOutputDownloader.return_value.download_job_output = mock_download
-        mock_submission_profile_name = _get_deadline_formatted_os()
+        mock_host_path_format_name = PathFormat.get_host_path_format_string()
 
         boto3_client_mock().get_job.return_value = {
             "name": "Mock Job",
@@ -310,7 +309,7 @@ def test_cli_handle_web_url_download_output_with_optional_input(fresh_deadline_c
                 "manifests": [
                     {
                         "rootPath": "/root/path",
-                        "osType": OperatingSystemFamily(mock_submission_profile_name),
+                        "rootPathFormat": PathFormat(mock_host_path_format_name),
                         "outputRelativeDirectories": ["."],
                     }
                 ],

--- a/test/unit/deadline_client/cli/test_cli_job.py
+++ b/test/unit/deadline_client/cli/test_cli_job.py
@@ -20,9 +20,8 @@ from deadline.client.cli._groups import job_group
 from deadline.job_attachments.models import (
     FileConflictResolution,
     JobAttachmentS3Settings,
-    OperatingSystemFamily,
+    PathFormat,
 )
-from deadline.job_attachments._utils import _get_deadline_formatted_os
 
 from ..api.test_job_bundle_submission import (
     MOCK_GET_QUEUE_RESPONSE,
@@ -302,7 +301,7 @@ def test_cli_job_download_output_stdout_with_only_required_input(
             },
         ]
 
-        mock_submission_profile_name = _get_deadline_formatted_os()
+        mock_host_path_format_name = PathFormat.get_host_path_format_string()
 
         boto3_client_mock().get_job.return_value = {
             "name": "Mock Job",
@@ -310,7 +309,7 @@ def test_cli_job_download_output_stdout_with_only_required_input(
                 "manifests": [
                     {
                         "rootPath": "/root/path",
-                        "osType": OperatingSystemFamily(mock_submission_profile_name),
+                        "rootPathFormat": PathFormat(mock_host_path_format_name),
                         "outputRelativeDirectories": ["."],
                     }
                 ],
@@ -393,7 +392,7 @@ def test_cli_job_dowuload_output_stdout_with_json_format(
             },
         ]
 
-        mock_submission_profile_name = _get_deadline_formatted_os()
+        mock_host_path_format_name = PathFormat.get_host_path_format_string()
 
         boto3_client_mock().get_job.return_value = {
             "name": "Mock Job",
@@ -401,7 +400,7 @@ def test_cli_job_dowuload_output_stdout_with_json_format(
                 "manifests": [
                     {
                         "rootPath": "/root/path",
-                        "osType": OperatingSystemFamily(mock_submission_profile_name),
+                        "rootPathFormat": PathFormat(mock_host_path_format_name),
                         "outputRelativeDirectories": ["."],
                     }
                 ],
@@ -457,7 +456,7 @@ def test_cli_job_download_output_handle_web_url_with_optional_input(fresh_deadli
     ):
         mock_download = MagicMock()
         MockOutputDownloader.return_value.download_job_output = mock_download
-        mock_submission_profile_name = _get_deadline_formatted_os()
+        mock_host_path_format_name = PathFormat.get_host_path_format_string()
 
         boto3_client_mock().get_job.return_value = {
             "name": "Mock Job",
@@ -465,7 +464,7 @@ def test_cli_job_download_output_handle_web_url_with_optional_input(fresh_deadli
                 "manifests": [
                     {
                         "rootPath": "/root/path",
-                        "osType": OperatingSystemFamily(mock_submission_profile_name),
+                        "rootPathFormat": PathFormat(mock_host_path_format_name),
                         "outputRelativeDirectories": ["."],
                     },
                 ],

--- a/test/unit/deadline_job_attachments/conftest.py
+++ b/test/unit/deadline_job_attachments/conftest.py
@@ -36,7 +36,7 @@ from deadline.job_attachments.models import (  # noqa: E402 isort:skip
     ManifestProperties,
     Job,
     JobAttachmentS3Settings,
-    OperatingSystemFamily,
+    PathFormat,
     Queue,
 )
 
@@ -113,7 +113,7 @@ def fixture_default_attachments(farm_id, queue_id):
         manifests=[
             ManifestProperties(
                 rootPath="/tmp",
-                osType=OperatingSystemFamily.LINUX,
+                rootPathFormat=PathFormat.POSIX,
                 inputManifestPath=f"assetRoot/Manifests/{farm_id}/{queue_id}/Inputs/0000/manifest_input.xxh128",
                 inputManifestHash="manifesthash",
                 outputRelativeDirectories=["test/outputs"],
@@ -131,7 +131,7 @@ def fixture_vfs_attachments():
         manifests=[
             ManifestProperties(
                 rootPath="/tmp",
-                osType=OperatingSystemFamily.LINUX,
+                rootPathFormat=PathFormat.POSIX,
                 inputManifestPath="manifest.json",
                 inputManifestHash="manifesthash",
                 outputRelativeDirectories=["test/outputs"],
@@ -150,7 +150,7 @@ def fixture_windows_attachments():
         manifests=[
             ManifestProperties(
                 rootPath=r"C:\Users\temp",
-                osType=OperatingSystemFamily.WINDOWS,
+                rootPathFormat=PathFormat.WINDOWS,
                 inputManifestPath="manifest.json",
                 inputManifestHash="manifesthash",
                 outputRelativeDirectories=["test/outputs"],
@@ -168,7 +168,7 @@ def fixture_attachments_no_required_assets():
         manifests=[
             ManifestProperties(
                 rootPath="/tmp",
-                osType=OperatingSystemFamily.LINUX,
+                rootPathFormat=PathFormat.POSIX,
                 outputRelativeDirectories=["test/outputs"],
             )
         ],

--- a/test/unit/deadline_job_attachments/test_asset_sync.py
+++ b/test/unit/deadline_job_attachments/test_asset_sync.py
@@ -24,7 +24,7 @@ from deadline.job_attachments.models import (
     Job,
     JobAttachmentS3Settings,
     ManifestProperties,
-    OperatingSystemFamily,
+    PathFormat,
     Queue,
 )
 from deadline.job_attachments.progress_tracker import (
@@ -162,14 +162,14 @@ class TestAssetSync:
             )
 
             # THEN
-            expected_source_os = (
-                "WINDOWS"
-                if default_job.attachments.manifests[0].osType == OperatingSystemFamily.WINDOWS
-                else "POSIX"
+            expected_source_path_format = (
+                "windows"
+                if default_job.attachments.manifests[0].rootPathFormat == PathFormat.WINDOWS
+                else "posix"
             )
             assert result_pathmap_rules == [
                 {
-                    "source_os": expected_source_os,
+                    "source_path_format": expected_source_path_format,
                     "source_path": default_job.attachments.manifests[0].rootPath,
                     "destination_path": local_root,
                 }
@@ -248,14 +248,14 @@ class TestAssetSync:
             )
 
             # THEN
-            expected_source_os = (
-                "WINDOWS"
-                if job.attachments.manifests[0].osType == OperatingSystemFamily.WINDOWS
-                else "POSIX"
+            expected_source_path_format = (
+                "windows"
+                if job.attachments.manifests[0].rootPathFormat == PathFormat.WINDOWS
+                else "posix"
             )
             assert result_pathmap_rules == [
                 {
-                    "source_os": expected_source_os,
+                    "source_path_format": expected_source_path_format,
                     "source_path": job.attachments.manifests[0].rootPath,
                     "destination_path": local_root,
                 }
@@ -317,14 +317,14 @@ class TestAssetSync:
             )
 
             # THEN
-            expected_source_os = (
-                "WINDOWS"
-                if default_job.attachments.manifests[0].osType == OperatingSystemFamily.WINDOWS
-                else "POSIX"
+            expected_source_path_format = (
+                "windows"
+                if default_job.attachments.manifests[0].rootPathFormat == PathFormat.WINDOWS
+                else "posix"
             )
             assert result_pathmap_rules == [
                 {
-                    "source_os": expected_source_os,
+                    "source_path_format": expected_source_path_format,
                     "source_path": default_job.attachments.manifests[0].rootPath,
                     "destination_path": local_root,
                 },
@@ -393,15 +393,15 @@ class TestAssetSync:
 
             # THEN
             merge_manifests_mock.assert_called()
-            expected_source_os = (
-                "WINDOWS"
-                if job.attachments.manifests[0].osType == OperatingSystemFamily.WINDOWS
-                else "POSIX"
+            expected_source_path_format = (
+                "windows"
+                if job.attachments.manifests[0].rootPathFormat == PathFormat.WINDOWS
+                else "posix"
             )
 
             assert result_pathmap_rules == [
                 {
-                    "source_os": expected_source_os,
+                    "source_path_format": expected_source_path_format,
                     "source_path": job.attachments.manifests[0].rootPath,
                     "destination_path": local_root,
                 },
@@ -650,7 +650,7 @@ class TestAssetSync:
             manifests=[
                 ManifestProperties(
                     rootPath="/tmp",
-                    osType=OperatingSystemFamily.LINUX,
+                    rootPathFormat=PathFormat.POSIX,
                     inputManifestPath="manifest_input.xxh128",
                     inputManifestHash="manifesthash",
                     outputRelativeDirectories=["test/outputs"],
@@ -658,7 +658,7 @@ class TestAssetSync:
                 ManifestProperties(
                     fileSystemLocationName="Movie 1",
                     rootPath="/home/user/movie1",
-                    osType=OperatingSystemFamily.LINUX,
+                    rootPathFormat=PathFormat.POSIX,
                     inputManifestPath="manifest-movie1_input.xxh128",
                     inputManifestHash="manifestmovie1hash",
                     outputRelativeDirectories=["test/outputs"],
@@ -704,7 +704,7 @@ class TestAssetSync:
             # THEN
             assert result_pathmap_rules == [
                 {
-                    "source_os": "POSIX",
+                    "source_path_format": "posix",
                     "source_path": default_job.attachments.manifests[0].rootPath,
                     "destination_path": local_root,
                 }
@@ -787,14 +787,14 @@ class TestAssetSync:
             )
 
             # THEN
-            expected_source_os = (
-                "WINDOWS"
-                if job.attachments.manifests[0].osType == OperatingSystemFamily.WINDOWS
-                else "POSIX"
+            expected_source_path_format = (
+                "windows"
+                if job.attachments.manifests[0].rootPathFormat == PathFormat.WINDOWS
+                else "posix"
             )
             assert result_pathmap_rules == [
                 {
-                    "source_os": expected_source_os,
+                    "source_path_format": expected_source_path_format,
                     "source_path": job.attachments.manifests[0].rootPath,
                     "destination_path": local_root,
                 }

--- a/test/unit/deadline_job_attachments/test_models.py
+++ b/test/unit/deadline_job_attachments/test_models.py
@@ -1,0 +1,19 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+from unittest.mock import patch
+
+from deadline.job_attachments.models import PathFormat
+
+import pytest
+
+
+class TestModels:
+    @pytest.mark.parametrize(
+        ("sys_os", "expected_output"),
+        [("win32", "windows"), ("darwin", "posix"), ("linux", "posix")],
+    )
+    def test_get_host_path_format_string(self, sys_os: str, expected_output: str):
+        """
+        Tests that the expected OS string is returned
+        """
+        with patch("sys.platform", sys_os):
+            assert PathFormat.get_host_path_format_string() == expected_output

--- a/test/unit/deadline_job_attachments/test_upload.py
+++ b/test/unit/deadline_job_attachments/test_upload.py
@@ -39,6 +39,7 @@ from deadline.job_attachments.models import (
     HashCacheEntry,
     JobAttachmentS3Settings,
     OperatingSystemFamily,
+    PathFormat,
     StorageProfile,
 )
 from deadline.job_attachments.progress_tracker import (
@@ -125,8 +126,8 @@ class TestUpload:
         )
 
         with patch(
-            f"{deadline.__package__}.job_attachments.upload._get_deadline_formatted_os",
-            return_value="linux",
+            f"{deadline.__package__}.job_attachments.upload.PathFormat.get_host_path_format",
+            return_value=PathFormat.POSIX,
         ), patch(
             f"{deadline.__package__}.job_attachments.upload._hash_data",
             side_effect=["e", "manifesthash"],
@@ -189,7 +190,7 @@ class TestUpload:
                 manifests=[
                     ManifestProperties(
                         rootPath=asset_root,
-                        osType=OperatingSystemFamily.LINUX,
+                        rootPathFormat=PathFormat.POSIX,
                         inputManifestPath=f"{farm_id}/{queue_id}/Inputs/0000/e_input.xxh128",
                         inputManifestHash="manifesthash",
                         outputRelativeDirectories=[
@@ -207,7 +208,7 @@ class TestUpload:
                 "manifests": [
                     {
                         "rootPath": f"{asset_root}",
-                        "osType": OperatingSystemFamily("linux").value,
+                        "rootPathFormat": PathFormat("posix").value,
                         "inputManifestPath": f"{farm_id}/{queue_id}/Inputs/0000/e_input.xxh128",
                         "inputManifestHash": "manifesthash",
                         "outputRelativeDirectories": [
@@ -352,13 +353,14 @@ class TestUpload:
                 manifests=[
                     ManifestProperties(
                         rootPath=root_c,
-                        osType=OperatingSystemFamily.WINDOWS,
+                        rootPathFormat=PathFormat.WINDOWS,
                         inputManifestPath=f"{farm_id}/{queue_id}/Inputs/0000/b_input.xxh128",
                         inputManifestHash="manifesthash",
                         outputRelativeDirectories=[],
                     ),
                     ManifestProperties(
                         rootPath=output_d,
+                        rootPathFormat=PathFormat.WINDOWS,
                         outputRelativeDirectories=["."],
                     ),
                 ],
@@ -371,13 +373,13 @@ class TestUpload:
                 "manifests": [
                     {
                         "rootPath": f"{root_c}",
-                        "osType": OperatingSystemFamily("windows").value,
+                        "rootPathFormat": PathFormat("windows").value,
                         "inputManifestPath": f"{farm_id}/{queue_id}/Inputs/0000/b_input.xxh128",
                         "inputManifestHash": "manifesthash",
                     },
                     {
                         "rootPath": f"{output_d}",
-                        "osType": OperatingSystemFamily("windows").value,
+                        "rootPathFormat": PathFormat("windows").value,
                         "outputRelativeDirectories": [
                             ".",
                         ],
@@ -466,8 +468,8 @@ class TestUpload:
         asset_root = str(tmpdir)
 
         with patch(
-            f"{deadline.__package__}.job_attachments.upload._get_deadline_formatted_os",
-            return_value="linux",
+            f"{deadline.__package__}.job_attachments.upload.PathFormat.get_host_path_format",
+            return_value=PathFormat.POSIX,
         ), patch(
             f"{deadline.__package__}.job_attachments.upload._hash_data",
             side_effect=["c", "manifesthash"],
@@ -523,7 +525,7 @@ class TestUpload:
                 manifests=[
                     ManifestProperties(
                         rootPath=asset_root,
-                        osType=OperatingSystemFamily.LINUX,
+                        rootPathFormat=PathFormat.POSIX,
                         inputManifestPath=f"{farm_id}/{queue_id}/Inputs/0000/c_input.xxh128",
                         inputManifestHash="manifesthash",
                         outputRelativeDirectories=["outputs"],
@@ -537,7 +539,7 @@ class TestUpload:
                 "manifests": [
                     {
                         "rootPath": f"{asset_root}",
-                        "osType": OperatingSystemFamily("linux").value,
+                        "rootPathFormat": PathFormat("posix").value,
                         "inputManifestPath": f"{farm_id}/{queue_id}/Inputs/0000/c_input.xxh128",
                         "inputManifestHash": "manifesthash",
                         "outputRelativeDirectories": ["outputs"],
@@ -621,8 +623,8 @@ class TestUpload:
 
         # Given
         with patch(
-            f"{deadline.__package__}.job_attachments.upload._get_deadline_formatted_os",
-            return_value="linux",
+            f"{deadline.__package__}.job_attachments.upload.PathFormat.get_host_path_format",
+            return_value=PathFormat.POSIX,
         ), patch(
             f"{deadline.__package__}.job_attachments.upload._hash_data",
             side_effect=["c", "manifesthash"],
@@ -730,14 +732,14 @@ class TestUpload:
 
         # Given
         with patch(
-            f"{deadline.__package__}.job_attachments.upload._get_deadline_formatted_os",
-            return_value="linux",
+            f"{deadline.__package__}.job_attachments.upload.PathFormat.get_host_path_format",
+            return_value=PathFormat.POSIX,
         ), patch(
             f"{deadline.__package__}.job_attachments.upload._hash_data",
             side_effect=["manifest", "manifesthash"],
         ), patch(
-            f"{deadline.__package__}.job_attachments.upload._get_deadline_formatted_os",
-            return_value="linux",
+            f"{deadline.__package__}.job_attachments.upload.PathFormat.get_host_path_format",
+            return_value=PathFormat.POSIX,
         ), patch(
             f"{deadline.__package__}.job_attachments.upload._hash_file", side_effect=mock_hash_file
         ), patch(
@@ -855,14 +857,14 @@ class TestUpload:
         """
         # Given
         with patch(
-            f"{deadline.__package__}.job_attachments.upload._get_deadline_formatted_os",
-            return_value="linux",
+            f"{deadline.__package__}.job_attachments.upload.PathFormat.get_host_path_format",
+            return_value=PathFormat.POSIX,
         ), patch(
             f"{deadline.__package__}.job_attachments.upload._hash_data",
             side_effect=["manifesto", "manifesthash"],
         ), patch(
-            f"{deadline.__package__}.job_attachments.upload._get_deadline_formatted_os",
-            return_value="linux",
+            f"{deadline.__package__}.job_attachments.upload.PathFormat.get_host_path_format",
+            return_value=PathFormat.POSIX,
         ), patch(
             f"{deadline.__package__}.job_attachments.upload._hash_file",
             side_effect=[str(i) for i in range(num_input_files)],
@@ -988,8 +990,8 @@ class TestUpload:
 
         # Given
         with patch(
-            f"{deadline.__package__}.job_attachments.upload._get_deadline_formatted_os",
-            return_value="linux",
+            f"{deadline.__package__}.job_attachments.upload.PathFormat.get_host_path_format",
+            return_value=PathFormat.POSIX,
         ), patch(
             f"{deadline.__package__}.job_attachments.upload._hash_data",
             side_effect=["a", "manifesthash"],
@@ -1031,7 +1033,7 @@ class TestUpload:
                 manifests=[
                     ManifestProperties(
                         rootPath=output_dir,
-                        osType=OperatingSystemFamily.LINUX,
+                        rootPathFormat=PathFormat.POSIX,
                         outputRelativeDirectories=["."],
                     )
                 ],
@@ -1043,7 +1045,7 @@ class TestUpload:
                 "manifests": [
                     {
                         "rootPath": f"{output_dir}",
-                        "osType": OperatingSystemFamily("linux").value,
+                        "rootPathFormat": PathFormat("posix").value,
                         "outputRelativeDirectories": ["."],
                     }
                 ],
@@ -1426,8 +1428,8 @@ class TestUpload:
         expected_total_input_bytes = scene_file.size()
 
         with patch(
-            f"{deadline.__package__}.job_attachments.upload._get_deadline_formatted_os",
-            return_value="linux",
+            f"{deadline.__package__}.job_attachments.upload.PathFormat.get_host_path_format",
+            return_value=PathFormat.POSIX,
         ), patch(
             f"{deadline.__package__}.job_attachments.upload._hash_data",
             side_effect=["c", "manifesthash"],
@@ -1543,8 +1545,8 @@ class TestUpload:
 
         # WHEN
         with patch(
-            f"{deadline.__package__}.job_attachments.upload._get_deadline_formatted_os",
-            return_value="linux",
+            f"{deadline.__package__}.job_attachments.upload.PathFormat.get_host_path_format",
+            return_value=PathFormat.POSIX,
         ), patch(
             f"{deadline.__package__}.job_attachments.upload._hash_data",
             side_effect=["manifest", "manifesthash"],
@@ -1586,7 +1588,7 @@ class TestUpload:
                 manifests=[
                     ManifestProperties(
                         rootPath=expected_root,
-                        osType=OperatingSystemFamily.LINUX,
+                        rootPathFormat=PathFormat.POSIX,
                         inputManifestPath=f"{farm_id}/{queue_id}/Inputs/0000/manifest_input.xxh128",
                         inputManifestHash="manifesthash",
                         outputRelativeDirectories=["sym_op_test_dir"],

--- a/test/unit/deadline_job_attachments/test_utils.py
+++ b/test/unit/deadline_job_attachments/test_utils.py
@@ -7,24 +7,12 @@ from unittest.mock import patch
 import pytest
 
 from deadline.job_attachments._utils import (
-    _get_deadline_formatted_os,
     _get_default_hash_cache_db_file_dir,
     _is_relative_to,
 )
 
 
 class TestUtils:
-    @pytest.mark.parametrize(
-        ("sys_os", "expected_output"),
-        [("win32", "windows"), ("darwin", "macos"), ("linux", "linux"), ("fakeos", "Unknown")],
-    )
-    def test_get_deadline_formatted_os(self, sys_os: str, expected_output: str):
-        """
-        Tests that the expected OS string is returned
-        """
-        with patch("sys.platform", sys_os):
-            assert _get_deadline_formatted_os() == expected_output
-
     def test_get_default_hash_cache_db_file_dir_env_var_path_exists(self, tmpdir):
         """
         Tests that when an environment variable exists, it uses that path for the hash cache


### PR DESCRIPTION
## ⚠️ Please use caution before merging, as it requires a preceding change to the backend service model. For more details, please contact @gahyusuh 🙏

### What was the problem/requirement? (What/Why)
The field `osType: OperatingSystemFamily` in job/attachments/manifests is currently being used just to determine how to handle the rootPath (i.e., is it 'posix' or 'windows',) in the API, so it follows more closely with the path mapping rules rather than storage profiles. The field `osType` in job attachment settings should be renamed to something else, to avoid inconsistencies around the usage of `osType`, `osFamily`, and whatever encapsulates 'windows' vs. 'posix' paths.

### What was the solution? (How)
- Renamed the field `osType: OperatingSystemFamily` -> `rootPathFormat: PathFormat`
- Changed the path mapping rules that are returned from the `sync_inputs` from `source_os` to `source_path_format`

### What is the impact of this change?
The field has a better/less-confusing name.

### How was this change tested?
- Ran unit tests: `hatch run lint && hatch run test`
- Ran integ tests: `hatch run integ:test`
- Ran docker-based tests: `hatch run test_docker`
- Run an end-to-end test (submitting a non-rendering job bundle --> running a CMF against my local backend)
  - ensuring that there were no issues/errors in the flow.
  - against locally deployed backend, which is (almost) up-to-date at this moment..
  - with the worker-agent changes (https://github.com/casillas2/deadline-cloud-worker-agent/pull/37)

### Was this change documented?
No.

### Is this a breaking change?
Yes!