### PR TITLE
fix: Revert adding hash alg file extension on upload

### DIFF
--- a/src/deadline/job_attachments/asset_sync.py
+++ b/src/deadline/job_attachments/asset_sync.py
@@ -145,9 +145,10 @@ class AssetSync:
         manifest_name_prefix = hash_data(
             f"{file_system_location_name or ''}{root_path}".encode(), hash_alg
         )
+        # TODO: Remove hash algorithm file extension after sufficient time after the next release
         manifest_path = _join_s3_paths(
             full_output_prefix,
-            f"{manifest_name_prefix}_output",
+            f"{manifest_name_prefix}_output.{output_manifest.hashAlg.value}",
         )
         metadata = {"Metadata": {"asset-root": root_path}}
         if file_system_location_name:
@@ -224,7 +225,8 @@ class AssetSync:
                 ):
                     file_size = file_path.lstat().st_size
                     file_hash = hash_file(str(file_path), self.hash_alg)
-                    s3_key = f"{file_hash}.{self.hash_alg.value}"
+                    # TODO: replace with uncommented line below after sufficient time after the next release
+                    s3_key = file_hash  # f"{file_hash}.{self.hash_alg.value}"
 
                     if s3_settings.full_cas_prefix():
                         s3_key = _join_s3_paths(s3_settings.full_cas_prefix(), s3_key)

--- a/src/deadline/job_attachments/upload.py
+++ b/src/deadline/job_attachments/upload.py
@@ -212,7 +212,8 @@ class S3AssetUploader:
             # If different files have the same content (and thus the same hash), they are counted as skipped files.
             file_dict: dict[str, base_manifest.BaseManifestPath] = {}
             for file in files_to_upload:
