### PR TITLE
chore: refactored bundle_submit to use create_job_from_job_bundle

### DIFF
--- a/src/deadline/client/cli/_groups/bundle_group.py
+++ b/src/deadline/client/cli/_groups/bundle_group.py
@@ -5,36 +5,18 @@ All the `deadline bundle` commands.
 """
 from __future__ import annotations
 
-import json
 import logging
-import os
 import re
-import textwrap
-from configparser import ConfigParser
-from typing import Any, Dict, List, Optional, Tuple
 
 import click
 from botocore.exceptions import ClientError
 
 from deadline.client import api
-from deadline.client.api import get_boto3_client, get_queue_user_boto3_session
-from deadline.client.api._session import _modified_logging_level
-from deadline.client.config import config_file, get_setting, set_setting
-from deadline.client.job_bundle.loader import read_yaml_or_json, read_yaml_or_json_object
-from deadline.client.job_bundle.parameters import (
-    apply_job_parameters,
-    merge_queue_job_parameters,
-    read_job_bundle_parameters,
-)
-from deadline.client.job_bundle.submission import AssetReferences, split_parameter_args
+from deadline.client.config import config_file, get_setting
+
 from deadline.job_attachments.exceptions import AssetSyncError, AssetSyncCancelledError
-from deadline.job_attachments.models import (
-    JobAttachmentsFileSystem,
-    AssetRootManifest,
-    JobAttachmentS3Settings,
-)
-from deadline.job_attachments.progress_tracker import ProgressReportMetadata, SummaryStatistics
-from deadline.job_attachments.upload import S3AssetManager
+from deadline.job_attachments.models import JobAttachmentsFileSystem
+from deadline.job_attachments.progress_tracker import ProgressReportMetadata
 from deadline.job_attachments._utils import _human_readable_file_size
 
 from ...exceptions import DeadlineOperationError, CreateJobWaiterCanceled
@@ -121,164 +103,50 @@ def bundle_submit(
     """
     # Check Whether the CLI options are modifying any of the default settings that affect
     # the job id. If not, we'll save the job id submitted as the default job id.
-    if args.get("profile") is None and args.get("farm_id") is None and args.get("queue_id") is None:
-        should_save_job_id = True
-    else:
-        should_save_job_id = False
+    should_save_job_id = (
+        args.get("profile") is None and args.get("farm_id") is None and args.get("queue_id") is None
+    )
     # Get a temporary config object with the standard options handled
     config = _apply_cli_options_to_config(required_options={"farm_id", "queue_id"}, **args)
 
+    def _echo_message(message: str) -> None:
+        click.echo(message)
+
+    hash_callback_manager = _ProgressBarCallbackManager(length=100, label="Hashing Attachments")
+    upload_callback_manager = _ProgressBarCallbackManager(length=100, label="Uploading Attachments")
+
+    def _check_create_job_wait_canceled() -> bool:
+        return sigint_handler.continue_operation
+
+    def _decide_cancel_submission(asset_references, hash_summary):
+        return (
+            not (yes or config_file.str2bool(get_setting("settings.auto_accept", config=config)))
+            and len(asset_references.input_filenames) > 0
+            and not click.confirm(
+                f"Job submission contains {hash_summary.total_files} files "
+                f"totaling {_human_readable_file_size(hash_summary.total_bytes)}. "
+                "All files will be uploaded to S3 if they are not already present in the job attachments bucket. "
+                "Do you wish to proceed?",
+                default=True,
+            )
+        )
+
     try:
