### PR TITLE
fix: Removing references to Fus3

### DIFF
--- a/src/deadline/job_attachments/asset_sync.py
+++ b/src/deadline/job_attachments/asset_sync.py
@@ -40,8 +40,8 @@ from .download import (
     mount_vfs_from_manifests,
 )
 
-from .fus3 import Fus3ProcessManager
-from .exceptions import AssetSyncError, Fus3ExecutableMissingError, JobAttachmentsS3ClientError
+from .exceptions import AssetSyncError, VFSExecutableMissingError, JobAttachmentsS3ClientError
+from .vfs import VFSProcessManager
 from .models import (
     Attachments,
     JobAttachmentsFileSystem,
@@ -409,7 +409,7 @@ class AssetSync:
             and "AWS_PROFILE" in os_env_vars
         ):
             try:
-                Fus3ProcessManager.find_fus3()
+                VFSProcessManager.find_vfs()
                 mount_vfs_from_manifests(
                     s3_bucket=s3_settings.s3BucketName,
                     manifests_by_root=merged_manifests_by_root,
@@ -421,7 +421,7 @@ class AssetSync:
                 )
                 summary_statistics = SummaryStatistics()
                 return (summary_statistics, list(pathmapping_rules.values()))
-            except Fus3ExecutableMissingError:
+            except VFSExecutableMissingError:
                 logger.error(
                     f"Virtual File System not found, falling back to {JobAttachmentsFileSystem.COPIED} for JobAttachmentsFileSystem."
                 )
@@ -549,8 +549,8 @@ class AssetSync:
         if file_system == JobAttachmentsFileSystem.COPIED.value:
             return
         try:
-            Fus3ProcessManager.find_fus3()
+            VFSProcessManager.find_vfs()
             # Shutdown all running Deadline VFS processes since session is complete
-            Fus3ProcessManager.kill_all_processes(session_dir=session_dir)
-        except Fus3ExecutableMissingError:
+            VFSProcessManager.kill_all_processes(session_dir=session_dir)
+        except VFSExecutableMissingError:
             logger.error("Virtual File System not found, no processes to kill.")

--- a/src/deadline/job_attachments/download.py
+++ b/src/deadline/job_attachments/download.py
@@ -30,7 +30,7 @@ from .exceptions import (
     JobAttachmentsError,
     MissingAssetRootError,
 )
