### PR TITLE
feat!: Add an 'operation' argument to the job bundle export callback.

### DIFF
--- a/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
@@ -39,6 +39,7 @@ from ..widgets.shared_job_settings_tab import SharedJobSettingsWidget
 from ..widgets.host_requirements_tab import HostRequirementsWidget
 from . import DeadlineConfigDialog, DeadlineLoginDialog
 from ...job_bundle.submission import AssetReferences
+from ._types import JobBundlePurpose
 
 logger = logging.getLogger(__name__)
 
@@ -350,11 +351,17 @@ class SubmitJobToDeadlineDialog(QDialog):
                     queue_parameters,
                     asset_references,
                     requirements,
+                    purpose=JobBundlePurpose.EXPORT,
                 )
             else:
                 # Maintaining backward compatibility for submitters that do not support host_requirements yet
                 self.on_create_job_bundle_callback(
-                    self, job_history_bundle_dir, settings, queue_parameters, asset_references
+                    self,
+                    job_history_bundle_dir,
+                    settings,
+                    queue_parameters,
+                    asset_references,
+                    purpose=JobBundlePurpose.EXPORT,
                 )
 
             logger.info(f"Saved the submission as a job bundle: {job_history_bundle_dir}")
@@ -407,11 +414,17 @@ class SubmitJobToDeadlineDialog(QDialog):
                     queue_parameters,
                     asset_references,
                     requirements,
+                    purpose=JobBundlePurpose.SUBMISSION,
                 )
             else:
                 # Maintaining backward compatibility for submitters that do not support host_requirements yet
                 self.on_create_job_bundle_callback(
-                    self, job_history_bundle_dir, settings, queue_parameters, asset_references
+                    self,
+                    job_history_bundle_dir,
+                    settings,
+                    queue_parameters,
+                    asset_references,
+                    purpose=JobBundlePurpose.SUBMISSION,
                 )
 
             farm_id = get_setting("defaults.farm_id")


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
When submitting a job to Deadline Cloud, it should be possible to run on the DCC certain sanity checks that are not required when exporting a bundle. For instance, when submitting, it makes sense to check if the scene file has become stale, and alert the user that the file should be saved. But when exporting a bundle that check makes no sense.

Currently there's no way for the DCC submitter to determine if the `create_job_bundle_callback` is called because of an export or a submission.

### What was the solution? (How)

This patch adds a new argument to the callback with an operation enum so that client code can determine if we are exporting or submitting. It also refactors the callback calls to avoid repeating the code related to backwards compatibility.

### What is the impact of this change?

This is backwards compatible with submitters that don't expect that argument. It should make it possible for submitters to cancel a submission early given DCC specific tests while leaving export functionality intact.

### How was this change tested?

With the Maya submitter, using a callback signature with and without the new argument.

### Was this change documented?

No.

### Is this a breaking change?

No.
