### PR TITLE
fix(cli): download-output command handles UNC paths

### DIFF
--- a/src/deadline/job_attachments/models.py
+++ b/src/deadline/job_attachments/models.py
@@ -88,9 +88,9 @@ class PathFormat(str, Enum):
     def get_host_path_format(cls) -> PathFormat:
         """Get the current path format."""
         if sys.platform.startswith("win"):
-            return PathFormat.WINDOWS
+            return cls.WINDOWS
         if sys.platform.startswith("darwin") or sys.platform.startswith("linux"):
-            return PathFormat.POSIX
+            return cls.POSIX
         else:
             raise NotImplementedError(f"Operating system {sys.platform} is not supported.")
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The `download-output` CLI command failed to download job outputs with UNC root paths, resulting in error that looks like below.
```
Download failed: Path \10.7.1.50\TestOutputShare\work is not an absolute path.
```
The current logic for checking if a path format is Posix or Windows cannot handle UNC path format. It is just doing a naive string check on the root paths.

### What was the solution? (How)
- Updated to properly handle UNC paths. Instead of the existing naive string check, it is now relying on the `rootPathFormat` property in job's `manifests` (the value is either "windows" or "posix") to determine the submitting OS of the job.
- Fixed or added unit tests to align with the changes, ensuring all tests pass.

### What is the impact of this change?
The download-output command can now support jobs with UNC root paths. 

### How was this change tested?
- All unit tests, including modified and newly added ones, passed successfully.
- Done some manual end-to-end tests including cross-platform scenarios, confirming that it worked as expected.
  - Downloading Linux-submitted job outputs on Windows: prompted users for an alternative root path to download to.
  - Downloading outputs from job with UNC format root paths on Windows: no errors, downloading files to the right location. 
  - Downloading Windows-submitted job outputs on Linux: prompted users for an alternative root path to download to.
  - Downloading outputs from jobs with UNC format root paths on Linux: prompted users for an alternative root path to download to.

### Was this change documented?
No.

### Is this a breaking change?
No.