### PR TITLE
chore: update job_history to job_bundle in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This submodule contains Qt GUIs, based on PySide2, for common controls
 and widgets used in interactive submitters, and to display the status
 of various Amazon Deadline Cloud resoruces.
 
-### job_history
+### job_bundle
 
 This submodule contains code related to the history of job submissions
 performed on the workstation. Its initial functionality is to create


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
README.md had wrong name for `deadline.client.job_bundle` package

### What was the solution? (How)
Fix the name in README.md

### What is the impact of this change?
It's correct

### How was this change tested?
N/A

### Was this change documented?
N/A

### Is this a breaking change?
No