### PR TITLE
fix!: Update get_queue_user_boto3_session to work with default creds

### DIFF
--- a/src/deadline/client/api/__init__.py
+++ b/src/deadline/client/api/__init__.py
@@ -18,7 +18,7 @@ __all__ = [
     "list_jobs",
     "list_fleets",
     "list_storage_profiles_for_queue",
-    "get_queue_boto3_session",
+    "get_queue_user_boto3_session",
     "get_queue_parameter_definitions",
     "get_telemetry_client",
 ]
@@ -31,7 +31,7 @@ from ._loginout import login, logout
 from ._session import (
     AwsCredentialsStatus,
     AwsCredentialsType,
-    get_queue_boto3_session,
+    get_queue_user_boto3_session,
     check_credentials_status,
     get_boto3_client,
     get_boto3_session,

--- a/src/deadline/client/api/_submit_job_bundle.py
+++ b/src/deadline/client/api/_submit_job_bundle.py
@@ -135,7 +135,7 @@ def create_job_from_job_bundle(
                 )
         asset_references.input_directories.clear()
 
-        queue_role_session = api.get_queue_boto3_session(
+        queue_role_session = api.get_queue_user_boto3_session(
             deadline=deadline,
             config=config,
             farm_id=create_job_args["farmId"],

--- a/src/deadline/client/cli/_groups/bundle_group.py
+++ b/src/deadline/client/cli/_groups/bundle_group.py
@@ -18,7 +18,7 @@ import click
 from botocore.exceptions import ClientError  # type: ignore[import]
 
 from deadline.client import api
-from deadline.client.api import get_boto3_client, get_queue_boto3_session
+from deadline.client.api import get_boto3_client, get_queue_user_boto3_session
 from deadline.client.api._session import _modified_logging_level
 from deadline.client.config import config_file, get_setting, set_setting
 from deadline.client.job_bundle.loader import read_yaml_or_json, read_yaml_or_json_object
@@ -172,7 +172,7 @@ def bundle_submit(job_bundle_dir, asset_loading_method, parameter, yes, **args):
                     )
             asset_references.input_directories.clear()
 
-            queue_role_session = get_queue_boto3_session(
+            queue_role_session = get_queue_user_boto3_session(
                 deadline=deadline,
                 config=config,
                 farm_id=farm_id,

--- a/src/deadline/client/cli/_groups/job_group.py
+++ b/src/deadline/client/cli/_groups/job_group.py
@@ -239,7 +239,7 @@ def _download_job_output(
 
     queue = deadline.get_queue(farmId=farm_id, queueId=queue_id)
 
-    queue_role_session = api.get_queue_boto3_session(
+    queue_role_session = api.get_queue_user_boto3_session(
         deadline=deadline,
         config=config,
         farm_id=farm_id,

--- a/src/deadline/client/config/config_file.py
+++ b/src/deadline/client/config/config_file.py
@@ -52,7 +52,7 @@ SETTINGS: Dict[str, Dict[str, Any]] = {
         "description": "The filesystem path to Deadline Cloud Monitor, set during login process.",
     },
     "defaults.aws_profile_name": {
-        "default": "",
+        "default": "(default)",
         "section_format": "profile-{}",
         "description": "The AWS profile name to use by default. Set to '' to use the default credentials."
         + " Other settings are saved with the profile.",

--- a/src/deadline/client/ui/dialogs/deadline_config_dialog.py
+++ b/src/deadline/client/ui/dialogs/deadline_config_dialog.py
@@ -371,10 +371,17 @@ class DeadlineWorkstationConfigWidget(QWidget):
         # if the configured profile does not exist.
         try:
             session = boto3.Session()
-            aws_profile_names = session._session.full_config["profiles"].keys()
+            aws_profile_names = [
+                "(default)",
+                *(
+                    name
+                    for name in session._session.full_config["profiles"].keys()
+                    if name != "default"
+                ),
+            ]
         except ProfileNotFound:
             logger.exception("Failed to create boto3.Session for AWS profile list")
-            aws_profile_names = f"{NOT_VALID_MARKER} <failed to retrieve AWS profile names>"
+            aws_profile_names = [f"{NOT_VALID_MARKER} <failed to retrieve AWS profile names>"]
 
         self.aws_profile_names = aws_profile_names
         with block_signals(self.aws_profiles_box):
@@ -402,7 +409,10 @@ class DeadlineWorkstationConfigWidget(QWidget):
             aws_profile_name = config_file.get_setting(
                 "defaults.aws_profile_name", config=self.config
             )
-            if aws_profile_name not in self.aws_profile_names:
+            # Change the values representing the default to the UI value representing the default
+            if aws_profile_name in ("(default)", "default", ""):
+                aws_profile_name = "(default)"
+            elif aws_profile_name not in self.aws_profile_names:
                 aws_profile_name = f"{NOT_VALID_MARKER} {aws_profile_name}"
             index = self.aws_profiles_box.findText(aws_profile_name, Qt.MatchFixedString)
             if index >= 0:

--- a/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
@@ -347,7 +347,7 @@ class SubmitJobToDeadlineDialog(QDialog):
 
             queue = deadline.get_queue(farmId=farm_id, queueId=queue_id)
 
-            queue_role_session = api.get_queue_boto3_session(
+            queue_role_session = api.get_queue_user_boto3_session(
                 deadline=deadline,
                 farm_id=farm_id,
                 queue_id=queue_id,

--- a/test/unit/deadline_client/api/test_job_bundle_submission.py
+++ b/test/unit/deadline_client/api/test_job_bundle_submission.py
@@ -432,7 +432,9 @@ def test_create_job_from_job_bundle_job_attachments(
     # Use a temporary directory for the job bundle
     with patch.object(_submit_job_bundle.api, "get_boto3_session"), patch.object(
         _submit_job_bundle.api, "get_boto3_client"
-    ) as client_mock, patch.object(_submit_job_bundle.api, "get_queue_boto3_session"), patch.object(
+    ) as client_mock, patch.object(
+        _submit_job_bundle.api, "get_queue_user_boto3_session"
+    ), patch.object(
         api._submit_job_bundle, "_hash_attachments"
     ) as mock_hash_attachments, patch.object(
         S3AssetManager, "upload_assets"
@@ -580,7 +582,9 @@ def test_create_job_from_job_bundle_with_single_asset_file(
     # Use a temporary directory for the job bundle
     with patch.object(_submit_job_bundle.api, "get_boto3_session"), patch.object(
         _submit_job_bundle.api, "get_boto3_client"
-    ) as client_mock, patch.object(_submit_job_bundle.api, "get_queue_boto3_session"), patch.object(
+    ) as client_mock, patch.object(
+        _submit_job_bundle.api, "get_queue_user_boto3_session"
+    ), patch.object(
         api._submit_job_bundle, "_hash_attachments"
     ) as mock_hash_attachments, patch.object(
         S3AssetManager, "upload_assets"

--- a/test/unit/deadline_client/api/test_job_bundle_submission_asset_refs.py
+++ b/test/unit/deadline_client/api/test_job_bundle_submission_asset_refs.py
@@ -135,7 +135,9 @@ def test_create_job_from_job_bundle_with_all_asset_ref_variants(
     # Use a temporary directory for the job bundle
     with patch.object(_submit_job_bundle.api, "get_boto3_session"), patch.object(
         _submit_job_bundle.api, "get_boto3_client"
-    ) as client_mock, patch.object(_submit_job_bundle.api, "get_queue_boto3_session"), patch.object(
+    ) as client_mock, patch.object(
+        _submit_job_bundle.api, "get_queue_user_boto3_session"
+    ), patch.object(
         S3AssetManager, "hash_assets_and_create_manifest"
     ) as mock_hash_assets, patch.object(
         S3AssetManager, "upload_assets"

--- a/test/unit/deadline_client/cli/test_cli_bundle.py
+++ b/test/unit/deadline_client/cli/test_cli_bundle.py
@@ -114,7 +114,7 @@ def test_cli_bundle_submit(fresh_deadline_config, temp_job_bundle_dir):
     ) as qp_boto3_client_mock, patch.object(
         bundle_group, "_hash_attachments", return_value=[]
     ), patch.object(
-        bundle_group, "get_queue_boto3_session"
+        bundle_group, "get_queue_user_boto3_session"
     ), patch.object(
         bundle_group, "_upload_attachments"
     ), patch.object(
@@ -247,7 +247,7 @@ def test_cli_bundle_asset_load_method(fresh_deadline_config, temp_job_bundle_dir
     ), patch.object(
         bundle_group.api, "get_boto3_session"
     ), patch.object(
-        bundle_group, "get_queue_boto3_session"
+        bundle_group, "get_queue_user_boto3_session"
     ), patch.object(
         bundle_group.api, "get_telemetry_client"
     ):
@@ -412,7 +412,9 @@ def test_cli_bundle_accept_upload_confirmation(fresh_deadline_config, temp_job_b
     ), patch.object(bundle_group, "_upload_attachments"), patch.object(
         bundle_group.api, "get_boto3_session"
     ), patch.object(
-        bundle_group, "get_queue_boto3_session"
+        bundle_group.api, "get_queue_parameter_definitions", return_value=[]
+    ), patch.object(
+        bundle_group, "get_queue_user_boto3_session"
     ), patch.object(
         bundle_group.api, "get_telemetry_client"
     ):
@@ -485,7 +487,7 @@ def test_cli_bundle_reject_upload_confirmation(fresh_deadline_config, temp_job_b
     ) as upload_attachments_mock, patch.object(
         bundle_group.api, "get_boto3_session"
     ), patch.object(
-        bundle_group, "get_queue_boto3_session"
+        bundle_group, "get_queue_user_boto3_session"
     ), patch.object(
         bundle_group.api, "get_telemetry_client"
     ):

--- a/test/unit/deadline_client/cli/test_cli_handle_web_url.py
+++ b/test/unit/deadline_client/cli/test_cli_handle_web_url.py
@@ -247,7 +247,7 @@ def test_cli_handle_web_url_download_output_only_required_input(fresh_deadline_c
     with patch.object(api, "get_boto3_client") as boto3_client_mock, patch.object(
         job_group, "OutputDownloader"
     ) as MockOutputDownloader, patch.object(job_group, "round", return_value=0), patch.object(
-        api, "get_queue_boto3_session"
+        api, "get_queue_user_boto3_session"
     ):
         mock_download = MagicMock()
         MockOutputDownloader.return_value.download_job_output = mock_download
@@ -297,7 +297,7 @@ def test_cli_handle_web_url_download_output_with_optional_input(fresh_deadline_c
     with patch.object(api, "get_boto3_client") as boto3_client_mock, patch.object(
         job_group, "OutputDownloader"
     ) as MockOutputDownloader, patch.object(job_group, "round", return_value=0), patch.object(
-        api, "get_queue_boto3_session"
+        api, "get_queue_user_boto3_session"
     ):
         mock_download = MagicMock()
         MockOutputDownloader.return_value.download_job_output = mock_download

--- a/test/unit/deadline_client/cli/test_cli_job.py
+++ b/test/unit/deadline_client/cli/test_cli_job.py
@@ -280,7 +280,7 @@ def test_cli_job_download_output_stdout_with_only_required_input(
     ), patch.object(
         job_group, "round", return_value=0
     ), patch.object(
-        api, "get_queue_boto3_session"
+        api, "get_queue_user_boto3_session"
     ):
         mock_download = MagicMock()
         MockOutputDownloader.return_value.download_job_output = mock_download
@@ -371,7 +371,7 @@ def test_cli_job_dowuload_output_stdout_with_json_format(
     ), patch.object(
         job_group, "_assert_valid_path", return_value=None
     ), patch.object(
-        api, "get_queue_boto3_session"
+        api, "get_queue_user_boto3_session"
     ):
         mock_download = MagicMock()
         MockOutputDownloader.return_value.download_job_output = mock_download
@@ -452,7 +452,7 @@ def test_cli_job_download_output_handle_web_url_with_optional_input(fresh_deadli
     with patch.object(api, "get_boto3_client") as boto3_client_mock, patch.object(
         job_group, "OutputDownloader"
     ) as MockOutputDownloader, patch.object(job_group, "round", return_value=0), patch.object(
-        api, "get_queue_boto3_session"
+        api, "get_queue_user_boto3_session"
     ):
         mock_download = MagicMock()
         MockOutputDownloader.return_value.download_job_output = mock_download

--- a/test/unit/deadline_client/config/test_config_file.py
+++ b/test/unit/deadline_client/config/test_config_file.py
@@ -19,7 +19,7 @@ from deadline.client.exceptions import DeadlineOperationError
 
 # This is imported by `test_cli_config.py` for a matching CLI test
 CONFIG_SETTING_ROUND_TRIP = [
-    ("defaults.aws_profile_name", "", "AnotherProfileName"),
+    ("defaults.aws_profile_name", "(default)", "AnotherProfileName"),
     (
         "settings.deadline_endpoint_url",
         DEFAULT_DEADLINE_ENDPOINT_URL,
@@ -61,7 +61,7 @@ def test_config_settings_hierarchy(fresh_deadline_config):
     assert config.get_setting("settings.storage_profile_id") == ""
 
     # Switch back to the default profile, and check the next layer of the onion
-    config.set_setting("defaults.aws_profile_name", "")
+    config.set_setting("defaults.aws_profile_name", "(default)")
     assert config.get_setting("settings.deadline_endpoint_url") == "nondefault-endpoint-url"
     assert config.get_setting("defaults.farm_id") == "farm-for-profile-default"
     # The queue id is still default
@@ -136,7 +136,7 @@ def test_config_file_env_var(fresh_deadline_config):
         os.environ["DEADLINE_CONFIG_FILE_PATH"] = alternate_deadline_config_file
 
         # Confirm that we see the default settings again
-        assert config.get_setting("defaults.aws_profile_name") == ""
+        assert config.get_setting("defaults.aws_profile_name") == "(default)"
 
         # Change the settings in this new file
         config.set_setting("defaults.aws_profile_name", "AlternateProfileName")


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

While writing the developer guide's getting started section, I found that downloading
job attachments did not work within cloudshell. The reason for that was related to
the default credentials.

### What was the solution? (How)

- Update get_queue_user_boto3_session to work with default creds
- Also noticed that the name `get_queue_boto3_session` was ambiguous, so clarified this name by changing it to `get_queue_user_boto3_session`.
- Change the default for the aws_profile_name to "(default)" as a more obvious name for the default credentials, matching error messages that e.g. the AWS CLI produces about this.
- Added a unit test confirming the correct value going to boto3.Session
- Update the config dialog to work properly with the default profile configuration, showing it as "(default)"

### What is the impact of this change?

Developers will be able to successfully run everything in the developer guide getting started section.

### How was this change tested?

Added unit test for this. Manually verified it works from the CLI on an actual farm as well, including from the GUI.

### Was this change documented?

No

### Is this a breaking change?

Yes, I also fixed some API names that were ambiguous.
