### PR TITLE
fix: Increased timeout on mount vfs, fixed bug with uploading empty files

### DIFF
--- a/src/deadline/job_attachments/fus3.py
+++ b/src/deadline/job_attachments/fus3.py
@@ -192,7 +192,7 @@ class Fus3ProcessManager(object):
         log.warning(f"No manifest found for mount {mount_point}")
         return None
 
-    def wait_for_mount(self, mount_wait_seconds=5) -> bool:
+    def wait_for_mount(self, mount_wait_seconds=60) -> bool:
         """
         After we've launched the fus3 subprocess we need to wait
         for the OS to validate that the mount is in place before use

--- a/src/deadline/job_attachments/upload.py
+++ b/src/deadline/job_attachments/upload.py
@@ -377,7 +377,9 @@ class S3AssetUploader:
                 current_chunksize=self.multipart_upload_chunk_size,
                 file_size=file_size,
             )
-            num_parts = int(math.ceil(file_size / float(chunk_size)))
+            # num_parts must have minimum value of 1, otherwise an empty file will generate no parts,
+            # and complete_multipart_upload throws an error if parts is empty.
+            num_parts = max(1, int(math.ceil(file_size / float(chunk_size))))
 
             # Start uploading parts
             with concurrent.futures.ThreadPoolExecutor(


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
- Submitting job bundle containing an empty file was failing with error: 
```
Failed to upload job attachments:
Error uploading file in bucket 'deadline-dev-farm-ja-529920871242', Target key or prefix: 'Deadline/Data/99aa06d3014798d86001c324468d497f.xxh128', HTTP Status Code: 400,  An error occurred (MalformedXML) when calling the CompleteMultipartUpload operation: The XML you provided was not well-formed or did not validate against our published schema (Failed to upload /local/home/npmac/job-bundles/empty_attachment_upload/west.txt)
```
- Mounting VFS was failing on a scene with a particularly large number of files. The VFS is only given 5 seconds to mount, which is pretty low.
### What was the solution? (How)
- Handle edge case of uploading empty file
- Increase timeout on VFS
### What is the impact of this change?
- non-descriptive MalformedXML error shouldn't appear if your job attachments contain an empty file.
- VFS should be able to mount on scenes with large numbers of files.
### How was this change tested?
1. Created simple job bundle that has an empty file in the job attachments. Verified this produced the MalformedXML error when trying to submit.
2. Added fix, ran `hatch shell` verified submission no longer produced the MalformedXML error.
3. Tested submitting a large scene (100gb, 11k files) and verified it hit a "Failed to mount" error.
4. Increased timeout on mounting VFS, verified job no longer hit "Failed to mount" error.
### Was this change documented?
no
### Is this a breaking change?
no