### PR TITLE
fix(job_attachments): handle output directory paths containing backslashes

### DIFF
--- a/test/unit/deadline_job_attachments/conftest.py
+++ b/test/unit/deadline_job_attachments/conftest.py
@@ -153,7 +153,7 @@ def fixture_windows_attachments():
                 rootPathFormat=PathFormat.WINDOWS,
                 inputManifestPath="manifest.json",
                 inputManifestHash="manifesthash",
-                outputRelativeDirectories=["test/outputs"],
+                outputRelativeDirectories=["test\\outputs"],
             )
         ],
     )


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
There is an issue that the output files (of a render job) are not being uploaded to s3 bucket. The reason seems to be that, during the output syncing, Job Attachment module does not handle the `outputRelativeDirectories` path correctly when the path is for Windows. (specifically [this line](https://github.com/casillas2/deadline-cloud/blob/2a35d73903070a0188c23c216c6df574024ff66b/src/deadline/job_attachments/asset_sync.py#L201C56-L201C56))

### What was the solution? (How)
- Fixed it to properly handle backslashes in output directory paths, converting them to the appropriate directory separator based on the current OS.
- Fixed a related unit test

### What is the impact of this change?
Output sync should work as expected regardless of the source format and the OS of the worker.

### How was this change tested?
- Ran `hatch run lint && hatch run test` and made sure that all passed.
- End-to-end tests 
  - Linux (Submitting from Linux --> processing it on Linux (CMF) worker)
  - Windows (Submitting from Windows --> processing it on Linux (CMF) worker): with a (non-render) Job that has backslash in the `outputRelativeDirectories`. The output files are correctly uploaded to my bucket.

### Was this change documented?
No.

### Is this a breaking change?
No.
