### PR TITLE
fix!: Validate paths for Job Bundles

### DIFF
--- a/examples/submit_job.py
+++ b/examples/submit_job.py
@@ -42,7 +42,10 @@ def process_job_attachments(farm_id, queue_id, inputs, outputDir, deadline_clien
         queue_id=queue_id,
         job_attachment_settings=JobAttachmentS3Settings(**queue["jobAttachmentSettings"]),
     )
-    (_, manifests) = asset_manager.hash_assets_and_create_manifest(inputs, [outputDir], [])
+    upload_group = asset_manager.prepare_paths_for_upload(".", inputs, [outputDir], [])
+    (_, manifests) = asset_manager.hash_assets_and_create_manifest(
+        upload_group.asset_groups, upload_group.total_input_files, upload_group.total_input_bytes
+    )
     (_, attachments) = asset_manager.upload_assets(manifests)
     attachments = attachments.to_dict()
     total = time.perf_counter() - start
@@ -167,7 +170,7 @@ if __name__ == "__main__":
     deadline_client = boto3.client(
         "deadline",
         region_name="us-west-2",
-        endpoint_url="https://management.gamma.bealine-dev.us-west-2.amazonaws.com",
+        endpoint_url="https://management.deadline.us-west-2.amazonaws.com",
     )
 
     attachments = process_job_attachments(

--- a/scripted_tests/upload_cancel_test.py
+++ b/scripted_tests/upload_cancel_test.py
@@ -99,10 +99,13 @@ def run():
 
     try:
         print("\nStart hashing...")
+        upload_group = asset_manager.prepare_paths_for_upload(
+            ".", files, [root_path / "outputs"], []
+        )
         (summary_statistics_hashing, manifests) = asset_manager.hash_assets_and_create_manifest(
-            input_paths=files,
-            output_paths=[root_path / "outputs"],
-            referenced_paths=[],
+            asset_groups=upload_group.asset_groups,
+            total_input_files=upload_group.total_input_files,
+            total_input_bytes=upload_group.total_input_bytes,
             on_preparing_to_submit=mock_on_preparing_to_submit,
         )
         print(f"Hashing Summary Statistics:\n{summary_statistics_hashing}")

--- a/scripted_tests/upload_scale_test.py
+++ b/scripted_tests/upload_scale_test.py
@@ -112,8 +112,11 @@ if __name__ == "__main__":
     print("\nStarting upload test...")
     start = time.perf_counter()
 
+    upload_group = asset_manager.prepare_paths_for_upload(".", files, [root_path / "outputs"], [])
     (summary_statistics_hashing, manifests) = asset_manager.hash_assets_and_create_manifest(
-        files, [root_path / "outputs"], []
+        asset_groups=upload_group.asset_groups,
+        total_input_files=upload_group.total_input_files,
+        total_input_bytes=upload_group.total_input_bytes,
     )
     print(f"Summary Statistics for file hashing:\n{summary_statistics_hashing}")
 

--- a/src/deadline/client/exceptions.py
+++ b/src/deadline/client/exceptions.py
@@ -11,3 +11,7 @@ class DeadlineOperationError(Exception):
 
 class CreateJobWaiterCanceled(Exception):
     """Error for when the waiter on CreateJob is interrupted"""
+
+
+class UserInitiatedCancel(Exception):
+    """Error for when the user requests cancelation"""

--- a/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
@@ -32,6 +32,7 @@ from ..deadline_credentials_status import DeadlineCredentialsStatus
 from .. import block_signals
 from ...config import get_setting
 from ...config.config_file import str2bool
+from ...exceptions import UserInitiatedCancel
 from ...job_bundle import create_job_history_bundle_dir
 from ...job_bundle.submission import AssetReferences
 from ..widgets.deadline_credentials_status_widget import DeadlineCredentialsStatusWidget
@@ -468,6 +469,10 @@ class SubmitJobToDeadlineDialog(QDialog):
                 deadline,
                 auto_accept=str2bool(get_setting("settings.auto_accept")),
             )
