### PR TITLE
chore(job_attachment): enhance session log for output syncing

### DIFF
--- a/src/deadline/job_attachments/progress_tracker.py
+++ b/src/deadline/job_attachments/progress_tracker.py
@@ -58,8 +58,8 @@ class SummaryStatistics:
 
     def __str__(self):
         return (
-            f"Processed {self.processed_files} files totaling"
-            + f" {_human_readable_file_size(self.processed_bytes)}.\n"
+            f"Processed {self.processed_files} file{'' if self.processed_files == 1 else 's'}"
+            + f" totaling {_human_readable_file_size(self.processed_bytes)}.\n"
             + f"Skipped re-processing {self.skipped_files} files totaling"
             + f" {_human_readable_file_size(self.skipped_bytes)}.\n"
             + f"Total processing time of {round(self.total_time, ndigits=5)} seconds"
@@ -206,7 +206,7 @@ class ProgressTracker:
                     self.processed_files += 1
                     self.completed_files_in_chunk += 1
                 # Logs progress message to the logger (if exists)
-                self.log_progress_message()
+                self._log_progress_message()
                 # Invokes the callback with current progress data
                 return self.report_progress()
 
@@ -342,7 +342,7 @@ class ProgressTracker:
         }
         return DownloadSummaryStatistics(**summary_statistics_dict)
 
-    def log_progress_message(self) -> None:
+    def _log_progress_message(self) -> None:
         """
         Logs progress message to the logger (if exists) on specific conditions:
         1. when the `log_interval` time has passed since the last call, (or since the


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
There is a lack of job attachment output-related logs. During the output syncing process, it was not transparent enough to understand which output files were being synced, how many were found, and at which paths. We should have some log lines in between these two lines in the Session log:
```
1696435995035 Started syncing outputs using Job Attachments
1696435995036 Finished syncing outputs using Job Attachments
```

### What was the solution? (How)
Add more informative logs. Specifically, logs the following details (for example):
- Found 3 files totaling <size> in output directory: <output directory path>
- Uploading 6 output files to S3: <bucket name>

### What is the impact of this change?
This makes the Session logs more verbose during output syncing, easier to debug.

### How was this change tested?
- Ran unit tests by `hatch run lint && hatch run test` and made sure that all passed.
- Manually (end-to-end) tested under different scenarios:
  - When no output files are generated
  ```
  1697727249300  Started syncing outputs using Job Attachments
  1697727249300  Found 0 files totaling 0.0 B in output directory: /tmp/openjd/session-86602596e0b747d6a3e04cf027422ecbvaetv0xl/assetroot-3a35971e389b597ebe17/gahyun_bundle/results
  1697727249300  Summary Statistics for file uploads: Processed 0 files totaling 0.0 B. Skipped re-processing 0 files totaling 0.0 B. Total processing time of 0.0 seconds at 0.0 B/s.
  1697727249300  Finished syncing outputs using Job Attachments
  ```

  - When a (10MB-size) output file is generated
  ```
  1697727047313  Started syncing outputs using Job Attachments
  1697727047337  Found 1 file totaling 10.49 MB in output directory: /tmp/openjd/session-54cf8649a76948519ae8725beebb5b25qpsh3m71/assetroot-3a35971e389b597ebe17/gahyun_bundle/results
  1697727047337  Uploading output manifest to rootPrefix/Manifests/farm-9884d77fe5e64f2399af8833aaa4c099/queue-0b985557872b461d8c55a7b7df2859ff/job-86fd9c32a9114eaaaa0ce853a1bbf9a5/step-4e431b2308d14007b68fa732a7928a28/task-4e431b2308d14007b68fa732a7928a28-1/2023-10-19T14:50:47.259231Z_sessionaction-54cf8649a76948519ae8725beebb5b25-2/dd620bb19abcb3be62a189f368bb3dd3_output.xxh128
  1697727047369  Uploading 1 output file to S3: job-attachments-bucket/rootPrefix/Data
  1697727047420  Uploaded 1.05 MB / 10.49 MB of 1 file (Transfer rate: 0.0 B/s)
  1697727047423  Uploaded 2.1 MB / 10.49 MB of 1 file (Transfer rate: 0.0 B/s)
  1697727047431  Uploaded 3.15 MB / 10.49 MB of 1 file (Transfer rate: 314.57 MB/s)
  1697727047436  Uploaded 4.19 MB / 10.49 MB of 1 file (Transfer rate: 209.72 MB/s)
  1697727047441  Uploaded 5.24 MB / 10.49 MB of 1 file (Transfer rate: 262.14 MB/s)
  1697727047445  Uploaded 6.29 MB / 10.49 MB of 1 file (Transfer rate: 209.72 MB/s)
  1697727047449  Uploaded 7.34 MB / 10.49 MB of 1 file (Transfer rate: 244.67 MB/s)
  1697727047452  Uploaded 8.39 MB / 10.49 MB of 1 file (Transfer rate: 279.62 MB/s)
  1697727047457  Uploaded 9.44 MB / 10.49 MB of 1 file (Transfer rate: 235.93 MB/s)
  1697727047460  Uploaded 10.49 MB / 10.49 MB of 1 file (Transfer rate: 262.14 MB/s)
  1697727047740  Summary Statistics for file uploads: Processed 1 file totaling 10.49 MB. Skipped re-processing 0 files totaling 0.0 B. Total processing time of 0.37069 seconds at 28.29 MB/s.
  1697727047740  Finished syncing outputs using Job Attachments
  ```

  - When an output file is already uploaded and thus skipped during syncing
  ```
  1697726170354  Started syncing outputs using Job Attachments
  1697726170385  Found 1 file totaling 65.0 B in output directory: /tmp/openjd/session-126daaf732564c9f8fb773b6097451f1htzi43gt/assetroot-3a35971e389b597ebe17/gahyun_bundle/results
  1697726170386  Uploading output manifest to rootPrefix/Manifests/farm-9884d77fe5e64f2399af8833aaa4c099/queue-0b985557872b461d8c55a7b7df2859ff/job-980ffe9ab1d84c4c8a0160fea06a1d6b/step-7caa3dee220444eb8cb03896432d37a1/task-7caa3dee220444eb8cb03896432d37a1-0/2023-10-19T14:36:10.029639Z_sessionaction-126daaf732564c9f8fb773b6097451f1-1/dd620bb19abcb3be62a189f368bb3dd3_output.xxh128
  1697726170447  Uploading 1 output file to S3: job-attachments-bucket/rootPrefix/Data
  1697726170448  Summary Statistics for file uploads: Processed 0 files totaling 0.0 B. Skipped re-processing 1 file totaling 65.0 B. Total processing time of 0.0 seconds at 0.0 B/s.
  1697726170448  Finished syncing outputs using Job Attachments
  ```

### Was this change documented?
No.

### Is this a breaking change?
No.