### PR TITLE
fix: Adding back default VFS install location for find_fus3

### DIFF
--- a/src/deadline/job_attachments/fus3.py
+++ b/src/deadline/job_attachments/fus3.py
@@ -252,7 +252,7 @@ class Fus3ProcessManager(object):
                     environ_check = os.environ[FUS3_PATH_ENV_VAR] + f"/bin/{exe}"
                 else:
                     log.info(f"{FUS3_PATH_ENV_VAR} and {DEADLINE_VFS_ENV_VAR} env vars not set")
-                    environ_check = ""
+                    environ_check = EXE_TO_INSTALL_PATH[exe] + f"/bin/{exe}"
                 if os.path.exists(environ_check):
                     log.info(f"Environ check found {exe} at {environ_check}")
                     found_path = environ_check


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Bad merge removed the default path for the Fus3 executable, so it couldn't be found when running the systemd version of deadline-worker

### What was the solution? (How)
Added the default path back to the find_fus3 method

### What is the impact of this change?
Deadline VFS works once again on SMFs

### How was this change tested?
hatch run test
deployed changes to my own worker agent and tested them using the systemd version of the worker agent

### Was this change documented?
No
### Is this a breaking change?
No