### PR TITLE
fix(job-attachments): Update example scripts in deadline-cloud/examples

### DIFF
--- a/examples/download_cancel_test.py
+++ b/examples/download_cancel_test.py
@@ -13,14 +13,15 @@ from deadline.job_attachments.download import OutputDownloader
 from deadline.job_attachments.exceptions import AssetSyncCancelledError
 
 """
-A testing script to simulate cancellation of (1) syncing inputs, and (2) downloading outputs.
+A testing script to simulate cancellation of (1) syncing inputs, or (2) downloading outputs.
 
 How to test:
+
 1. Run the script with the following command for each test:
   (1) To test canceling syncing inputs, run the following command:
-      $ python3 download_cancel_test.py sync_inputs -f <farm_id> -q <queue_id> -j <job_id>
+      python3 download_cancel_test.py sync_inputs -f <farm_id> -q <queue_id> -j <job_id>
   (2) To test canceling downloading outputs, run the following command:
-      $ python3 download_cancel_test.py download_outputs -f <farm_id> -q <queue_id> -j <job_id>
+      python3 download_cancel_test.py download_outputs -f <farm_id> -q <queue_id> -j <job_id>
 2. In the middle of downloading files, you can send a cencel signal by pressing 'k' key
    and then pressing 'Enter' key in succession. Confirm that cancelling is working as expected.
 """
