### PR TITLE
feat: Submit bundle with host requirements from UI inputs

### DIFF
--- a/src/deadline/client/cli/_deadline_web_url.py
+++ b/src/deadline/client/cli/_deadline_web_url.py
@@ -3,7 +3,7 @@
 import os
 import re
 import sys
-import urllib
+import urllib.parse
 from logging import getLogger
 from typing import Any, Dict, List
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Customer specified inputs on the Host Requirements UI Tab need to be included in the job submission.

### What was the solution? (How)

Inputs from the Host Requirements UI are converted into required openjd capabilities format. The generated dict can be used by each submitter to append host requirements into job bundle templates.

### What is the impact of this change?

This PR does not enable Host Requirements UI for any of the submitters, so no changes should be observed by user. 

### How was this change tested?
Tested by turning `show_host_requirements_tab=True` for Job Bundle Submitter, and added the below to `on_create_job_bundle_callback`:
```
        # If "HostRequirements" is provided, inject it into each of the "Step"
        if host_requirements:
            # for each step in the template, append the same host requirements.
            for step in template["steps"]:
                step["hostRequirements"] = copy.deepcopy(host_requirements)
```
(The above change is not included in the PR since Job Bundle Submitter normally would not show a Host Requirements Tab, but DCC submitters are expected to implement something similar after turning on host_requirements_tab)

On `deadline bundle gui-submit` and exporting the bundle, verified that the generated history template has host requirements appended for each step, such as:
```steps:
- name: Wide1
  parameterSpace:
    taskParameterDefinitions:
    - name: W
      type: INT
      range: '{{Param.WideTaskIndex}}'
  script:
    actions:
      onRun:
        command: '{{ Task.File.run }}'
    embeddedFiles:
    - name: run
      runnable: true
      type: TEXT
      data: |
        #!/bin/env bash

        set -euo pipefail

        RandomSleep {{Param.WideSleepMean}} {{Param.WideSleepStdDev}}
        echo Task Wide1 Done!
  hostRequirements:
    attributes:
    - name: attr.worker.os.family
      anyOf:
      - linux
    - name: attr.worker.cpu.arch
      anyOf:
      - x86_64
    amounts:
    - name: amount.worker.vcpu
      min: 0
      max: 100
    - name: amount.worker.memory
      min: 1
      max: 200
    - name: amount.worker.gpu
      min: 11
    - name: amount.worker.gpu.memory
      max: 100
    - name: amount.worker.disk.scratch
      min: 3
```

### Was this change documented?
yes

### Is this a breaking change?
no