### PR TITLE
fix: queue parameter handling errors

### DIFF
--- a/src/deadline/client/job_bundle/submission.py
+++ b/src/deadline/client/job_bundle/submission.py
@@ -4,13 +4,13 @@
 Helper functions to enable submission of a Job Bundle to CreateJob
 """
 from __future__ import annotations
-
 import dataclasses
 import logging
 import os
 from typing import Any, Tuple, Optional
 
 from ..exceptions import DeadlineOperationError
+from .parameters import JobParameter
 
 logger = logging.getLogger(__name__)
 
@@ -98,7 +98,7 @@ class AssetReferences:
 
 
 def split_parameter_args(
-    job_bundle_parameters: list[dict[str, Any]],
+    parameters: list[JobParameter],
     job_bundle_dir: str,
     app_name: Optional[str] = None,
     supported_app_parameter_names: Optional[list[str]] = None,
@@ -108,7 +108,7 @@ def split_parameter_args(
     and job specific parameters.
 
     Args:
-        job_bundle_parameters (list): The list of parameter values from the job bundle.
+        parameters (list): The list of submission parameters.
         job_bundle_dir (str): The job bundle directory, used for error messages.
         app_name (str): The name of the application prefix to accept for application-specific
             parameters.
@@ -124,8 +124,8 @@ def split_parameter_args(
     job_parameters: dict[str, Any] = {}
     app_parameters: dict[str, Any] = {}
 
-    if job_bundle_parameters:
-        for parameter in job_bundle_parameters:
+    if parameters:
+        for parameter in parameters:
             if "value" in parameter:
                 parameter_name = parameter["name"]
                 parameter_value = parameter["value"]

--- a/src/deadline/client/ui/dataclasses/__init__.py
+++ b/src/deadline/client/ui/dataclasses/__init__.py
@@ -7,7 +7,8 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass, field
-from typing import Any
+
+from ...job_bundle.parameters import JobParameter
 
 
 @dataclass
@@ -25,7 +26,7 @@ class JobBundleSettings:  # pylint: disable=too-many-instance-attributes
 
     # Job Bundle settings
     input_job_bundle_dir: str = field(default="")
-    parameters: list[dict[str, Any]] = field(default_factory=list)
+    parameters: list[JobParameter] = field(default_factory=list)
 
     # Whether to allow ability to "Load a different job bundle"
     browse_enabled: bool = field(default=False)

--- a/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
@@ -33,12 +33,12 @@ from .. import block_signals
 from ...config import get_setting
 from ...config.config_file import str2bool
 from ...job_bundle import create_job_history_bundle_dir
+from ...job_bundle.submission import AssetReferences
 from ..widgets.deadline_credentials_status_widget import DeadlineCredentialsStatusWidget
 from ..widgets.job_attachments_tab import JobAttachmentsWidget
 from ..widgets.shared_job_settings_tab import SharedJobSettingsWidget
 from ..widgets.host_requirements_tab import HostRequirementsWidget
 from . import DeadlineConfigDialog, DeadlineLoginDialog
-from ...job_bundle.submission import AssetReferences
 from ._types import JobBundlePurpose
 
 logger = logging.getLogger(__name__)

--- a/src/deadline/client/ui/job_bundle_submitter.py
+++ b/src/deadline/client/ui/job_bundle_submitter.py
@@ -20,7 +20,12 @@ from ..job_bundle.loader import (
     read_yaml_or_json,
     read_yaml_or_json_object,
 )
-from ..job_bundle.parameters import apply_job_parameters, read_job_bundle_parameters
+from ..job_bundle.parameters import (
+    JobParameter,
+    apply_job_parameters,
+    merge_queue_job_parameters,
+    read_job_bundle_parameters,
+)
 from .dataclasses import JobBundleSettings
 from .dialogs.submit_job_to_deadline_dialog import (
     SubmitJobToDeadlineDialog,
@@ -62,7 +67,7 @@ def show_job_bundle_submitter(
         widget: SubmitJobToDeadlineDialog,
         job_bundle_dir: str,
         settings: JobBundleSettings,
-        queue_parameters: list[dict[str, Any]],
+        queue_parameters: list[JobParameter],
         asset_references: AssetReferences,
         purpose: JobBundlePurpose = JobBundlePurpose.SUBMISSION,
     ) -> None:
@@ -112,11 +117,15 @@ def show_job_bundle_submitter(
             {"name": param["name"], "value": param["value"]} for param in settings.parameters
         )
 
+        parameters = merge_queue_job_parameters(
+            queue_parameters=queue_parameters,
+            job_parameters=settings.parameters,
+        )
+
         apply_job_parameters(
             parameters_values,
             job_bundle_dir,
-            settings.parameters,
-            queue_parameters,
+            parameters,
             AssetReferences(),
         )
 

--- a/src/deadline/client/ui/widgets/openjd_parameters_widget.py
+++ b/src/deadline/client/ui/widgets/openjd_parameters_widget.py
@@ -27,7 +27,7 @@ from PySide2.QtWidgets import (  # type: ignore
 )
 
 from ...job_bundle.job_template import ControlType
-from ...job_bundle.parameters import get_ui_control_for_parameter_definition
+from ...job_bundle.parameters import JobParameter, get_ui_control_for_parameter_definition
 from .path_widgets import (
     DirectoryPickerWidget,
     InputFilePickerWidget,
@@ -59,7 +59,7 @@ class OpenJDParametersWidget(QWidget):
     def __init__(
         self,
         *,
-        parameter_definitions: List[Dict[str, Any]] = [],
+        parameter_definitions: List[JobParameter] = [],
         async_loading_state: str = "",
         parent=None,
     ):
@@ -70,7 +70,10 @@ class OpenJDParametersWidget(QWidget):
         )
 
     def rebuild_ui(
-        self, *, parameter_definitions: list[dict[str, Any]] = [], async_loading_state: str = ""
+        self,
+        *,
+        parameter_definitions: list[JobParameter] = [],
+        async_loading_state: str = "",
     ):
         """
         Rebuilds the widget's UI to the new parameter_definitions, or to display the

--- a/test/unit/deadline_client/job_bundle/test_job_bundle_loader.py
+++ b/test/unit/deadline_client/job_bundle/test_job_bundle_loader.py
@@ -28,7 +28,7 @@ parameterDefinitions:
   description: "Unrestricted line of text!"
   default: Default line edit value.
 - name: IntSpinner
-  type: NUMBER
+  type: INT
   description: A default integer spinner.
   default: 42
 - name: StringDropdown