@@ -79,13 +80,13 @@ def test_sync_inputs(
         job = get_job(farm_id=farm_id, queue_id=queue_id, job_id=job_id)
 
         print("Starting test to sync inputs...")
-        asset_sync = AssetSync()
+        asset_sync = AssetSync(farm_id=farm_id)
 
         try:
             download_start = time.perf_counter()
             (summary_statistics, local_roots) = asset_sync.sync_inputs(
                 s3_settings=queue.jobAttachmentSettings,
-                ja_settings=job.attachmentSettings,
+                attachments=job.attachments,
                 queue_id=queue_id,
                 job_id=job_id,
                 session_dir=pathlib.Path(temp_root_dir),
@@ -125,6 +126,8 @@ def test_download_outputs(
         download_start = time.perf_counter()
         output_downloader = OutputDownloader(
             s3_settings=queue.jobAttachmentSettings,
+            farm_id=farm_id,
+            queue_id=queue_id,
             job_id=job_id,
         )
         summary_statistics = output_downloader.download_job_output(

--- a/examples/download_output.py
+++ b/examples/download_output.py
@@ -2,7 +2,6 @@
 
 #! /usr/bin/env python3
 import argparse
-import pathlib
 import sys
 import time
 
@@ -16,7 +15,7 @@ include the Job, Step, and Task ID to get the outputs for a specific Task.
 
 Example usage:
 
-python download_output.py -f $FARM_ID -q $QUEUE_ID -j $JOB_ID -d /path/to/download/to
+python download_output.py -f $FARM_ID -q $QUEUE_ID -j $JOB_ID
 """
 
 if __name__ == "__main__":
@@ -41,9 +40,6 @@ if __name__ == "__main__":
         type=str,
         help="Optional. Deadline Task you want outputs of. If specifying, must include Step ID.",
     )
-    parser.add_argument(
-        "-d", "--download-dir", type=str, help="Where files will be downloaded to.", required=True
-    )
     args = parser.parse_args()
 
     farm_id = args.farm_id
@@ -56,18 +52,18 @@ if __name__ == "__main__":
         print("Must specify Step ID when including Task ID! Stopping.")
         sys.exit()
 
-    down_dir = pathlib.Path(args.download_dir)
-    if not down_dir.is_dir():
-        print("Download directory given is not a directory! Stopping.")
-        sys.exit()
-
     print("\nGetting queue settings...")
     settings = get_queue(farm_id, queue_id).jobAttachmentSettings
 
     print("\nStarting download...")
     start = time.perf_counter()
     output_downloader = OutputDownloader(
-        s3_settings=settings, job_id=job_id, step_id=step_id, task_id=task_id
+        s3_settings=settings,
+        farm_id=farm_id,
+        queue_id=queue_id,
+        job_id=job_id,
+        step_id=step_id,
+        task_id=task_id,
     )
     output_downloader.download_job_output()
     total = time.perf_counter() - start

--- a/examples/submit_job.py
+++ b/examples/submit_job.py
@@ -2,14 +2,6 @@
 
 #! /usr/bin/env python3
 
-"""
-This is a sample script that illustrates how to submit a custom job using
-the job attachments library.
-
-Example usage:
-python submit_job.py -f $FARM_ID -q $QUEUE_ID -r /tmp/asset_root -i /tmp/asset_root/inputs -o /tmp/asset_root/outputs
-"""
-
 import argparse
 import pprint
 import time
@@ -19,6 +11,16 @@ import boto3
 
 from deadline.job_attachments.upload import S3AssetManager
 from deadline.job_attachments.models import JobAttachmentS3Settings
+
+"""
+This is a sample script that illustrates how to submit a custom job using the
+Job Attachments library. Please make sure to specify `endpoint_url` to the target
+endpoint you want to test, when creating a (boto3) service client for deadline.
+
+Example usage:
+
+python submit_job.py -f $FARM_ID -q $QUEUE_ID -i /tmp/asset_root/inputs -o /tmp/asset_root/outputs
+"""
 
 
 def process_job_attachments(farm_id, queue_id, inputs, outputDir, deadline_client):
@@ -50,12 +52,12 @@ def process_job_attachments(farm_id, queue_id, inputs, outputDir, deadline_clien
     return attachments
 
 
-JOB_TEMPLATE = """specificationVersion: '2022-09-01'
+JOB_TEMPLATE = """specificationVersion: 'jobtemplate-2023-09'
 name: SubmitJobExample
 description: >
     A Job that counts the number of files and total size,
     and also creates a default output file.
-parameters:
+parameterDefinitions:
   - name: DataDir
     type: PATH
     objectType: DIRECTORY
@@ -165,7 +167,7 @@ if __name__ == "__main__":
     deadline_client = boto3.client(
         "deadline",
         region_name="us-west-2",
-        endpoint_url="https://gamma.us-west-2.bealine.creative-tools.aws.dev",
+        endpoint_url="https://management.gamma.bealine-dev.us-west-2.amazonaws.com",
     )
 
     attachments = process_job_attachments(

--- a/src/deadline/job_attachments/_aws/deadline.py
+++ b/src/deadline/job_attachments/_aws/deadline.py
@@ -91,7 +91,9 @@ def get_job(
                     fileSystemLocationName=manifest_properties.get("fileSystemLocationName", None),
                     rootPath=manifest_properties["rootPath"],
                     rootPathFormat=PathFormat(manifest_properties["rootPathFormat"]),
-                    outputRelativeDirectories=manifest_properties["outputRelativeDirectories"],
+                    outputRelativeDirectories=manifest_properties.get(
+                        "outputRelativeDirectories", None
+                    ),
                     inputManifestPath=manifest_properties.get("inputManifestPath", None),
                 )
                 for manifest_properties in response["attachments"]["manifests"]


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
In the last few months, a lot of changes have been made to our backend services, but our examples scripts in [deadline-cloud/examples](https://github.com/casillas2/deadline-cloud/tree/mainline/examples), which are for manual testing for the Job Attachments library, has not been updated accordingly.

### What was the solution? (How)
The example scripts are updated to ensure they function properly with these recent backend changes.

### What is the impact of this change?
We can use those example scripts to do some manual upload/download tests.

### How was this change tested?
- Ran unit tests: `hatch run lint && hatch run test`
- Ran integration tests: `hatch run integ:test`
- Ran each script individually, and confirmed that they all ran without any issues.

### Was this change documented?
No.

### Is this a breaking change?
No.