### PR TITLE
fix(deps)!: downgrade xxhash

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,8 @@ dependencies = [
     # Job Attachments
     "typing_extensions == 4.7.*; python_version == '3.7'",
     "typing_extensions >= 4.8; python_version > '3.7'",
-    "xxhash >= 3.4",
+    # Pinning due to 3.4 not being available upstream
+    "xxhash == 3.3.*",
     # Pinning due to new 4.18 dependencies breaking pyinstaller implementation
     "jsonschema == 4.17.*",
     "pywin32 == 306; sys_platform == 'win32'",


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

xxhash 3.4.0 was yanked and 3.4.1 is not available upstream yet.

### What was the solution? (How)

Downgrade to 3.3

### What is the impact of this change?
Downgrades xxhash to 3.3

### How was this change tested?
```
hatch run lint
hatch run test
```

### Was this change documented?
No

### Is this a breaking change?
Yes