### PR TITLE
fix: correct validation for Task ID format

### DIFF
--- a/test/unit/deadline_client/cli/test_cli_handle_web_url.py
+++ b/test/unit/deadline_client/cli/test_cli_handle_web_url.py
@@ -146,44 +146,54 @@ def test_validate_resource_ids_successful(ids: Dict[str, str]):
 @pytest.mark.parametrize(
     ("ids", "exception_message"),
     [
-        ({"": ""}, 'The ID "": "" is not valid.'),
-        ({"farm_id": "farm-123"}, 'The ID "farm_id": "farm-123" is not valid.'),
+        ({"": ""}, 'The given resource ID "": "" has invalid format.'),
+        (
+            {"farm_id": "farm-123"},
+            'The given resource ID "farm_id": "farm-123" has invalid format.',
+        ),
         (
             {"farm_id": "farm-0123456789abcdefabcdefabcdefabc"},
-            'The ID "farm_id": "farm-0123456789abcdefabcdefabcdefabc" is not valid.',
+            'The given resource ID "farm_id": "farm-0123456789abcdefabcdefabcdefabc" has invalid format.',
         ),
         (
             {"farm_id": "farm-0123456789abcdefabcdefabcdefabcdef"},
-            'The ID "farm_id": "farm-0123456789abcdefabcdefabcdefabcdef" is not valid.',
+            'The given resource ID "farm_id": "farm-0123456789abcdefabcdefabcdefabcdef" has invalid format.',
         ),
         (
             {"farm_id": "0123456789abcdefabcdefabcdefabcd"},
-            'The ID "farm_id": "0123456789abcdefabcdefabcdefabcd" is not valid.',
+            'The given resource ID "farm_id": "0123456789abcdefabcdefabcdefabcd" has invalid format.',
         ),
         (
             {"farm_id": "far-0123456789abcdefabcdefabcdefabcd"},
-            'The ID "farm_id": "far-0123456789abcdefabcdefabcdefabcd" is not valid.',
+            'The given resource ID "farm_id": "far-0123456789abcdefabcdefabcdefabcd" has invalid format.',
         ),
         (
             {"farm_id": "-farm-0123456789abcdefabcdefabcdefabcd"},
-            'The ID "farm_id": "-farm-0123456789abcdefabcdefabcdefabcd" is not valid.',
+            'The given resource ID "farm_id": "-farm-0123456789abcdefabcdefabcdefabcd" has invalid format.',
         ),
         (
             {"farm_id": "farm--0123456789abcdefabcdefabcdefabcd"},
-            'The ID "farm_id": "farm--0123456789abcdefabcdefabcdefabcd" is not valid.',
+            'The given resource ID "farm_id": "farm--0123456789abcdefabcdefabcdefabcd" has invalid format.',
         ),
         (
             {"farm_id": "farm-farm-0123456789abcdefabcdefabcdefabcd"},
-            'The ID "farm_id": "farm-farm-0123456789abcdefabcdefabcdefabcd" is not valid.',
+            'The given resource ID "farm_id": "farm-farm-0123456789abcdefabcdefabcdefabcd" has invalid format.',
         ),
         (
             {"mission_id": "mission-0123456789abcdefabcdefabcdefabcd"},
-            'The ID "mission_id": "mission-0123456789abcdefabcdefabcdefabcd" is not valid.',
+            'The given resource ID "mission_id": "mission-0123456789abcdefabcdefabcdefabcd" has invalid format.',
         ),
-        ({"farm_id": MOCK_QUEUE_ID}, f'The ID "farm_id": "{MOCK_QUEUE_ID}" is not valid.'),
+        (
+            {"farm_id": MOCK_QUEUE_ID},
+            f'The given resource ID "farm_id": "{MOCK_QUEUE_ID}" has invalid format.',
+        ),
         (
             {"farm_id": MOCK_FARM_ID, "queue_id": "queue-123"},
-            'The ID "queue_id": "queue-123" is not valid.',
+            'The given resource ID "queue_id": "queue-123" has invalid format.',
+        ),
+        (
+            {"task_id": "task-0123456789abcdefabcdefabcdefabcd"},
+            'The given resource ID "task_id": "task-0123456789abcdefabcdefabcdefabcd" has invalid format.',
         ),
     ],
 )
@@ -228,6 +238,9 @@ def test_validate_id_format_successful(resource_type: str, full_id_str: str):
         ("farm", "queue-0123456789abcdefabcdefabcdefabcd"),
         ("farmfarm", "farmfarm-0123456789abcdefabcdefabcdefabcd"),
         ("mission", "mission-0123456789abcdefabcdefabcdefabcd"),
+        ("task", "task-0123456789abcdefabcdefabcdefabcd"),
+        ("task", "task-0123456789abcdefabcdefabcdefabcd-00"),
+        ("task", "task-0123456789abcdefabcdefabcdefabcd-12345678912345"),
     ],
 )
 def test_validate_id_format_failed(resource_type: str, full_id_str: str):

--- a/test/unit/deadline_client/shared_constants.py
+++ b/test/unit/deadline_client/shared_constants.py
@@ -6,7 +6,7 @@ MOCK_BUCKET_NAME = "deadline-job-attachments-mock-bucket"
 MOCK_STORAGE_PROFILE_ID = "sp-0123456789abcdefabcdefabcdefabcd"
 MOCK_JOB_ID = "job-0123456789abcdefabcdefabcdefabcd"
 MOCK_STEP_ID = "step-0123456789abcdefabcdefabcdefabcd"
-MOCK_TASK_ID = "task-0123456789abcdefabcdefabcdefabcd"
+MOCK_TASK_ID = "task-0123456789abcdefabcdefabcdefabcd-99"
 MOCK_PROFILE_NAME = "my-studio-profile"
 MOCK_QUEUES_LIST = [
     {


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
- There was a bug where a valid Task ID was incorrectly being marked as invalid when attempting to download files for a individual Task. For example:
  ```
  The ID "task_id": "task-6e90ed947ba6454caea839b863c6ee6d-0" is not valid. The ID format must be a valid resource 
  name followed by a hyphen, then a hexadecimal string of 32 characters.
  ```
  But this Task ID is a valid one.

- The Task ID format is slightly different than other resources such as Queue, Job, Step. Task ID has an additional part - a hyphen (`-`) followed by a numeric string from 0 - up to 10 digits, which was being overlooked.

### What was the solution? (How)
Updated the validation logic to correctly identify the Task ID format as valid, especially the pattern with an additional hyphen and numeric string.

### What is the impact of this change?
Users will be able to successfully download Task outputs (from the web Portal) without seeing any invalid ID format errors.

### How was this change tested?
- Updated unit tests to reflect the changes, and confirmed that all tests passed.
- Manually tested on Windows by installing the updated local client, and successfully downloaded Task outputs without any errors.
 
### Was this change documented?
No.

### Is this a breaking change?
No.
