### PR TITLE
fix: Change telemetry log from warning to debug

### DIFF
--- a/src/deadline/client/api/_telemetry.py
+++ b/src/deadline/client/api/_telemetry.py
@@ -139,7 +139,6 @@ class TelemetryClient:
         success = False
         while not success:
             try:
-                logger.warning(f"Sending telemetry data: {req.data}")
                 with request.urlopen(req):
                     logger.debug("Successfully sent telemetry.")
                     success = True
@@ -188,6 +187,7 @@ class TelemetryClient:
             request_body_encoded = str(json.dumps(request_body)).encode("utf-8")
             req = request.Request(url=self.endpoint, data=request_body_encoded, headers=headers)
             try:
+                logger.debug("Sending telemetry data: %s", request_body)
                 self._send_request(req)
             except Exception:
                 # Silently swallow any kind of uncaught exception and stop sending telemetry


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We were erroneously logging telemetry data locally at the "warning" log level. This was intended to be logged at the "debug" level for users that want more info on the data sent with telemetry. Further, we were printing the encoded string, which is pretty hard to read.

### What was the solution? (How)
Change the log level to "debug", and print the data dict so it's a little easier to read.

### What is the impact of this change?
We aren't logging telemetry all of the time as a warning, and logs are more readable.

### How was this change tested?
Ran the code locally, confirmed it only printed if debug log level was set.

### Was this change documented?
N/A

### Is this a breaking change?
No