### PR TITLE
fix(job_attachments): include file path in error message for upload failures

### DIFF
--- a/src/deadline/job_attachments/download.py
+++ b/src/deadline/job_attachments/download.py
@@ -389,7 +389,7 @@ def download_file(
             status_code=status_code,
             bucket_name=s3_bucket,
             key_or_prefix=s3_key,
-            message=f"{status_code_guidance.get(status_code, '')} {str(exc)}",
+            message=f"{status_code_guidance.get(status_code, '')} {str(exc)} (Failed to download the file to {str(local_file_name)})",
         ) from exc
 
     download_logger.debug(f"Downloaded {file.path} to {str(local_file_name)}")

--- a/src/deadline/job_attachments/exceptions.py
+++ b/src/deadline/job_attachments/exceptions.py
@@ -48,13 +48,13 @@ class JobAttachmentsS3ClientError(AssetSyncError):
         self.key_or_prefix = key_or_prefix
 
         message_parts = [
-            f"Error {action} in bucket '{bucket_name}'. Target key or prefix: '{key_or_prefix}'.",
+            f"Error {action} in bucket '{bucket_name}', Target key or prefix: '{key_or_prefix}'",
             f"HTTP Status Code: {status_code}",
         ]
         if message:
             message_parts.append(message)
 
-        super().__init__(" ".join(message_parts))
+        super().__init__(", ".join(message_parts))
 
 
 class MissingS3BucketError(JobAttachmentsError):
@@ -89,7 +89,7 @@ class MissingManifestError(JobAttachmentsError):
 
 class MissingAssetRootError(JobAttachmentsError):
     """
-    Exception for when trying to retrieve asset root from metatdata (in S3) that doesn't exist.
+    Exception for when trying to retrieve asset root from metadata (in S3) that doesn't exist.
     """
 
 

--- a/src/deadline/job_attachments/upload.py
+++ b/src/deadline/job_attachments/upload.py
@@ -342,7 +342,7 @@ class S3AssetUploader:
                     self._upload_part,
                     s3_bucket,
                     s3_upload_key,
-                    local_path,
+                    str(local_path),
                     upload_id,
                     chunk_size,
                     progress_tracker,
@@ -397,7 +397,7 @@ class S3AssetUploader:
                 status_code=status_code,
                 bucket_name=s3_bucket,
                 key_or_prefix=s3_upload_key,
-                message=status_code_guidance.get(status_code, ""),
+                message=f"{status_code_guidance.get(status_code, '')} {str(exc)} (Failed to upload {str(local_path)})",
             ) from exc
         except Exception as exc:
             if upload_id:


### PR DESCRIPTION
```
- Added file path in custom error messages when multipart uploads fail due to a ClientError.
- Corrected indentation in existing unit tests for error message verification (in test_download.py).
```

### What was the problem/requirement? (What/Why)
Previously, when multipart upload failed, the custom error message (in the `JobAttachmentsS3ClientError`) did not provide an info of which file had failed to upload. This lack of detail made debugging more difficult.

### What was the solution? (How)
This PR has the following changes:
- Enhanced the error messages to include the file path when multipart uploads fail. The updated error message looks like below:
  ```
  Error uploading file in bucket 'test-bucket', Target key or prefix: 'test_key', HTTP Status Code: 400,  An error occurred (InvalidPart) when calling the UploadPart operation: Invalid Part (Failed to upload /tmp/pytest-of-gahyusuh/pytest-4555/popen-gw7/test_upload_error_message0/test_file.txt)
  ```
- Fixed some existing unit tests in `test_download.py` to have correct indentation, ensuring that the assertions for verifying error messages are properly executed.

### What is the impact of this change?
Provide clearer context for debugging, helping users to identify the file in question and address issues with file uploads.

### How was this change tested?
- Added a new unit test `test_upload_file_to_s3_upload_part_failure` to verify that the error message includes the file path during a failed upload.
- Ran `hatch run test`, ensuring that the corrected unit tests are properly executed and all tests successfully passed.
- Checked that job submission with some job attachments was working.

### Was this change documented?
No.

### Is this a breaking change?
No.
