### PR TITLE
fix: Validate the template prior to job bundle load and on job submission

### DIFF
--- a/src/deadline/client/ui/dialogs/submit_job_progress_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_progress_dialog.py
@@ -28,7 +28,7 @@ from PySide2.QtWidgets import (  # pylint: disable=import-error; type: ignore
 )
 
 from deadline.client import api
-from deadline.client.exceptions import CreateJobWaiterCanceled
+from deadline.client.exceptions import CreateJobWaiterCanceled, DeadlineOperationError
 from deadline.client.config import set_setting, config_file
 from deadline.client.job_bundle.loader import read_yaml_or_json, read_yaml_or_json_object
 from deadline.client.job_bundle.parameters import apply_job_parameters, read_job_bundle_parameters
@@ -343,7 +343,7 @@ class SubmitJobProgressDialog(QDialog):
             if success:
                 self.create_job_thread_succeeded.emit(success, message)
             else:
-                self.create_job_thread_exception.emit(message)
+                self.create_job_thread_exception.emit(DeadlineOperationError(message))
         except CreateJobWaiterCanceled as e:
             # If it wasn't canceled, send the exception to the dialog
             if self._continue_submission:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Bea-16157

These changes validate the template in two different cases:
1. Prior to job submission
2. Prior to job bundle load (for the job bundle gui-submit submitter)

From Nuke I noticed that submitting a job with an invalid template did not halt the submission (I was modifying the template to support a new workflow). This resulted in the job being submitted even though it was invalid, and the "status message" that contained the error was hidden in the job progress UI (not clear that an error even occurred).

With these changes the template validation happens prior to the job creation. User is notified of the error as shown:
<img width="445" alt="Screenshot 2023-10-11 at 7 05 29 PM" src="https://github.com/casillas2/deadline-cloud/assets/69699954/f77c5de6-ea3e-43d2-a520-890f5417ff74">

### What was the solution? (How)

Use openjd to validate the template (similar to the `openjd-cli check` command)


### What is the impact of this change?

Improved user experience. We're no longer creating jobs with invalid templates.

### How was this change tested?
Tested the job bundle submitter: 
1. `deadline bundle gui-submit invalid_template` -> error raised to user
2. Loaded a valid template in the deadline bundle gui-subnmit, but then tried reloading a bundle with an invalid template -> error raised to user
3. Tried submitting a job with an invalid template from Nuke -> error raised to user
4.  Ran the bundle output tests in Nuke with valid template -> all tests passed

### Was this change documented?
No, small bug

### Is this a breaking change?
No