-                file_key = f"{file.hash}.{manifest.hashAlg.value}"
+                # TODO: replace with uncommented line below after sufficient time after the next release
+                file_key = f"{file.hash}"  # .{manifest.hashAlg.value}"
                 if file_key in file_dict and progress_tracker:
                     progress_tracker.increase_skipped(
                         1, (source_root.joinpath(file.path)).stat().st_size
@@ -322,7 +323,8 @@ class S3AssetUploader:
         Returns a tuple (whether it has been uploaded, the file size).
         """
         local_path = source_root.joinpath(file.path)
-        s3_upload_key = f"{file.hash}.{hash_algorithm.value}"
+        # TODO: replace with uncommented line below after sufficient time after the next release
+        s3_upload_key = f"{file.hash}"  # .{hash_algorithm.value}"
         if s3_cas_prefix:
             s3_upload_key = _join_s3_paths(s3_cas_prefix, s3_upload_key)
         is_uploaded = False

--- a/test/integ/deadline_job_attachments/test_job_attachments.py
+++ b/test/integ/deadline_job_attachments/test_job_attachments.py
@@ -154,7 +154,7 @@ def upload_input_files_assets_not_in_cas(job_attachment_test: JobAttachmentTest)
 
     # THEN
     scene_ma_s3_path = (
-        f"{job_attachment_settings.full_cas_prefix()}/{job_attachment_test.SCENE_MA_HASH}.xxh128"
+        f"{job_attachment_settings.full_cas_prefix()}/{job_attachment_test.SCENE_MA_HASH}"
     )
 
     object_summary_iterator = job_attachment_test.bucket.objects.filter(
@@ -200,7 +200,7 @@ def upload_input_files_one_asset_in_cas(
     ]
 
     scene_ma_s3_path = (
-        f"{job_attachment_settings.full_cas_prefix()}/{job_attachment_test.SCENE_MA_HASH}.xxh128"
+        f"{job_attachment_settings.full_cas_prefix()}/{job_attachment_test.SCENE_MA_HASH}"
     )
 
     # This file has already been uploaded
@@ -226,8 +226,8 @@ def upload_input_files_one_asset_in_cas(
     brick_png_hash = hash_file(str(job_attachment_test.BRICK_PNG_PATH), HashAlgorithm.XXH128)
     cloth_png_hash = hash_file(str(job_attachment_test.CLOTH_PNG_PATH), HashAlgorithm.XXH128)
 
-    brick_png_s3_path = f"{job_attachment_settings.full_cas_prefix()}/{brick_png_hash}.xxh128"
-    cloth_png_s3_path = f"{job_attachment_settings.full_cas_prefix()}/{cloth_png_hash}.xxh128"
+    brick_png_s3_path = f"{job_attachment_settings.full_cas_prefix()}/{brick_png_hash}"
+    cloth_png_s3_path = f"{job_attachment_settings.full_cas_prefix()}/{cloth_png_hash}"
 
     object_summary_iterator = job_attachment_test.bucket.objects.filter(
         Prefix=f"{job_attachment_settings.full_cas_prefix()}/",
@@ -804,11 +804,11 @@ def sync_outputs(
     object_key_set = set(obj.key for obj in object_summary_iterator)
 
     assert (
-        f"{job_attachment_settings.full_cas_prefix()}/{hash_file(str(file_to_be_synced_step0_task0), HashAlgorithm.XXH128)}.xxh128"
+        f"{job_attachment_settings.full_cas_prefix()}/{hash_file(str(file_to_be_synced_step0_task0), HashAlgorithm.XXH128)}"
         in object_key_set
     )
     assert (
-        f"{job_attachment_settings.full_cas_prefix()}/{hash_file(str(file_not_to_be_synced), HashAlgorithm.XXH128)}.xxh128"
+        f"{job_attachment_settings.full_cas_prefix()}/{hash_file(str(file_not_to_be_synced), HashAlgorithm.XXH128)}"
         not in object_key_set
     )
 

--- a/test/unit/deadline_job_attachments/test_asset_sync.py
+++ b/test/unit/deadline_job_attachments/test_asset_sync.py
@@ -482,11 +482,11 @@ class TestAssetSync:
         s3 = boto3.Session(region_name="us-west-2").resource("s3")  # pylint: disable=invalid-name
         bucket = s3.Bucket(s3_settings.s3BucketName)
         bucket.put_object(
-            Key=f"{expected_cas_prefix}hash1.xxh128",
+            Key=f"{expected_cas_prefix}hash1",
             Body="a",
         )
         expected_metadata = s3.meta.client.head_object(
-            Bucket=s3_settings.s3BucketName, Key=f"{expected_cas_prefix}hash1.xxh128"
+            Bucket=s3_settings.s3BucketName, Key=f"{expected_cas_prefix}hash1"
         )
 
         # WHEN
@@ -539,21 +539,21 @@ class TestAssetSync:
 
             # THEN
             actual_metadata = s3.meta.client.head_object(
-                Bucket=s3_settings.s3BucketName, Key=f"{expected_cas_prefix}hash1.xxh128"
+                Bucket=s3_settings.s3BucketName, Key=f"{expected_cas_prefix}hash1"
             )
             assert actual_metadata["LastModified"] == expected_metadata["LastModified"]
             assert_expected_files_on_s3(
                 bucket,
                 expected_files={
-                    f"{expected_cas_prefix}hash1.xxh128",
-                    f"{expected_cas_prefix}hash2.xxh128",
-                    f"{expected_output_prefix}hash3_output",
+                    f"{expected_cas_prefix}hash1",
+                    f"{expected_cas_prefix}hash2",
+                    f"{expected_output_prefix}hash3_output.xxh128",
                 },
             )
 
             assert_canonical_manifest(
                 bucket,
-                f"{expected_output_prefix}hash3_output",
+                f"{expected_output_prefix}hash3_output.xxh128",
                 expected_manifest='{"hashAlg":"xxh128","manifestVersion":"2023-03-03",'
                 f'"paths":[{{"hash":"hash2","mtime":{expected_sub_file_mtime},"path":"{expected_sub_file_rel_path}",'
                 f'"size":{expected_processed_bytes}}},'

--- a/test/unit/deadline_job_attachments/test_upload.py
+++ b/test/unit/deadline_job_attachments/test_upload.py
@@ -259,10 +259,10 @@ class TestUpload:
                 bucket,
                 expected_files={
                     f"assetRoot/Manifests/{farm_id}/{queue_id}/Inputs/0000/e_input",
-                    f"{self.job_attachment_s3_settings.full_cas_prefix()}/a.xxh128",
-                    f"{self.job_attachment_s3_settings.full_cas_prefix()}/b.xxh128",
-                    f"{self.job_attachment_s3_settings.full_cas_prefix()}/c.xxh128",
-                    f"{self.job_attachment_s3_settings.full_cas_prefix()}/d.xxh128",
+                    f"{self.job_attachment_s3_settings.full_cas_prefix()}/a",
+                    f"{self.job_attachment_s3_settings.full_cas_prefix()}/b",
+                    f"{self.job_attachment_s3_settings.full_cas_prefix()}/c",
+                    f"{self.job_attachment_s3_settings.full_cas_prefix()}/d",
                 },
             )
 
@@ -423,7 +423,7 @@ class TestUpload:
                 bucket,
                 expected_files={
                     f"{self.job_attachment_s3_settings.rootPrefix}/Manifests/{farm_id}/{queue_id}/Inputs/0000/b_input",
-                    f"{self.job_attachment_s3_settings.full_cas_prefix()}/a.xxh128",
+                    f"{self.job_attachment_s3_settings.full_cas_prefix()}/a",
                 },
             )
 
@@ -582,7 +582,7 @@ class TestUpload:
 
             expected_files = set(
                 [
-                    f"{self.job_attachment_s3_settings.full_cas_prefix()}/{i}.xxh128"
+                    f"{self.job_attachment_s3_settings.full_cas_prefix()}/{i}"
                     for i in range(num_input_files)
                 ]
             )
@@ -769,7 +769,7 @@ class TestUpload:
 
             # mock pre-uploading the file
             bucket.put_object(
-                Key=f"{self.job_attachment_s3_settings.full_cas_prefix()}/existinghash.xxh128",
+                Key=f"{self.job_attachment_s3_settings.full_cas_prefix()}/existinghash",
                 Body="a",
             )
 
@@ -826,8 +826,8 @@ class TestUpload:
                 bucket,
                 expected_files={
                     f"{self.job_attachment_s3_settings.rootPrefix}/Manifests/{farm_id}/{queue_id}/Inputs/0000/manifest_input",
-                    f"{self.job_attachment_s3_settings.full_cas_prefix()}/existinghash.xxh128",
-                    f"{self.job_attachment_s3_settings.full_cas_prefix()}/somethingnew.xxh128",
+                    f"{self.job_attachment_s3_settings.full_cas_prefix()}/existinghash",
+                    f"{self.job_attachment_s3_settings.full_cas_prefix()}/somethingnew",
                 },
             )
 
@@ -907,7 +907,7 @@ class TestUpload:
                 input_files.append(test_file)
                 # mock pre-uploading the file
                 bucket.put_object(
-                    Key=f"{self.job_attachment_s3_settings.full_cas_prefix()}/{i}.xxh128",
+                    Key=f"{self.job_attachment_s3_settings.full_cas_prefix()}/{i}",
                     Body=f"test {i}",
                 )
 
@@ -964,7 +964,7 @@ class TestUpload:
 
             expected_files = set(
                 [
-                    f"{self.job_attachment_s3_settings.full_cas_prefix()}/{i}.xxh128"
+                    f"{self.job_attachment_s3_settings.full_cas_prefix()}/{i}"
                     for i in range(num_input_files)
                 ]
             )
@@ -1759,7 +1759,7 @@ class TestUpload:
                 bucket,
                 expected_files={
                     f"assetRoot/Manifests/{farm_id}/{queue_id}/Inputs/0000/manifest_input",
-                    f"{self.job_attachment_s3_settings.full_cas_prefix()}/a.xxh128",
+                    f"{self.job_attachment_s3_settings.full_cas_prefix()}/a",
                 },
             )
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
I introduced changes in https://github.com/casillas2/deadline-cloud/pull/162 that could break SMF customers if they don't upgrade their CLI once the change rolls out, as an SMF worker would upload files to the CAS adding the `.xxh128` file extension, but old clients wouldn't be able to download the output.

### What was the solution? (How)
Instead do a phased deployment. I'm [keeping the changes](https://github.com/casillas2/deadline-cloud/blob/mainline/src/deadline/job_attachments/download.py#L413) that try to download a file from the CAS expecting the hashing algorithm file extension, and if not found, tries downloading a file without the extension. After this change has been released for a while, we can reintroduce the few lines I commented out so that new SMF workers will add the file extension and old clients will be able to download their outputs.

### What is the impact of this change?
Sets us up for future changes without breaking customers

### How was this change tested?
- ran unit and integ tests, confirmed they passed
- Manual testing:
  - Put some input files in the Job Attachments CAS with a `xxh128` file extension, confirmed a worker could download the inputs, and calling download-job-output for files with the `xxx128` file extension worked (I included adding the hash alg file extension to a few output manifests and confirmed that downloaded successfully as well)
  - Confirmed files uploaded do not have the hash alg file extension added
  - Confirmed a manual job submission with these changes completed successfully with a CMF worker
  - With changes before https://github.com/casillas2/deadline-cloud/pull/162 confirmed I could download output created by a Worker using the changes from this PR

### Was this change documented?
N/A

### Is this a breaking change?
No, this is to prevent breaking changes introduced in https://github.com/casillas2/deadline-cloud/pull/162