### PR TITLE
fix: improve error message for unsupported manifest versions

### DIFF
--- a/src/deadline/job_attachments/asset_manifests/decode.py
+++ b/src/deadline/job_attachments/asset_manifests/decode.py
@@ -49,8 +49,12 @@ def decode_manifest(manifest: str) -> BaseAssetManifest:
         version = ManifestVersion(document["manifestVersion"])
     except ValueError:
         # Value of the manifest version is not one we know.
+        supported_versions = ", ".join(
+            [v.value for v in ManifestVersion if v != ManifestVersion.UNDEFINED]
+        )
         raise ManifestDecodeValidationError(
-            f"Unknown manifest version: {document['manifestVersion']}"
+            f"Unknown manifest version: {document['manifestVersion']} "
+            f"(Currently supported Manifest versions: {supported_versions})"
         )
     except KeyError:
         raise ManifestDecodeValidationError(


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
When Job Attachments library tries to decode a manifest but gets an unsupported manifest version, the current error message does not provide clear info about what the actual supported versions are.

### What was the solution? (How)
We need to make the error messages very clear. Improved the error message to include a list of currently supported versions.

### What is the impact of this change?
Makes the error message more informative, aiding in quicker issue resolution.

### How was this change tested?
- Added a new unit test, and ran: `hatch run lint && hatch run test`
- Ran integ tests: `hatch run integ:test`

### Was this change documented?
No.

### Is this a breaking change?
No.