@@ -90,7 +90,7 @@ READ_JOB_BUNDLE_PARAMETERS_RESULT = """
   default: Default line edit value.
   value: Testing one two three.
 - name: IntSpinner
-  type: NUMBER
+  type: INT
   description: A default integer spinner.
   default: 42
 - name: StringDropdown

--- a/test/unit/deadline_client/job_bundle/test_job_submission.py
+++ b/test/unit/deadline_client/job_bundle/test_job_submission.py
@@ -10,6 +10,8 @@ from typing import Any, Dict
 import pytest
 
 from deadline.client.job_bundle import submission
+from deadline.client.job_bundle.parameters import JobParameter
+from deadline.client.job_bundle.submission import AssetReferences
 
 MOCK_FARM_ID = "farm-0123456789abcdef0123456789abcdef"
 MOCK_QUEUE_ID = "queue-0123456789abcdef0123456789abcdef"
@@ -20,7 +22,7 @@ MOCK_QUEUE_ID = "queue-0123456789abcdef0123456789abcdef"
     [
         pytest.param(
             {},
-            submission.AssetReferences(),
+            AssetReferences(),
         ),
         pytest.param(
             {
@@ -29,7 +31,7 @@ MOCK_QUEUE_ID = "queue-0123456789abcdef0123456789abcdef"
                     "outputs": {"directories": []},
                 }
             },
-            submission.AssetReferences(),
+            AssetReferences(),
         ),
         pytest.param(
             {
@@ -41,7 +43,7 @@ MOCK_QUEUE_ID = "queue-0123456789abcdef0123456789abcdef"
                     "outputs": {"directories": ["output_dir_1"]},
                 }
             },
-            submission.AssetReferences(
+            AssetReferences(
                 input_filenames=set(["input_file_1.txt", "input_file_2.txt"]),
                 output_directories=set(["output_dir_1"]),
             ),
@@ -56,7 +58,7 @@ MOCK_QUEUE_ID = "queue-0123456789abcdef0123456789abcdef"
                     "outputs": {"directories": ["output_dir_1"]},
                 }
             },
-            submission.AssetReferences(
+            AssetReferences(
                 input_filenames=set(
                     [
                         "input_file_1.txt",
@@ -71,13 +73,13 @@ MOCK_QUEUE_ID = "queue-0123456789abcdef0123456789abcdef"
 )
 def test_flatten_asset_references(
     assets_input: Dict[str, Any],
-    expected_output: submission.AssetReferences,
+    expected_output: AssetReferences,
 ) -> None:
     """
     Test that FlatAssetReferences.from_dict creates a FlatAssetReferences object with
     all of the filenames/directories from an input.
     """
-    response = submission.AssetReferences.from_dict(assets_input)
+    response = AssetReferences.from_dict(assets_input)
 
     assert response.input_filenames == expected_output.input_filenames
     assert response.input_directories == expected_output.input_directories
@@ -90,7 +92,7 @@ def test_split_parameter_args() -> None:
     and creates properly formatted app/job parameter dictionaries as returns.
     """
 