+        except UserInitiatedCancel as uic:
+            logger.info("Canceling submission.")
+            QMessageBox.information(self, f"{settings.submitter_name} Job Submission", str(uic))
+            job_progress_dialog.close()
         except Exception as exc:
             logger.exception("error submitting job")
             api.get_deadline_cloud_library_telemetry_client().record_error(

--- a/src/deadline/client/ui/job_bundle_submitter.py
+++ b/src/deadline/client/ui/job_bundle_submitter.py
@@ -19,6 +19,7 @@ from ..job_bundle.loader import (
     parse_yaml_or_json_content,
     read_yaml_or_json,
     read_yaml_or_json_object,
+    validate_directory_symlink_containment,
 )
 from ..job_bundle.parameters import (
     JobParameter,
@@ -131,6 +132,9 @@ def show_job_bundle_submitter(
 
         with open(os.path.join(job_bundle_dir, "parameter_values.yaml"), "w", encoding="utf8") as f:
             deadline_yaml_dump({"parameterValues": parameters_values}, f)
+
+    # Ensure the job bundle doesn't contain files that resolve outside of the bundle directory
+    validate_directory_symlink_containment(input_job_bundle_dir)
 
     # Load the template to get the starting name
     template = read_yaml_or_json_object(input_job_bundle_dir, "template", True)

--- a/src/deadline/client/ui/widgets/job_bundle_settings_tab.py
+++ b/src/deadline/client/ui/widgets/job_bundle_settings_tab.py
@@ -24,7 +24,7 @@ from PySide2.QtWidgets import (  # type: ignore
 from ..dataclasses import JobBundleSettings
 from .openjd_parameters_widget import OpenJDParametersWidget
 from ...job_bundle.submission import AssetReferences
-from ...job_bundle.loader import read_yaml_or_json_object
+from ...job_bundle.loader import read_yaml_or_json_object, validate_directory_symlink_containment
 from ...job_bundle.parameters import read_job_bundle_parameters
 from ...config import config_file
 
@@ -99,6 +99,8 @@ class JobBundleSettingsWidget(QWidget):
 
         # Warn the user if the Job Bundle could not be loaded
         try:
+            validate_directory_symlink_containment(input_job_bundle_dir)
+
             asset_references_obj = (
                 read_yaml_or_json_object(input_job_bundle_dir, "asset_references", False) or {}
             )

--- a/src/deadline/job_attachments/models.py
+++ b/src/deadline/job_attachments/models.py
@@ -51,6 +51,16 @@ class AssetRootGroup:
 
 
 @dataclass
+class AssetUploadGroup:
+    """Represents all of the information needed to prepare to upload assets"""
+
+    asset_groups: List[AssetRootGroup] = field(default_factory=list)
+    num_outside_files_by_root: dict[str, int] = field(default_factory=dict)
+    total_input_files: int = 0
+    total_input_bytes: int = 0
+
+
+@dataclass
 class ManifestPathGroup:
     """
     Represents paths combined from multiple manifests under the same root path, organized by hash algorithm.

--- a/test/integ/deadline_job_attachments/test_job_attachments.py
+++ b/test/integ/deadline_job_attachments/test_job_attachments.py
@@ -143,10 +143,16 @@ def upload_input_files_assets_not_in_cas(job_attachment_test: JobAttachmentTest)
     mock_on_uploading_files = MagicMock(return_value=True)
 
     # WHEN
-    (_, manifests) = asset_manager.hash_assets_and_create_manifest(
+    upload_group = asset_manager.prepare_paths_for_upload(
+        job_bundle_path=str(job_attachment_test.ASSET_ROOT),
         input_paths=[str(job_attachment_test.SCENE_MA_PATH)],
         output_paths=[str(job_attachment_test.OUTPUT_PATH)],
         referenced_paths=[],
+    )
+    (_, manifests) = asset_manager.hash_assets_and_create_manifest(
+        asset_groups=upload_group.asset_groups,
+        total_input_files=upload_group.total_input_files,
+        total_input_bytes=upload_group.total_input_bytes,
         hash_cache_dir=str(job_attachment_test.hash_cache_dir),
         on_preparing_to_submit=mock_on_preparing_to_submit,
     )
@@ -210,10 +216,16 @@ def upload_input_files_one_asset_in_cas(
     mock_on_uploading_files = MagicMock(return_value=True)
 
     # WHEN
-    (_, manifests) = asset_manager.hash_assets_and_create_manifest(
+    upload_group = asset_manager.prepare_paths_for_upload(
+        job_bundle_path=str(job_attachment_test.ASSET_ROOT),
         input_paths=input_paths,
         output_paths=[str(job_attachment_test.OUTPUT_PATH)],
         referenced_paths=[],
+    )
+    (_, manifests) = asset_manager.hash_assets_and_create_manifest(
+        asset_groups=upload_group.asset_groups,
+        total_input_files=upload_group.total_input_files,
+        total_input_bytes=upload_group.total_input_bytes,
         hash_cache_dir=str(job_attachment_test.hash_cache_dir),
         on_preparing_to_submit=mock_on_preparing_to_submit,
     )
@@ -290,10 +302,16 @@ def test_upload_input_files_all_assets_in_cas(
     mock_on_uploading_files = MagicMock(return_value=True)
 
     # WHEN
-    (_, manifests) = asset_manager.hash_assets_and_create_manifest(
+    upload_group = asset_manager.prepare_paths_for_upload(
+        job_bundle_path=str(job_attachment_test.ASSET_ROOT),
         input_paths=input_paths,
         output_paths=[str(job_attachment_test.OUTPUT_PATH)],
         referenced_paths=[],
+    )
+    (_, manifests) = asset_manager.hash_assets_and_create_manifest(
+        asset_groups=upload_group.asset_groups,
+        total_input_files=upload_group.total_input_files,
+        total_input_bytes=upload_group.total_input_bytes,
         hash_cache_dir=str(job_attachment_test.hash_cache_dir),
         on_preparing_to_submit=mock_on_preparing_to_submit,
     )
@@ -1038,10 +1056,16 @@ def upload_input_files_no_input_paths(
     mock_on_uploading_files = MagicMock(return_value=True)
 
     # WHEN
-    (_, manifests) = asset_manager.hash_assets_and_create_manifest(
+    upload_group = asset_manager.prepare_paths_for_upload(
+        job_bundle_path=str(job_attachment_test.ASSET_ROOT),
         input_paths=[],
         output_paths=[str(job_attachment_test.OUTPUT_PATH)],
         referenced_paths=[],
+    )
+    (_, manifests) = asset_manager.hash_assets_and_create_manifest(
+        asset_groups=upload_group.asset_groups,
+        total_input_files=upload_group.total_input_files,
+        total_input_bytes=upload_group.total_input_bytes,
         hash_cache_dir=str(job_attachment_test.hash_cache_dir),
         on_preparing_to_submit=mock_on_preparing_to_submit,
     )
@@ -1098,10 +1122,16 @@ def test_upload_input_files_no_download_paths(job_attachment_test: JobAttachment
     mock_on_uploading_files = MagicMock(return_value=True)
 
     # WHEN
-    (_, manifests) = asset_manager.hash_assets_and_create_manifest(
+    upload_group = asset_manager.prepare_paths_for_upload(
+        job_bundle_path=str(job_attachment_test.ASSET_ROOT),
         input_paths=[str(job_attachment_test.SCENE_MA_PATH)],
         output_paths=[],
         referenced_paths=[],
+    )
+    (_, manifests) = asset_manager.hash_assets_and_create_manifest(
+        asset_groups=upload_group.asset_groups,
+        total_input_files=upload_group.total_input_files,
+        total_input_bytes=upload_group.total_input_bytes,
         hash_cache_dir=str(job_attachment_test.hash_cache_dir),
         on_preparing_to_submit=mock_on_preparing_to_submit,
     )
@@ -1205,10 +1235,16 @@ def test_upload_bucket_wrong_account(external_bucket: str, job_attachment_test: 
     with pytest.raises(
         AssetSyncError, match=f"Error checking if object exists in bucket '{external_bucket}'"
     ):
-        (_, manifests) = asset_manager.hash_assets_and_create_manifest(
+        upload_group = asset_manager.prepare_paths_for_upload(
+            job_bundle_path=str(job_attachment_test.ASSET_ROOT),
             input_paths=[str(job_attachment_test.SCENE_MA_PATH)],
             output_paths=[str(job_attachment_test.OUTPUT_PATH)],
             referenced_paths=[],
+        )
+        (_, manifests) = asset_manager.hash_assets_and_create_manifest(
+            asset_groups=upload_group.asset_groups,
+            total_input_files=upload_group.total_input_files,
+            total_input_bytes=upload_group.total_input_bytes,
             hash_cache_dir=str(job_attachment_test.hash_cache_dir),
             on_preparing_to_submit=mock_on_preparing_to_submit,
         )

--- a/test/unit/deadline_job_attachments/test_upload.py
+++ b/test/unit/deadline_job_attachments/test_upload.py
@@ -161,10 +161,8 @@ class TestUpload:
             )
 
             # When
-            (
-                hash_summary_statistics,
-                asset_root_manifests,
-            ) = asset_manager.hash_assets_and_create_manifest(
+            upload_group = asset_manager.prepare_paths_for_upload(
+                job_bundle_path=str(asset_root),
                 input_paths=[
                     str(scene_file),
                     str(texture_file),
@@ -181,6 +179,14 @@ class TestUpload:
                     "",
                 ],
                 referenced_paths=[],
+            )
+            (
+                hash_summary_statistics,
+                asset_root_manifests,
+            ) = asset_manager.hash_assets_and_create_manifest(
+                asset_groups=upload_group.asset_groups,
+                total_input_files=upload_group.total_input_files,
+                total_input_bytes=upload_group.total_input_bytes,
                 hash_cache_dir=str(cache_dir),
                 on_preparing_to_submit=mock_on_preparing_to_submit,
             )
@@ -191,6 +197,7 @@ class TestUpload:
             )
 
             # Then
+            assert not upload_group.num_outside_files_by_root  # Shouldn't be any outside files
             expected_attachments = Attachments(
                 manifests=[
                     ManifestProperties(
@@ -334,13 +341,19 @@ class TestUpload:
             )
 
             # When
+            upload_group = asset_manager.prepare_paths_for_upload(
+                job_bundle_path=str(root_c),
+                input_paths=[input_c, input_d],
+                output_paths=[output_d],
+                referenced_paths=[],
+            )
             (
                 hash_summary_statistics,
                 asset_root_manifests,
             ) = asset_manager.hash_assets_and_create_manifest(
-                input_paths=[input_c, input_d],
-                output_paths=[output_d],
-                referenced_paths=[],
+                asset_groups=upload_group.asset_groups,
+                total_input_files=upload_group.total_input_files,
+                total_input_bytes=upload_group.total_input_bytes,
                 hash_cache_dir=cache_dir,
                 on_preparing_to_submit=mock_on_preparing_to_submit,
             )
@@ -507,13 +520,19 @@ class TestUpload:
             cache_dir = tmpdir.mkdir("cache")
 
             # When
+            upload_group = asset_manager.prepare_paths_for_upload(
+                job_bundle_path=str(asset_root),
+                input_paths=input_files,
+                output_paths=[str(Path(asset_root).joinpath("outputs"))],
+                referenced_paths=[],
+            )
             (
                 hash_summary_statistics,
                 asset_root_manifests,
             ) = asset_manager.hash_assets_and_create_manifest(
-                input_paths=input_files,
-                output_paths=[str(Path(asset_root).joinpath("outputs"))],
-                referenced_paths=[],
+                asset_groups=upload_group.asset_groups,
+                total_input_files=upload_group.total_input_files,
+                total_input_bytes=upload_group.total_input_bytes,
                 hash_cache_dir=cache_dir,
                 on_preparing_to_submit=mock_on_preparing_to_submit,
             )
@@ -659,13 +678,19 @@ class TestUpload:
             cache_dir = tmpdir.mkdir("cache")
 
             # When
+            upload_group = asset_manager.prepare_paths_for_upload(
+                job_bundle_path=str(asset_root),
+                input_paths=input_files,
+                output_paths=[str(Path(asset_root).joinpath("outputs"))],
+                referenced_paths=[],
+            )
             (
                 hash_summary_statistics,
                 asset_root_manifests,
             ) = asset_manager.hash_assets_and_create_manifest(
-                input_paths=input_files,
-                output_paths=[str(Path(asset_root).joinpath("outputs"))],
-                referenced_paths=[],
+                asset_groups=upload_group.asset_groups,
+                total_input_files=upload_group.total_input_files,
+                total_input_bytes=upload_group.total_input_bytes,
                 hash_cache_dir=cache_dir,
                 on_preparing_to_submit=mock_on_preparing_to_submit,
             )
@@ -776,13 +801,19 @@ class TestUpload:
             cache_dir = tmpdir.mkdir("cache")
 
             # When
+            upload_group = asset_manager.prepare_paths_for_upload(
+                job_bundle_path=str(tmpdir),
+                input_paths=[already_uploaded_file, not_yet_uploaded_file],
+                output_paths=[],
+                referenced_paths=[],
+            )
             (
                 hash_summary_statistics,
                 asset_root_manifests,
             ) = asset_manager.hash_assets_and_create_manifest(
-                input_paths=[already_uploaded_file, not_yet_uploaded_file],
-                output_paths=[],
-                referenced_paths=[],
+                asset_groups=upload_group.asset_groups,
+                total_input_files=upload_group.total_input_files,
+                total_input_bytes=upload_group.total_input_bytes,
                 hash_cache_dir=cache_dir,
                 on_preparing_to_submit=mock_on_preparing_to_submit,
             )
@@ -917,13 +948,19 @@ class TestUpload:
             cache_dir = tmpdir.mkdir("cache")
 
             # When
+            upload_group = asset_manager.prepare_paths_for_upload(
+                job_bundle_path=str(tmpdir),
+                input_paths=input_files,
+                output_paths=[],
+                referenced_paths=[],
+            )
             (
                 hash_summary_statistics,
                 asset_root_manifests,
             ) = asset_manager.hash_assets_and_create_manifest(
-                input_paths=input_files,
-                output_paths=[],
-                referenced_paths=[],
+                asset_groups=upload_group.asset_groups,
+                total_input_files=upload_group.total_input_files,
+                total_input_bytes=upload_group.total_input_bytes,
                 hash_cache_dir=cache_dir,
                 on_preparing_to_submit=mock_on_preparing_to_submit,
             )
@@ -1020,13 +1057,19 @@ class TestUpload:
             cache_dir = tmpdir.mkdir("cache")
 
             # When
+            upload_group = asset_manager.prepare_paths_for_upload(
+                job_bundle_path=str(tmpdir),
+                input_paths=[],
+                output_paths=[output_dir],
+                referenced_paths=[],
+            )
             (
                 hash_summary_statistics,
                 asset_root_manifests,
             ) = asset_manager.hash_assets_and_create_manifest(
-                input_paths=[],
-                output_paths=[output_dir],
-                referenced_paths=[],
+                asset_groups=upload_group.asset_groups,
+                total_input_files=upload_group.total_input_files,
+                total_input_bytes=upload_group.total_input_bytes,
                 hash_cache_dir=cache_dir,
                 on_preparing_to_submit=mock_on_preparing_to_submit,
             )
@@ -1204,8 +1247,17 @@ class TestUpload:
                 cache_dir = tmpdir.mkdir("cache")
                 test_file = tmpdir.join("test.txt")
                 test_file.write("test")
+                upload_group = asset_manager.prepare_paths_for_upload(
+                    job_bundle_path=str(tmpdir),
+                    input_paths=[test_file],
+                    output_paths=[],
+                    referenced_paths=[],
+                )
                 asset_manager.hash_assets_and_create_manifest(
-                    [test_file], [], [], hash_cache_dir=cache_dir
+                    upload_group.asset_groups,
+                    upload_group.total_input_files,
+                    upload_group.total_input_bytes,
+                    hash_cache_dir=cache_dir,
                 )
 
     def test_asset_uploader_constructor(self, fresh_deadline_config):
@@ -1606,13 +1658,19 @@ class TestUpload:
             )
 
             # When
+            upload_group = asset_manager.prepare_paths_for_upload(
+                job_bundle_path=str(asset_root),
+                input_paths=[input_not_exist, scene_file],
+                output_paths=[str(Path(asset_root).joinpath("outputs"))],
+                referenced_paths=[],
+            )
             (
                 hash_summary_statistics,
                 asset_root_manifests,
             ) = asset_manager.hash_assets_and_create_manifest(
-                input_paths=[input_not_exist, scene_file],
-                output_paths=[str(Path(asset_root).joinpath("outputs"))],
-                referenced_paths=[],
+                asset_groups=upload_group.asset_groups,
+                total_input_files=upload_group.total_input_files,
+                total_input_bytes=upload_group.total_input_bytes,
                 hash_cache_dir=cache_dir,
                 on_preparing_to_submit=mock_on_preparing_to_submit,
             )
@@ -1723,13 +1781,19 @@ class TestUpload:
                 asset_manifest_version=manifest_version,
             )
 
+            upload_group = asset_manager.prepare_paths_for_upload(
+                job_bundle_path=str(tmpdir),
+                input_paths=[str(symlink_input_path)],
+                output_paths=[str(symlink_output_path)],
+                referenced_paths=[],
+            )
             (
                 hash_summary_statistics,
                 asset_root_manifests,
             ) = asset_manager.hash_assets_and_create_manifest(
-                input_paths=[str(symlink_input_path)],
-                output_paths=[str(symlink_output_path)],
-                referenced_paths=[],
+                asset_groups=upload_group.asset_groups,
+                total_input_files=upload_group.total_input_files,
+                total_input_bytes=upload_group.total_input_bytes,
                 hash_cache_dir=str(cache_dir),
                 on_preparing_to_submit=mock_on_preparing_to_submit,
             )


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We need to safeguard users when uploading inputs. There's a few cases here:
1. A Job bundle directory cannot contain symlinks that resolve outside of the bundle directory
2. The default PATH values in the template defined in the bundle:
  a. cannot have default parameters that are absolute, and
  b. the default relative paths must resolve inside the bundle directory (so no escaping with `../`)
3.  For input paths in the Asset References file, any PATH values in the Job bundle parameters file, as well as any queue environment PATH parameters:
  a. If the path resolves outside of the job bundle directory AND is not part of a configured storage profile location for the queue being submitted to, we need to warn the user, so they're aware files will be uploaded from an unexpected area 

### What was the solution? (How)
1. When loading a job bundle, walk the directory and ensure all paths resolve inside the resolved job bundle directory (as the Job Bundle directory could itself be a symlink)
  a. This was mostly added in `src/deadline/client/job_bundle/parameters.py` and `src/deadline/client/job_bundle/loader.py`
3. Reorganize the submission workflow, adding a new function to `src/deadline/job_attachments/upload.py` to first process all asset paths (these are combined with the validated Job Bundle, parameters file, queue environment parameters, and asset references files), and prompt the user to confirm if they want to continue submission if files are found outside of the Job Bundle dir and any storage profile locations for the queue
  a. Note that I moved the confirmation popup that happens AFTER hashing to BEFORE hashing to include a combined confirmation message
  b. Also note: when submitting through the GUI, since we move the job bundle to the `~/.deadline/job_history/` dir, the actual input files for the job bundle do not move, so if the files in the original job bundle are not part of a Storage Profile filesystem location, it will always prompt the user
4. I also took the opportunity to clean up our GUI a little bit (I haven't done much QT work before, so it was fun to try paying the beauty tax)
  a. Fixed some text that didn't render as it was using HTML tags
  b. Grouped the progress bars so it's more clear

### What is the impact of this change?
Users should have more information about what they're submitting when they attempt to submit a Job Bundle. This protects users from job bundles that could contain symlinks that resolve outside of the job bundle directory. Also, the UI is a little nicer to look at (at least I think so ;) )

### How was this change tested?
- unit / integration tests pass
- LOOOOTS of manual submission testing (for both CLI and GUI workflows):
  - Job bundle with symlinks that resolve within the job bundle -> submits successfully
  - Job bundle with symlinks that resolve outside the job bundle -> raises an error
  - Job bundle with relative default PATH values that resolve outside the bundle dir -> raises an error
  - Job bundle with absolute default PATH -> raises an error
  - Set a storage profile filesystem location, included asset references within that directory -> normal submission with no warnings
  - Set a storage profile filesystem location, included asset references outside that directory -> makes a warning popup
  - Added a queue environment with IN and INOUT PATH parameters. Confirmed that absolute paths that resolved outside of my configured storage profile locations presented a warning popup, and relative / absolute paths that resolved within storage profiles did not

### UI Changes
<details>
  <summary>Old UI</summary>

  - The status boxes at the bottom had cut off text and white borders that didn't fit with the overall theme
  ![Screenshot 2024-02-02 at 5 19 52 PM](https://github.com/casillas2/deadline-cloud/assets/132690522/b8f9bf6e-bb75-4237-be1f-0df2fed41f41)
  - Submission progress UI didn't have information clearly separated
  ![Screenshot 2024-02-02 at 5 20 04 PM](https://github.com/casillas2/deadline-cloud/assets/132690522/feaf2ca3-9cda-4199-b7e8-694472406a3f)

</details>

<details>
  <summary>New UI</summary>

- Made the credential stats boxes (at the bottom) look more in line with the rest of the styling
  ![Screenshot 2024-02-07 at 10 29 47 AM](https://github.com/casillas2/deadline-cloud/assets/132690522/d25beec4-2b97-4e67-a11a-4f84a3f40308)
  ![Screenshot 2024-02-07 at 10 29 55 AM](https://github.com/casillas2/deadline-cloud/assets/132690522/0ec142ff-606b-4fdb-b611-9f1b556fc4d7)
  ![Screenshot 2024-02-07 at 10 30 15 AM](https://github.com/casillas2/deadline-cloud/assets/132690522/82985487-4cd1-4106-9ed1-8a5c9fa468b4)
  ![Screenshot 2024-02-07 at 10 30 28 AM](https://github.com/casillas2/deadline-cloud/assets/132690522/4bc1c932-22ee-4ee9-8355-cbbf5bc07fd9)
- Made the submission progress UI more clear
  ![Screenshot 2024-02-07 at 10 42 52 AM](https://github.com/casillas2/deadline-cloud/assets/132690522/2e0d5294-e083-488a-9778-42eb4b0ab3e5)
- Warning when files are outside of SP file location / job bundle dir
  ![Screenshot 2024-02-02 at 3 37 04 PM](https://github.com/casillas2/deadline-cloud/assets/132690522/86e6eba0-3aab-48ba-b2bb-ceb7b55f14a9)
- What happens if you hit cancel
  ![Screenshot 2024-02-02 at 3 37 18 PM](https://github.com/casillas2/deadline-cloud/assets/132690522/079b8aff-ca3a-4678-a4ac-eda116a1ab99)
- Error when you try to load a Job Bundle with paths that resolve outside of the bundle dir
  ![Screenshot 2024-02-02 at 3 41 33 PM](https://github.com/casillas2/deadline-cloud/assets/132690522/d446dbef-b5dd-4649-9b9b-bc975fd4774e)
- What the submission UI looks like if you have all valid paths within a SP file location / bundle dir
  ![Screenshot 2024-02-02 at 3 43 26 PM](https://github.com/casillas2/deadline-cloud/assets/132690522/3eb8b4cb-9ebf-4559-bc73-1dcee09eaeee)
- Successful submission UI
  ![Screenshot 2024-02-07 at 10 43 02 AM](https://github.com/casillas2/deadline-cloud/assets/132690522/5575ce59-0e80-42fa-88a4-ac8f169358d8)
  ![Screenshot 2024-02-07 at 10 43 22 AM](https://github.com/casillas2/deadline-cloud/assets/132690522/da18a6ac-17e9-45b9-b3c0-ecd0596a8d68)




</details>

### Was this change documented?
Not yet

### Is this a breaking change?
Yes, the interface for the Job Attachments S3AssetManager has changed (should only affect custom Python scripts that import the library)
- `hash_assets_and_create_manifest` takes different arguments
- `prepare_paths_for_upload` was added and needs to be called before `hash_assets_and_create_manifest` 

Also:
- the user is prompted for confirmation before hashing when submitting (previously, they'd be prompted after hashing, before uploading)
- can no longer open job bundles with paths that resolve outside of the job bundle directory
- can no longer open job bundles withe default PATH parameters in the template, and/or relative paths that resolve outside of the job bundle directory