### PR TITLE
fix: Add back deadline cli overide for pyinstaller

### DIFF
--- a/src/deadline/client/cli/deadline_cli_main.py
+++ b/src/deadline/client/cli/deadline_cli_main.py
@@ -1,0 +1,19 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Runs the Deadline CLI. Can be run as a python script file.
+Required by pyinstaller, do not delete.
+"""
+
+
+def main() -> None:
+    from deadline.client.cli._deadline_cli import main
+
+    main(
+        # Override the program name to always be "deadline"
+        prog_name="deadline",
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Submitters are failing to build because deadline_cli_main.py was removed. This was in place because pyinstaller exe cannot be the same name as the module name.

```
script '/codebuild/output/src1825354300/src/git-codecommit.us-west-2.amazonaws.com/v1/repos/deadline-cloud/src/deadline/client/cli/deadline_cli_main.py' not found
```

### What was the solution? (How)
Add `deadline_cli_main.py` back

### What is the impact of this change?
Fixing pyinstaller build

### How was this change tested?
```
hatch run lint
hatch run test
hatch run installer:make_exe
./deadline --help
```

### Was this change documented?
No

### Is this a breaking change?
No