### PR TITLE
fix: add input validation for job bundle history dir

### DIFF
--- a/src/deadline/client/job_bundle/__init__.py
+++ b/src/deadline/client/job_bundle/__init__.py
@@ -29,6 +29,11 @@ def create_job_history_bundle_dir(submitter_name: str, job_name: str) -> str:
     job_history_dir = str(get_setting("settings.job_history_dir"))
     job_history_dir = os.path.expanduser(job_history_dir)
 
+    # Clean the submitter_name's characters
+    submitter_name_cleaned = "".join(
+        char for char in submitter_name if char.isalnum() or char in " -_"
+    )
+
     # Clean the job_name's characters and truncate for the filename
     job_name_cleaned = "".join(char for char in job_name if char.isalnum() or char in " -_")
     job_name_cleaned = job_name_cleaned[:128]
@@ -48,6 +53,8 @@ def create_job_history_bundle_dir(submitter_name: str, job_name: str) -> str:
         latest_dir = existing_dirs[-1]
         number = int(os.path.basename(latest_dir)[len(date_tag) + 1 :].split("-", 1)[0]) + 1
 
-    result = os.path.join(month_dir, f"{date_tag}-{number:02}-{submitter_name}-{job_name_cleaned}")
+    result = os.path.join(
+        month_dir, f"{date_tag}-{number:02}-{submitter_name_cleaned}-{job_name_cleaned}"
+    )
     os.makedirs(result)
     return result


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
There was no input validation being done on the submitter_name that is passed to create the job bundle history directory.
### What was the solution? (How)
Added the same sanitization rules as applied to the job_name. The submitter_name will be stripped of any characters that are not alphanumeric or ' ', '-', '_'.
### What is the impact of this change?
No visible impact

### How was this change tested?
Created and ran new unit tests along with the existing unit tests.
Loaded up the dev gui, modified the submitter_name setting, exported the job bundle and verified that the sanitization was working.
### Was this change documented?
No
### Is this a breaking change?
No