### PR TITLE
fix: HashCache inter-process locking and connections per thread

### DIFF
--- a/src/deadline/job_attachments/hash_cache.py
+++ b/src/deadline/job_attachments/hash_cache.py
@@ -117,10 +117,11 @@ class ReadDbCursor:
 
     @staticmethod
     def _get_db_con(cache_db_file) -> sqlite3.Connection:
-        ReadDbCursor.thread_local_connection
         if "db" not in ReadDbCursor.thread_local_connection.__dict__:
-            ReadDbCursor.thread_local_connection.__dict__["db"] = DbConnection(cache_db_file)
-        return ReadDbCursor.thread_local_connection.db.con
+            ReadDbCursor.thread_local_connection.__dict__["db"] = dict()
+        if cache_db_file not in ReadDbCursor.thread_local_connection.db:
+            ReadDbCursor.thread_local_connection.db[cache_db_file] = DbConnection(cache_db_file)
+        return ReadDbCursor.thread_local_connection.db[cache_db_file].con
 
     def __init__(self, db_file_path: str):
         self._db_lock_file = f"{db_file_path}.lock"

--- a/src/deadline/job_attachments/hash_cache.py
+++ b/src/deadline/job_attachments/hash_cache.py
@@ -82,7 +82,10 @@ class DbConnection:
     def __init__(self, cache_db_file):
         try:
             self.con: sqlite3.Connection = sqlite3.connect(
-                cache_db_file, check_same_thread=True, isolation_level=None
+                cache_db_file,
+                check_same_thread=True,
+                isolation_level="IMMEDIATE",
+                timeout=15,
             )
             self.con.execute("pragma journal_mode=wal")
         except sqlite3.OperationalError as oe:

--- a/src/deadline/job_attachments/hash_cache.py
+++ b/src/deadline/job_attachments/hash_cache.py
@@ -6,7 +6,10 @@ Module for accessing the local file hash cache.
 
 import logging
 import os
-from threading import Lock
+import sqlite3
+import threading
+import time
+import random
 from typing import Optional
 
 from .exceptions import JobAttachmentsError
@@ -18,18 +21,136 @@ CACHE_FILE_NAME = "hash_cache.db"
 logger = logging.getLogger("Deadline")
 
 
+class FileLocking:
+    """
+    Handles file locking.
+    File locking is necessary to control access to the HashCache database across processes.
+    multiprocessing.Lock only works between processes that were spawned through multiprocessing itself.
+    """
+
+    MAX_RETRY_ATTEMPTS = 10
+    MAX_BACKOFF_SECONDS = 1.0
+
+    def __init__(self, db_lock_file_path):
+        self._db_lock_file_path = db_lock_file_path
+        self._db_lock_file = os.open(self._db_lock_file_path, os.O_APPEND | os.O_CREAT)
+
+    def __del__(self):
+        os.close(self._db_lock_file)
+
+    def __enter__(self):
+        attempts = 0
+        while True:
+            try:
+                if os.name == "posix":
+                    import fcntl
+
+                    fcntl.flock(self._db_lock_file, fcntl.LOCK_EX | fcntl.LOCK_NB)  # type: ignore[attr-defined]
+                elif os.name == "nt":
+                    import msvcrt
+
+                    msvcrt.locking(self._db_lock_file, msvcrt.LK_LOCK, 1)  # type: ignore[attr-defined]
+                else:
+                    raise RuntimeError("File locking not supported in current platform")
+                break
+            except (PermissionError, OSError):
+                attempts += 1
+                if attempts > self.MAX_RETRY_ATTEMPTS:
+                    raise
+                time.sleep(random.uniform(0.0, self.MAX_BACKOFF_SECONDS))
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        if os.name == "posix":
+            import fcntl
+
+            fcntl.flock(self._db_lock_file, fcntl.LOCK_UN)  # type: ignore[attr-defined]
+        elif os.name == "nt":
+            import msvcrt
+
+            msvcrt.locking(self._db_lock_file, msvcrt.LK_UNLCK, 1)  # type: ignore[attr-defined]
+        else:
+            raise RuntimeError("File unlocking not supported in current platform")
+
+
+class DbConnection:
+    """
+    Handles a sqlite3.Connection. This class is needed to tie the create/close connection to
+    the lifetime of the object (necessary to store it in a thread local object).
+    Basically, a RAII class around sqlite3.Connection.
+    """
+
+    def __init__(self, cache_db_file):
+        try:
+            # print(f"Creating connection for thread {threading.get_ident()}")
+            self.con: sqlite3.Connection = sqlite3.connect(
+                cache_db_file, check_same_thread=True, isolation_level=None
+            )
+            self.con.execute("pragma journal_mode=wal")
+        except sqlite3.OperationalError as oe:
+            raise JobAttachmentsError(
+                f"Could not access hash cache file in {cache_db_file}"
+            ) from oe
+
+    def __del__(self):
+        # print(f"Removing connection for thread {threading.get_ident()}")
+        self.con.close()
+
+
+# We maintain a connection per thread, we reuse it and maintain it for the lifetime of the thread.
+# Most compilations of sqlite3 have threadsafety=1 (SQLITE_THREADSAFE=2) which allows to share the
+# module, but connections cannot be shared between threads. This code is compatible with
+# threadsafety=1 and threadsafety=3.
+assert sqlite3.threadsafety in (1, 3)
+
+__thread_local_connection = threading.local()
+
+
+def _get_db_con(cache_db_file) -> sqlite3.Connection:
+    global __thread_local_connection
+    if "db" not in __thread_local_connection.__dict__:
+        __thread_local_connection.__dict__["db"] = DbConnection(cache_db_file)
+    return __thread_local_connection.db.con
+
+
+class DbCursorContext(FileLocking):
+    """
+    Class to use the sqlite cursor with context manager (not supported by default)
+    This class also helds a file lock on <database_file>.lock to allow multiple writers to
+    sync (threads and processes).
+    """
+
+    def __init__(self, db_file_path):
+        super().__init__(f"{db_file_path}.lock")
+        self._db_con = _get_db_con(db_file_path)
+
+    def __enter__(self):
+        self._db_cur = self._db_con.cursor()
+        super().__enter__()
+        return self._db_cur
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        self._db_con.commit()
+        self._db_cur.close()
+        super().__exit__(exc_type, exc_value, exc_traceback)
+
+
 class HashCache:
     """
     Class used to store and retrieve entries in the local file hash cache.
 
-    This class is intended to always be used with a context manager to properly
-    close the connection to the hash cache database.
+    This class handles multithreading and multiprocessing by creating a connection per
+    thread, using cursors, committing when done, enabling WAL and doing file locking
+    when accessing the database.
 
-    This class also automatically locks, so it can be called by multiple threads.
-    Context manager functions (__enter__ and __exit__) are not thread safe.
+    This class can be used with context manager to close the database connection on
+    exit. Closing on exit is optional and enabled by default. If false, connection
+    will be closed on thread destruction.
     """
 
