### PR TITLE
chore(deps): pin to coverage==7.3.*

### DIFF
--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,5 +1,5 @@
 coverage[toml] ~= 7.2; python_version == '3.7'
-coverage[toml] ~= 7.4; python_version > '3.7'
+coverage[toml] ~= 7.3; python_version > '3.7'
 pytest ~= 7.4
 pytest-cov ~= 4.1
 pytest-timeout ~= 2.2


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Our CIs are failing to fetch `coverage~=7.4`

### What was the solution? (How)

Pin back to `coverage~=7.3`

### What is the impact of this change?

CIs will resume working

### How was this change tested?

Ran:

```sh
hatch env prune
hatch run fmt
hatch run lint
hatch build
hatch run test
```

### Was this change documented?

No

### Is this a breaking change?

No