-        deadline = get_boto3_client("deadline", config=config)
-        farm_id = get_setting("defaults.farm_id", config=config)
-        queue_id = get_setting("defaults.queue_id", config=config)
-        if job_attachments_file_system is None:
-            job_attachments_file_system = get_setting(
-                "defaults.job_attachments_file_system", config=config
-            )
-
-        queue = deadline.get_queue(farmId=farm_id, queueId=queue_id)
-        click.echo(f"Submitting to Queue: {queue['displayName']}")
-
-        queue_parameter_definitions = api.get_queue_parameter_definitions(
-            farmId=farm_id, queueId=queue_id
+        api.create_job_from_job_bundle(
+            job_bundle_dir=job_bundle_dir,
+            job_parameters=parameter,
+            job_attachments_file_system=job_attachments_file_system,
+            should_save_job_id=should_save_job_id,
+            config=config,
+            priority=priority,
+            max_failed_tasks_count=max_failed_tasks_count,
+            max_retries_per_task=max_retries_per_task,
+            hashing_progress_callback=hash_callback_manager.callback,
+            upload_progress_callback=upload_callback_manager.callback,
+            create_job_result_callback=_check_create_job_wait_canceled,
+            handle_echo_messages_callback=_echo_message,
+            decide_cancel_submission_callback=_decide_cancel_submission,
         )
-
-        # Read in the job template
-        file_contents, file_type = read_yaml_or_json(job_bundle_dir, "template", required=True)
-
-        create_job_args: Dict[str, Any] = {
-            "farmId": farm_id,
-            "queueId": queue_id,
-            "template": file_contents,
-            "templateType": file_type,
-        }
-
-        storage_profile_id = get_setting("settings.storage_profile_id", config=config)
-        if storage_profile_id:
-            create_job_args["storageProfileId"] = storage_profile_id
-
-        # The job parameters
-        job_bundle_parameters = read_job_bundle_parameters(job_bundle_dir)
-
-        asset_references_obj = read_yaml_or_json_object(
-            job_bundle_dir, "asset_references", required=False
-        )
-        asset_references = AssetReferences.from_dict(asset_references_obj)
-
-        parameters = merge_queue_job_parameters(
-            job_parameters=job_bundle_parameters,
-            queue_parameters=queue_parameter_definitions,
-            queue_id=queue_id,
-        )
-
-        apply_job_parameters(
-            parameter,
-            job_bundle_dir,
-            parameters,
-            asset_references,
-        )
-        app_parameters_formatted, job_parameters_formatted = split_parameter_args(
-            parameters, job_bundle_dir
-        )
-
-        # Hash and upload job attachments if there are any
-        if asset_references and "jobAttachmentSettings" in queue:
-            # Extend input_filenames with all the files in the input_directories
-            for directory in asset_references.input_directories:
-                for root, _, files in os.walk(directory):
-                    asset_references.input_filenames.update(
-                        os.path.normpath(os.path.join(root, file)) for file in files
-                    )
-            asset_references.input_directories.clear()
-
-            queue_role_session = get_queue_user_boto3_session(
-                deadline=deadline,
-                config=config,
-                farm_id=farm_id,
-                queue_id=queue_id,
-                queue_display_name=queue["displayName"],
-            )
-
-            asset_manager = S3AssetManager(
-                farm_id=create_job_args["farmId"],
-                queue_id=create_job_args["queueId"],
-                job_attachment_settings=JobAttachmentS3Settings(**queue["jobAttachmentSettings"]),
-                session=queue_role_session,
-            )
-
-            hash_summary, asset_manifests = _hash_attachments(
-                asset_manager,
-                asset_references,
-                storage_profile_id=storage_profile_id,
-                config=config,
-            )
-
-            if (
-                not (
-                    yes or config_file.str2bool(get_setting("settings.auto_accept", config=config))
-                )
-                and len(asset_references.input_filenames) > 0
-                and not click.confirm(
-                    f"Job submission contains {hash_summary.total_files} files "
-                    f"totaling {_human_readable_file_size(hash_summary.total_bytes)}. "
-                    "All files will be uploaded to S3 if they are not already present in the job attachments bucket. "
-                    "Do you wish to proceed?",
-                    default=True,
-                )
-            ):
-                click.echo("Job submission canceled.")
-                return
-
-            attachment_settings = _upload_attachments(asset_manager, asset_manifests, config)
-
-            attachment_settings["fileSystem"] = JobAttachmentsFileSystem(
-                job_attachments_file_system
-            )
-            create_job_args["attachments"] = attachment_settings
-
-        create_job_args.update(app_parameters_formatted)
-
-        if job_parameters_formatted:
-            create_job_args["parameters"] = job_parameters_formatted
-
-        if priority is not None:
-            create_job_args["priority"] = priority
-        if max_failed_tasks_count is not None:
-            create_job_args["maxFailedTasksCount"] = max_failed_tasks_count
-        if max_retries_per_task is not None:
-            create_job_args["maxRetriesPerTask"] = max_retries_per_task
-
-        if logging.DEBUG >= logger.getEffectiveLevel():
-            logger.debug(json.dumps(create_job_args, indent=1))
-
-        create_job_response = deadline.create_job(**create_job_args)
-        logger.debug(f"CreateJob Response {create_job_response}")
-
-        if create_job_response and "jobId" in create_job_response:
-            job_id = create_job_response["jobId"]
-            click.echo("Waiting for Job to be created...")
-
-            # If using the default config, set the default job id so it holds the
-            # most-recently submitted job.
-            if should_save_job_id:
-                set_setting("defaults.job_id", job_id)
-
-            def _check_create_job_wait_canceled() -> bool:
-                return sigint_handler.continue_operation
-
-            success, status_message = api.wait_for_create_job_to_complete(
-                create_job_args["farmId"],
-                create_job_args["queueId"],
-                job_id,
-                deadline,
-                _check_create_job_wait_canceled,
-            )
-            status_message += f"\n{job_id}\n"
-        else:
-            raise DeadlineOperationError(
-                "CreateJob response was empty, or did not contain a Job ID."
-            )
     except AssetSyncCancelledError as exc:
         if sigint_handler.continue_operation:
             raise DeadlineOperationError(f"Job submission unexpectedly canceled:\n{exc}") from exc
@@ -299,10 +167,6 @@ def bundle_submit(
         raise DeadlineOperationError(
             f"Failed to submit the job bundle to Amazon Deadline Cloud:\n{exc}"
         ) from exc
-
-    click.echo("Submitted job bundle:")
-    click.echo(f"   {job_bundle_dir}")
-    click.echo(status_message)
 
 
 @cli_bundle.command(name="gui-submit")
@@ -347,76 +211,38 @@ def bundle_gui_submit(job_bundle_dir, browse, **args):
             click.echo("Job submission canceled.")
 
 
-def _hash_attachments(
-    asset_manager: S3AssetManager,
-    asset_references: AssetReferences,
-    storage_profile_id: Optional[str] = None,
-    config: Optional[ConfigParser] = None,
-) -> Tuple[SummaryStatistics, List[AssetRootManifest]]:
+class _ProgressBarCallbackManager:
     """
-    Starts the job attachments hashing and handles the progress reporting
-    callback. Returns a list of the asset manifests of the hashed files.
+    Manages creation, update, and deletion of a progress bar. On first call of the callback, the progress bar is created. The progress bar is closed
+    on the final call (100% completion)
     """
-    # Note: click doesn't export the return type of progressbar(), so we suppress mypy warnings for
-    # not annotating the type of hashing_progress.
-    with click.progressbar(length=100, label="Hashing Attachments") as hashing_progress:  # type: ignore[var-annotated]
 
-        def _update_hash_progress(hashing_metadata: ProgressReportMetadata) -> bool:
-            new_progress = int(hashing_metadata.progress) - hashing_progress.pos
-            if new_progress > 0:
-                hashing_progress.update(new_progress)
+    BAR_NOT_CREATED = 0
+    BAR_CREATED = 1
+    BAR_CLOSED = 2
+
+    def __init__(self, length: int, label: str):
+        self._length = length
+        self._label = label
+        self._bar_status = self.BAR_NOT_CREATED
+
+    def callback(self, upload_metadata: ProgressReportMetadata) -> bool:
+        if self._bar_status == self.BAR_CLOSED:
+            # from multithreaded execution this can be called after completion somtimes.
             return sigint_handler.continue_operation
+        elif self._bar_status == self.BAR_NOT_CREATED:
+            # Note: click doesn't export the return type of progressbar(), so we suppress mypy warnings for
+            # not annotating the type of hashing_progress.
+            self._upload_progress = click.progressbar(length=self._length, label=self._label)  # type: ignore[var-annotated]
+            self._bar_status = self.BAR_CREATED
 
-        hashing_summary, manifests = asset_manager.hash_assets_and_create_manifest(
-            input_paths=sorted(asset_references.input_filenames),
-            output_paths=sorted(asset_references.output_directories),
-            referenced_paths=sorted(asset_references.referenced_paths),
-            storage_profile_id=storage_profile_id,
-            hash_cache_dir=os.path.expanduser(os.path.join("~", ".deadline", "cache")),
-            on_preparing_to_submit=_update_hash_progress,
-        )
+        total_progress = int(upload_metadata.progress)
+        new_progress = total_progress - self._upload_progress.pos
+        if new_progress > 0:
+            self._upload_progress.update(new_progress)
 
-    api.get_deadline_cloud_library_telemetry_client(config=config).record_hashing_summary(
-        hashing_summary
-    )
-    click.echo("Hashing Summary:")
-    click.echo(textwrap.indent(str(hashing_summary), "    "))
+        if total_progress == self._length or not sigint_handler.continue_operation:
+            self._bar_status = self.BAR_CLOSED
+            self._upload_progress.__exit__(None, None, None)
 
-    return hashing_summary, manifests
-
-
-def _upload_attachments(
-    asset_manager: S3AssetManager,
-    manifests: List[AssetRootManifest],
-    config: Optional[ConfigParser] = None,
-) -> Dict[str, Any]:
-    """
-    Starts the job attachments upload and handles the progress reporting callback.
-    Returns the attachment settings from the upload.
-    """
-
-    # TODO: remove logging level setting when the max number connections for boto3 client
-    # in Job Attachments library can be increased (currently using default number, 10, which
-    # makes it keep logging urllib3 warning messages when uploading large files)
-    with _modified_logging_level(logging.getLogger("urllib3"), logging.ERROR):
-        # Note: click doesn't export the return type of progressbar(), so we suppress mypy warnings for
-        # not annotating the type of hashing_progress.
-        with click.progressbar(length=100, label="Uploading Attachments") as upload_progress:  # type: ignore[var-annotated]
-
-            def _update_upload_progress(upload_metadata: ProgressReportMetadata) -> bool:
-                new_progress = int(upload_metadata.progress) - upload_progress.pos
-                if new_progress > 0:
-                    upload_progress.update(new_progress)
-                return sigint_handler.continue_operation
-
-            upload_summary, attachment_settings = asset_manager.upload_assets(
-                manifests, _update_upload_progress
-            )
-
-    api.get_deadline_cloud_library_telemetry_client(config=config).record_upload_summary(
-        upload_summary
-    )
-    click.echo("Upload Summary:")
-    click.echo(textwrap.indent(str(upload_summary), "    "))
-
-    return attachment_settings.to_dict()
+        return sigint_handler.continue_operation

--- a/src/deadline/job_attachments/upload.py
+++ b/src/deadline/job_attachments/upload.py
@@ -6,6 +6,7 @@ Classes for handling uploading of assets.
 from __future__ import annotations
 
 import concurrent.futures
+import threading
 import functools
 import logging
 import math
@@ -653,6 +654,8 @@ class S3AssetManager:
             ManifestVersion.v2023_03_03,
         }:
             paths: list[base_manifest.BaseManifestPath] = []
+
+            callback_lock = threading.Lock()
             with concurrent.futures.ThreadPoolExecutor() as executor:
                 futures = {
                     executor.submit(
@@ -668,7 +671,9 @@ class S3AssetManager:
                             progress_tracker.increase_processed(1, file_size)
                         else:
                             progress_tracker.increase_skipped(1, file_size)
-                        progress_tracker.report_progress()
+
+                        with callback_lock:
+                            progress_tracker.report_progress()
 
             # Need to sort the list to keep it canonical
             paths.sort(key=lambda x: x.path, reverse=True)

--- a/test/unit/deadline_client/api/test_job_bundle_submission_asset_refs.py
+++ b/test/unit/deadline_client/api/test_job_bundle_submission_asset_refs.py
@@ -242,7 +242,9 @@ def test_create_job_from_job_bundle_with_all_asset_ref_variants(
         )
 
         # This is the function we're testing
-        api.create_job_from_job_bundle(temp_job_bundle_dir, job_parameters=job_parameters)
+        api.create_job_from_job_bundle(
+            temp_job_bundle_dir, job_parameters=job_parameters, queue_parameter_definitions=[]
+        )
 
         # The values of input_paths and output_paths are the first
         # thing this test needs to verify, confirming that the

--- a/test/unit/deadline_client/cli/test_cli_bundle.py
+++ b/test/unit/deadline_client/cli/test_cli_bundle.py
@@ -16,6 +16,7 @@ from deadline.client import config
 from deadline.client.api import _queue_parameters
 from deadline.client.cli import main
 from deadline.client.cli._groups import bundle_group
+from deadline.client.api import _submit_job_bundle
 from deadline.client.config.config_file import set_setting
 from deadline.job_attachments.models import JobAttachmentsFileSystem
 from deadline.job_attachments.progress_tracker import SummaryStatistics
@@ -110,14 +111,16 @@ def test_cli_bundle_submit(fresh_deadline_config, temp_job_bundle_dir):
     ) as f:
         f.write(MOCK_PARAMETERS_CASES["TEMPLATE_ONLY_JSON"][1])
 
-    with patch.object(bundle_group, "get_boto3_client") as get_boto3_client_mock, patch.object(
+    with patch.object(
+        _submit_job_bundle.api, "get_boto3_client"
+    ) as get_boto3_client_mock, patch.object(
         _queue_parameters, "get_boto3_client"
     ) as qp_boto3_client_mock, patch.object(
-        bundle_group, "_hash_attachments", return_value=[]
+        _submit_job_bundle, "_hash_attachments", return_value=[]
     ), patch.object(
-        bundle_group, "get_queue_user_boto3_session"
+        _submit_job_bundle.api, "get_queue_user_boto3_session"
     ), patch.object(
-        bundle_group, "_upload_attachments"
+        _submit_job_bundle, "_upload_attachments"
     ), patch.object(
         bundle_group.api, "get_telemetry_client"
     ):
@@ -294,16 +297,18 @@ def test_cli_bundle_asset_load_method(fresh_deadline_config, temp_job_bundle_dir
     attachment_mock.total_bytes = 0
     attachment_mock.total_files.return_value = 0
 
-    with patch.object(bundle_group, "get_boto3_client") as bundle_boto3_client_mock, patch.object(
+    with patch.object(
+        _submit_job_bundle.api, "get_boto3_client"
+    ) as bundle_boto3_client_mock, patch.object(
         _queue_parameters, "get_boto3_client"
     ) as qp_boto3_client_mock, patch.object(
-        bundle_group, "_hash_attachments", return_value=(attachment_mock, {})
+        _submit_job_bundle, "_hash_attachments", return_value=(attachment_mock, {})
     ), patch.object(
-        bundle_group, "_upload_attachments", return_value={}
+        _submit_job_bundle, "_upload_attachments", return_value={}
     ), patch.object(
-        bundle_group.api, "get_boto3_session"
+        _submit_job_bundle.api, "get_boto3_session"
     ), patch.object(
-        bundle_group, "get_queue_user_boto3_session"
+        _submit_job_bundle.api, "get_queue_user_boto3_session"
     ), patch.object(
         bundle_group.api, "get_telemetry_client"
     ):
@@ -465,14 +470,18 @@ def test_cli_bundle_accept_upload_confirmation(fresh_deadline_config, temp_job_b
         }
         json.dump(data, f)
 
-    with patch.object(bundle_group, "get_boto3_client") as get_boto3_client_mock, patch.object(
-        bundle_group, "_hash_attachments", return_value=[SummaryStatistics(), "test"]
-    ), patch.object(bundle_group, "_upload_attachments"), patch.object(
-        bundle_group.api, "get_boto3_session"
+    with patch.object(
+        _submit_job_bundle.api, "get_boto3_client"
+    ) as get_boto3_client_mock, patch.object(
+        _submit_job_bundle, "_hash_attachments", return_value=[SummaryStatistics(), "test"]
     ), patch.object(
-        bundle_group.api, "get_queue_parameter_definitions", return_value=[]
+        _submit_job_bundle, "_upload_attachments"
     ), patch.object(
-        bundle_group, "get_queue_user_boto3_session"
+        _submit_job_bundle.api, "get_boto3_session"
+    ), patch.object(
+        _submit_job_bundle.api, "get_queue_parameter_definitions", return_value=[]
+    ), patch.object(
+        _submit_job_bundle.api, "get_queue_user_boto3_session"
     ), patch.object(
         bundle_group.api, "get_telemetry_client"
     ):
@@ -536,16 +545,18 @@ def test_cli_bundle_reject_upload_confirmation(fresh_deadline_config, temp_job_b
         }
         json.dump(data, f)
 
-    with patch.object(bundle_group, "get_boto3_client") as get_boto3_client_mock, patch.object(
+    with patch.object(
+        _submit_job_bundle.api, "get_boto3_client"
+    ) as get_boto3_client_mock, patch.object(
         _queue_parameters, "get_boto3_client"
     ) as qp_boto3_client_mock, patch.object(
-        bundle_group, "_hash_attachments", return_value=[SummaryStatistics(), "test"]
+        _submit_job_bundle, "_hash_attachments", return_value=[SummaryStatistics(), "test"]
     ), patch.object(
-        bundle_group, "_upload_attachments"
+        _submit_job_bundle, "_upload_attachments"
     ) as upload_attachments_mock, patch.object(
-        bundle_group.api, "get_boto3_session"
+        _submit_job_bundle.api, "get_boto3_session"
     ), patch.object(
-        bundle_group, "get_queue_user_boto3_session"
+        _submit_job_bundle.api, "get_queue_user_boto3_session"
     ), patch.object(
         bundle_group.api, "get_telemetry_client"
     ):


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
- The `bundle_submit` and `create_job_from_job_bundle` had a high degree of code duplication.
- `create_job_from_job_bundle` had no option for parameter to choose file system type (COPIED vs VIRTUAL).
- 'create_job_from_job_bundle` required queue parameter definitions to be passed in as an argument, with no option retrieve them by calling `get_queue_parameter_definitions`
### What was the solution? (How)
- Refactored `create_job_from_job_bundle` to support the user input and echo messages used by `bundle_submit`, and rewrote `bundle_submit` to call `create_job_from_job_bundle`.
- In `create_job_from_job_bundle` added new parameter for file system type. Changed `queue_parameter_definitions` to an optional argument, in the unprovided case `get_queue_parameter_definitions` is called.
### What is the impact of this change?
Reduced code duplication, `create_job_from_job_bundle` able to create jobs using virtual file system.
### How was this change tested?
- ran `hatch run all:test`
- ran `hatch shell`, and tested submitting job using the CLI.
```
dev-dsk-npmac-2a-eaa59587 % deadline bundle submit .
Submitting to Queue: Peaceful Plot
Hashing Attachments  [####################################]  100%
Hashing Summary:
    Processed 0 files totaling 0.0 B.
    Skipped re-processing 1 files totaling 2.81 MB.
    Total processing time of 0.01174 seconds at 0.0 B/s.

Job submission contains 1 files totaling 2.81 MB. All files will be uploaded to S3 if they are not already present in the job attachments bucket. Do you wish to proceed? [Y/n]: y
Uploading Attachments  [####################################]  100%
Upload Summary:
    Processed 0 files totaling 0.0 B.
    Skipped re-processing 1 files totaling 2.81 MB.
    Total processing time of 0.10725 seconds at 0.0 B/s.

Waiting for Job to be created...
Submitted job bundle:
   .
Job creation completed successfully
job-5368087153ad48178f21a9818fc6c2f7
```
### Was this change documented?
no
### Is this a breaking change?
no