### PR TITLE
fix: Refreshing the lists on setting's dialog creation

### DIFF
--- a/src/deadline/client/ui/dialogs/deadline_config_dialog.py
+++ b/src/deadline/client/ui/dialogs/deadline_config_dialog.py
@@ -111,6 +111,9 @@ class DeadlineConfigDialog(QDialog):
         self.button_box.addButton(self.logout_button, QDialogButtonBox.ResetRole)
         self.layout.addWidget(self.button_box)
 
+        # Refresh the lists so queue/farm show the description instead of the ID
+        self.config_box.refresh_lists()
+
     @property
     def changes_were_applied(self) -> bool:
         return self.config_box.changes_were_applied


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Always have to refresh the farm and queue in the Submitter settings
The Farm and Queue remain as their ID until the refresh button is pressed

### What was the solution? (How)

Refresh them on dialog creation.

### What is the impact of this change?

Users will see the name of the queue/farm/storage profile when they open the settings dialog (instead of IDs). They won't need to refresh the different comboboxes.

### How was this change tested?

Manually

### Was this change documented?

No

### Is this a breaking change?

No