### PR TITLE
fix(DCM): Starting DCM binary without CLI process getting suspended

### DIFF
--- a/src/deadline/client/api/_loginout.py
+++ b/src/deadline/client/api/_loginout.py
@@ -9,6 +9,7 @@ from configparser import ConfigParser
 from logging import getLogger
 from typing import Callable, Optional
 import subprocess
+import sys
 
 
 from ._session import (
@@ -47,6 +48,10 @@ def _login_deadline_cloud_monitor(
         p = subprocess.Popen(
             args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, stdin=subprocess.PIPE
         )
+        # Linux takes time to start DCM binary, which causes the TTY to suspend the process and send it to background job
+        # With wait here, the DCM binary starts and TTY does not suspend the deadline process.
+        if sys.platform == "linux":
+            time.sleep(0.5)
     except FileNotFoundError:
         raise DeadlineOperationError(
             f"Could not find Deadline Cloud Monitor at {deadline_cloud_monitor_path}. Please ensure Deadline Cloud Monitor is installed correctly and setup the {profile_name} profile again."


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
In Linux (tested on RHEL, Rocky Linux), in terminal running command `deadline login` suspends the CLI process. To continue user would need to use fg command to bring process into foreground to continue with DCM login flow.
### What was the solution? (How)
In case of Linux, added wait after creating DCM subprocess, before going into loop for user to complete login flow. With adding wait, terminal does not suspend the CLI process and DCM login flow starts.
### What is the impact of this change?
On Linux, when using DCM profile for login, in terminal running command `deadline login` will not suspend the CLI. Instead DCM starts, user completes the login flow and deadline login command succeeds.
### How was this change tested?
- Ran unit tests: `hatch run lint && hatch run test`
- Tested the CLI change on RHEL, Rocky Linux with DCM installed, to ensure CLI process is not suspended
### Was this change documented?
No

### Is this a breaking change?
No