-    def __init__(self, cache_dir: Optional[str] = None) -> None:
+    def __init__(self, cache_dir: Optional[str] = None, close_on_exit: bool = True) -> None:
+        self.enabled = False
+        self.close_on_exit = close_on_exit
+        self.cache_dir = cache_dir
         try:
             # SQLite is included in Python installers, but might not exist if building python from source.
             import sqlite3  # noqa
@@ -37,81 +158,58 @@ class HashCache:
             self.enabled = True
         except ImportError:
             logger.warn("SQLite was not found, the Hash Cache will not be used.")
-            self.enabled = False
             return
 
-        if cache_dir is None:
-            cache_dir = _get_default_hash_cache_db_file_dir()
-        if cache_dir is None:
+        if self.cache_dir is None:
+            self.cache_dir = _get_default_hash_cache_db_file_dir()
+        if self.cache_dir is None:
             raise JobAttachmentsError(
                 "No default hash cache path found. Please provide a hash cache directory."
             )
-        os.makedirs(cache_dir, exist_ok=True)
-        self.cache_dir: str = os.path.join(cache_dir, CACHE_FILE_NAME)
-        self.db_lock = Lock()
+        os.makedirs(self.cache_dir, exist_ok=True)
+        self.cache_db_file: str = os.path.join(self.cache_dir, CACHE_FILE_NAME)
+
+        with DbCursorContext(self.cache_db_file) as cur:
+            cur.execute(
+                "CREATE TABLE IF NOT EXISTS hashesV1(file_path text primary key, file_hash text, last_modified_time timestamp)"
+            )
 
     def __enter__(self):
         """Called when entering the context manager."""
-        if self.enabled:
-            import sqlite3
-
-            try:
-                self.db_connection: sqlite3.Connection = sqlite3.connect(
-                    self.cache_dir, check_same_thread=False
-                )
-            except sqlite3.OperationalError as oe:
-                raise JobAttachmentsError(
-                    f"Could not access hash cache file in {self.cache_dir}"
-                ) from oe
-
-            try:
-                cur = self.db_connection.cursor()
-                cur.execute("SELECT * FROM hashesV1")
-                cur.close()
-            except Exception:
-                # DB file doesn't have our table, so we need to create it
-                if not cur:
-                    cur = self.db_connection.cursor()
-                cur.execute(
-                    "CREATE TABLE hashesV1(file_path text primary key, file_hash text, last_modified_time timestamp)"
-                )
-                cur.close()
         return self
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
         """Called when exiting the context manager."""
