### PR TITLE
fix: When writing to a config file, set file permissions such that only the writing user has access

### DIFF
--- a/test/unit/deadline_client/conftest.py
+++ b/test/unit/deadline_client/conftest.py
@@ -4,9 +4,9 @@
 Common fixtures for Deadline Client Library tests.
 """
 
-import os
 import tempfile
 from unittest.mock import patch
+from pathlib import Path
 
 import pytest
 
@@ -21,17 +21,18 @@ def fresh_deadline_config():
 
     try:
         # Create an empty temp file to set as the Amazon Deadline Cloud config
-        with tempfile.NamedTemporaryFile(
-            mode="w+t", suffix="", encoding="utf8", delete=False
-        ) as temp:
-            temp.write("")
+        temp_dir = tempfile.TemporaryDirectory()
+        temp_dir_path = Path(temp_dir.name)
+        temp_file_path = temp_dir_path / "config"
+        with open(temp_file_path, "w+t", encoding="utf8") as temp_file:
+            temp_file.write("")
 
         # Yield the temp file name with it patched in as the
         # Amazon Deadline Cloud config file
-        with patch.object(config_file, "CONFIG_FILE_PATH", temp.name):
-            yield temp.name
+        with patch.object(config_file, "CONFIG_FILE_PATH", str(temp_file_path)):
+            yield str(temp_file_path)
     finally:
-        os.remove(temp.name)
+        temp_dir.cleanup()
 
 
 @pytest.fixture(scope="function")

--- a/test/unit/deadline_job_attachments/test_download.py
+++ b/test/unit/deadline_job_attachments/test_download.py
@@ -1902,4 +1902,4 @@ def test_download_files_from_manifests(
             on_downloading_files=on_downloading_files,
         )
 
-    assert downloaded_files == ["a.txt", "b.txt", "c.txt", "d.txt"]
+    assert sorted(downloaded_files) == ["a.txt", "b.txt", "c.txt", "d.txt"]


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

When writing the config file, permissions were not explicitly being set, so had the potential to be overly broad.

### What was the solution? (How)

In Windows, by default, files inherit permissions from their parent directory. In this case, the config file gets written to the .deadline directory, so just setting the parent directory's permissions such that only the current user has access to the .deadline directory before we write the config file is a reliable solution. We use the `icacls` command to strip off all existing permissions from that directory and they add the correct ones.

On other operating systems where we have Unix file permissions, files default to having permissions of the creating users umask. We set the user's umask to zero before writing to the file, and then when writing the file we explicitly set `0o600` as the permissions.

Since the config file is completely overwritten on write, we take the extra precaution of deleting the old config file before writing the new one.

### What is the impact of this change?

Deadline client config files now have the correct permissions when they are written.

### How was this change tested?

On each Windows and Linux I set my .deadline/config file to have overly permissive permissions (`0o777` on Linux, and gave another user write permissions on Windows). I then ran:

```py
from deadline.client.config import config_file
config_file.set_setting("telemetry.identifier", "test")
```

I then inspected the config files and noted that they now had correct permissions (`0o600` on Linux, and only myself having access to the file on Windows).

Additionally:

```sh
hatch build
hatch run lint
hatch run test
```

### Was this change documented?

No

### Is this a breaking change?

No