-    input_bundle_params: list[Dict[str, Any]] = [
+    input_bundle_params: list[JobParameter] = [
         {"name": "param_1", "value": "TESTING", "type": "STRING"},
         {"name": "param_2", "value": 10, "type": "INT"},
         {"name": "param_3", "value": 10.123, "type": "FLOAT"},
@@ -133,7 +135,7 @@ def test_split_parameter_args_custom_app() -> None:
     This case provides a custom app name for the prefix.
     """
 
-    input_bundle_params: list[Dict[str, Any]] = [
+    input_bundle_params: list[JobParameter] = [
         {"name": "param_1", "value": "TESTING", "type": "STRING"},
         {"name": "param_2", "value": 10, "type": "INT"},
         {"name": "param_3", "value": 10.123, "type": "FLOAT"},

--- a/test/unit/deadline_client/job_bundle/test_validate_file_filter.py
+++ b/test/unit/deadline_client/job_bundle/test_validate_file_filter.py
@@ -1,0 +1,217 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Test cases for deadline.client.job_bundle.parameters.validate_user_interface_file_filter"""
+
+from __future__ import annotations
+from typing import Any
+
+import pytest
+
+from deadline.client.job_bundle import parameters
+
+
+@pytest.fixture
+def parameter_name() -> str:
+    return "param"
+
+
+@pytest.fixture
+def field_path() -> str:
+    return '"userInterface" -> "fileFilterDefault"'
+
+
+@pytest.fixture
+def valid_label() -> str:
+    return "mylabel"
+
+
+@pytest.fixture(params=(1, 20))
+def valid_pattern_length(request: pytest.FixtureRequest) -> int:
+    return request.param
+
+
+@pytest.fixture
+def valid_pattern(valid_pattern_length: int) -> str:
+    return "a" * valid_pattern_length
+
+
+@pytest.fixture
+def valid_file_filter(
+    valid_label: str,
+    valid_pattern: str,
+) -> parameters.UserInterfaceFileFilter:
+    return {
+        "label": valid_label,
+        "patterns": [valid_pattern],
+    }
+
+
+def test_validate_user_interface_file_filter_valid(
+    valid_file_filter: parameters.UserInterfaceFileFilter,
+    parameter_name: str,
+    field_path: str,
+) -> None:
+    """Tests that valid input will not raise an exception when a valid file filter is passed to
+    validate_user_interface_file_filter and that the return value is a reference to the input.
+    """
+    # WHEN
+    result = parameters.validate_user_interface_file_filter(
+        valid_file_filter,
+        parameter_name=parameter_name,
+        field_path=field_path,
+    )
+
+    # THEN
+    assert result is valid_file_filter
+
+
+@pytest.mark.parametrize(
+    argnames="field",
+    argvalues=("label", "patterns"),
+)
+def test_validate_user_interface_file_filter_nonvalid_missing(
+    valid_file_filter: parameters.UserInterfaceFileFilter,
+    parameter_name: str,
+    field_path: str,
+    field: str,
+) -> None:
+    """Tests that valid input will raise an exception when a required field is missing from the
+    input passed to validate_user_interface_file_filter."""
+    # GIVEN
+    file_filter = valid_file_filter.copy()
+    del file_filter[field]  # type: ignore
+
+    # WHEN
+    def when() -> None:
+        parameters.validate_user_interface_file_filter(
+            file_filter,
+            parameter_name=parameter_name,
+            field_path=field_path,
+        )
+
+    # THEN
+    with pytest.raises(ValueError) as ctx:
+        when()
+    assert (
+        str(ctx.value)
+        == f'Job parameter "{parameter_name}" is missing required key {field_path} -> "{field}"'
+    )
+
+
+@pytest.mark.parametrize(
+    argnames="label",
+    argvalues=(
+        pytest.param(1, id="int"),
+        pytest.param(1.5, id="float"),
+        pytest.param(True, id="bool"),
+        pytest.param(None, id="none"),
+        pytest.param([], id="list"),
+        pytest.param({}, id="dict"),
+    ),
+)
+def test_validate_user_interface_file_filter_nonvalid_label_type(
+    label: Any,
+    parameter_name: str,
+    field_path: str,
+) -> None:
+    """Tests that a nonvalid type passed for the \"label\" field will raise a TypeError
+    with a user-friendly error message"""
+    # GIVEN
+    file_filter = {
+        "label": label,
+        "patterns": [],
+    }
+
+    # WHEN
+    def when() -> None:
+        parameters.validate_user_interface_file_filter(
+            file_filter,
+            parameter_name=parameter_name,
+            field_path=field_path,
+        )
+
+    # THEN
+    with pytest.raises(TypeError) as ctx:
+        when()
+    assert (
+        str(ctx.value)
+        == f'Job parameter "{parameter_name}" got {type(label).__name__} for {field_path} -> "label" but expected str'
+    )
+
+
+@pytest.mark.parametrize(
+    argnames="pattern",
+    argvalues=(
+        pytest.param(1, id="int"),
+        pytest.param(1.5, id="float"),
+        pytest.param(True, id="bool"),
+        pytest.param(None, id="none"),
+        pytest.param([], id="list"),
+        pytest.param({}, id="dict"),
+    ),
+)
+def test_validate_user_interface_file_filter_nonvalid_patterns_type(
+    valid_label: str,
+    pattern: str,
+    parameter_name: str,
+    field_path: str,
+) -> None:
+    """Tests that a nonvalid type passed for the \"patterns\" field will raise a TypeError
+    with a user-friendly error message"""
+    # GIVEN
+    file_filter = {
+        "label": valid_label,
+        "patterns": [pattern],
+    }
+
+    # WHEN
+    def when() -> None:
+        parameters.validate_user_interface_file_filter(
+            file_filter,
+            parameter_name=parameter_name,
+            field_path=field_path,
+        )
+
+    # THEN
+    with pytest.raises(TypeError) as ctx:
+        when()
+    assert (
+        str(ctx.value)
+        == f'Job parameter "{parameter_name}" got "{repr(pattern)}" for {field_path} -> "patterns" [0] but expected str'
+    )
+
+
+@pytest.mark.parametrize(
+    argnames="pattern_length",
+    argvalues=(0, 21),
+)
+def test_validate_user_interface_file_filter_nonvalid_pattern_length(
+    valid_label: str,
+    pattern_length: int,
+    parameter_name: str,
+    field_path: str,
+) -> None:
+    """Tests that a nonvalid type passed for the \"label\" field will raise a TypeError
+    with a user-friendly error message"""
+    # GIVEN
+    pattern = "a" * pattern_length
+    file_filter = {
+        "label": valid_label,
+        "patterns": [pattern],
+    }
+
+    # WHEN
+    def when() -> None:
+        parameters.validate_user_interface_file_filter(
+            file_filter,
+            parameter_name=parameter_name,
+            field_path=field_path,
+        )
+
+    # THEN
+    with pytest.raises(ValueError) as ctx:
+        when()
+    assert (
+        str(ctx.value)
+        == f'Job parameter "{parameter_name}" got "{pattern}" for {field_path} -> "patterns" [0] but must be between 1 and 20 characters'
+    )

--- a/test/unit/deadline_client/job_bundle/test_validate_job_parameter.py
+++ b/test/unit/deadline_client/job_bundle/test_validate_job_parameter.py
@@ -1,0 +1,757 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Test cases for deadline.client.job_bundle.parameters.validate_job_parameter"""
+
+from __future__ import annotations
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from deadline.client.job_bundle import parameters
+
+
+VALID_DEFAULTS_BY_TYPE = {
+    "STRING": "valid",
+    "INT": 1,
+    "FLOAT": 2.5,
+    "PATH": "/a/path",
+}
+
+
+@pytest.fixture
+def valid_name() -> str:
+    return "paramname"
+
+
+@pytest.fixture
+def valid_description() -> str:
+    return "description"
+
+
+@pytest.fixture(
+    params=("STRING", "INT", "FLOAT", "PATH"),
+    ids=("type-STRING", "type-INT", "type-FLOAT", "t"),
+)
+def valid_type(request: pytest.FixtureRequest) -> str:
+    return request.param
+
+
+@pytest.fixture
+def valid_default(valid_type: str) -> Any:
+    return VALID_DEFAULTS_BY_TYPE[valid_type]
+
+
+@pytest.fixture
+def valid_allowed_values(valid_default: Any) -> list[Any]:
+    return [valid_default]
+
+
+@pytest.fixture(
+    params=("NONE", "IN", "OUT", "INOUT"),
+    ids=(("dataFlow-NONE", "dataFlow-IN", "dataFlow-OUT", "dataFlow-INOUT")),
+)
+def valid_data_flow(request: pytest.FixtureRequest) -> str:
+    return request.param
+
+
+@pytest.fixture
+def valid_min_length() -> int:
+    return 1
+
+
+@pytest.fixture
+def valid_max_length() -> int:
+    return 2
+
+
+@pytest.fixture(
+    params=(1, 1.5, "2.7", "3"),
+    ids=(("minValue-int", "minValue-float", "minValue-floatstring", "minValue-intstring")),
+)
+def valid_min_value(request: pytest.FixtureRequest) -> str | int | float:
+    return request.param
+
+
+@pytest.fixture(
+    params=(4, 4.5, "5.7", "6"),
+    ids=(("maxValue-int", "maxValue-float", "maxValue-floatstring", "maxValue-intstring")),
+)
+def valid_max_value(request: pytest.FixtureRequest) -> str | int | float:
+    return request.param
+
+
+@pytest.fixture(
+    params=("FILE", "DIRECTORY"),
+    ids=("objectType-FILE", "objectType-DIRECTORY"),
+)
+def valid_object_type(request: pytest.FixtureRequest) -> str:
+    return request.param
+
+
+@pytest.fixture
+def valid_user_interface() -> parameters.UserInterfaceSpec:
+    return {
+        "control": "CHECK_BOX",
+        "label": "labela",
+        "groupLabel": "groupa",
+        "decimal": 1,
+        "singleStepDelta": 1.5,
+    }
+
+
+@pytest.fixture
+def valid_job_parameter(
+    valid_name: str,
+    valid_description: str,
+    valid_type: str,
+    valid_default: Any,
+    valid_allowed_values: list[Any],
+    valid_data_flow: str,
+    valid_object_type: str,
+    valid_min_length: int,
+    valid_max_length: int,
+    valid_min_value: str | int | float,
+    valid_max_value: str | int | float,
+    valid_user_interface: parameters.UserInterfaceSpec,
+) -> parameters.JobParameter:
+    return {
+        "name": valid_name,
+        "description": valid_description,
+        "type": valid_type,
+        "default": valid_default,
+        "allowedValues": valid_allowed_values,
+        "dataFlow": valid_data_flow,
+        "minLength": valid_min_length,
+        "maxLength": valid_max_length,
+        "minValue": valid_min_value,
+        "maxValue": valid_max_value,
+        "objectType": valid_object_type,
+        "userInterface": valid_user_interface,
+    }
+
+
+def test_validate_job_parameter_valid(
+    valid_job_parameter: parameters.JobParameter,
+) -> None:
+    """Tests that passing a valid job parameter to validate_job_parameter does not raise an
+    exception"""
+    # WHEN
+    result = parameters.validate_job_parameter(valid_job_parameter)
+
+    # THEN
+    assert result is valid_job_parameter
+
+
+@pytest.mark.parametrize(
+    argnames="input",
+    argvalues=(
+        pytest.param(1, id="int"),
+        pytest.param(1.2, id="float"),
+        pytest.param(True, id="bool"),
+        pytest.param("not-valid", id="non-valid-str"),
+        pytest.param(None, id="none"),
+        pytest.param([], id="list"),
+    ),
+)
+def test_validate_job_parameter_nonvalid_root_type(
+    input: Any,
+) -> None:
+    """Tests that a non-dict input passed to validate_job_parameter raises an exception"""
+
+    # WHEN
+    def when() -> None:
+        parameters.validate_job_parameter(input)
+
+    # THEN
+    with pytest.raises(TypeError) as ctx:
+        when()
+    assert str(ctx.value) == f"Expected a dict for job parameter, but got {type(input).__name__}"
+
+
+@pytest.mark.parametrize(
+    argnames="name",
+    argvalues=(
+        pytest.param(1, id="int"),
+        pytest.param(1.2, id="float"),
+        pytest.param(True, id="bool"),
+        pytest.param(None, id="none"),
+        pytest.param([], id="list"),
+        pytest.param({}, id="dict"),
+    ),
+)
+def test_validate_job_parameter_nonvalid_name(
+    name: Any,
+) -> None:
+    """Tests that when calling validate_job_parameter with an nonvalid values for "name"
+    that an exception is raised."""
+    # GIVEN
+    job_parameter = {"name": name}
+
+    # WHEN
+    def when() -> None:
+        parameters.validate_job_parameter(job_parameter)
+
+    # THEN
+    with pytest.raises(TypeError) as ctx:
+        when()
+    assert str(ctx.value) == f'Job parameter had {type(name).__name__} for "name" but expected str'
+
+
+def test_validate_job_parameter_missing_name() -> None:
+    """Tests that when calling validate_job_parameter without a "name" raises an exception."""
+    # GIVEN
+    job_parameter: dict = {}
+
+    # WHEN
+    def when() -> None:
+        parameters.validate_job_parameter(job_parameter)
+
+    # THEN
+    with pytest.raises(ValueError) as ctx:
+        when()
+    assert str(ctx.value) == f'No "name" field in job parameter. Got {job_parameter}'
+
+
+def test_validate_job_parameter_empty_name() -> None:
+    """Tests that when calling validate_job_parameter without a "name" raises an exception."""
+    # GIVEN
+    job_parameter: dict = {"name": ""}
+
+    # WHEN
+    def when() -> None:
+        parameters.validate_job_parameter(job_parameter)
+
+    # THEN
+    with pytest.raises(ValueError) as ctx:
+        when()
+    assert str(ctx.value) == "Job parameter has an empty name"
+
+
+def test_validate_job_parameter_valid_no_type() -> None:
+    """Tests that passing a job parameter without a "type" does not raise an exception by
+    default or if type_required is False"""
+    # GIVEN
+    job_parameter: parameters.JobParameter = {"name": "foo"}
+
+    # WHEN
+    result = parameters.validate_job_parameter(job_parameter)
+
+    # THEN
+    assert result is job_parameter
+
+    # WHEN
+    result = parameters.validate_job_parameter(job_parameter, type_required=False)
+
+    # THEN
+    assert result is job_parameter
+
+
+@pytest.mark.parametrize(
+    argnames="typ",
+    argvalues=(
+        pytest.param(1, id="int"),
+        pytest.param(1.2, id="float"),
+        pytest.param(True, id="bool"),
+        pytest.param("not-valid", id="non-valid-str"),
+        pytest.param(None, id="none"),
+        pytest.param([], id="list"),
+        pytest.param({}, id="dict"),
+    ),
+)
+def test_validate_job_parameter_nonvalid_type(
+    typ: Any,
+) -> None:
+    """Tests that when calling validate_job_parameter with an nonvalid values for "type"
+    that an exception is raised."""
+    # GIVEN
+    job_parameter: parameters.JobParameter = {
+        "name": "foo",
+        "type": typ,
+    }
+
+    # WHEN
+    def when() -> None:
+        parameters.validate_job_parameter(job_parameter)
+
+    # THEN
+    with pytest.raises(ValueError) as ctx:
+        when()
+    assert (
+        str(ctx.value)
+        == f'Job parameter "foo" had "type" {typ} but expected one of ("STRING", "PATH", "INT", "FLOAT")'
+    )
+
+
+@pytest.mark.parametrize(
+    argnames="description",
+    argvalues=(
+        pytest.param(1, id="int"),
+        pytest.param(1.2, id="float"),
+        pytest.param(True, id="bool"),
+        pytest.param(None, id="none"),
+        pytest.param([], id="list"),
+        pytest.param({}, id="dict"),
+    ),
+)
+def test_validate_job_parameter_nonvalid_description(
+    description: Any,
+) -> None:
+    """Tests that when calling validate_job_parameter with an nonvalid values for "description"
+    that an exception is raised."""
+    # GIVEN
+    job_parameter = {
+        "name": "a",
+        "description": description,
+    }
+
+    # WHEN
+    def when() -> None:
+        parameters.validate_job_parameter(job_parameter)
+
+    # THEN
+    with pytest.raises(TypeError) as ctx:
+        when()
+    assert (
+        str(ctx.value)
+        == f'Job parameter "a" had {type(description).__name__} for "description" but expected str'
+    )
+
+
+def test_validate_job_parameter_valid_no_default() -> None:
+    """Tests that passing a job parameter to validate_job_parameter without a "default" key does
+    not raise an exception by default or if default_required is False"""
+    # GIVEN
+    job_parameter: parameters.JobParameter = {
+        "name": "foo",
+        "type": "INT",
+    }
+
+    # WHEN
+    # Default is to not require a default
+    result = parameters.validate_job_parameter(job_parameter)
+
+    # THEN
+    assert result is job_parameter
+
+    # WHEN
+    # Explicitly not require a default
+    result = parameters.validate_job_parameter(job_parameter, default_required=False)
+
+    # THEN
+    assert result is job_parameter
+
+
+def test_validate_job_parameter_valid_no_allowed_values() -> None:
+    """Tests that passing a job parameter to validate_job_parameter without a "allowedValues"
+    key does not raise an exception by default or if default_required is False"""
+    # GIVEN
+    job_parameter: parameters.JobParameter = {"name": "foo"}
+
+    # WHEN
+    result = parameters.validate_job_parameter(job_parameter)
+
+    # THEN
+    assert result is job_parameter
+
+
+@pytest.mark.parametrize(
+    argnames="allowed_values",
+    argvalues=(
+        pytest.param("a", id="str"),
+        pytest.param(1, id="int"),
+        pytest.param(1.2, id="float"),
+        pytest.param(True, id="bool"),
+        pytest.param(None, id="none"),
+        pytest.param({}, id="dict"),
+    ),
+)
+def test_validate_job_parameter_nonvalid_allowed_values(
+    allowed_values: Any,
+) -> None:
+    """Tests that passing a job parameter to validate_job_parameter without a "allowedValues"
+    key does not raise an exception by default or if default_required is False"""
+    # GIVEN
+    job_parameter: parameters.JobParameter = {
+        "name": "foo",
+        "allowedValues": allowed_values,
+    }
+
+    # WHEN
+    def when() -> None:
+        parameters.validate_job_parameter(job_parameter)
+
+    # THEN
+    with pytest.raises(TypeError) as ctx:
+        when()
+    assert (
+        str(ctx.value)
+        == f'Job parameter "foo" got {type(allowed_values).__name__} for "allowedValues" but expected list'
+    )
+
+
+def test_validate_job_parameter_valid_no_data_flow(
+    valid_type: str,
+) -> None:
+    """Tests that passing a job parameter to validate_job_parameter without a "dataFlow" key
+    no exception is raised"""
+    # GIVEN
+
+    job_parameter: parameters.JobParameter = {
+        "name": "foo",
+        "type": valid_type,
+    }
+
+    # WHEN
+    # Default is to not require a default
+    result = parameters.validate_job_parameter(job_parameter)
+
+    # THEN
+    assert result is job_parameter
+
+
+@pytest.mark.parametrize(
+    argnames="data_flow",
+    argvalues=(
+        pytest.param(1, id="int"),
+        pytest.param(1.2, id="float"),
+        pytest.param(True, id="bool"),
+        pytest.param("not-valid", id="non-valid-str"),
+        pytest.param(None, id="none"),
+        pytest.param([], id="list"),
+        pytest.param({}, id="dict"),
+    ),
+)
+def test_validate_job_parameter_nonvalid_data_flow(
+    data_flow: Any,
+) -> None:
+    """Tests that when calling validate_job_parameter with an nonvalid values for "dataFlow"
+    that an exception is raised."""
+    # GIVEN
+    job_parameter: parameters.JobParameter = {
+        "name": "foo",
+        "type": "PATH",
+        "dataFlow": data_flow,
+    }
+
+    # WHEN
+    def when() -> None:
+        parameters.validate_job_parameter(job_parameter)
+
+    # THEN
+    with pytest.raises(ValueError) as ctx:
+        when()
+    assert (
+        str(ctx.value)
+        == f'Job parameter "foo" got "{data_flow}" for "dataFlow" but expected one of ("NONE", "IN", "OUT", "INOUT")'
+    )
+
+
+@pytest.mark.parametrize(
+    argnames="min_length",
+    argvalues=(
+        pytest.param(1.2, id="float"),
+        pytest.param("a", id="str"),
+        pytest.param(True, id="bool"),
+        pytest.param(None, id="none"),
+        pytest.param([], id="list"),
+        pytest.param({}, id="dict"),
+    ),
+)
+def test_validate_job_parameter_nonvalid_min_length_type(
+    min_length: Any,
+) -> None:
+    """Tests that passing a value with an nonvalid "minLength" value raises an exception"""
+    # GIVEN
+    job_parameter: dict = {
+        "name": "a",
+        "minLength": min_length,
+    }
+
+    # WHEN
+    def when() -> None:
+        parameters.validate_job_parameter(job_parameter)
+
+    # THEN
+    with pytest.raises(TypeError) as ctx:
+        when()
+    assert (
+        str(ctx.value)
+        == f'Job parameter "a" got {type(min_length).__name__} for "minLength" but expected int'
+    )
+
+
+def test_validate_job_parameter_nonvalid_min_length_negative() -> None:
+    """Tests that passing a value with an nonvalid "minLength" value raises an exception"""
+    # GIVEN
+    min_length = -1
+    job_parameter: dict = {
+        "name": "a",
+        "minLength": min_length,
+    }
+
+    # WHEN
+    def when() -> None:
+        parameters.validate_job_parameter(job_parameter)
+
+    # THEN
+    with pytest.raises(ValueError) as ctx:
+        when()
+    assert (
+        str(ctx.value)
+        == f'Job parameter "a" got {min_length} for "minLength" but the value must be non-negative'
+    )
+
+
+@pytest.mark.parametrize(
+    argnames="max_length",
+    argvalues=(
+        pytest.param(1.2, id="float"),
+        pytest.param("a", id="str"),
+        pytest.param(True, id="bool"),
+        pytest.param(None, id="none"),
+        pytest.param([], id="list"),
+        pytest.param({}, id="dict"),
+    ),
+)
+def test_validate_job_parameter_nonvalid_max_length_type(
+    max_length: Any,
+) -> None:
+    """Tests that passing a value with an nonvalid "maxLength" value raises an exception"""
+    # GIVEN
+    job_parameter: dict = {
+        "name": "a",
+        "maxLength": max_length,
+    }
+
+    # WHEN
+    def when() -> None:
+        parameters.validate_job_parameter(job_parameter)
+
+    # THEN
+    with pytest.raises(TypeError) as ctx:
+        when()
+    assert (
+        str(ctx.value)
+        == f'Job parameter "a" got "{type(max_length).__name__}" for "maxLength" but expected int'
+    )
+
+
+def test_validate_job_parameter_nonvalid_max_length_negative() -> None:
+    """Tests that passing a value with an nonvalid "maxLength" value raises an exception"""
+    # GIVEN
+    max_length = -1
+    job_parameter: dict = {
+        "name": "a",
+        "maxLength": max_length,
+    }
+
+    # WHEN
+    def when() -> None:
+        parameters.validate_job_parameter(job_parameter)
+
+    # THEN
+    with pytest.raises(ValueError) as ctx:
+        when()
+    assert (
+        str(ctx.value)
+        == f'Job parameter "a" got {max_length} for "maxLength" but the value must be non-negative'
+    )
+
+
+@pytest.mark.parametrize(
+    argnames="min_value",
+    argvalues=(
+        pytest.param(True, id="bool"),
+        pytest.param(None, id="none"),
+        pytest.param([], id="list"),
+        pytest.param({}, id="dict"),
+    ),
+)
+def test_validate_job_parameter_nonvalid_min_value_type(
+    min_value: Any,
+) -> None:
+    """Tests that passing a value with an nonvalid "minValue" value raises an exception"""
+    # GIVEN
+    job_parameter: dict = {
+        "name": "a",
+        "minValue": min_value,
+    }
+
+    # WHEN
+    def when() -> None:
+        parameters.validate_job_parameter(job_parameter)
+
+    # THEN
+    with pytest.raises(TypeError) as ctx:
+        when()
+    assert (
+        str(ctx.value)
+        == f'Job parameter "a" got {type(min_value).__name__} for "minValue" but expected int'
+    )
+
+
+@pytest.mark.parametrize(
+    argnames="min_value",
+    argvalues=("one", "two"),
+)
+def test_validate_job_parameter_nonvalid_min_value_str(min_value: str) -> None:
+    """Tests that passing a non-numeric string value to "minValue" raises an exception"""
+    # GIVEN
+    job_parameter: dict = {
+        "name": "a",
+        "minValue": min_value,
+    }
+
+    # WHEN
+    def when() -> None:
+        parameters.validate_job_parameter(job_parameter)
+
+    # THEN
+    with pytest.raises(ValueError) as ctx:
+        when()
+    assert (
+        str(ctx.value)
+        == f'Job parameter "a" has a non-numeric string value for "minValue": {min_value}'
+    )
+
+
+@pytest.mark.parametrize(
+    argnames="max_value",
+    argvalues=(
+        pytest.param(True, id="bool"),
+        pytest.param(None, id="none"),
+        pytest.param([], id="list"),
+        pytest.param({}, id="dict"),
+    ),
+)
+def test_validate_job_parameter_nonvalid_max_value_type(
+    max_value: Any,
+) -> None:
+    """Tests that passing a value with an nonvalid "maxValue" value raises an exception"""
+    # GIVEN
+    job_parameter: dict = {
+        "name": "a",
+        "maxValue": max_value,
+    }
+
+    # WHEN
+    def when() -> None:
+        parameters.validate_job_parameter(job_parameter)
+
+    # THEN
+    with pytest.raises(TypeError) as ctx:
+        when()
+    assert (
+        str(ctx.value)
+        == f'Job parameter "a" got {type(max_value).__name__} for "maxValue" but expected int'
+    )
+
+
+@pytest.mark.parametrize(
+    argnames="max_value",
+    argvalues=("one", "two"),
+)
+def test_validate_job_parameter_nonvalid_max_value_str(max_value: str) -> None:
+    """Tests that passing a non-numeric string value to "maxValue" raises an exception"""
+    # GIVEN
+    job_parameter: dict = {
+        "name": "a",
+        "maxValue": max_value,
+    }
+
+    # WHEN
+    def when() -> None:
+        parameters.validate_job_parameter(job_parameter)
+
+    # THEN
+    with pytest.raises(ValueError) as ctx:
+        when()
+    assert (
+        str(ctx.value)
+        == f'Job parameter "a" has a non-numeric string value for "maxValue": {max_value}'
+    )
+
+
+@pytest.mark.parametrize(
+    argnames="object_type",
+    argvalues=(
+        pytest.param(1, id="int"),
+        pytest.param(1.2, id="float"),
+        pytest.param(True, id="bool"),
+        pytest.param("not-valid", id="non-valid-str"),
+        pytest.param(None, id="none"),
+        pytest.param([], id="list"),
+        pytest.param({}, id="dict"),
+    ),
+)
+def test_validate_job_parameter_nonvalid_object_type(
+    object_type: Any,
+) -> None:
+    """Tests that when calling validate_job_parameter with an nonvalid values for "objectType"
+    that an exception is raised."""
+    # GIVEN
+    job_parameter: parameters.JobParameter = {
+        "name": "foo",
+        "type": "PATH",
+        "objectType": object_type,
+    }
+
+    # WHEN
+    def when() -> None:
+        parameters.validate_job_parameter(job_parameter)
+
+    # THEN
+    with pytest.raises(ValueError) as ctx:
+        when()
+    assert (
+        str(ctx.value)
+        == f'Job parameter "foo" got {object_type} for "objectType" but expected one of ("FILE", "DIRECTORY")'
+    )
+
+
+def test_validate_job_parameter_valid_no_user_interface(
+    valid_type: str,
+) -> None:
+    """Tests that passing a job parameter to validate_job_parameter without a "userInterface"
+    key does not raise an exception"""
+    # GIVEN
+
+    job_parameter: parameters.JobParameter = {
+        "name": "foo",
+        "type": valid_type,
+    }
+
+    # WHEN
+    # Default is to not require a default
+    result = parameters.validate_job_parameter(job_parameter)
+
+    # THEN
+    assert result is job_parameter
+
+
+def test_validate_job_parameter_nonvalid_userinterface(
+    valid_type: str,
+) -> None:
+    """Tests that an nonvalid user interface raises an exception. This is simply testing that
+    an exception raised by validate_user_interface_spec is not caught and ignored"""
+    # GIVEN
+    job_parameter: parameters.JobParameter = {
+        "name": "foo",
+        "type": valid_type,
+        "userInterface": {},
+    }
+    error_msg = "error message"
+    user_interface_validation_error = Exception(error_msg)
+    with patch.object(
+        parameters, "validate_user_interface_spec", side_effect=user_interface_validation_error
+    ):
+        # WHEN
+        def when():
+            parameters.validate_job_parameter(job_parameter)
+
+        # THEN
+        with pytest.raises(Exception) as ctx:
+            when()
+
+        assert ctx.value is user_interface_validation_error

--- a/test/unit/deadline_client/job_bundle/test_validate_user_interface_spec.py
+++ b/test/unit/deadline_client/job_bundle/test_validate_user_interface_spec.py
@@ -1,0 +1,466 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Test cases for deadline.client.job_bundle.parameters.validate_user_interface_spec"""
+
+
+from __future__ import annotations
+import re
+from typing import Any, Dict, cast
+from unittest.mock import patch
+
+import pytest
+
+from deadline.client.job_bundle import parameters
+
+
+@pytest.fixture(
+    params=(
+        "CHECK_BOX",
+        "CHOOSE_DIRECTORY",
+        "CHOOSE_INPUT_FILE",
+        "CHOOSE_OUTPUT_FILE",
+        "DROPDOWN_LIST",
+        "LINE_EDIT",
+        "MULTILINE_EDIT",
+        "SPIN_BOX",
+    ),
+    ids=(
+        "control-CHECK_BOX",
+        "control-CHOOSE_DIRECTORY",
+        "control-CHOOSE_INPUT_FILE",
+        "control-CHOOSE_OUTPUT_FILE",
+        "control-DROPDOWN_LIST",
+        "control-LINE_EDIT",
+        "control-MULTILINE_EDIT",
+        "control-SPIN_BOX",
+    ),
+)
+def valid_control(request: pytest.FixtureRequest) -> str:
+    return request.param
+
+
+@pytest.fixture
+def valid_label() -> str:
+    return "alabel"
+
+
+@pytest.fixture
+def valid_group_label() -> str:
+    return "agrouplabel"
+
+
+@pytest.fixture
+def valid_decimal() -> int:
+    return 1
+
+
+@pytest.fixture
+def valid_single_step_delta() -> float:
+    return 1.5
+
+
+@pytest.fixture
+def parameter_name() -> str:
+    return "myparam"
+
+
+@pytest.fixture
+def valid_user_interface_spec(
+    valid_control: str,
+    valid_label: str,
+    valid_group_label: str,
+    valid_decimal: int,
+    valid_single_step_delta: float,
+) -> parameters.UserInterfaceSpec:
+    return {
+        "control": valid_control,
+        "label": valid_label,
+        "groupLabel": valid_group_label,
+        "decimal": valid_decimal,
+        "singleStepDelta": valid_single_step_delta,
+    }
+
+
+def test_validate_user_interface_spec_valid(
+    valid_user_interface_spec: parameters.UserInterfaceSpec,
+    parameter_name: str,
+) -> None:
+    """Tests that when calling validate_user_interface_spec with a valid user interface spec
+    that no exception is raised"""
+    # WHEN
+    result = parameters.validate_user_interface_spec(
+        valid_user_interface_spec,
+        parameter_name=parameter_name,
+    )
+
+    # THEN
+    assert result is valid_user_interface_spec
+
+
+@pytest.mark.parametrize(
+    argnames="field",
+    argvalues=("control", "label", "groupLabel", "decimal", "singleStepDelta"),
+)
+# Fix the valid_control fixture to a single value so we don't parametrize on it more than
+# once. It's value does not matter to the test
+@pytest.mark.parametrize(
+    argnames="valid_control",
+    argvalues=("CHECK_BOX",),
+)
+def test_validate_user_interface_spec_valid_optional_missing(
+    valid_user_interface_spec: parameters.UserInterfaceSpec,
+    field: str,
+    parameter_name: str,
+) -> None:
+    """Tests that optional fields for the user interface are still valid when missing:
+
+    - control
+    - label
+    - groupLabel
+    - decimal
+    - singleStepDelta
+    """
+    # GIVEN
+    user_interface_spec = cast(Dict[str, Any], valid_user_interface_spec.copy())
+    del user_interface_spec[field]
+
+    # WHEN
+    parameters.validate_user_interface_spec(
+        user_interface_spec,
+        parameter_name=parameter_name,
+    )
+
+
+@pytest.mark.parametrize(
+    argnames="control",
+    argvalues=(
+        pytest.param(1, id="int"),
+        pytest.param(1.2, id="float"),
+        pytest.param(True, id="bool"),
+        pytest.param(None, id="none"),
+        pytest.param([], id="list"),
+        pytest.param({}, id="dict"),
+    ),
+)
+def test_validate_user_interface_spec_nonvalid_control_type(
+    control: Any,
+    parameter_name: str,
+) -> None:
+    """Tests that passing a value with an nonvalid "control" value raises an exception"""
+    # GIVEN
+    user_interface_spec: dict = {"control": control}
+
+    # WHEN
+    def when() -> None:
+        parameters.validate_user_interface_spec(
+            user_interface_spec,
+            parameter_name=parameter_name,
+        )
+
+    # THEN
+    with pytest.raises(ValueError) as ctx:
+        when()
+    ctx.match(
+        rf'Job parameter "{re.escape(parameter_name)}" got but expected one of \(.*\) for "userInterface" -> "control" but got {re.escape(str(control))}'
+    )
+
+
+@pytest.mark.parametrize(
+    argnames="label",
+    argvalues=(
+        pytest.param(1, id="int"),
+        pytest.param(1.2, id="float"),
+        pytest.param(True, id="bool"),
+        pytest.param(None, id="none"),
+        pytest.param([], id="list"),
+        pytest.param({}, id="dict"),
+    ),
+)
+def test_validate_user_interface_spec_nonvalid_label_type(
+    label: Any,
+    parameter_name: str,
+) -> None:
+    """Tests that passing a value with an nonvalid "label" value raises an exception"""
+    # GIVEN
+    user_interface_spec: dict = {"label": label}
+
+    # WHEN
+    def when() -> None:
+        parameters.validate_user_interface_spec(
+            user_interface_spec,
+            parameter_name=parameter_name,
+        )
+
+    # THEN
+    with pytest.raises(TypeError) as ctx:
+        when()
+    assert (
+        str(ctx.value)
+        == f'Job parameter "{parameter_name}" got {type(label).__name__} for "userInterface" -> "label" but expected str'
+    )
+
+
+@pytest.mark.parametrize(
+    argnames="group_label",
+    argvalues=(
+        pytest.param(1, id="int"),
+        pytest.param(1.2, id="float"),
+        pytest.param(True, id="bool"),
+        pytest.param(None, id="none"),
+        pytest.param([], id="list"),
+        pytest.param({}, id="dict"),
+    ),
+)
+def test_validate_user_interface_spec_nonvalid_group_label_type(
+    group_label: Any,
+    parameter_name: str,
+) -> None:
+    """Tests that passing a value with an nonvalid "groupLabel" value raises an exception"""
+    # GIVEN
+    user_interface_spec: dict = {"groupLabel": group_label}
+
+    # WHEN
+    def when() -> None:
+        parameters.validate_user_interface_spec(
+            user_interface_spec,
+            parameter_name=parameter_name,
+        )
+
+    # THEN
+    with pytest.raises(TypeError) as ctx:
+        when()
+    assert (
+        str(ctx.value)
+        == f'Job parameter "{parameter_name}" got {type(group_label).__name__} for "userInterface" -> "groupLabel" but expected str'
+    )
+
+
+@pytest.mark.parametrize(
+    argnames="decimals",
+    argvalues=(
+        pytest.param(1.2, id="float"),
+        pytest.param("a", id="str"),
+        pytest.param(True, id="bool"),
+        pytest.param(None, id="none"),
+        pytest.param([], id="list"),
+        pytest.param({}, id="dict"),
+    ),
+)
+def test_validate_user_interface_spec_nonvalid_decimals_type(
+    decimals: Any,
+    parameter_name: str,
+) -> None:
+    """Tests that passing a value with an nonvalid "decimals" value raises an exception"""
+    # GIVEN
+    user_interface_spec: dict = {"decimals": decimals}
+
+    # WHEN
+    def when() -> None:
+        parameters.validate_user_interface_spec(
+            user_interface_spec,
+            parameter_name=parameter_name,
+        )
+
+    # THEN
+    with pytest.raises(TypeError) as ctx:
+        when()
+    assert (
+        str(ctx.value)
+        == f'Job parameter "{parameter_name}" got {type(decimals).__name__} for "userInterface" -> "decimals" but expected int'
+    )
+
+
+def test_validate_user_interface_spec_nonvalid_decimals_negative(
+    parameter_name: str,
+) -> None:
+    """Tests that passing a negative value for "decimals" raises an exception"""
+    # GIVEN
+    decimals = -1
+    user_interface_spec: dict = {"decimals": decimals}
+
+    # WHEN
+    def when() -> None:
+        parameters.validate_user_interface_spec(
+            user_interface_spec,
+            parameter_name=parameter_name,
+        )
+
+    # THEN
+    with pytest.raises(ValueError) as ctx:
+        when()
+    assert (
+        str(ctx.value)
+        == f'Job parameter "{parameter_name}" got {decimals} for "userInterface" -> "decimals" but expected a non-negative int'
+    )
+
+
+@pytest.mark.parametrize(
+    argnames="single_step_delta",
+    argvalues=(
+        pytest.param("a", id="str"),
+        pytest.param(True, id="bool"),
+        pytest.param(None, id="none"),
+        pytest.param([], id="list"),
+        pytest.param({}, id="dict"),
+    ),
+)
+def test_validate_user_interface_spec_nonvalid_single_step_delta_type(
+    single_step_delta: Any,
+    parameter_name: str,
+) -> None:
+    """Tests that passing a value with an nonvalid "singleStepDelta" value raises an exception"""
+    # GIVEN
+    user_interface_spec: dict = {"singleStepDelta": single_step_delta}
+
+    # WHEN
+    def when() -> None:
+        parameters.validate_user_interface_spec(
+            user_interface_spec,
+            parameter_name=parameter_name,
+        )
+
+    # THEN
+    with pytest.raises(TypeError) as ctx:
+        when()
+    assert (
+        str(ctx.value)
+        == f'Job parameter "{parameter_name}" got but expected float for "userInterface" -> "singleStepDelta", but got {type(single_step_delta).__name__}'
+    )
+
+
+@pytest.mark.parametrize(
+    argnames="single_step_delta",
+    argvalues=(
+        pytest.param(0, id="zero"),
+        pytest.param(-1, id="negative"),
+    ),
+)
+def test_validate_user_interface_spec_nonvalid_single_step_delta_non_positive(
+    single_step_delta: float,
+    parameter_name: str,
+) -> None:
+    """Tests that passing a non-positive value for "singleStepDelta" value raises an exception"""
+    # GIVEN
+    user_interface_spec: dict = {"singleStepDelta": single_step_delta}
+
+    # WHEN
+    def when() -> None:
+        parameters.validate_user_interface_spec(
+            user_interface_spec,
+            parameter_name=parameter_name,
+        )
+
+    # THEN
+    with pytest.raises(ValueError) as ctx:
+        when()
+    assert (
+        str(ctx.value)
+        == f'Job parameter "{parameter_name}" got {single_step_delta} for "userInterface" -> "singleStepDelta" but expected a positive number'
+    )
+
+
+def test_validate_user_interface_spec_nonvalid_file_filters(
+    parameter_name: str,
+) -> None:
+    """Tests that when the input contains a "fileFilters" field, that its elements are passed
+    to validate_user_interface_file_filter and exceptions raised by that call are not caught."""
+    # GIVEN
+    file_filter = object()
+    user_interface_spec = {
+        # We need something here in order for validate_user_interface_spec to call
+        # validate_user_interface_file_filter
+        "fileFilters": [file_filter]
+    }
+    error = Exception()
+
+    with patch.object(
+        parameters, "validate_user_interface_file_filter", side_effect=error
+    ) as mock_validate_user_interface_file_filter:
+        # WHEN
+        def when() -> None:
+            parameters.validate_user_interface_spec(
+                user_interface_spec,
+                parameter_name=parameter_name,
+            )
+
+        # THEN
+        with pytest.raises(Exception) as ctx:
+            when()
+        mock_validate_user_interface_file_filter.assert_called_once_with(
+            file_filter,
+            parameter_name=parameter_name,
+            field_path='"userInterface" -> "fileFilters" -> [0]',
+        )
+        assert ctx.value is error
+
+
+@pytest.mark.parametrize(
+    argnames="file_filters",
+    argvalues=(
+        pytest.param("a", id="str"),
+        pytest.param(1, id="int"),
+        pytest.param(1.5, id="float"),
+        pytest.param(True, id="bool"),
+        pytest.param({}, id="dict"),
+        pytest.param(None, id="None"),
+    ),
+)
+def test_validate_user_interface_spec_nonvalid_file_filters_nonlist(
+    parameter_name: str,
+    file_filters: Any,
+) -> None:
+    """Tests that when the input contains a "fileFilters" field value that is not a list that an
+    exception is raised"""
+    # GIVEN
+    user_interface_spec = {"fileFilters": file_filters}
+
+    # WHEN
+    def when() -> None:
+        parameters.validate_user_interface_spec(
+            user_interface_spec,
+            parameter_name=parameter_name,
+        )
+
+    # THEN
+    with pytest.raises(TypeError) as ctx:
+        when()
+
+    assert (
+        str(ctx.value)
+        == f'Job parameter "{parameter_name}" got but expected list for "userInterface" -> "fileFilters", but got {type(file_filters).__name__}'
+    )
+
+
+def test_validate_user_interface_spec_nonvalid_file_filter_default(
+    parameter_name: str,
+) -> None:
+    """Tests that when the input contains a "fileFilterDefault" field, that its value is passed
+    to validate_user_interface_file_filter and exceptions raised by that call are not caught."""
+    # GIVEN
+    file_filter = object()
+    user_interface_spec = {
+        # We need something here in order for validate_user_interface_spec to call
+        # validate_user_interface_file_filter
+        "fileFilterDefault": file_filter,
+    }
+    error = Exception()
+
+    with patch.object(
+        parameters, "validate_user_interface_file_filter", side_effect=error
+    ) as mock_validate_user_interface_file_filter:
+        # WHEN
+        def when() -> None:
+            parameters.validate_user_interface_spec(
+                user_interface_spec,
+                parameter_name=parameter_name,
+            )
+
+        # THEN
+        with pytest.raises(Exception) as ctx:
+            when()
+        mock_validate_user_interface_file_filter.assert_called_once_with(
+            file_filter,
+            parameter_name=parameter_name,
+            field_path='"userInterface" -> "fileFilterDefault"',
+        )
+        assert ctx.value is error


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

1. Submitting to a queue that has an environment without parameters caused the following error to be displayed:

    *   CLI Bundle Submission

        ```sh
        $ deadline bundle submit --queue-id $QUEUE_ID bundleDir
        Submitting to Queue: CMFQueue
        'parameterDefinitions' not in queue template keys: dict_keys(['specificationVersion', 'environment'])
        ```
    *   Integrated Submitter Submission

        ```txt
        Error Loading Queue Environments: Invalid Queue Parameters

        Error Traceback: 'parameterDefinitions' not in queue template keys: dict_keys(['specificationVersion', 'environment'])
        ```

2. Submitting a job bundle to a queue with a queue environment parameter and the job bundle has no parameter defined with the same name causes the parameter value to not be submitted in the `CreateJob` request. For example:

    ```sh
    # Assuming foo is defined on the target queue but not in $BUNDLE_DIR,
    # the value "bar" for foo will not be passed in the CreateJob request
    deadline bundle submit -p foo=bar $BUNDLE_DIR
    ```

### What was the solution? (How)

1.  Relax the validation in `deadline.client.api.get_queue_parameter_definitions` from raising an exception to instead ignore the queue environment.
2.  Rework the parameter handling in the library to better account for queue parameters and their
    interaction with job parameters. Since the parameters share a common namespace we need to
    ensure their type definitions agree and that we have a well-defined priority for default values.

    1.  Create a `merge_queue_job_parameters` function for applying these validations and priority
        of defaults
    2.  Modify the code to use this new function

While in the code, I took a few other opportunities:

*   add type hints
*   improve code organization
*   added parameter input validation

### What is the impact of this change?

1.  Users can submit jobs to queues that have queue environments without any parameters.
2.  Users can submit jobs from job bundles and override queue parameter default values even if the
    job bundle doesn't define a same-named parameter
3.  The client library will fail fast with a validation error if the job parameters are not valid

### How was this change tested?

1.  Reproduced the issue prior to making the code changes both using the CLI bundle submission and the `deadline-cloud-for-nuke` integrated submitter.
2.  Made the code change and used the reproductions steps to successfully submit jobs both using:
    1.  the `deadline-cloud-for-nuke` submitter
    2.  the command-line bundle submitter

### Was this change documented?

No

### Is this a breaking change?

No