### PR TITLE
refactor: Fix submitting jobs to queues with no job attachment settings

### DIFF
--- a/src/deadline/client/api/_submit_job_bundle.py
+++ b/src/deadline/client/api/_submit_job_bundle.py
@@ -123,8 +123,10 @@ def create_job_from_job_bundle(
         job_bundle_parameters, job_bundle_dir
     )
 
+    queue = deadline.get_queue(farmId=create_job_args["farmId"], queueId=create_job_args["queueId"])
+
     # Hash and upload job attachments if there are any
-    if asset_references:
+    if asset_references and "jobAttachmentSettings" in queue:
         # Extend input_filenames with all the files in the input_directories
         for directory in asset_references.input_directories:
             for root, _, files in os.walk(directory):
@@ -132,10 +134,6 @@ def create_job_from_job_bundle(
                     os.path.normpath(os.path.join(root, file)) for file in files
                 )
         asset_references.input_directories.clear()
-
-        queue = deadline.get_queue(
-            farmId=create_job_args["farmId"], queueId=create_job_args["queueId"]
-        )
 
         queue_role_session = api.get_queue_boto3_session(
             deadline=deadline,

--- a/src/deadline/client/cli/_groups/bundle_group.py
+++ b/src/deadline/client/cli/_groups/bundle_group.py
@@ -163,7 +163,7 @@ def bundle_submit(job_bundle_dir, asset_loading_method, parameter, yes, **args):
         )
 
         # Hash and upload job attachments if there are any
-        if asset_references:
+        if asset_references and "jobAttachmentSettings" in queue:
             # Extend input_filenames with all the files in the input_directories
             for directory in asset_references.input_directories:
                 for root, _, files in os.walk(directory):

--- a/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
@@ -333,12 +333,16 @@ class SubmitJobToDeadlineDialog(QDialog):
                 queue_display_name=queue["displayName"],
             )
 
-            asset_manager = S3AssetManager(
-                farm_id=farm_id,
-                queue_id=queue_id,
-                job_attachment_settings=JobAttachmentS3Settings(**queue["jobAttachmentSettings"]),
-                session=queue_role_session,
-            )
+            asset_manager: Optional[S3AssetManager] = None
+            if "jobAttachmentSettings" in queue:
+                asset_manager = S3AssetManager(
+                    farm_id=farm_id,
+                    queue_id=queue_id,
+                    job_attachment_settings=JobAttachmentS3Settings(
+                        **queue["jobAttachmentSettings"]
+                    ),
+                    session=queue_role_session,
+                )
 
             self.create_job_response = job_progress_dialog.start_submission(
                 farm_id,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

When writing a developer 'getting started' guide, I ran into an error
when running `deadline bundle submit ...` to a queue that had no
job attachment settings.

### What was the solution? (How)

- Whereever we run the job attachments flow, first check that the queue has jobAttachmentsSettings.

### What is the impact of this change?

The commands in the developer getting started guide work successfully.

### How was this change tested?

I've only tested the change to the function in `bundle_group.py`.

The other changes should work the same, but I haven't confirmed them yet.

### Was this change documented?

No

### Is this a breaking change?

No