### PR TITLE
feat: Add the ability to set the job name with `deadline bundle submit`

### DIFF
--- a/src/deadline/client/api/_session.py
+++ b/src/deadline/client/api/_session.py
@@ -382,8 +382,6 @@ class DeadlineClient:
         if "targetTaskRunStatus" in kwargs:
             if "initialState" in create_job_input_members:
                 kwargs["initialState"] = kwargs.pop("targetTaskRunStatus")
-        if "priority" not in kwargs:
-            kwargs["priority"] = 50
         return self._real_client.create_job(*args, **kwargs)
 
     def assume_queue_role_for_user(self, *args, **kwargs) -> Any:

--- a/src/deadline/client/cli/_groups/bundle_group.py
+++ b/src/deadline/client/cli/_groups/bundle_group.py
@@ -14,7 +14,6 @@ from botocore.exceptions import ClientError
 
 from deadline.client import api
 from deadline.client.config import config_file, get_setting, set_setting
-
 from deadline.job_attachments.exceptions import AssetSyncError, AssetSyncCancelledError
 from deadline.job_attachments.models import JobAttachmentsFileSystem
 from deadline.job_attachments.progress_tracker import ProgressReportMetadata
@@ -64,7 +63,8 @@ def validate_parameters(ctx, param, value):
 @click.option("--profile", help="The AWS profile to use.")
 @click.option("--farm-id", help="The Amazon Deadline Cloud Farm to use.")
 @click.option("--queue-id", help="The Amazon Deadline Cloud Queue to use.")
