### PR TITLE
fix: do not throw an exception when SubmitJobProgressDialog closes if submission did not start

### DIFF
--- a/src/deadline/client/ui/dialogs/submit_job_progress_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_progress_dialog.py
@@ -76,6 +76,15 @@ class SubmitJobProgressDialog(QDialog):
 
     def __init__(self, parent: QWidget) -> None:
         super().__init__(parent=parent)
+        self._submission_complete = False
+        self._continue_submission = True
+        self._submission_complete = False
+        self._create_job_args: Dict[str, Any] = {}
+        self._create_job_response: Dict[str, Any] = {}
+        self.__hashing_thread: Optional[threading.Thread] = None
+        self.__upload_thread: Optional[threading.Thread] = None
+        self.__create_job_thread: Optional[threading.Thread] = None
+
         self._build_ui()
 
     def start_submission(
@@ -114,14 +123,6 @@ class SubmitJobProgressDialog(QDialog):
         self._asset_manager = asset_manager
         self._deadline_client = deadline_client
         self._auto_accept = auto_accept
-
-        self._continue_submission = True
-        self._submission_complete = False
-        self._create_job_args: Dict[str, Any] = {}
-        self._create_job_response: Dict[str, Any] = {}
-        self.__hashing_thread: Optional[threading.Thread] = None
-        self.__upload_thread: Optional[threading.Thread] = None
-        self.__create_job_thread: Optional[threading.Thread] = None
 
         self._start_submission()
         return self.exec()

--- a/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
@@ -475,6 +475,7 @@ class SubmitJobToDeadlineDialog(QDialog):
                 exception_type=str(type(exc)),
             )
             QMessageBox.warning(self, f"{settings.submitter_name} Job Submission", str(exc))
+            job_progress_dialog.close()
 
         if self.create_job_response:
             # Close the submitter window to signal the submission is done


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

It was reported by a user that if an error occurred after the `SubmitJobProgressDialog` was created but before it started submitting (ie `on_create_job_bundle_callback`), then it would also throw additional exceptions when trying to close the SubmitJobProgressDialog since `closeEvent` was trying to access variables that weren't initialized (which happened in `start_submission`).

```
ERROR:deadline.client.ui.dialogs.submit_job_to_deadline_dialog:error submitting job
Traceback (most recent call last):
  File "/opt/homebrew/Caskroom/miniforge/base/envs/bealine/lib/python3.9/site-packages/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py", line 460, in on_submit
    raise Exception
Exception
Traceback (most recent call last):
  File "/opt/homebrew/Caskroom/miniforge/base/envs/bealine/lib/python3.9/site-packages/deadline/client/ui/dialogs/submit_job_progress_dialog.py", line 545, in closeEvent
    if self._submission_complete:
AttributeError: 'SubmitJobProgressDialog' object has no attribute '_submission_complete'
```

### What was the solution? (How)

Ensure the relevant variables are initialized on `SubmitJobProgressDialog` creation, rather than on `start_submission`. This way, the close event won't throw exceptions if it wasn't started.

### What is the impact of this change?

Less errors!

### How was this change tested?

built and ran locally with a `raise Exception` before `start_submission` was called. Successfully reproduced the issue and got the stack trace above.

Added my change, and ensured that the job progress dialog now closes without exception if an error occurred after it's created but before the start function is called.

### Was this change documented?

N/A

### Is this a breaking change?

Fixing :)