### PR TITLE
feat!(job_attachment): cancelable multipart file upload

### DIFF
--- a/scripted_tests/upload_cancel_test.py
+++ b/scripted_tests/upload_cancel_test.py
@@ -23,6 +23,9 @@ How to test:
 2. In the middle of hashing or uploading those files, you can send a cancel
    signal by pressing 'k' and Enter keys in succession. Confirm that cancelling
    is working as expected by checking the console output.
+
+Note: This script generates test files in the /tmp/test_submit directory for testing
+purpose. But it does not delete these files after the test is completed.
 """
 
 MESSAGE_HOW_TO_CANCEL = (
@@ -30,7 +33,7 @@ MESSAGE_HOW_TO_CANCEL = (
 )
 
 NUM_SMALL_FILES = 0
-NUM_MEDIUM_FILES = 5
+NUM_MEDIUM_FILES = 0
 NUM_LARGE_FILES = 1
 
 continue_reporting = True
@@ -74,7 +77,7 @@ def run():
             file_path = root_path / f"medium_test{i}.txt"
             if not os.path.exists(file_path):
                 with file_path.open("wb") as f:
-                    f.write(os.urandom(102428800))  # 100 MB files
+                    f.write(os.urandom(100 * (1024**2)))  # 100 MB files
             files.append(str(file_path))
 
     # Make large files
@@ -82,9 +85,8 @@ def run():
         for i in range(0, NUM_LARGE_FILES):
             file_path = root_path / f"large_test{i}.txt"
             if not os.path.exists(file_path):
-                for i in range(1):
-                    with file_path.open("ab") as f:
-                        f.write(os.urandom(1073741824))  # Write 1 GB at a time
+                with file_path.open("ab") as f:
+                    f.write(os.urandom(1 * (1024**3)))  # Write 1 GB at a time
             files.append(str(file_path))
 
     queue = get_queue(farm_id=farm_id, queue_id=queue_id)
@@ -117,7 +119,7 @@ def run():
         )
     except AssetSyncCancelledError as asce:
         print(f"AssetSyncCancelledError: {asce}")
-        print(f"payload: {asce.summary_statistics}")
+        print(f"payload:\n{asce.summary_statistics}")
 
     print(f"\nTotal test runtime: {time.perf_counter() - start_time}")
 

--- a/src/deadline/job_attachments/asset_sync.py
+++ b/src/deadline/job_attachments/asset_sync.py
@@ -30,7 +30,6 @@ from .asset_manifests import BaseManifestPath as RelativeFilePath
 from ._aws.aws_clients import get_boto3_session
 from ._aws.deadline import get_job, get_queue
 from .download import (
-    _progress_logger,
     merge_asset_manifests,
     download_files_from_manifests,
     get_manifest_from_s3,
@@ -122,12 +121,10 @@ class AssetSync:
                 continue
 
             self.s3_uploader.upload_file_to_s3(
-                file.full_path,
+                Path(file.full_path),
                 s3_settings.s3BucketName,
                 file.s3_key,
-                progress_handler=_progress_logger(
-                    file.file_size, progress_tracker.track_progress_callback
-                ),
+                progress_tracker,
             )
 
         progress_tracker.total_time = time.perf_counter() - start_time
@@ -480,7 +477,7 @@ class AssetSync:
                         )
                     else:
                         raise AssetSyncError(
-                            "Error occurred while attempting to sync input files: "
+                            "Error occurred while attempting to sync output files: "
                             f"No path mapping rule found for the source path {manifest_properties.rootPath}"
                         )
                 else:

--- a/src/deadline/job_attachments/progress_tracker.py
+++ b/src/deadline/job_attachments/progress_tracker.py
@@ -105,7 +105,7 @@ class DownloadSummaryStatistics(SummaryStatistics):
 
 class ProgressStatus(Enum):
     """
-    Reperesents the current stage of asset/file processing
+    Represents the current stage of asset/file processing
     """
 
     NONE = ("NONE", "")
@@ -194,7 +194,7 @@ class ProgressTracker:
 
         self._lock = Lock()
 
-        def track_progress(bytes_amount: int, current_file_done: bool) -> bool:
+        def track_progress(bytes_amount: int, current_file_done: Optional[bool] = False) -> bool:
             """
             When uploading or downloading files using boto3, pass this to the `Callback` argument
             so that the progress can be updated with the amount of bytes processed.


### PR DESCRIPTION
Refactored file upload process to enable cancellation check during the upload of files.

### What was the problem/requirement? (What/Why)
Currently Job Attachments only checks for if the uploading of files is cancelled only after the completion of a file. If users upload a single large file to upload, e.g. 10 GB, and a cancellation is sent (by pressing Cancel button on GUI,) there may be quite a long delay until the upload actually cancels, because they need to hang and wait the file currently being uploaded is completely finished. 

### What was the solution? (How)
- Refactor upload functions to use boto3's [low-level multipart upload API](https://docs.aws.amazon.com/AmazonS3/latest/userguide/mpu-upload-object.html). This approach allows us to check for cancellation signals during the upload of individual file parts and to abort the upload if necessary.
- Implement multipart upload using S3 API calls `create_multipart_upload`, `upload_parts`, `complete_multipart_upload` and `abort_multipart_upload`.
- Use `ProgressTracker` to monitor upload progress and respond to cancellation requests.

### What is the impact of this change?
This change enables users to cancel ongoing uploads mid-way, providing better control over the upload process.

### How was this change tested?
- Unit tests: `hatch run fmt && hatch run lint`
- Manual script-based test: run `scripted_tests/upload_cancel_test.py` to manually initiate and cancel file uploads, using various combinations of files of different sizes. Verified that I can abort any upload process when I want.
- End-to-end test: This involved starting job submission using GUI, and then press a Cancel button. Verified that aborted uploads did not result in the file being left in the S3 bucket. (Note that any file that have already been fully uploaded at the point when the Cancel is signalled are not deleted or removed.)

### Was this change documented?
No.

### Is this a breaking change?
Yes.