-@click.option("--priority", type=int, help="The priority of the job.")
+@click.option("--name", help="The job name to use in place of the one in the job bundle.")
+@click.option("--priority", type=int, default=50, help="The priority of the job.")
 @click.option(
     "--max-failed-tasks-count",
     type=int,
@@ -94,6 +94,7 @@ def bundle_submit(
     job_attachments_file_system,
     parameter,
     yes,
+    name,
     priority,
     max_failed_tasks_count,
     max_retries_per_task,
@@ -128,6 +129,7 @@ def bundle_submit(
         job_id = api.create_job_from_job_bundle(
             job_bundle_dir=job_bundle_dir,
             job_parameters=parameter,
+            name=name,
             job_attachments_file_system=job_attachments_file_system,
             config=config,
             priority=priority,

--- a/test/unit/deadline_client/api/test_api_session.py
+++ b/test/unit/deadline_client/api/test_api_session.py
@@ -386,7 +386,6 @@ def test_create_job_max_errors_to_max_retries(kwargs_input, name_in_model, kwarg
     1. Calling the underlying client method
     2. Replacing the appropriate key
     """
-    kwargs_output["priority"] = 50
     fake_client = MagicMock()
     deadline_client = DeadlineClient(fake_client)
     with patch.object(deadline_client, "_get_deadline_api_input_shape") as input_shape_mock:
@@ -446,34 +445,6 @@ def test_create_job_old_api_compatibility(kwargs_input, kwargs_output) -> None:
     1. Calling the underlying client method
     2. Replacing the appropriate key
 
-    """
-    fake_client = MagicMock()
-    kwargs_output["priority"] = 50
-    deadline_client = DeadlineClient(fake_client)
-    with patch.object(deadline_client, "_get_deadline_api_input_shape") as input_shape_mock:
-        input_shape_mock.return_value = kwargs_output
-        deadline_client.create_job(**kwargs_input)
-    fake_client.create_job.assert_called_once_with(**kwargs_output)
-
-
-@pytest.mark.parametrize(
-    "kwargs_input, kwargs_output",
-    [
-        pytest.param(
-            {"jobTemplate": "", "jobTemplateType": "", "jobParameters": ""},
-            {"jobTemplate": "", "jobTemplateType": "", "jobParameters": "", "priority": 50},
-            id="jobTemplate_addPriority",
-        ),
-        pytest.param(
-            {"jobTemplate": "", "jobTemplateType": "", "jobParameters": "", "priority": 99},
-            {"jobTemplate": "", "jobTemplateType": "", "jobParameters": "", "priority": 99},
-            id="jobTemplate_leavePriority",
-        ),
-    ],
-)
-def test_create_job_priority_api_compatibility(kwargs_input, kwargs_output) -> None:
-    """
-    create_job will either leave priority parameter as is or add if missing
     """
     fake_client = MagicMock()
     deadline_client = DeadlineClient(fake_client)

--- a/test/unit/deadline_client/api/test_job_bundle_submission.py
+++ b/test/unit/deadline_client/api/test_job_bundle_submission.py
@@ -58,49 +58,42 @@ MOCK_STATUS_MESSAGE = "Testing123"
 
 MOCK_GET_JOB_RESPONSE = {"state": "READY", "lifecycleStatusMessage": MOCK_STATUS_MESSAGE}
 
+
+def get_minimal_json_job_template(job_name):
+    return json.dumps(
+        {
+            "specificationVersion": "jobtemplate-2023-09",
+            "name": job_name,
+            "parameterDefinitions": [
+                {"name": "priority", "type": "INT", "default": 10},
+                {"name": "sceneFile", "type": "STRING", "default": "/tmp/scene"},
+            ],
+            "steps": [
+                {
+                    "name": "CliScript",
+                    "script": {
+                        "embeddedFiles": [
+                            {
+                                "name": "runScript",
+                                "type": "TEXT",
+                                "runnable": True,
+                                "data": '#!/usr/bin/env bash\n\necho "Running the task"\nsleep 35\n',
+                            }
+                        ],
+                        "actions": {"onRun": {"command": "{{Task.File.runScript}}"}},
+                    },
+                }
+            ],
+        }
+    )
+
+
 # This contains tuples of:
 #    (file type, JSON/YAML content)
 MOCK_JOB_TEMPLATE_CASES = {
     "MINIMAL_JSON": (
         "JSON",
-        """
-{
- "specificationVersion": "jobtemplate-2023-09",
- "name": "CLI Job",
- "parameterDefinitions": [
-  {
-    "name": "priority",
-    "type": "INT",
-    "default": 10
-  },
-  {
-    "name": "sceneFile",
-    "type": "STRING",
-    "default": "/tmp/scene"
-  }
- ],
- "steps": [
-  {
-   "name": "CliScript",
-   "script": {
-    "embeddedFiles": [
-     {
-      "name": "runScript",
-      "type": "TEXT",
-      "runnable": true,
-      "data": "#!/usr/bin/env bash\\n\\necho \\"Running the task\\"\\nsleep 35\\n"
-     }
-    ],
-    "actions": {
-     "onRun": {
-      "command": "{{Task.File.runScript}}"
-     }
-    }
-   }
-  }
- ]
-}
-""",
+        get_minimal_json_job_template(job_name="CLI Job"),
     ),
     "MINIMAL_YAML": (
         "YAML",
@@ -530,6 +523,7 @@ def test_create_job_from_job_bundle_job_attachments(
             queueId=MOCK_QUEUE_ID,
             template=ANY,
             templateType=ANY,
+            priority=50,
             storageProfileId=MOCK_STORAGE_PROFILE_ID,
             attachments={
                 "manifests": [],
@@ -687,6 +681,7 @@ def test_create_job_from_job_bundle_with_single_asset_file(
             queueId=MOCK_QUEUE_ID,
             template=ANY,
             templateType=ANY,
+            priority=50,
             storageProfileId=MOCK_STORAGE_PROFILE_ID,
             attachments={
                 "manifests": [

--- a/test/unit/deadline_client/api/test_job_bundle_submission_asset_refs.py
+++ b/test/unit/deadline_client/api/test_job_bundle_submission_asset_refs.py
@@ -294,6 +294,7 @@ def test_create_job_from_job_bundle_with_all_asset_ref_variants(
             queueId=MOCK_QUEUE_ID,
             template=ANY,
             templateType="YAML",
+            priority=50,
             attachments={
                 "manifests": [
                     {


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

There was no way to set the job name when submitting a job with `deadline bundle submit`, as compared to with `deadline bundle gui-submit`. This means that jobs submitted from the CLI always get the job template's name and can't be overridden, leading to many repeating generic job names.

### What was the solution? (How)

* Add the `--name` option to `deadline bundle submit`
* Also noticed that the code wasn't updated for the `priority` compatibility shim. Modified the CLI input to use a default of 50 for `priority` instead of skipping the parameter, because it is a required parameter in the API model.

### What is the impact of this change?

* Users can use the CLI bundle submit option and control the job name
* The `priority` option is ready for removing the API compatibility shim code.

### How was this change tested?

Added a unit test. Submitted jobs with the option to Deadline Cloud.

### Was this change documented?

It's in the `-h` output.

### Is this a breaking change?

No