### PR TITLE
feat(cli): add log message for no output in download-output command

### DIFF
--- a/src/deadline/client/cli/_groups/job_group.py
+++ b/src/deadline/client/cli/_groups/job_group.py
@@ -286,6 +286,11 @@ def _download_job_output(
 
     output_paths_by_root = job_output_downloader.get_output_paths_by_root()
 
+    # If no output paths were found, log a message and exit.
+    if output_paths_by_root == {}:
+        click.echo(_get_no_output_message(is_json_format))
+        return
+
     # Check if the asset roots came from different OS. If so, prompt users to
     # select alternative root paths to download to, (regardless of the auto-accept.)
     asset_roots = list(output_paths_by_root.keys())
@@ -454,6 +459,17 @@ def _get_start_message(
                     + "}"
                 )
             return f"Downloading output from Job {job_name!r} Step {step_name!r} Task {task_parameters_summary}"
+
+
+def _get_no_output_message(is_json_format: bool) -> str:
+    msg = (
+        "There are no output files available for download at this moment. Please verify that"
+        " the Job/Step/Task you are trying to download output from has completed successfully."
+    )
+    if is_json_format:
+        return _get_json_line(JSON_MSG_TYPE_SUMMARY, msg)
+    else:
+        return msg
 
 
 def _get_mismatch_os_root_warning(root: str, root_path_format: str, is_json_format: bool) -> str:

--- a/src/deadline/job_attachments/download.py
+++ b/src/deadline/job_attachments/download.py
@@ -347,7 +347,7 @@ def download_file(
     if not s3_client:
         s3_client = get_s3_client(session=session)
 
-    #  The modified time in the manifest is in microseconds, but utime requires the time be expressed in seconds.
+    # The modified time in the manifest is in microseconds, but utime requires the time be expressed in seconds.
     modified_time_override = file.mtime / 1000000  # type: ignore[attr-defined]
 
     file_bytes = file.size


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Currently, if we run `download-output` command on a job that has no output (for whatever reason), we see the below logs:
```
Outputs will be downloaded to the following root paths:

> Please enter a number of root path to edit, y to proceed, or n to cancel the download: (y, n) [y]: 1
Error: '1' is not one of 'y', 'n'.
> Please enter a number of root path to edit, y to proceed, or n to cancel the download: (y, n) [y]: y
Outputs will be downloaded to the following root paths:

Downloading Outputs  [------------------------------------]    0%
Download Summary:
    Downloaded 0 files totaling 0.0 B.
    Total download time of 5e-05 seconds at 0.0 B/s.
    Download locations (file counts):
```
which does not make sense. 

### What was the solution? (How)
Display an informative message when the download-output command is executed but no output files are available for download.
- In a `--output verbose` form:
```
Downloading output from Job "Gahyun's Test Job"
There are no output files available for download at this moment. Please verify that the Job/Step/Task you are trying to download output from has completed successfully.
```
- In a `--output json` form:
```
{"messageType": "title", "value": "Gahyun's Test Job"}
{"messageType": "summary", "value": "There are no output files available for download at this moment. Please verify that the Job/Step/Task you are trying to download output from has completed successfully."}
```

### What is the impact of this change?
improves user experience by providing a clear message

### How was this change tested?
- Added a unit test
- Ran `hatch run lint && hatch run test` and made sure all tests passed.
- Manual end-to-end test a scenario where the output files are not available. Verified that new message displayed correctly.

### Was this change documented?
No.

### Is this a breaking change?
No.