### PR TITLE
feat!: incoprorate ListSessionActions API change in job trace-schedule

### DIFF
--- a/src/deadline/client/cli/_groups/job_group.py
+++ b/src/deadline/client/cli/_groups/job_group.py
@@ -683,7 +683,7 @@ def job_trace_schedule(verbose, trace_format, trace_file, **args):
             farmId=farm_id, queueId=queue_id, jobId=job_id, sessionId=session["sessionId"]
         )
         while "nextToken" in response:
-            old_list = response["sessionactions"]
+            old_list = response["sessionActions"]
             response = deadline.list_session_actions(
                 farmId=farm_id,
                 queueId=queue_id,
@@ -691,10 +691,10 @@ def job_trace_schedule(verbose, trace_format, trace_file, **args):
                 sessionId=session["sessionId"],
                 nextToken=response["nextToken"],
             )
-            response["sessionactions"] = old_list + response["sessionactions"]
+            response["sessionActions"] = old_list + response["sessionActions"]
         response.pop("ResponseMetadata", None)
 
-        session["actions"] = response["sessionactions"]
+        session["actions"] = response["sessionActions"]
 
     # Cache steps and tasks by their id, to only get each once
     steps: dict[str, Any] = {}

--- a/test/unit/deadline_client/cli/test_cli_job.py
+++ b/test/unit/deadline_client/cli/test_cli_job.py
@@ -787,7 +787,7 @@ def test_cli_job_trace_schedule(fresh_deadline_config):
         deadline_mock.get_job.return_value = MOCK_JOBS_LIST[0]
         deadline_mock.list_sessions.return_value = {"sessions": MOCK_SESSIONS_LIST}
         deadline_mock.list_session_actions.return_value = {
-            "sessionactions": MOCK_SESSION_ACTIONS_LIST
+            "sessionActions": MOCK_SESSION_ACTIONS_LIST
         }
         deadline_mock.get_step.return_value = MOCK_STEP
         deadline_mock.get_task.return_value = MOCK_TASK


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Following [naming convention in Smithy Guides](https://smithy.io/2.0/guides/model-linters.html?highlight=camelcase#camelcase), 

> attribute names should be in camel case. 

Deadline Cloud service model has been updated to replace `sessionactions` attribute in ListSessionActionsResponse with `sessionActions`. This service model change is backwards incompatible and breaks `job trace-schedule` commend in Deadline CLI.

### What was the solution? (How)
Update `job trace-schedule` code to work with the new attribute name

### What is the impact of this change?
`job trace-schedule` commend will work as expected

### How was this change tested?
We have unit test coverage for these code paths, so I updated those.

### Was this change documented?
The service API documentation will be updated.

### Is this a breaking change?
No