### PR TITLE
feat!: Add hash alg file extension to items in CAS

### DIFF
--- a/src/deadline/job_attachments/_utils.py
+++ b/src/deadline/job_attachments/_utils.py
@@ -1,17 +1,14 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 import datetime
-import io
 import os
 from hashlib import shake_256
 from pathlib import Path
 from typing import Optional, Tuple, Union
 import uuid
-import xxhash
+
 
 __all__ = [
-    "_hash_file",
-    "_hash_data",
     "_join_s3_paths",
     "_generate_random_guid",
     "_float_to_iso_datetime_string",
@@ -24,23 +21,6 @@ __all__ = [
 
 CONFIG_ROOT = ".deadline"
 COMPONENT_NAME = "job_attachments"
-
-
-def _hash_file(file_path: str) -> str:
-    with open(file_path, "rb") as file:
-        hasher = xxhash.xxh3_128()
-        while True:
-            chunk = file.read(io.DEFAULT_BUFFER_SIZE)
-            if not chunk:
-                break
-            hasher.update(chunk)
-        return hasher.hexdigest()
-
-
-def _hash_data(data: bytes) -> str:
-    hasher = xxhash.xxh3_128()
-    hasher.update(data)
-    return hasher.hexdigest()
 
 
 def _join_s3_paths(root: str, *args: str):

--- a/src/deadline/job_attachments/asset_manifests/__init__.py
+++ b/src/deadline/job_attachments/asset_manifests/__init__.py
@@ -1,6 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 from .base_manifest import BaseAssetManifest, BaseManifestPath
+from .hash_algorithms import HashAlgorithm, hash_data, hash_file
 from .manifest_model import BaseManifestModel, ManifestModelRegistry
 from .versions import ManifestVersion
 
@@ -10,6 +11,9 @@ __all__ = [
     "BaseAssetManifest",
     "BaseManifestModel",
     "BaseManifestPath",
+    "HashAlgorithm",
+    "hash_data",
+    "hash_file",
 ]
 
 ManifestModelRegistry.register()

--- a/src/deadline/job_attachments/asset_manifests/base_manifest.py
+++ b/src/deadline/job_attachments/asset_manifests/base_manifest.py
@@ -7,6 +7,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, fields
 from typing import Any, ClassVar
 
+from .hash_algorithms import HashAlgorithm
 from .versions import ManifestVersion
 
 
@@ -44,7 +45,7 @@ class BaseManifestPath(ABC):
 class BaseAssetManifest(ABC):
     """Base class for the Asset Manifest."""
 
-    hashAlg: str  # pylint: disable=invalid-name
+    hashAlg: HashAlgorithm
     paths: list[BaseManifestPath]
     manifestVersion: ManifestVersion
 
@@ -52,10 +53,18 @@ class BaseAssetManifest(ABC):
         self,
         *,
         paths: list[BaseManifestPath],
-        hash_alg: str,
+        hash_alg: HashAlgorithm,
     ):
         self.paths = paths
         self.hashAlg = hash_alg
+
+    @classmethod
+    @abstractmethod
+    def get_default_hash_alg(cls) -> HashAlgorithm:  # pragma: no cover
+        """Returns the default hashing algorithm for the Asset Manifest"""
+        raise NotImplementedError(
+            "Asset Manifest base class does not implement get_default_hash_alg"
+        )
 
     @classmethod
     @abstractmethod

--- a/src/deadline/job_attachments/asset_manifests/hash_algorithms.py
+++ b/src/deadline/job_attachments/asset_manifests/hash_algorithms.py
@@ -1,0 +1,56 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+""" Module that defines the hashing algorithms supported by this library. """
+
+import io
+
+from enum import Enum
+
+from ..exceptions import UnsupportedHashingAlgorithmError
+
+
+class HashAlgorithm(str, Enum):
+    """
+    Enumerant of all hashing algorithms supported by this library.
+
+    Algorithms:
+      XXH128 - The xxhash 128-bit hashing algorithm.
+
+    """
+
+    XXH128 = "xxh128"
+
+
+def hash_file(file_path: str, hash_alg: HashAlgorithm) -> str:
+    """Hashes the given file using the given hashing algorithm."""
+    if hash_alg == HashAlgorithm.XXH128:
+        from xxhash import xxh3_128
+
+        hasher = xxh3_128()
+    else:
+        raise UnsupportedHashingAlgorithmError(
+            f"Unsupported hashing algorithm provided: {hash_alg}"
+        )
+
+    with open(file_path, "rb") as file:
+        while True:
+            chunk = file.read(io.DEFAULT_BUFFER_SIZE)
+            if not chunk:
+                break
+            hasher.update(chunk)
+        return hasher.hexdigest()
+
+
+def hash_data(data: bytes, hash_alg: HashAlgorithm) -> str:
+    """Hashes the given data bytes using the given hashing algorithm."""
+    if hash_alg == HashAlgorithm.XXH128:
+        from xxhash import xxh3_128
+
+        hasher = xxh3_128()
+    else:
+        raise UnsupportedHashingAlgorithmError(
+            f"Unsupported hashing algorithm provided: {hash_alg}"
+        )
+
+    hasher.update(data)
+    return hasher.hexdigest()

--- a/src/deadline/job_attachments/asset_manifests/v2023_03_03/asset_manifest.py
+++ b/src/deadline/job_attachments/asset_manifests/v2023_03_03/asset_manifest.py
@@ -7,10 +7,15 @@ from dataclasses import dataclass
 from typing import Any, Type
 
 from .._canonical_json import canonical_path_comparator, manifest_to_canonical_json_string
-from ..base_manifest import BaseAssetManifest
-from ..base_manifest import BaseManifestPath
+from ..base_manifest import BaseAssetManifest, BaseManifestPath
+from ..hash_algorithms import HashAlgorithm
 from ..manifest_model import BaseManifestModel
 from ..versions import ManifestVersion
+from ...exceptions import ManifestDecodeValidationError
+
+
+SUPPORTED_HASH_ALGS: set[HashAlgorithm] = {HashAlgorithm.XXH128}
+DEFAULT_HASH_ALG: HashAlgorithm = HashAlgorithm.XXH128
 
 
 @dataclass
@@ -31,7 +36,14 @@ class AssetManifest(BaseAssetManifest):
 
     totalSize: int  # pyline: disable=invalid-name
 
-    def __init__(self, *, hash_alg: str, paths: list[BaseManifestPath], total_size: int) -> None:
+    def __init__(
+        self, *, hash_alg: HashAlgorithm, paths: list[BaseManifestPath], total_size: int
+    ) -> None:
+        if hash_alg not in SUPPORTED_HASH_ALGS:
+            raise ManifestDecodeValidationError(
+                f"Unsupported hashing algorithm: {hash_alg}. Must be one of: {[e.value for e in SUPPORTED_HASH_ALGS]}"
+            )
+
         super().__init__(hash_alg=hash_alg, paths=paths)
         self.totalSize = total_size
         self.manifestVersion = ManifestVersion.v2023_03_03
@@ -42,8 +54,15 @@ class AssetManifest(BaseAssetManifest):
         Return an instance of this class given a manifest dictionary.
         Assumes the manifest has been validated prior to calling.
         """
+        try:
+            hash_alg: HashAlgorithm = HashAlgorithm(manifest_data["hashAlg"])
+        except ValueError:
+            raise ManifestDecodeValidationError(
+                f"Unsupported hashing algorithm: {hash_alg}. Must be one of: {[e.value for e in SUPPORTED_HASH_ALGS]}"
+            )
+
         return cls(
-            hash_alg=manifest_data["hashAlg"],
+            hash_alg=hash_alg,
             paths=[
                 ManifestPath(
                     path=path["path"], hash=path["hash"], size=path["size"], mtime=path["mtime"]
@@ -52,6 +71,11 @@ class AssetManifest(BaseAssetManifest):
             ],
             total_size=manifest_data["totalSize"],
         )
+
+    @classmethod
+    def get_default_hash_alg(cls) -> HashAlgorithm:  # pragma: no cover
+        """Returns the default hashing algorithm for the Asset Manifest, represented as a string"""
+        return DEFAULT_HASH_ALG
 
     def encode(self) -> str:
         """

--- a/src/deadline/job_attachments/exceptions.py
+++ b/src/deadline/job_attachments/exceptions.py
@@ -129,3 +129,9 @@ class Fus3FailedToMountError(JobAttachmentsError):
     """
     Exception for when trying to mount Fus3 at a given path.
     """
+
+
+class UnsupportedHashingAlgorithmError(JobAttachmentsError):
+    """
+    Exception for when an unsupported hashing algorithm is provided.
+    """

--- a/test/unit/deadline_job_attachments/asset_manifests/test_decode.py
+++ b/test/unit/deadline_job_attachments/asset_manifests/test_decode.py
@@ -13,7 +13,7 @@ from unittest.mock import patch
 import pytest
 
 import deadline
-from deadline.job_attachments.asset_manifests import decode, versions
+from deadline.job_attachments.asset_manifests import decode, versions, HashAlgorithm
 from deadline.job_attachments.asset_manifests.v2023_03_03 import (
     AssetManifest as AssetManifest_v2023_03_03,
 )
@@ -92,7 +92,7 @@ def test_decode_manifest_v2023_03_03(default_manifest_str_v2023_03_03: str):
     Test that a v2023-03-03 manifest string decodes to an AssetManifest object as expected.
     """
     expected_manifest = AssetManifest_v2023_03_03(
-        hash_alg="xxh128",
+        hash_alg=HashAlgorithm.XXH128,
         total_size=10,
         paths=[
             Path_v2023_03_03(path="\r", hash="Carriage Return", size=1, mtime=1679079744833848),

--- a/test/unit/deadline_job_attachments/asset_manifests/v2023_03_03/test_asset_manifest.py
+++ b/test/unit/deadline_job_attachments/asset_manifests/v2023_03_03/test_asset_manifest.py
@@ -7,6 +7,7 @@ from deadline.job_attachments.asset_manifests.v2023_03_03.asset_manifest import 
     AssetManifest,
     ManifestPath,
 )
+from deadline.job_attachments.asset_manifests import HashAlgorithm
 
 
 def test_encode():
@@ -14,7 +15,7 @@ def test_encode():
     Ensure the expected JSON string is returned from the encode function.
     """
     manifest = AssetManifest(
-        hash_alg="xxh128",
+        hash_alg=HashAlgorithm("xxh128"),
         total_size=10,
         paths=[
             ManifestPath(path="test_file", hash="a", size=1, mtime=167907934333848),
@@ -63,7 +64,7 @@ def test_decode(default_manifest_str_v2023_03_03: str):
     Ensure the expected AssetManifest is returned from the decode function.
     """
     expected = AssetManifest(
-        hash_alg="xxh128",
+        hash_alg=HashAlgorithm("xxh128"),
         total_size=10,
         paths=[
             ManifestPath(path="\r", hash="Carriage Return", size=1, mtime=1679079744833848),

--- a/test/unit/deadline_job_attachments/conftest.py
+++ b/test/unit/deadline_job_attachments/conftest.py
@@ -114,7 +114,7 @@ def fixture_default_attachments(farm_id, queue_id):
             ManifestProperties(
                 rootPath="/tmp",
                 rootPathFormat=PathFormat.POSIX,
-                inputManifestPath=f"assetRoot/Manifests/{farm_id}/{queue_id}/Inputs/0000/manifest_input.xxh128",
+                inputManifestPath=f"assetRoot/Manifests/{farm_id}/{queue_id}/Inputs/0000/manifest_input",
                 inputManifestHash="manifesthash",
                 outputRelativeDirectories=["test/outputs"],
             )


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Job Attachments stores files in the user's S3 bucket, based on a hash of the contents of each file. That is, the S3 key is the hash of the contents. However, we need to include the hashing algorithm used to generate the hash as a file extension, for any potential future proofing needs. Further, we currently include the hashing algorithm as file extension for the manifest names, which is not necessary.

While adding the file extensions, I noticed that our hashing logic isn't super organized (I was tipped off by @natmatn's suggestion to change the hash alg to an enum). While we have an enum of supported hash algs in the Manifest version schema, we aren't strictly enforcing it in the manifest model code itself, and rely on constant strings in the upload.py and asset_sync.py files, which isn't the best.

### What was the solution? (How)
Plumbed the hashing algorithm to all of the upload/downloading logic, as the manifest specification only provides the hashing algorithm as metadata in the manifest, along with all of the file hashes, so we need to tack on the hashing algorithm when generating the S3 key. This lead to some refactoring in our download functions since there are certain workflows where we conglomerate files from multiple manifests.

Moved the hashing logic to the `asset_manifests.hash_algorithms` submodule, and added a HashAlgorithm enum (currently just XXHash128). I then added a set of supported hash algs to the only current manifest version, and added an abstract method to get a default hash alg for the manifest version, so our upload code doesn't have to rely on magic strings.

In an effort not to break backwards compatibility for downloading outputs for customers with existing jobs, I've included a temporary (very hacky) change to our download logic, where we retry fetching a file from the CAS if we get a 404 (removing the hashing algorithm extension). I'll revert that change a few weeks after this gets released, as all of the existing jobs should be expired by then.

Further, I updated the hash cache to include the hashing algorithm as a secondary key, so it's clear exactly which kind of hash for a file is being cached.

### What is the impact of this change?
Files stored in the Job Attachments CAS will include their hashing algorithm as the file extension (currently only `xxh128` for xxhash 128 bit), to better future-proof the CAS. Customers shouldn't be impacted due to the temporary workaround.

### How was this change tested?
- ran unit and Job Attachments integration tests against my dev account, confirmed they passed
- ran a worker agent locally, using a sample step dependency data flow Job Bundle
  - [Test case 1: Updated submitter and worker agent] confirmed job completed successfully, and confirmed I could download outputs successfully
  - [Test case 2: Old submitter, updated worker agent] cleared out my Job Attachments bucket, used a version of the client lib without these changes to submit a Job, confirmed a Worker with my changes completed successfully and I could download the outputs
  - [Test case 3: Updated submitter downloading 'old' outputs] manually changed the output manifests to include the previous `xxh128` file extension, and confirmed I could download outputs successfully
- ran some download tests with the output of the above Job, confirming I could use all file conflict resolutions successfully, and downloading to a new asset root worked as expected
- also re-ran a Job that completed, and re-downloaded assets, confirming that worked as expected
- ran the `scripted_tests/upload_scale_test.py` which uploads thousands of files and downloads them back into a different directory; confirmed this worked successfully
- ran the docker container test, just in case

### Was this change documented?
N/A

### Is this a breaking change?
Yes, but no. 
- Breakage would be around downloading outputs from old jobs, but I've added a temporary change to prevent breakage that we intend to revert after some time has passed.
- I did add new stuff to the base manifest model, but it's mostly validation for the hashing algorithm, which we were already doing in the schema validation, we're just strictly enforcing it in the code now