### PR TITLE
chore(job_attachments): remove hard-coded endpoint

### DIFF
--- a/src/deadline/job_attachments/_aws/aws_config.py
+++ b/src/deadline/job_attachments/_aws/aws_config.py
@@ -1,11 +1,8 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 """AWS configuration."""
+VENDOR_CODE: str = "deadline"
 
 # S3 related
 S3_CONNECT_TIMEOUT_IN_SECS: int = 30
 S3_READ_TIMEOUT_IN_SECS: int = 30
-
-# TODO: This is currently set to our closed-beta endpoint. We need to update this for GA.
-DEADLINE_ENDPOINT: str = "https://btpdb6qczg.execute-api.us-west-2.amazonaws.com"
-VENDOR_CODE: str = "deadline"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The Job Attachments module contains a hard-coded service endpoint constant that is currently not being used anywhere in the codebase. Also, defining such endpoint within the module (or library) seems incorrect.

### What was the solution? (How)
Removed the hard-coded service endpoint from the Job Attachments module

### What is the impact of this change?
It's a minor clean-up. This removal has no impact on the existing functionality as the constant was not in use.

### How was this change tested?
- Ran `hatch run lint && hatch run test` and made sure that all unit tests passed.
- Performed an end-to-end test in the Beta environment by submitting a job through CLI --> processing it with a worker agent (CMF) to ensure there are no issues during the process.

### Was this change documented?
No.

### Is this a breaking change?
No.