### PR TITLE
remove end point url setting

### DIFF
--- a/src/deadline/client/ui/deadline_credentials_status.py
+++ b/src/deadline/client/ui/deadline_credentials_status.py
@@ -116,7 +116,6 @@ class DeadlineCredentialsStatus(QObject):
             creds_config_changed = False
             for setting_name in [
                 "defaults.aws_profile_name",
-                "settings.deadline_endpoint_url",
             ]:
                 if config_file.get_setting(setting_name, self.config) != config_file.get_setting(
                     setting_name, config


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Missed a reference to `settings.deadline_endpoint_url` this causes the library to crash when loading the config settings

### What was the solution? (How)
remove reference to setting

### What is the impact of this change?
fix the library

### How was this change tested?
ran library in hatch shell, created config, ran the affected method directly from the command line ensured it did not  crash
ran unit tests

### Was this change documented?
no

### Is this a breaking change?
no