### PR TITLE
fix(JobAttachments)!: If no assets return empty attachments

### DIFF
--- a/examples/submit_job.py
+++ b/examples/submit_job.py
@@ -47,7 +47,7 @@ def process_job_attachments(farm_id, queue_id, inputs, outputDir, deadline_clien
         upload_group.asset_groups, upload_group.total_input_files, upload_group.total_input_bytes
     )
     (_, attachments) = asset_manager.upload_assets(manifests)
-    attachments = attachments.to_dict()
+    attachments = attachments.to_dict() if attachments else {}
     total = time.perf_counter() - start
     print(f"Finished processing job attachments after {total} seconds.\n")
     print(f"Created these attachment settings: {attachments}\n")
@@ -177,7 +177,7 @@ if __name__ == "__main__":
         args.farm_id, args.queue_id, inputs, args.output_dir, deadline_client
     )
 
-    if not args.assets_only:
+    if attachments and not args.assets_only:
         root_dir = attachments["manifests"][0]["rootPath"]
         rel_output = str(Path(args.output_dir).relative_to(root_dir))
         submit_custom_job(

--- a/scripted_tests/upload_cancel_test.py
+++ b/scripted_tests/upload_cancel_test.py
@@ -117,8 +117,9 @@ def run():
         print(f"Upload Summary Statistics:\n{summary_statistics_upload}")
 
         total = time.perf_counter() - start
+        attachments = attachment_settings.to_dict() if attachment_settings else {}
         print(
-            f"Finished uploading after {total} seconds, created these attachment settings:\n{attachment_settings.to_dict()}"
+            f"Finished uploading after {total} seconds, created these attachment settings:\n{attachments}"
         )
     except AssetSyncCancelledError as asce:
         print(f"AssetSyncCancelledError: {asce}")

--- a/scripted_tests/upload_scale_test.py
+++ b/scripted_tests/upload_scale_test.py
@@ -124,11 +124,13 @@ if __name__ == "__main__":
     print(f"Summary Statistics for file uploads:\n{summary_statistics_upload}")
 
     total = time.perf_counter() - start
+
+    attachments = attachment_settings.to_dict() if attachment_settings else {}
     print(
-        f"Finished uploading after {total} seconds, created these attachment settings:\n{attachment_settings.to_dict()}"
+        f"Finished uploading after {total} seconds, created these attachment settings:\n{attachments}"
     )
 
-    if not args.skip_download:
+    if attachments and not args.skip_download:
         print("\nStarting download test...")
         start = time.perf_counter()
         manifest_key = f"{queue.jobAttachmentSettings.rootPrefix}/{S3_MANIFEST_FOLDER_NAME}/{attachment_settings.manifests[0].inputManifestPath}"

--- a/src/deadline/client/api/_submit_job_bundle.py
+++ b/src/deadline/client/api/_submit_job_bundle.py
@@ -257,8 +257,11 @@ def create_job_from_job_bundle(
             asset_manager, asset_manifests, print_function_callback, upload_progress_callback
         )
 
-        attachment_settings["fileSystem"] = JobAttachmentsFileSystem(job_attachments_file_system)
-        create_job_args["attachments"] = attachment_settings
+        if attachment_settings:
+            attachment_settings["fileSystem"] = JobAttachmentsFileSystem(
+                job_attachments_file_system
+            )
+            create_job_args["attachments"] = attachment_settings
 
     create_job_args.update(app_parameters_formatted)
 
@@ -420,4 +423,4 @@ def _upload_attachments(
     print_function_callback("Upload Summary:")
     print_function_callback(textwrap.indent(str(upload_summary), "    "))
 
-    return attachment_settings.to_dict()
+    return attachment_settings.to_dict() if attachment_settings else {}

--- a/src/deadline/client/ui/dialogs/submit_job_progress_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_progress_dialog.py
@@ -341,7 +341,9 @@ class SubmitJobProgressDialog(QDialog):
 
             logger.info("Finished uploading job attachments files.")
 
-            self.upload_thread_succeeded.emit(upload_summary, attachment_settings.to_dict())
+            self.upload_thread_succeeded.emit(
+                upload_summary, attachment_settings.to_dict() if attachment_settings else {}
+            )
         except AssetSyncCancelledError as e:
             # If it wasn't canceled, send the exception to the dialog
             if self._continue_submission:

--- a/src/deadline/job_attachments/upload.py
+++ b/src/deadline/job_attachments/upload.py
@@ -1012,7 +1012,7 @@ class S3AssetManager:
         manifests: list[AssetRootManifest],
         on_uploading_assets: Optional[Callable[[Any], bool]] = None,
         s3_check_cache_dir: Optional[str] = None,
-    ) -> tuple[SummaryStatistics, Attachments]:
+    ) -> tuple[SummaryStatistics, Optional[Attachments]]:
         """
         Uploads all the files for provided manifests and manifests themselves to S3.
 
@@ -1085,5 +1085,5 @@ class S3AssetManager:
 
         return (
             progress_tracker.get_summary_statistics(),
-            Attachments(manifests=manifest_properties_list),
+            Attachments(manifests=manifest_properties_list) if manifest_properties_list else None,
         )

--- a/test/integ/deadline_job_attachments/test_job_attachments.py
+++ b/test/integ/deadline_job_attachments/test_job_attachments.py
@@ -7,6 +7,7 @@ import shutil
 import time
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Optional
 from unittest.mock import MagicMock
 
 from deadline.job_attachments.models import JobAttachmentS3Settings
@@ -177,7 +178,7 @@ def upload_input_files_assets_not_in_cas(job_attachment_test: JobAttachmentTest)
 
 @dataclass
 class UploadInputFilesOneAssetInCasOutputs:
-    attachments: Attachments
+    attachments: Optional[Attachments]
 
 
 @pytest.fixture(scope="session")
@@ -329,7 +330,7 @@ def test_upload_input_files_all_assets_in_cas(
     )
 
     # THEN
-
+    assert attachments is not None
     assert attachments.manifests[0].inputManifestPath is not None
 
     # Confirm nothing was uploaded
@@ -401,6 +402,7 @@ def sync_inputs(
     dest_dir = _get_unique_dest_dir_name(str(job_attachment_test.ASSET_ROOT))
 
     # THEN
+    assert upload_input_files_one_asset_in_cas.attachments is not None
     assert Path(session_dir / dest_dir / job_attachment_test.SCENE_MA_PATH).exists()
     assert Path(session_dir / dest_dir / job_attachment_test.BRICK_PNG_PATH).exists()
     assert Path(session_dir / dest_dir / job_attachment_test.CLOTH_PNG_PATH).exists()
@@ -1086,6 +1088,7 @@ def upload_input_files_no_input_paths(
 
     # THEN
     mock_host_path_format_name = PathFormat.get_host_path_format_string()
+    assert attachments is not None
     assert attachments.manifests == [
         ManifestProperties(
             rootPath=str(job_attachment_test.OUTPUT_PATH),
@@ -1162,6 +1165,7 @@ def test_upload_input_files_no_download_paths(job_attachment_test: JobAttachment
         bytes(manifests[0].asset_manifest.encode(), "utf-8"), HashAlgorithm.XXH128
     )
 
+    assert attachments is not None
     assert len(attachments.manifests) == 1
     assert attachments.manifests[0].fileSystemLocationName is None
     assert attachments.manifests[0].rootPath == str(job_attachment_test.INPUT_PATH)

--- a/test/unit/deadline_job_attachments/test_upload.py
+++ b/test/unit/deadline_job_attachments/test_upload.py
@@ -1862,6 +1862,28 @@ class TestUpload:
             )
 
     @pytest.mark.parametrize(
+        "manifest_version",
+        [ManifestVersion.v2023_03_03],
+    )
+    def test_upload_assets_no_manifests(
+        self,
+        farm_id,
+        queue_id,
+        manifest_version: ManifestVersion,
+    ):
+        """Confirms no Attachments are returned if no manifests are provided"""
+        asset_manager = S3AssetManager(
+            farm_id=farm_id,
+            queue_id=queue_id,
+            job_attachment_settings=self.job_attachment_s3_settings,
+            asset_manifest_version=manifest_version,
+        )
+        (upload_summary_statistics, attachments) = asset_manager.upload_assets(manifests=[])
+        assert upload_summary_statistics.total_files == 0
+        assert upload_summary_statistics.total_bytes == 0
+        assert attachments is None
+
+    @pytest.mark.parametrize(
         "mock_file_system_locations, expected_result",
         [
             (


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
If customers have SHARED Storage Profiles configured for their Queue and are using Job Attachments, they can get into a state where they have no Job Attachments to upload. This hit an edge case where an empty `Attachments` object is passed to the CreateJob API, causing a submission error.

### What was the solution? (How)
Modified the `S3AssetManager.upload_assets` function to return `None` if there are no attachments, and updated all the calling code to handle it to not include in the CreateJob request if it is `None`

### What is the impact of this change?
Customers submitting jobs with SHARED storage profiles configured with their Queue should be able to submit successfully without needing Job Attachments.

### How was this change tested?
- Added new unit tests and confirmed they passed.
- Set up a SHARED storage profile location, and submitted a job bundle with files under that location
  - with changes from mainline, confirmed submit job failed with "Error Occurred: Parameter validation failed:
Invalid length for parameter attachments.manifests, value: 0, valid min length: 1"
  - resubmitted with these changes, confirmed it submitted successfully

### Was this change documented?
N/A

### Is this a breaking change?
Yes, the return type of `upload_assets` now includes an Optional type