### PR TITLE
fix: add JobBundlePurpose to callbacks.

### DIFF
--- a/src/deadline/client/ui/cli_job_submitter.py
+++ b/src/deadline/client/ui/cli_job_submitter.py
@@ -15,7 +15,10 @@ from PySide2.QtWidgets import (  # pylint: disable=import-error; type: ignore
 
 from ..job_bundle import deadline_yaml_dump
 from .dataclasses import CliJobSettings
-from .dialogs.submit_job_to_deadline_dialog import SubmitJobToDeadlineDialog
+from .dialogs.submit_job_to_deadline_dialog import (
+    SubmitJobToDeadlineDialog,
+    JobBundlePurpose,
+)
 from .widgets.cli_job_settings_tab import CliJobSettingsWidget
 from ..job_bundle.submission import AssetReferences
 
@@ -47,6 +50,7 @@ def show_cli_job_submitter(parent=None, f=Qt.WindowFlags()) -> None:
         settings: CliJobSettings,
         queue_parameters: list[dict[str, Any]],
         asset_references: AssetReferences,
+        purpose: JobBundlePurpose = JobBundlePurpose.SUBMISSION,
     ) -> None:
         """
         Perform a submission when the submit button is pressed

--- a/src/deadline/client/ui/job_bundle_submitter.py
+++ b/src/deadline/client/ui/job_bundle_submitter.py
@@ -22,7 +22,10 @@ from ..job_bundle.loader import (
 )
 from ..job_bundle.parameters import apply_job_parameters, read_job_bundle_parameters
 from .dataclasses import JobBundleSettings
-from .dialogs.submit_job_to_deadline_dialog import SubmitJobToDeadlineDialog
+from .dialogs.submit_job_to_deadline_dialog import (
+    SubmitJobToDeadlineDialog,
+    JobBundlePurpose,
+)
 from .widgets.job_bundle_settings_tab import JobBundleSettingsWidget
 from ..job_bundle.submission import AssetReferences
 
@@ -61,6 +64,7 @@ def show_job_bundle_submitter(
         settings: JobBundleSettings,
         queue_parameters: list[dict[str, Any]],
         asset_references: AssetReferences,
+        purpose: JobBundlePurpose = JobBundlePurpose.SUBMISSION,
     ) -> None:
         """
         Perform a submission when the submit button is pressed


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
With the new purpose argument, callbacks need to be updated in the clients and in deadline-cloud itself.

### What was the solution? (How)
Add the purpose optional parameter to the callback.

### What is the impact of this change?
Fixes the issue that was preventing the CLI gui-submit from running.

### How was this change tested?
Passes all the tests.

### Was this change documented?
No

### Is this a breaking change?
No