-        if self.enabled:
-            self.db_connection.close()
+        if self.close_on_exit:
+            global thread_local_connection
+            thread_local_connection.__dict__.clear()
+        return
 
     def get_entry(self, file_path_key: str) -> Optional[HashCacheEntry]:
-        """
-        Returns an entry from the hash cache, if it exists.
-        """
+        """Returns an entry from the hash cache, if it exists."""
         if not self.enabled:
             return None
 
-        with self.db_lock:
-            cur = self.db_connection.cursor()
+        with DbCursorContext(self.cache_db_file) as cur:
             entry_vals = cur.execute(
                 "SELECT * FROM hashesV1 WHERE file_path=?", [file_path_key]
             ).fetchone()
-            cur.close()
-            if entry_vals:
-                return HashCacheEntry(
-                    file_path=entry_vals[0],
-                    file_hash=entry_vals[1],
-                    last_modified_time=str(entry_vals[2]),
-                )
-            else:
-                return None
+        if entry_vals:
+            return HashCacheEntry(
+                file_path=entry_vals[0],
+                file_hash=entry_vals[1],
+                last_modified_time=str(entry_vals[2]),
+            )
+        else:
+            return None
 
     def put_entry(self, entry: HashCacheEntry) -> None:
         """Inserts or replaces an entry into the hash cache database after acquiring the lock."""
-        if self.enabled:
-            with self.db_lock:
-                cur = self.db_connection.cursor()
-                cur.execute(
-                    "INSERT OR REPLACE INTO hashesV1 VALUES(:file_path, :file_hash, :last_modified_time)",
-                    entry.to_dict(),
-                )
-                cur.close()
+        if not self.enabled:
+            return
+
+        with DbCursorContext(self.cache_db_file) as cur:
+            cur.execute(
+                "INSERT OR REPLACE INTO hashesV1 VALUES(:file_path, :file_hash, :last_modified_time)",
+                entry.to_dict(),
+            )

--- a/test/unit/deadline_job_attachments/test_hash_cache.py
+++ b/test/unit/deadline_job_attachments/test_hash_cache.py
@@ -116,7 +116,7 @@ class TestHashCache:
     def test_parallelization(self, tmpdir):
         # keeping count low to decrease the time the test takes to run. Was locally run with
         # iterations=10000 without issues
-        iterations = 10
+        iterations = 100
 
         # Test that we can have multiple threads on the same hashcache
         with HashCache(tmpdir) as hc:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

This is a follow up to PR #66. In that PR the issue was fixed by using `threading.Lock` instead of `multiprocessing.Lock`  
That PR's fix is correct, `multiprocessing.Lock` was the reason behind windows being created in some platforms. 
The intention of using `multiprocessing.Lock` was to lock access to the database across processes. However, after diving through the code, we found that `multiprocessing.Lock` only works across processes that are spawned/forked using `multiprocessing`. 
In scenarios where there are multiple processes accessing the hash cache database, one or more of them could get a "database locked" error. Sqlite3 provides support for multiple threads accessing the same database, but does does not handle multiprocess access to it. 

### What was the solution? (How)

This solution feels overkill for what its solving. In practice, a user would have to submit jobs from multiple DCC instances (same or different tools) and process/hash enough files to create heavy contention on the HashCache database access. I was able to reproduce database locked scenarios through unit tests, which are added in this PR.
I am open to drop this PR if we think that we should not support such scenario (multiple DCC instances or different ones submitting at the same time). If we want to support the scenario of multiple submissions happening from different processes at the same time, we need a solution like this (which seems to be the intention behind the use of `multiprocessing.Lock`).

The solution uses a combination of the following:
- a file locking mechanism to provide cross-process synchronization. Each process locks a `database_file.lock` file only once while editing the file. 
- multiple threads can be reading and/or editing at the same time. There is a timeout provided internally by sqlite3, configured to 30s, this prevented failure in the test at big iteration numbers.
- writers within a process will held one file lock. This reduces the amount of open files and locks per process (its also faster, tests with 1000 iterations improved by 2.7x with this change)
- each thread has a connection to the database
- connections have `IMMEDIATE` isolation level (https://www.sqlite.org/isolation.html), and WAL (https://www.sqlite.org/wal.html)
- reads and edits happen with cursors
- tests validate that different scenarios of parallelization work do not lock the database and produce the expected operations
- connections will remain in the process until the process exits. `HashCache` can be configured to close connections at destruction.

### What is the impact of this change?

Multiple processes can submit jobs at the same time.

### How was this change tested?

Unit tests

### Was this change documented?

NA, code is heavily commented

### Is this a breaking change?

No