### PR TITLE
feat(job_attachments): make hard-coded parameters configurable

### DIFF
--- a/src/deadline/client/config/config_file.py
+++ b/src/deadline/client/config/config_file.py
@@ -107,6 +107,25 @@ SETTINGS: Dict[str, Dict[str, Any]] = {
     "telemetry.opt_out": {"default": "false"},
     "telemetry.identifier": {"default": ""},
     "defaults.job_attachments_file_system": {"default": "COPIED", "depend": "defaults.farm_id"},
+    "settings.list_object_threshold": {
+        "default": "100",
+        "description": "If the number of files to be uploaded are bigger than this threshold, it switches to call list-objects S3 API from head-object call to check if files have already been uploaded.",
+    },
+    "settings.multipart_upload_chunk_size": {
+        "default": "8388608",  # 8 MB (Default chunk size for multipart upload)
+        "description": "The chunk size to use when uploading files in multi-parts.",
+    },
+    "settings.multipart_upload_max_workers": {
+        "default": "10",
+        "description": "The maximum number of workers (processes) to use when uploading files in multi-parts.",
+    },
+    "settings.small_file_threshold_multiplier": {
+        "default": "20",  # By default, the small file threshold is 160 MB (since the default S3 multipart-upload chunk size is 8 MB.)
+        "description": (
+            "When uploading job attachments, the file size threshold is set to separate 'large' files from 'small' files so that 'large' files can be processed serially. "
+            "This multiplier is used to calculate the size threshold. (Small files are defined as those smaller than or equal to the chunk size multiplied by this factor.)"
+        ),
+    },
 }
 
 

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -1,0 +1,30 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import pytest
+import tempfile
+
+from unittest.mock import patch
+from pathlib import Path
+from deadline.client.config import config_file
+
+
+@pytest.fixture(scope="function")
+def fresh_deadline_config():
+    """
+    Fixture to start with a blank Amazon Deadline Cloud config file.
+    """
+
+    try:
+        # Create an empty temp file to set as the Amazon Deadline Cloud config
+        temp_dir = tempfile.TemporaryDirectory()
+        temp_dir_path = Path(temp_dir.name)
+        temp_file_path = temp_dir_path / "config"
+        with open(temp_file_path, "w+t", encoding="utf8") as temp_file:
+            temp_file.write("")
+
+        # Yield the temp file name with it patched in as the
+        # Amazon Deadline Cloud config file
+        with patch.object(config_file, "CONFIG_FILE_PATH", str(temp_file_path)):
+            yield str(temp_file_path)
+    finally:
+        temp_dir.cleanup()

--- a/test/unit/deadline_client/cli/test_cli_config.py
+++ b/test/unit/deadline_client/cli/test_cli_config.py
@@ -35,7 +35,7 @@ def test_cli_config_show_defaults(fresh_deadline_config):
     assert fresh_deadline_config in result.output
 
     # Assert the expected number of settings
-    assert len(settings.keys()) == 13
+    assert len(settings.keys()) == 17
 
     for setting_name in settings.keys():
         assert setting_name in result.output
@@ -102,6 +102,10 @@ def test_cli_config_show_modified_config(fresh_deadline_config):
     config.set_setting("settings.log_level", "DEBUG")
     config.set_setting("telemetry.opt_out", "True")
     config.set_setting("telemetry.identifier", "user-id-123abc-456def")
+    config.set_setting("settings.list_object_threshold", "200")
+    config.set_setting("settings.multipart_upload_chunk_size", "10000000")
+    config.set_setting("settings.multipart_upload_max_workers", "16")
+    config.set_setting("settings.small_file_threshold_multiplier", "15")
 
     runner = CliRunner()
     result = runner.invoke(main, ["config", "show"])

--- a/test/unit/deadline_client/conftest.py
+++ b/test/unit/deadline_client/conftest.py
@@ -5,34 +5,7 @@ Common fixtures for Deadline Client Library tests.
 """
 
 import tempfile
-from unittest.mock import patch
-from pathlib import Path
-
 import pytest
-
-from deadline.client.config import config_file
-
-
-@pytest.fixture(scope="function")
-def fresh_deadline_config():
-    """
-    Fixture to start with a blank Amazon Deadline Cloud config file.
-    """
-
-    try:
-        # Create an empty temp file to set as the Amazon Deadline Cloud config
-        temp_dir = tempfile.TemporaryDirectory()
-        temp_dir_path = Path(temp_dir.name)
-        temp_file_path = temp_dir_path / "config"
-        with open(temp_file_path, "w+t", encoding="utf8") as temp_file:
-            temp_file.write("")
-
-        # Yield the temp file name with it patched in as the
-        # Amazon Deadline Cloud config file
-        with patch.object(config_file, "CONFIG_FILE_PATH", str(temp_file_path)):
-            yield str(temp_file_path)
-    finally:
-        temp_dir.cleanup()
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Currently, Job Attachments uses hard-coded default values for parameters that may impact file upload performance. (They are defined [here](https://github.com/casillas2/deadline-cloud/blob/d68ec2c368e5acd3c375fedd3ab5ded67840091d/src/deadline/job_attachments/upload.py#L64-L71).) These default values seemed reasonable when we introduced them, but they are arbitrarily chosen without specific rationale. Each of the parameters should be fine-tuned later to optimize the Job Attachment's performance.

### What was the solution? (How)
- We make those parameters configurable through the config file. For example,
  ```
  [settings]
  auto_accept = True
  conflict_resolution = SKIP
  list_object_threshold = 100
  ```
- If the parameters are not specified in the config file, use the default values.

### What is the impact of this change?
This change will allow us to adjust those parameters and find values for each parameter which optimize the Job Attachment's upload performance.

### How was this change tested?
- Ran unit tests: `hatch run lint && hatch run test`
  - Note: the fixture `fresh_deadline_config` which was previously in `test/unit/deadline_client/conftests.py` was moved to a new file `test/unit/conftest.py`, so that the unit tests in `deadline_job_attachments` can also use that fixture.
- Manually submitted jobs through CLI and GUI to make sure job submission was working as normal. Also, checked that the asset (input) syncing in CMF worker was working as normal. 

### Was this change documented?
No.

### Is this a breaking change?
No.