### PR TITLE
feat(job_attachments): enable output download cancellation

### DIFF
--- a/scripted_tests/download_cancel_test.py
+++ b/scripted_tests/download_cancel_test.py
@@ -22,7 +22,7 @@ How to test:
       python3 download_cancel_test.py sync_inputs -f <farm_id> -q <queue_id> -j <job_id>
   (2) To test canceling downloading outputs, run the following command:
       python3 download_cancel_test.py download_outputs -f <farm_id> -q <queue_id> -j <job_id>
-2. In the middle of downloading files, you can send a cencel signal by pressing 'k' key
+2. In the middle of downloading files, you can send a cancel signal by pressing 'k' key
    and then pressing 'Enter' key in succession. Confirm that cancelling is working as expected.
 """
 

--- a/src/deadline/client/cli/_groups/_sigint_handler.py
+++ b/src/deadline/client/cli/_groups/_sigint_handler.py
@@ -1,0 +1,23 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import signal
+
+
+class SigIntHandler:
+    """
+    A singleton class to handle SIGINT signals (triggered by Ctrl + C). Sets
+    a flag `continue_operation` to False to indicate the interruption of an
+    ongoing process. (e.g. job submission, output download)
+    """
+
+    _instance = None
+
+    def __new__(cls, *args, **kwargs):
+        if not cls._instance:
+            cls._instance = super().__new__(cls)
+            cls._instance.continue_operation = True
+            signal.signal(signal.SIGINT, cls._instance._handle_sigint)
+        return cls._instance
+
+    def _handle_sigint(self, signum, frame):
+        self.continue_operation = False

--- a/test/unit/deadline_client/cli/test_cli_sigint_handler.py
+++ b/test/unit/deadline_client/cli/test_cli_sigint_handler.py
@@ -1,0 +1,11 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from deadline.client.cli._groups._sigint_handler import SigIntHandler
+
+
+class TestSigIntHAndler:
+    def test_singleton_instance(self):
+        """Ensures that only one instance of SigIntHandler can exist"""
+        handler1 = SigIntHandler()
+        handler2 = SigIntHandler()
+        assert handler1 is handler2

--- a/test/unit/deadline_job_attachments/test_asset_sync.py
+++ b/test/unit/deadline_job_attachments/test_asset_sync.py
@@ -73,6 +73,7 @@ class TestAssetSync:
         """
         # GIVEN
         mock_progress_tracker_callback = MagicMock()
+        mock_progress_tracker_callback.return_value = True
         callback = _progress_logger(
             file_size_in_bytes=10,
             progress_tracker_callback=mock_progress_tracker_callback,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The CLI command `deadline job download-output` allows users to download output files for a given job. However, it lacked the functionality to interrupt/stop this download process once initiated. This is an issue for users who needs to stop the download due to various reasons.

### What was the solution? (How)
Adds  the ability for users to interrupt the output download using the SIGINT signal, triggered by Ctrl + C keyboard input.
When Ctrl + C is pressed, the console stdout looks like below:
```
...
Downloading Outputs  [####################----------------]   56%  00:00:02^C
Failed to download output:
Download cancelled. (Downloaded 0 files before cancellation.)
```

### What is the impact of this change?
Enhances user experience, giving the flexibility to stop the download mid-way. Now, when users run the command and wish to halt the download process at any point, they can press Ctrl + C, and the download will be stopped gracefully. 

### How was this change tested?
- Ran unit tests:`hatch run lint && hatch run test`
- Ran scripted tests `download_cancel_test.py` and verified that the download process (both input syncing and output downloading) can be halted immediately when Ctrl + C pressed.
- Double-checked that upload process (in job submission via CLI) is also cancellable using Ctrl + C.
- End-to-end testing: initiated `download-output`, and interrupted the download using Ctrl + C ensuring that it is working.

### Was this change documented?
No.

### Is this a breaking change?
No.