-from .fus3 import Fus3ProcessManager
+from .vfs import VFSProcessManager
 from .models import (
     Attachments,
     FileConflictResolution,
@@ -843,7 +843,7 @@ def handle_existing_vfs(
     if not os.path.ismount(mount_point):
         return manifest
 
-    input_manifest_path: Optional[Path] = Fus3ProcessManager.get_manifest_path_for_mount(
+    input_manifest_path: Optional[Path] = VFSProcessManager.get_manifest_path_for_mount(
         session_dir=session_dir, mount_point=mount_point
     )
     if input_manifest_path is not None:
@@ -858,7 +858,7 @@ def handle_existing_vfs(
         download_logger.error(f"input manifest not found for mount at {mount_point}")
         return manifest
 
-    Fus3ProcessManager.kill_process_at_mount(session_dir=session_dir, mount_point=mount_point)
+    VFSProcessManager.kill_process_at_mount(session_dir=session_dir, mount_point=mount_point)
 
     return manifest
 
@@ -901,7 +901,7 @@ def mount_vfs_from_manifests(
         # Write out a temporary file with the contents of the newly merged manifest
         manifest_path: str = write_manifest_to_temp_file(final_manifest)
 
-        vfs_manager: Fus3ProcessManager = Fus3ProcessManager(
+        vfs_manager: VFSProcessManager = VFSProcessManager(
             s3_bucket,
             boto3_session.region_name,
             manifest_path,

--- a/src/deadline/job_attachments/exceptions.py
+++ b/src/deadline/job_attachments/exceptions.py
@@ -113,21 +113,21 @@ class PathOutsideDirectoryError(JobAttachmentsError):
     """
 
 
-class Fus3ExecutableMissingError(JobAttachmentsError):
+class VFSExecutableMissingError(JobAttachmentsError):
     """
-    Exception for when trying to retrieve Fus3 executable path doesn't exist.
-    """
-
-
-class Fus3LaunchScriptMissingError(JobAttachmentsError):
-    """
-    Exception for when trying to retrieve Fus3 launch script path doesn't exist.
+    Exception for when trying to retrieve VFS executable path doesn't exist.
     """
 
 
-class Fus3FailedToMountError(JobAttachmentsError):
+class VFSLaunchScriptMissingError(JobAttachmentsError):
     """
-    Exception for when trying to mount Fus3 at a given path.
+    Exception for when trying to retrieve VFS launch script path doesn't exist.
+    """
+
+
+class VFSFailedToMountError(JobAttachmentsError):
+    """
+    Exception for when trying to mount VFS at a given path.
     """
 
 

--- a/src/deadline/job_attachments/vfs.py
+++ b/src/deadline/job_attachments/vfs.py
@@ -12,45 +12,31 @@ from signal import SIGTERM
 from typing import Dict, List, Union, Optional
 
 from .exceptions import (
-    Fus3ExecutableMissingError,
-    Fus3FailedToMountError,
-    Fus3LaunchScriptMissingError,
+    VFSExecutableMissingError,
+    VFSFailedToMountError,
+    VFSLaunchScriptMissingError,
 )
 
 log = logging.getLogger(__name__)
-
-FUS3_PATH_ENV_VAR = "FUS3_PATH"
-FUS3_EXECUTABLE = "fus3"
-FUS3_DEFAULT_INSTALL_PATH = "/opt/fus3"
-FUS3_EXECUTABLE_SCRIPT = "/scripts/production/al2/run_fus3_al2.sh"
 
 DEADLINE_VFS_ENV_VAR = "DEADLINE_VFS_PATH"
 DEADLINE_VFS_EXECUTABLE = "deadline_vfs"
 DEADLINE_VFS_INSTALL_PATH = "/opt/deadline_vfs"
 DEADLINE_VFS_EXECUTABLE_SCRIPT = "/scripts/production/al2/run_deadline_vfs_al2.sh"
 
-EXE_TO_SCRIPT = {
-    DEADLINE_VFS_EXECUTABLE: DEADLINE_VFS_EXECUTABLE_SCRIPT,
-    FUS3_EXECUTABLE: FUS3_EXECUTABLE_SCRIPT,
-}
 
-EXE_TO_INSTALL_PATH = {
-    DEADLINE_VFS_EXECUTABLE: DEADLINE_VFS_INSTALL_PATH,
-    FUS3_EXECUTABLE: FUS3_DEFAULT_INSTALL_PATH,
-}
-
-FUS3_PID_FILE_NAME = "fus3_pids.txt"
+DEADLINE_VFS_PID_FILE_NAME = "vfs_pids.txt"
 
 
-class Fus3ProcessManager(object):
+class VFSProcessManager(object):
     exe_path: Optional[str] = None
     launch_script_path: Optional[str] = None
     library_path: Optional[str] = None
     cwd_path: Optional[str] = None
 
     _mount_point: str
-    _fus3_proc: Optional[subprocess.Popen]
-    _fus3_thread: Optional[threading.Thread]
+    _vfs_proc: Optional[subprocess.Popen]
+    _vfs_thread: Optional[threading.Thread]
     _mount_temp_directory: Optional[str]
     _run_path: Optional[Union[os.PathLike, str]]
     _asset_bucket: str
@@ -75,8 +61,8 @@ class Fus3ProcessManager(object):
             raise NotImplementedError("Windows is not currently supported for Job Attachments")
 
         self._mount_point = mount_point
-        self._fus3_proc = None
-        self._fus3_thread = None
+        self._vfs_proc = None
+        self._vfs_thread = None
         self._mount_temp_directory = None
         self._run_path = None
         self._asset_bucket = asset_bucket
@@ -89,12 +75,12 @@ class Fus3ProcessManager(object):
     @classmethod
     def kill_all_processes(cls, session_dir: Path) -> None:
         """
-        Kill all existing Fus3 processes when outputs have been uploaded.
+        Kill all existing VFS processes when outputs have been uploaded.
         :param session_dir: tmp directory for session
         """
-        log.info("Terminating all Fus3 processes.")
+        log.info("Terminating all VFS processes.")
         try:
-            pid_file_path = (session_dir / FUS3_PID_FILE_NAME).resolve()
+            pid_file_path = (session_dir / DEADLINE_VFS_PID_FILE_NAME).resolve()
             with open(pid_file_path, "r") as file:
                 for line in file.readlines():
                     line = line.strip()
@@ -106,13 +92,13 @@ class Fus3ProcessManager(object):
                     try:
                         os.kill(int(pid), SIGTERM)
                     except OSError as e:
-                        # This is raised when the Fus3 process has already terminated.
+                        # This is raised when the VFS process has already terminated.
                         # This shouldn't happen, but won't cause an error if ignored
                         if e.errno == 3:
                             log.error(f"No process found for {pid}")
             os.remove(pid_file_path)
         except FileNotFoundError:
-            log.warning(f"Fus3 pid file not found at {pid_file_path}")
+            log.warning(f"VFS pid file not found at {pid_file_path}")
 
     @classmethod
     def kill_process_at_mount(cls, session_dir: Path, mount_point: str) -> bool:
@@ -129,7 +115,7 @@ class Fus3ProcessManager(object):
         log.info(f"Terminating deadline_vfs processes at {mount_point}.")
         mount_point_found: bool = False
         try:
-            pid_file_path = (session_dir / FUS3_PID_FILE_NAME).resolve()
+            pid_file_path = (session_dir / DEADLINE_VFS_PID_FILE_NAME).resolve()
             with open(pid_file_path, "r") as file:
                 lines = file.readlines()
             with open(pid_file_path, "w") as file:
@@ -146,7 +132,7 @@ class Fus3ProcessManager(object):
                             try:
                                 os.kill(int(pid), SIGTERM)
                             except OSError as e:
-                                # This is raised when the Fus3 process has already terminated.
+                                # This is raised when the VFS process has already terminated.
                                 # This shouldn't happen, but won't cause an error if ignored
                                 if e.errno == 3:
                                     log.error(f"No process found for {pid}")
@@ -159,7 +145,7 @@ class Fus3ProcessManager(object):
                         else:
                             file.write(line)
         except FileNotFoundError:
-            log.warning(f"Fus3 pid file not found at {pid_file_path}")
+            log.warning(f"VFS pid file not found at {pid_file_path}")
             return False
 
         return mount_point_found
@@ -175,7 +161,7 @@ class Fus3ProcessManager(object):
         :returns: Path to the manifest file for mount if there is one
         """
         try:
-            pid_file_path = (session_dir / FUS3_PID_FILE_NAME).resolve()
+            pid_file_path = (session_dir / DEADLINE_VFS_PID_FILE_NAME).resolve()
             with open(pid_file_path, "r") as file:
                 for line in file.readlines():
                     line = line.strip()
@@ -187,14 +173,14 @@ class Fus3ProcessManager(object):
                             log.warn(f"Expected VFS input manifest at {manifest_path}")
                             return None
         except FileNotFoundError:
-            log.warning(f"Fus3 pid file not found at {pid_file_path}")
+            log.warning(f"VFS pid file not found at {pid_file_path}")
 
         log.warning(f"No manifest found for mount {mount_point}")
         return None
 
     def wait_for_mount(self, mount_wait_seconds=60) -> bool:
         """
-        After we've launched the fus3 subprocess we need to wait
+        After we've launched the VFS subprocess we need to wait
         for the OS to validate that the mount is in place before use
         """
         log.info(f"Testing for mount at {self.get_mount_point()}")
@@ -208,27 +194,27 @@ class Fus3ProcessManager(object):
                 log.info(f"{self.get_mount_point()} not a mount, sleeping...")
                 time.sleep(1)
         log.info(f"Failed to find mount at {self.get_mount_point()}")
-        Fus3ProcessManager.print_log_end()
+        VFSProcessManager.print_log_end()
         return False
 
     @classmethod
     def get_logs_folder(cls) -> Union[os.PathLike, str]:
         """
-        Find the folder we expect fus3_ logs to be written to
+        Find the folder we expect VFS logs to be written to
         """
-        return os.path.join(os.path.dirname(Fus3ProcessManager.find_fus3()), "..", "logs")
+        return os.path.join(os.path.dirname(VFSProcessManager.find_vfs()), "..", "logs")
 
     @classmethod
-    def print_log_end(cls, log_file_name="fus3_log.txt", lines=100, log_level=logging.WARNING):
+    def print_log_end(cls, log_file_name="vfs_log.txt", lines=100, log_level=logging.WARNING):
         """
         Print out the end of our VFS Log.  Reads the full log file into memory.  Our VFS logs are size
         capped so this is not an issue for the intended use case.
-        :param log_file_name: Name of file within the logs folder to read from.  Defaults to fus3_log.txt which
+        :param log_file_name: Name of file within the logs folder to read from.  Defaults to vfs_log.txt which
         is our "most recent" log file.
         :param lines: Maximum number of lines from the end of the log to print
         :param log_level: Level to print logging as
         """
-        log_file_path = os.path.join(Fus3ProcessManager.get_logs_folder(), log_file_name)
+        log_file_path = os.path.join(VFSProcessManager.get_logs_folder(), log_file_name)
         log.log(log_level, f"Printing last {lines} lines from {log_file_path}")
         if not os.path.exists(log_file_path):
             log.warning(f"No log file found at {log_file_path}")
@@ -238,22 +224,22 @@ class Fus3ProcessManager(object):
                 log.log(log_level, this_line)
 
     @classmethod
-    def find_fus3_link_dir(cls) -> str:
+    def find_vfs_link_dir(cls) -> str:
         """
         Get the path where links to any necessary executables which should be added to the path should live
         :returns: Path to the link folder
         """
-        return os.path.join(os.path.dirname(Fus3ProcessManager.find_fus3()), "..", "link")
+        return os.path.join(os.path.dirname(VFSProcessManager.find_vfs()), "..", "link")
 
     def build_launch_command(self, mount_point: Union[os.PathLike, str]) -> List:
         """
-        Build command to pass to Popen to launch fus3
+        Build command to pass to Popen to launch VFS
         :param mount_point: directory to mount which must be the first parameter seen by our executable
         :return: command
         """
         command = []
 
-        executable = Fus3ProcessManager.find_fus3_launch_script()
+        executable = VFSProcessManager.find_vfs_launch_script()
         if self._cas_prefix is None:
             command = [
                 "%s %s -f --clienttype=deadline --bucket=%s --manifest=%s --region=%s -oallow_other"
@@ -276,102 +262,93 @@ class Fus3ProcessManager(object):
         return command
 
     @classmethod
-    def find_fus3_launch_script(cls) -> Union[os.PathLike, str]:
+    def find_vfs_launch_script(cls) -> Union[os.PathLike, str]:
         """
-        Determine where the fus3 launch script lives so we can build the launch command
-        :return: Path to fus3 launch script
+        Determine where the VFS launch script lives so we can build the launch command
+        :return: Path to VFS launch script
         """
-        if Fus3ProcessManager.launch_script_path is not None:
-            log.info(f"Using saved path {Fus3ProcessManager.launch_script_path} for launch script")
-            return Fus3ProcessManager.launch_script_path
+        if VFSProcessManager.launch_script_path is not None:
+            log.info(f"Using saved path {VFSProcessManager.launch_script_path} for launch script")
+            return VFSProcessManager.launch_script_path
 
-        executables = [DEADLINE_VFS_EXECUTABLE, FUS3_EXECUTABLE]
-        for exe in executables:
-            log.info(f"Searching for {exe} launch script")
-            exe_script = EXE_TO_SCRIPT[exe]
-            # Look for env var to construct script path
-            if DEADLINE_VFS_ENV_VAR in os.environ:
-                log.info(f"{DEADLINE_VFS_ENV_VAR} found in environment")
-                environ_check = os.environ[DEADLINE_VFS_ENV_VAR] + exe_script
-            elif FUS3_PATH_ENV_VAR in os.environ:
-                log.info(f"{FUS3_PATH_ENV_VAR} found in environment")
-                environ_check = os.environ[FUS3_PATH_ENV_VAR] + exe_script
-            else:
-                log.warning(
-                    f"{FUS3_PATH_ENV_VAR} and {DEADLINE_VFS_ENV_VAR} not found in environment"
-                )
-                environ_check = EXE_TO_INSTALL_PATH[exe] + exe_script
-            # Test if script path exists
-            if os.path.exists(environ_check):
-                log.info(f"Environ check found {exe} launch script at {environ_check}")
-                Fus3ProcessManager.launch_script_path = environ_check
-                return environ_check  # type: ignore[return-value]
-            else:
-                log.error(f"Failed to find {exe} launch script!")
+        exe = DEADLINE_VFS_EXECUTABLE
+        # for exe in executables:
+        log.info(f"Searching for {exe} launch script")
+        exe_script = DEADLINE_VFS_EXECUTABLE_SCRIPT
+        # Look for env var to construct script path
+        if DEADLINE_VFS_ENV_VAR in os.environ:
+            log.info(f"{DEADLINE_VFS_ENV_VAR} found in environment")
+            environ_check = os.environ[DEADLINE_VFS_ENV_VAR] + exe_script
+        else:
+            log.warning(f"{DEADLINE_VFS_ENV_VAR} not found in environment")
+            environ_check = DEADLINE_VFS_INSTALL_PATH + exe_script
+        # Test if script path exists
+        if os.path.exists(environ_check):
+            log.info(f"Environ check found {exe} launch script at {environ_check}")
+            VFSProcessManager.launch_script_path = environ_check
+            return environ_check  # type: ignore[return-value]
+        else:
+            log.error(f"Failed to find {exe} launch script!")
 
         log.error("Failed to find both executables scripts!")
-        raise Fus3LaunchScriptMissingError
+        raise VFSLaunchScriptMissingError
 
     @classmethod
-    def find_fus3(cls) -> Union[os.PathLike, str]:
+    def find_vfs(cls) -> Union[os.PathLike, str]:
         """
-        Determine where the fus3 executable we'll be launching lives so we can
+        Determine where the VFS executable we'll be launching lives so we can
         find the correct relative paths around it for LD_LIBRARY_PATH and config files
-        :return: Path to fus3
+        :return: Path to VFS executable
         """
-        if Fus3ProcessManager.exe_path is not None:
-            log.info(f"Using saved path {Fus3ProcessManager.exe_path}")
-            return Fus3ProcessManager.exe_path
+        if VFSProcessManager.exe_path is not None:
+            log.info(f"Using saved path {VFSProcessManager.exe_path}")
+            return VFSProcessManager.exe_path
 
-        executables = [DEADLINE_VFS_EXECUTABLE, FUS3_EXECUTABLE]
-        for exe in executables:
-            # Use "which fus3" by default to find fus3 executable location
-            found_path = shutil.which(exe)
-            if found_path is None:
-                log.info(f"Cwd when finding {exe} is {os.getcwd()}")
-                # If fus3 executable isn't on the PATH, check if environment variable is set
-                if DEADLINE_VFS_ENV_VAR in os.environ:
-                    log.info(f"{DEADLINE_VFS_ENV_VAR} set to {os.environ[DEADLINE_VFS_ENV_VAR]}")
-                    environ_check = os.environ[DEADLINE_VFS_ENV_VAR] + f"/bin/{exe}"
-                elif FUS3_PATH_ENV_VAR in os.environ:
-                    log.info(f"{FUS3_PATH_ENV_VAR} set to {os.environ[FUS3_PATH_ENV_VAR]}")
-                    environ_check = os.environ[FUS3_PATH_ENV_VAR] + f"/bin/{exe}"
+        exe = DEADLINE_VFS_EXECUTABLE
+        # Use "which deadline_vfs" by default to find the executable location
+        found_path = shutil.which(exe)
+        if found_path is None:
+            log.info(f"Cwd when finding {exe} is {os.getcwd()}")
+            # If VFS executable isn't on the PATH, check if environment variable is set
+            if DEADLINE_VFS_ENV_VAR in os.environ:
+                log.info(f"{DEADLINE_VFS_ENV_VAR} set to {os.environ[DEADLINE_VFS_ENV_VAR]}")
+                environ_check = os.environ[DEADLINE_VFS_ENV_VAR] + f"/bin/{exe}"
+            else:
+                log.info(f"{DEADLINE_VFS_ENV_VAR} env var not set")
+                environ_check = DEADLINE_VFS_INSTALL_PATH + f"/bin/{exe}"
+            if os.path.exists(environ_check):
+                log.info(f"Environ check found {exe} at {environ_check}")
+                found_path = environ_check
+            else:
+                # Last attempt looks for deadline_vfs in bin
+                bin_check = os.path.join(os.getcwd(), f"bin/{exe}")
+                if os.path.exists(bin_check):
+                    log.info(f"Bin check found VFS at {bin_check}")
+                    found_path = bin_check
                 else:
-                    log.info(f"{FUS3_PATH_ENV_VAR} and {DEADLINE_VFS_ENV_VAR} env vars not set")
-                    environ_check = EXE_TO_INSTALL_PATH[exe] + f"/bin/{exe}"
-                if os.path.exists(environ_check):
-                    log.info(f"Environ check found {exe} at {environ_check}")
-                    found_path = environ_check
-                else:
-                    # Last attempt looks for fus3 in bin
-                    bin_check = os.path.join(os.getcwd(), f"bin/{exe}")
-                    if os.path.exists(bin_check):
-                        log.info(f"Bin check found fus3 at {bin_check}")
-                        found_path = bin_check
-                    else:
-                        log.error(f"Failed to find {exe}!")
+                    log.error(f"Failed to find {exe}!")
 
-            # Run final check to see if exe path was found
-            if found_path is not None:
-                log.info(f"Found {exe} at {found_path}")
-                Fus3ProcessManager.exe_path = found_path
-                return found_path  # type: ignore[return-value]
+        # Run final check to see if exe path was found
+        if found_path is not None:
+            log.info(f"Found {exe} at {found_path}")
+            VFSProcessManager.exe_path = found_path
+            return found_path  # type: ignore[return-value]
 
         log.error("Failed to find both executables!")
-        raise Fus3ExecutableMissingError
+        raise VFSExecutableMissingError
 
     @classmethod
     def get_library_path(cls) -> Union[os.PathLike, str]:
         """
         Find our library dependencies which should be at ../lib relative to our executable
         """
-        if Fus3ProcessManager.library_path is None:
-            exe_path = Fus3ProcessManager.find_fus3()
-            Fus3ProcessManager.library_path = os.path.normpath(
+        if VFSProcessManager.library_path is None:
+            exe_path = VFSProcessManager.find_vfs()
+            VFSProcessManager.library_path = os.path.normpath(
                 os.path.join(os.path.dirname(exe_path), "../lib")
             )
-        log.info(f"Using library path {Fus3ProcessManager.library_path}")
-        return Fus3ProcessManager.library_path
+        log.info(f"Using library path {VFSProcessManager.library_path}")
+        return VFSProcessManager.library_path
 
     def get_file_path(self, relative_file_name: str) -> Union[os.PathLike, str]:
         return os.path.join(self._mount_point, relative_file_name)
@@ -393,24 +370,22 @@ class Fus3ProcessManager(object):
         Determine the cwd we should hand to Popen.
         We expect a config/logging.ini file to exist relative to this folder.
         """
-        if Fus3ProcessManager.cwd_path is None:
-            exe_path = Fus3ProcessManager.find_fus3()
+        if VFSProcessManager.cwd_path is None:
+            exe_path = VFSProcessManager.find_vfs()
             # Use cwd one folder up from bin
-            Fus3ProcessManager.cwd_path = os.path.normpath(
+            VFSProcessManager.cwd_path = os.path.normpath(
                 os.path.join(os.path.dirname(exe_path), "..")
             )
-        return Fus3ProcessManager.cwd_path
+        return VFSProcessManager.cwd_path
 
     def get_launch_environ(self) -> dict:
         """
         Get the environment variables we'll pass to the launch command.
-        :returns: dictionary of default environment variables with fus3 changes applied
+        :returns: dictionary of default environment variables with VFS changes applied
         """
         my_env = {**os.environ, **self._os_env_vars}
-        my_env[
-            "PATH"
-        ] = f"{Fus3ProcessManager.find_fus3_link_dir()}{os.pathsep}{os.environ['PATH']}"
-        my_env["LD_LIBRARY_PATH"] = Fus3ProcessManager.get_library_path()  # type: ignore[assignment]
+        my_env["PATH"] = f"{VFSProcessManager.find_vfs_link_dir()}{os.pathsep}{os.environ['PATH']}"
+        my_env["LD_LIBRARY_PATH"] = VFSProcessManager.get_library_path()  # type: ignore[assignment]
 
         my_env["AWS_CONFIG_FILE"] = str(Path(f"~{self._os_user}/.aws/config").expanduser())
 
@@ -418,29 +393,29 @@ class Fus3ProcessManager(object):
 
     def start(self, session_dir: Path) -> None:
         """
-        Start our fus3 process
-        :return: fus3 process id
+        Start our VFS process
+        :return: VFS process id
         """
-        self._run_path = Fus3ProcessManager.get_cwd()
+        self._run_path = VFSProcessManager.get_cwd()
         log.info(f"Using run_path {self._run_path}")
         log.info(f"Using mount_point {self._mount_point}")
-        Fus3ProcessManager.create_mount_point(self._mount_point)
+        VFSProcessManager.create_mount_point(self._mount_point)
         start_command = self.build_launch_command(self._mount_point)
         launch_env = self.get_launch_environ()
-        log.info(f"Launching fus3 with command {start_command}")
+        log.info(f"Launching VFS with command {start_command}")
         log.info(f"Launching with environment {launch_env}")
 
         try:
 
             def read_output_thread(pipe, log):
-                # Runs in a thread to redirect fus3 output into our log
+                # Runs in a thread to redirect VFS output into our log
                 try:
                     for line in pipe:
                         log.info(line.decode("utf-8").strip())
                 except Exception:
-                    log.exception("Error reading fus3 output")
+                    log.exception("Error reading VFS output")
 
-            self._fus3_proc = subprocess.Popen(
+            self._vfs_proc = subprocess.Popen(
                 args=start_command,
                 stdout=subprocess.PIPE,  # Create a new pipe
                 stderr=subprocess.STDOUT,  # Merge stderr into the stdout pipe
@@ -450,26 +425,26 @@ class Fus3ProcessManager(object):
                 executable="/bin/bash",
             )
 
-            self._fus3_thread = threading.Thread(
-                target=read_output_thread, args=[self._fus3_proc.stdout, log], daemon=True
+            self._vfs_thread = threading.Thread(
+                target=read_output_thread, args=[self._vfs_proc.stdout, log], daemon=True
             )
-            self._fus3_thread.start()
+            self._vfs_thread.start()
 
         except Exception as e:
             log.exception(f"Exception during launch with command {start_command} exception {e}")
             raise e
-        log.info(f"Launched fus3 as pid {self._fus3_proc.pid}")
+        log.info(f"Launched VFS as pid {self._vfs_proc.pid}")
         if not self.wait_for_mount():
             log.error("Failed to mount, shutting down")
-            raise Fus3FailedToMountError
+            raise VFSFailedToMountError
 
         try:
             # if the pid file exists, add the new VFS instance and remove any it replaced
-            pid_file_path = (session_dir / FUS3_PID_FILE_NAME).resolve()
+            pid_file_path = (session_dir / DEADLINE_VFS_PID_FILE_NAME).resolve()
             with open(pid_file_path, "r") as file:
                 lines = file.readlines()
             with open(pid_file_path, "w") as file:
-                file.write(f"{self._mount_point}:{self._fus3_proc.pid}:{self._manifest_path}\n")
+                file.write(f"{self._mount_point}:{self._vfs_proc.pid}:{self._manifest_path}\n")
                 for line in lines:
                     line = line.strip()
                     entry_mount_point, entry_pid, entry_manifest_path = line.split(":")
@@ -480,7 +455,7 @@ class Fus3ProcessManager(object):
         except FileNotFoundError:
             # if the pid file doesn't exist, this will create it
             with open(pid_file_path, "a") as file:
-                file.write(f"{self._mount_point}:{self._fus3_proc.pid}:{self._manifest_path}")
+                file.write(f"{self._mount_point}:{self._vfs_proc.pid}:{self._manifest_path}")
 
     def get_mount_point(self) -> Union[os.PathLike, str]:
         return self._mount_point

--- a/test/unit/deadline_job_attachments/test_asset_sync.py
+++ b/test/unit/deadline_job_attachments/test_asset_sync.py
@@ -20,7 +20,7 @@ from deadline.job_attachments.asset_sync import AssetSync
 from deadline.job_attachments.os_file_permission import PosixFileSystemPermissionSettings
 from deadline.job_attachments.download import _progress_logger
 from deadline.job_attachments.exceptions import (
-    Fus3ExecutableMissingError,
+    VFSExecutableMissingError,
     JobAttachmentsS3ClientError,
 )
 from deadline.job_attachments.models import (
@@ -249,7 +249,7 @@ class TestAssetSync:
         ), patch(
             f"{deadline.__package__}.job_attachments.asset_sync.mount_vfs_from_manifests"
         ), patch(
-            f"{deadline.__package__}.job_attachments.asset_sync.Fus3ProcessManager.find_fus3"
+            f"{deadline.__package__}.job_attachments.asset_sync.VFSProcessManager.find_vfs"
         ):
             mock_on_downloading_files = MagicMock(return_value=True)
 
@@ -851,8 +851,8 @@ class TestAssetSync:
             f"{deadline.__package__}.job_attachments.asset_sync._get_unique_dest_dir_name",
             side_effect=[dest_dir],
         ), patch(
-            f"{deadline.__package__}.job_attachments.asset_sync.Fus3ProcessManager.find_fus3",
-            side_effect=Fus3ExecutableMissingError,
+            f"{deadline.__package__}.job_attachments.asset_sync.VFSProcessManager.find_vfs",
+            side_effect=VFSExecutableMissingError,
         ), patch(
             f"{deadline.__package__}.job_attachments.asset_sync.mount_vfs_from_manifests"
         ) as mock_mount_vfs, patch(
@@ -884,22 +884,22 @@ class TestAssetSync:
             ]
             mock_mount_vfs.assert_not_called()
 
-    def test_cleanup_session_fus3_terminate_called(self, tmp_path):
+    def test_cleanup_session_vfs_terminate_called(self, tmp_path):
         with patch(
-            f"{deadline.__package__}.job_attachments.asset_sync.Fus3ProcessManager.find_fus3",
-        ) as mock_find_fus3, patch(
-            f"{deadline.__package__}.job_attachments.asset_sync.Fus3ProcessManager.kill_all_processes",
+            f"{deadline.__package__}.job_attachments.asset_sync.VFSProcessManager.find_vfs",
+        ) as mock_find_vfs, patch(
+            f"{deadline.__package__}.job_attachments.asset_sync.VFSProcessManager.kill_all_processes",
         ):
             self.default_asset_sync.cleanup_session(
                 session_dir=tmp_path,
                 file_system=JobAttachmentsFileSystem.COPIED,
             )
 
-            mock_find_fus3.assert_not_called()
+            mock_find_vfs.assert_not_called()
 
             self.default_asset_sync.cleanup_session(
                 session_dir=tmp_path,
                 file_system=JobAttachmentsFileSystem.VIRTUAL,
             )
 
-            mock_find_fus3.assert_called_once()
+            mock_find_vfs.assert_called_once()


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Code had references to projects using internal names

### What was the solution? (How)
Replace references to "Fus3" with "VFS"

### What is the impact of this change?
No impact for customers

### How was this change tested?
* hatch run test
* manually confirmed on a CMF worker agent that virtual jobs still succeed

### Was this change documented?
No

### Is this a breaking change?
No