### PR TITLE
feat(ui): Add 'Do not ask again' button in the upload confirmation dialog

### DIFF
--- a/src/deadline/client/ui/dialogs/submit_job_progress_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_progress_dialog.py
@@ -22,6 +22,7 @@ from PySide2.QtWidgets import (  # pylint: disable=import-error; type: ignore
     QLabel,
     QMessageBox,
     QProgressBar,
+    QPushButton,
     QTextEdit,
     QVBoxLayout,
     QWidget,
@@ -513,7 +514,7 @@ class SubmitJobProgressDialog(QDialog):
     def _confirm_job_attachments_upload(self, num_files: int, upload_size: int) -> bool:
         """
         Creates a dialog to prompt the user to confirm that they want to proceed
-        with uploding the specified number of files totaling a certain size.
+        with uploading the specified number of files totaling a certain size.
         """
         message_box = QMessageBox(self)
         message_box.setText(
@@ -522,10 +523,17 @@ class SubmitJobProgressDialog(QDialog):
         )
         message_box.setStandardButtons(QMessageBox.Ok | QMessageBox.Cancel)
         message_box.setDefaultButton(QMessageBox.Ok)
+
+        # Add the "Do not ask again" button that acts like 'OK' but sets the config
+        # setting to always auto-accept similar prompts in the future.
+        dont_ask_button = QPushButton("Do not ask again", self)
+        dont_ask_button.clicked.connect(lambda: set_setting("settings.auto_accept", "true"))
+        message_box.addButton(dont_ask_button, QMessageBox.ActionRole)
+
         message_box.setWindowTitle("Job Attachments Upload Confirmation")
         selection = message_box.exec_()
 
-        return selection == QMessageBox.Ok
+        return selection != QMessageBox.Cancel
 
     def closeEvent(self, event: QCloseEvent) -> None:
         """


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Our GUI submitter shows an upload confirmation dialog that pops up when submitting a job. This dialog box lacked an option for users to prevent the same dialog from reappearing.

### What was the solution? (How)
Add a new button "Do not ask again" in the dialog. This button acts as an OK button, but also updates the `auto_accept` setting in the config file to always auto-accept similar prompts in the future.

### What is the impact of this change?
Enhances user control and convenience. Users now see the new button:

![Screenshot 2023-11-22 at 9 19 28 AM](https://github.com/casillas2/deadline-cloud/assets/132245153/6ed4fb71-1879-48db-a831-a18413e3efca)

If the "Do not ask again" button is clicked, the `auto_accept` setting in the config file is set to `true`:
```
[settings]
auto_accept = true
```

### How was this change tested?
- Ran unit tests by `hatch run test` and made sure all tests passed successfully.
- Manual testing: The new button was tested manually to ensure it performs as expected.
  - On clicking it, verified that the config file updates correctly.
  - Also, other buttons (`OK`, `Cancel`) were tested as well to confirm they continue to operate as before.

### Was this change documented?
No.

### Is this a breaking change?
No.
