### PR TITLE
chore: dedupe variable init

### DIFF
--- a/src/deadline/client/ui/dialogs/submit_job_progress_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_progress_dialog.py
@@ -76,7 +76,6 @@ class SubmitJobProgressDialog(QDialog):
 
     def __init__(self, parent: QWidget) -> None:
         super().__init__(parent=parent)
-        self._submission_complete = False
         self._continue_submission = True
         self._submission_complete = False
         self._create_job_args: Dict[str, Any] = {}


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

we set a variable twice in the init

### What was the solution? (How)

dedupe

### What is the impact of this change?

cleanliness

### How was this change tested?

it all still works

### Was this change documented?

n/a

### Is this a breaking change?

n/a