### PR TITLE
feat(job_attachments)!: Allow inclusion of resource IDs in Telemetry data

### DIFF
--- a/src/deadline/client/api/_telemetry.py
+++ b/src/deadline/client/api/_telemetry.py
@@ -237,7 +237,25 @@ class TelemetryClient:
         # Possibility to add stack trace here
         self.record_event("com.amazon.rum.deadline.error", event_details)
 
-    def record_event(self, event_type: str, event_details: Dict[str, Any]):
+    def record_event(
+        self,
+        event_type: str,
+        event_details: Dict[str, Any],
+        farm_id: Optional[str] = None,
+        queue_id: Optional[str] = None,
+        job_id: Optional[str] = None,
+    ):
+        if farm_id or queue_id or job_id:
+            resource_ids = {}
+            if farm_id:
+                resource_ids["farm_id"] = farm_id
+            if queue_id:
+                resource_ids["queue_id"] = queue_id
+            if job_id:
+                resource_ids["job_id"] = job_id
+            if len(resource_ids) > 0:
+                event_details["resource_ids"] = resource_ids
+
         self._put_telemetry_record(
             TelemetryEvent(
                 event_type=event_type,

--- a/src/deadline/client/cli/_groups/bundle_group.py
+++ b/src/deadline/client/cli/_groups/bundle_group.py
@@ -235,7 +235,7 @@ class _ProgressBarCallbackManager:
 
     def callback(self, upload_metadata: ProgressReportMetadata) -> bool:
         if self._bar_status == self.BAR_CLOSED:
-            # from multithreaded execution this can be called after completion somtimes.
+            # from multithreaded execution this can be called after completion sometimes.
             return sigint_handler.continue_operation
         elif self._bar_status == self.BAR_NOT_CREATED:
             # Note: click doesn't export the return type of progressbar(), so we suppress mypy warnings for

--- a/test/unit/deadline_job_attachments/test_upload.py
+++ b/test/unit/deadline_job_attachments/test_upload.py
@@ -1657,7 +1657,7 @@ class TestUpload:
         the link.
 
         /tmp/source_folder/test.txt
-            /symlink-folder
+            /symlink_folder
         """
         # Given
         test_file = tmpdir.mkdir("source_folder").join("test.txt")


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
When sending a Telemetry request, if required, it would be beneficial to include resource IDs (farm ID, queue ID, job ID) in the data to be sent.

### What was the solution? (How)
Added support for including resource IDs in the `record_event()` method as an optional argument. If provided, these IDs are now included in the `event_details`.

### What is the impact of this change?
This change allows client library to include relevant resource IDs as an optional information when making a Telemetry request.

### How was this change tested?
Manually tested it with the change where Worker Agent included a Queue ID when calling [`record_sync_outputs_telemetry_event()`](https://github.com/casillas2/deadline-cloud-worker-agent/blob/9e0a8f642e398510ff1bda380a35e11c34a21d97/src/deadline_worker_agent/sessions/session.py#L865). The shape of the Telemetry data received looked as below. It has `"resourceIds": {"queueId": "..."}` in the `"event_details"`.
```
{
    "event_timestamp": 1705351536000,
    "event_type": "com.amazon.rum.deadline.worker_agent.sync_outputs_summary",
    "event_id": "f6e58a61-d595-4960-abd1-1e7108ff90d8",
    "event_version": "1.0.0",
    "log_stream": "2024-01-15T13",
    "application_id": "00cf4815-a611-42f0-85ac-1e05b995e6e6",
    "metadata": {
        "version": "0.18.0",
        "osName": "Linux",
        "osVersion": "5.10.205-172.804.amzn2int.x86_64",
        "domain": "*.madstudio.aws.dev",
        "service": "deadline-cloud-worker-agent",
        "python_version": "3.10.8",
        "countryCode": "US",
        "subdivisionCode": "OR"
    },
    "user_details": {
        "sessionId": "52417f24-4ad9-4e97-bd16-1d4cd86fe13f",
        "userId": "e726a3a4-d7c4-4e32-9610-dc333200a625"
    },
    "event_details": {
        "total_time": 1.6211010069819167,
        "total_files": 2,
        "total_bytes": 209715200,
        "processed_files": 2,
        "processed_bytes": 209715200,
        "skipped_files": 0,
        "skipped_bytes": 0,
        "transfer_rate": 129365905.70037155,
        "resource_ids": {
            "queue_id": "queue-a0c93fade6de47009999b273cc5b6249"
        }
    }
}
```

### Was this change documented?
No.

### Is this a breaking change?
Yes. This PR introduces some interface changes in `record_event()`.