### PR TITLE
fix: prefix telemetry endpoint with 'management.'

### DIFF
--- a/test/unit/deadline_client/api/test_api_telemetry.py
+++ b/test/unit/deadline_client/api/test_api_telemetry.py
@@ -181,3 +181,33 @@ def test_record_error(telemetry_client):
 
     # THEN
     queue_mock.put_nowait.assert_called_once_with(expected_event)
+
+
+@pytest.mark.parametrize(
+    "endpoint,prefix,expected_result",
+    [
+        pytest.param(
+            "test.endpoint.url",
+            "",
+            "test.endpoint.url",
+            id="The endpoint is not prefixed if the prefix is empty.",
+        ),
+        pytest.param(
+            "test.endpoint.url",
+            "management.",
+            "test.endpoint.url",
+            id="The endpoint is not prefixed if the endpoint does not start with 'https://'.",
+        ),
+        pytest.param(
+            "https://test.endpoint.url",
+            "management.",
+            "https://management.test.endpoint.url",
+            id="The prefix is inserted right after 'https://'.",
+        ),
+    ],
+)
+def test_get_prefixed_endpoint(
+    telemetry_client: TelemetryClient, endpoint: str, prefix: str, expected_result: str
+):
+    """Test that the _get_prefixed_endpoint function returns the expected prefixed endpoint"""
+    assert telemetry_client._get_prefixed_endpoint(endpoint, prefix) == expected_result


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
From the client submitter, we used to send client telemetry requests ([code here](https://github.com/casillas2/deadline-cloud/blob/62e62f4bd6d95580c5b42e9a0e7746ba5ff8a785/src/deadline/client/api/_telemetry.py#L142C26-L142C26)) to the service endpoint. I found that `request.urlopen(req)` is failing with below error.
```
<urlopen error [Errno -2] Name or service not known>
```

### What was the solution? (How)
The endpoint that we were using was incorrect. It should be prefixed with `management.`.

### What is the impact of this change?
We can now send the client telemetry requests.

### How was this change tested?
- Ran unit tests and made sure all tests passed.
- Manually tested by submitting jobs using the CLI against Alpha, Beta, and Prod endpoints. Confirmed that the client telemetry events were correctly recorded for each of those stage.

### Was this change documented?
No.

### Is this a breaking change?
No.