### PR TITLE
chore(deps)!: update all dependencies to latest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,14 +9,17 @@ readme = "README.md"
 license = ""
 requires-python = ">=3.7"
 
+# Note: All deps should be using >= since this is a *library* as well as an application.
+# Applications that consume this library should be the ones that are more strictly
+# limiting dependencies if they want/need to.
 dependencies = [
-    "boto3 ~= 1.26",
-    # 8.1.4 failing with mypy
-    "click == 8.1.3",
-    "pyyaml ~= 6.0",
+    "boto3 >= 1.28.80",
+    "click >= 8.1.7",
+    "pyyaml >= 6.0",
     # Job Attachments
-    "typing_extensions ~= 4.5",
-    "xxhash ~= 3.2",
+    "typing_extensions == 4.7.*; python_version == '3.7'",
+    "typing_extensions >= 4.8; python_version > '3.7'",
+    "xxhash >= 3.4",
     # Pinning due to new 4.18 dependencies breaking pyinstaller implementation
     "jsonschema == 4.17.*",
 ]

--- a/requirements-integ-testing.txt
+++ b/requirements-integ-testing.txt
@@ -1,1 +1,1 @@
-deadline-cloud-test-fixtures ~= 0.3.0
+deadline-cloud-test-fixtures ~= 0.5.0

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,14 +1,16 @@
-coverage[toml] ~= 7.2
+coverage[toml] ~= 7.2; python_version == '3.7'
+coverage[toml] ~= 7.3; python_version > '3.7'
 pytest ~= 7.4
 pytest-cov ~= 4.1
-pytest-timeout ~= 2.1
+pytest-timeout ~= 2.2
 pytest-xdist ~= 3.3
 freezegun ~= 1.2
 types-pyyaml ~= 6.0
 twine ~= 4.0
 black == 23.3.*; python_version == '3.7'
 black == 23.*; python_version > '3.7'
-mypy ~= 1.4
-ruff ~= 0.0.290
+mypy ~= 1.4; python_version == '3.7'
+mypy ~= 1.6; python_version > '3.7'
+ruff ~= 0.1.4
 moto ~= 4.2
 jsondiff ~= 2.0

--- a/src/deadline/client/cli/_groups/job_group.py
+++ b/src/deadline/client/cli/_groups/job_group.py
@@ -359,7 +359,9 @@ def _download_job_output(
     # makes it keep logging urllib3 warning messages when downloading large files)
     with _modified_logging_level(logging.getLogger("urllib3"), logging.ERROR):
         if not is_json_format:
-            with click.progressbar(length=100, label="Downloading Outputs") as download_progress:
+            # Note: click doesn't export the return type of progressbar(), so we suppress mypy warnings for
+            # not annotating the type of download_progress.
+            with click.progressbar(length=100, label="Downloading Outputs") as download_progress:  # type: ignore[var-annotated]
 
                 def _update_download_progress(download_metadata: ProgressReportMetadata) -> bool:
                     new_progress = int(download_metadata.progress) - download_progress.pos


### PR DESCRIPTION

### What was the problem/requirement? (What/Why)

A large number of the agent's dependencies are not on the latest versions. It's time to update them.

### What was the solution? (How)

Specifically:
boto3 to 1.28.80
click to 8.1.7
typing_extensions to 4.8
xxhash to 3.4

And testing dependencies:
deadline-cloud-test-fixtures to 0.5.0
coverage to 7.3
pytest-timeout to 2.2
mypy to 1.6
tuff to 0.1.4

### What is the impact of this change?

We incorporate bugfixes that have been made to the agent's dependencies.

### How was this change tested?

Just running our unit tests

### Was this change documented?

N/A

### Is this a breaking change?

Yes. This is a library as well as an application. The change of the boto3 dependency can be a breaking change for consumers.
