### PR TITLE
feat: Add a few more stats and trace json output data

### DIFF
--- a/test/unit/deadline_client/cli/test_cli_job.py
+++ b/test/unit/deadline_client/cli/test_cli_job.py
@@ -630,13 +630,16 @@ Session Total Duration: 0:01:00
 Session Action Count: 1
 Session Action Total Duration: 0:00:30
 Task Run Count: 1
-Task Run Total Duration: 0:00:30
+Task Run Total Duration: 0:00:30 (50.0%)
 Non-Task Run Count: 0
-Non-Task Run Total Duration: 0:00:00
+Non-Task Run Total Duration: 0:00:00 (0.0%)
+Sync Job Attachments Count: 0
+Sync Job Attachments Total Duration: 0:00:00 (0.0%)
+Env Action Count: 0
+Env Action Total Duration: 0:00:00 (0.0%)
 
-Within-session Overhead Duration: 0:00:30
+Within-session Overhead Duration: 0:00:30 (50.0%)
 Within-session Overhead Duration Per Action: 0:00:30
-Within-session Overhead: 50.0%
 """
         )
         assert result.exit_code == 0


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The job attachments session actions were named as their session id, so not as obvious in the displayed graphs. The percentage of time spent on each type of session action wasn't visible, and the stats didn't split the job attachments vs env actions.

### What was the solution? (How)

- Set the name of the sync job attachments session action appropriately, indicating whether it's syncing dependencies or submitted job attachments.
- Add some args to the trace events including resource IDs, statuses, and names.
- Add counts and durations of the sync job attachments and event enter/exit session actions to the printed statistics.

### What is the impact of this change?

The `deadline job trace-schedule` produces more useful output.

### How was this change tested?

I ran it on a sample job, and visualized it in the UI.

### Was this change documented?

No

### Is this a breaking change?

No