### PR TITLE
feat!: add conflict resolution option to configuration file

### DIFF
--- a/src/deadline/client/cli/_common.py
+++ b/src/deadline/client/cli/_common.py
@@ -103,6 +103,12 @@ def _apply_cli_options_to_config(
         auto_accept = args.pop("yes", None)
         if auto_accept:
             config_file.set_setting("settings.auto_accept", "true", config=config)
+
+        conflict_resolution = args.pop("conflict_resolution", None)
+        if conflict_resolution:
+            config_file.set_setting(
+                "settings.conflict_resolution", conflict_resolution, config=config
+            )
     else:
         # Remove the standard option names from the args list
         for name in ["profile", "farm_id", "queue_id", "job_id"]:

--- a/src/deadline/client/config/config_file.py
+++ b/src/deadline/client/config/config_file.py
@@ -21,7 +21,8 @@ from configparser import ConfigParser
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-import boto3  # type: ignore[import]
+import boto3
+from deadline.job_attachments.models import FileConflictResolution
 
 from ..exceptions import DeadlineOperationError
 import re
@@ -97,6 +98,10 @@ SETTINGS: Dict[str, Dict[str, Any]] = {
     },
     "settings.auto_accept": {
         "default": "false",
+    },
+    "settings.conflict_resolution": {
+        "default": FileConflictResolution.NOT_SELECTED.name,
+        "description": "How to handle duplicate files when downloading (if a file with the same path/name already exists.)",
     },
     "settings.log_level": {
         "default": "WARNING",

--- a/src/deadline/client/ui/dialogs/deadline_config_dialog.py
+++ b/src/deadline/client/ui/dialogs/deadline_config_dialog.py
@@ -18,6 +18,7 @@ from typing import Callable, List, Optional
 
 import boto3  # type: ignore[import]
 from botocore.exceptions import ProfileNotFound  # type: ignore[import]
+from deadline.job_attachments.models import FileConflictResolution
 from PySide2.QtCore import QSize, Qt, Signal
 from PySide2.QtWidgets import (  # pylint: disable=import-error; type: ignore
     QCheckBox,
@@ -274,6 +275,15 @@ class DeadlineWorkstationConfigWidget(QWidget):
     def _build_general_settings_ui(self, group, layout):
         self.auto_accept = self._init_checkbox_setting(
             group, layout, "settings.auto_accept", "Auto Accept Confirmation Prompts"
+        )
+
+        self._conflict_resolution_options = [option.name for option in FileConflictResolution]
+        self.conflict_resolution_box = self._init_combobox_setting(
+            group,
+            layout,
+            "settings.conflict_resolution",
+            "Conflict Resolution Option",
+            self._conflict_resolution_options,
         )
 
         self._log_levels = ["ERROR", "WARNING", "INFO", "DEBUG"]

--- a/src/deadline/job_attachments/models.py
+++ b/src/deadline/job_attachments/models.py
@@ -276,6 +276,7 @@ class FileSystemLocationType(str, Enum):
 
 
 class FileConflictResolution(Enum):
+    NOT_SELECTED = 0
     SKIP = 1
     OVERWRITE = 2
     CREATE_COPY = 3

--- a/test/unit/deadline_client/cli/test_cli_config.py
+++ b/test/unit/deadline_client/cli/test_cli_config.py
@@ -35,7 +35,7 @@ def test_cli_config_show_defaults(fresh_deadline_config):
     assert fresh_deadline_config in result.output
 
     # Assert the expected number of settings
-    assert len(settings.keys()) == 13
+    assert len(settings.keys()) == 14
 
     for setting_name in settings.keys():
         assert setting_name in result.output
@@ -98,6 +98,7 @@ def test_cli_config_show_modified_config(fresh_deadline_config):
     config.set_setting("defaults.queue_id", "queue-389348u234jhk34")
     config.set_setting("defaults.job_id", "job-239u40234jkl234nkl23")
     config.set_setting("settings.auto_accept", "False")
+    config.set_setting("settings.conflict_resolution", "CREATE_COPY")
     config.set_setting("defaults.job_attachments_file_system", "VIRTUAL")
     config.set_setting("settings.log_level", "DEBUG")
     config.set_setting("telemetry.opt_out", "True")
@@ -119,6 +120,7 @@ def test_cli_config_show_modified_config(fresh_deadline_config):
     assert "farm-82934h23k4j23kjh" in result.output
     assert "queue-389348u234jhk34" in result.output
     assert "job-239u40234jkl234nkl23" in result.output
+    assert "settings.conflict_resolution:\n   CREATE_COPY" in result.output
     assert "settings.log_level:\n   DEBUG" in result.output
     assert "user-id-123abc-456def" in result.output
     # It shouldn't say anywhere that there is a default setting


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We need to provide a way for users to set their preferences for how file conflicts are resolved during downloads (when downloading files with the same file path or filename that already exist on the local.)

### What was the solution? (How)
- Added a new `conflict_resolution` setting to the configuration file.
- Provided a dropdown in the Configuration GUI where users can select their preferred conflict resolution option.
- Ensured that the `--conflict-resolution` option can still be specified in the `download-output` CLI command, which will override the config setting if both are present.


### What is the impact of this change?
Users can now set their preferred method for resolving file conflicts directly in the configuration file, providing a more streamlined user experience.

### How was this change tested?
- `hatch run lint && hatch run test`
- Configuration GUI testing: verified that the selected conflict resolution option is accurately saved in the config file.
- CLI testing: Checked the behaviour when downloading output with file conflicts. Specifically, tested the combination of `auto-accept` and `conflict-resolution`.
  - `auto-accept` True, and `conflict-resolution` NOT_SELECTED --> No user prompt, executes default behaviour - CREATE_COPY
  - `auto-accept` True, and `conflict-resolution` something selected --> No user prompt, executes selected resolution
  - `auto-accept` False, and `conflict-resolution` NOT_SELECTED --> No user prompt, executes selected resolution
  - `auto-accept` False, and `conflict-resolution` something selected --> User is prompted for resolution, executes selected option
- Priority testing: Verified that CLI-specified conflict resolution takes precedence over the config file setting.

![Screenshot 2023-10-16 at 9 52 53 PM](https://github.com/casillas2/deadline-cloud/assets/132245153/b16746c0-218c-46c6-beff-6569649c877f)

### Was this change documented?
No.

### Is this a breaking change?
No.
