### PR TITLE
fix(Fus3): Adding default Fus3 install path if it's not accessible

### DIFF
--- a/src/deadline/job_attachments/exceptions.py
+++ b/src/deadline/job_attachments/exceptions.py
@@ -119,6 +119,12 @@ class Fus3ExecutableMissingError(JobAttachmentsError):
     """
 
 
+class Fus3LaunchScriptMissingError(JobAttachmentsError):
+    """
+    Exception for when trying to retrieve Fus3 launch script path doesn't exist.
+    """
+
+
 class Fus3FailedToMountError(JobAttachmentsError):
     """
     Exception for when trying to mount Fus3 at a given path.

--- a/src/deadline/job_attachments/fus3.py
+++ b/src/deadline/job_attachments/fus3.py
@@ -11,7 +11,11 @@ import threading
 from signal import SIGTERM
 from typing import List, Union, Optional
 
-from .exceptions import Fus3ExecutableMissingError, Fus3FailedToMountError
+from .exceptions import (
+    Fus3ExecutableMissingError,
+    Fus3FailedToMountError,
+    Fus3LaunchScriptMissingError,
+)
 
 log = logging.getLogger(__name__)
 
@@ -192,7 +196,7 @@ class Fus3ProcessManager(object):
             found_path = environ_check
         else:
             log.error("Failed to find fus3 launch script!")
-            raise Fus3ExecutableMissingError
+            raise Fus3LaunchScriptMissingError
         Fus3ProcessManager.fus3_script_path = found_path
         return found_path  # type: ignore[return-value]
 
@@ -215,10 +219,10 @@ class Fus3ProcessManager(object):
 
             if FUS3_PATH_ENV_VAR in os.environ:
                 log.info(f"{FUS3_PATH_ENV_VAR} found in environment")
-                environ_check = os.environ[FUS3_PATH_ENV_VAR] + "/bin/fus3"
+                environ_check = os.environ[FUS3_PATH_ENV_VAR] + f"/bin/{FUS3_EXECUTABLE}"
             else:
                 log.warning(f"{FUS3_PATH_ENV_VAR} not found in environment")
-                environ_check = FUS3_DEFAULT_INSTALL_PATH + "/bin/fus3"
+                environ_check = FUS3_DEFAULT_INSTALL_PATH + f"/bin/{FUS3_EXECUTABLE}"
             if os.path.exists(environ_check):
                 log.info(f"Environ check found fus3 at {environ_check}")
                 found_path = environ_check

--- a/test/unit/deadline_job_attachments/test_fus3.py
+++ b/test/unit/deadline_job_attachments/test_fus3.py
@@ -16,7 +16,10 @@ import pytest
 
 import deadline
 from deadline.job_attachments.asset_sync import AssetSync
-from deadline.job_attachments.exceptions import Fus3ExecutableMissingError
+from deadline.job_attachments.exceptions import (
+    Fus3ExecutableMissingError,
+    Fus3LaunchScriptMissingError,
+)
 from deadline.job_attachments.models import JobAttachmentS3Settings
 from deadline.job_attachments.fus3 import (
     Fus3ProcessManager,
@@ -242,6 +245,12 @@ class TestFus3Processmanager:
             process_manager.find_fus3_launch_script()
 
             mock_os_path_exists.assert_called_once()
+
+            Fus3ProcessManager.fus3_script_path = None
+            mock_os_path_exists.return_value = False
+
+            with pytest.raises(Fus3LaunchScriptMissingError):
+                process_manager.find_fus3_launch_script()
 
     def test_create_mount_point(
         self,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
FUS3_PATH environment variable isn't being propogated to the worker agent when it's launched using an EC2 launch template. This results in the Fus3 executable not being found and uses the COPIED JobAttachmentsFileSystem instead.

### What was the solution? (How)
Add a default path as a fallback when the environment variable isn't set to attempt to find Fus3 at. This is a temporary fix until we determine the correct way to pass variables down to the profile that user data is running.

### What is the impact of this change?
SMF jobs will actually use the VFS instead of the fallback when running jobs that specify it.

### How was this change tested?
hatch run test
hatch run fmt
Manually confirmed the VFS was used instead of the fallback when the FUS3_PATH env var isn't set on the worker

### Was this change documented?
No

### Is this a breaking change?
No