### PR TITLE
fix(JobAttachments): Ignore empty lists for job attachments

### DIFF
--- a/test/unit/deadline_client/api/test_job_bundle_submission.py
+++ b/test/unit/deadline_client/api/test_job_bundle_submission.py
@@ -16,6 +16,7 @@ import time
 from deadline.client import api, config
 from deadline.client.api import _submit_job_bundle
 from deadline.job_attachments.models import (
+    AssetRootGroup,
     AssetUploadGroup,
     Attachments,
     JobAttachmentsFileSystem,
@@ -452,7 +453,9 @@ def test_create_job_from_job_bundle_job_attachments(
         client_mock().get_queue.side_effect = [MOCK_GET_QUEUE_RESPONSE]
         client_mock().create_job.side_effect = [MOCK_CREATE_JOB_RESPONSE]
         client_mock().get_job.side_effect = [MOCK_GET_JOB_RESPONSE]
-        expected_upload_group = AssetUploadGroup(total_input_files=3, total_input_bytes=256)
+        expected_upload_group = AssetUploadGroup(
+            total_input_files=3, total_input_bytes=256, asset_groups=[AssetRootGroup()]
+        )
         mock_prepare_paths.return_value = expected_upload_group
         mock_upload_assets.return_value = [
             SummaryStatistics(),
@@ -521,7 +524,7 @@ def test_create_job_from_job_bundle_job_attachments(
         )
         mock_hash_attachments.assert_called_once_with(
             asset_manager=ANY,
-            asset_groups=[],
+            asset_groups=[AssetRootGroup()],
             total_input_files=3,
             total_input_bytes=256,
             print_function_callback=fake_print_callback,
@@ -538,6 +541,110 @@ def test_create_job_from_job_bundle_job_attachments(
                 "manifests": [],
                 "fileSystem": JobAttachmentsFileSystem.COPIED,
             },
+        )
+
+
+def test_create_job_from_job_bundle_empty_job_attachments(
+    fresh_deadline_config, temp_job_bundle_dir, temp_assets_dir
+):
+    """
+    Test that when we have asset references that do not fall under Job Attachments
+    (for example, if under a SHARED Storage Profile Filesystem Location), no Job
+    Attachments calls are made.
+    """
+    # Use a temporary directory for the job bundle
+    with patch.object(_submit_job_bundle.api, "get_boto3_session"), patch.object(
+        _submit_job_bundle.api, "get_boto3_client"
+    ) as client_mock, patch.object(
+        _submit_job_bundle.api, "get_queue_user_boto3_session"
+    ), patch.object(
+        api._submit_job_bundle, "_hash_attachments", return_value=(None, None)
+    ) as mock_hash_attachments, patch.object(
+        S3AssetManager,
+        "prepare_paths_for_upload",
+    ) as mock_prepare_paths, patch.object(
+        S3AssetManager, "upload_assets"
+    ) as mock_upload_assets, patch.object(
+        _submit_job_bundle.api, "get_telemetry_client"
+    ):
+        client_mock().get_queue.side_effect = [MOCK_GET_QUEUE_RESPONSE]
+        client_mock().create_job.side_effect = [MOCK_CREATE_JOB_RESPONSE]
+        client_mock().get_job.side_effect = [MOCK_GET_JOB_RESPONSE]
+
+        # When this function returns an empty object, we skip Job Attachments calls
+        expected_upload_group = AssetUploadGroup()
+        mock_prepare_paths.return_value = expected_upload_group
+
+        config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+        config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+        config.set_setting("settings.storage_profile_id", MOCK_STORAGE_PROFILE_ID)
+
+        # Write a JSON template
+        with open(os.path.join(temp_job_bundle_dir, "template.json"), "w", encoding="utf8") as f:
+            f.write(MOCK_JOB_TEMPLATE_CASES["MINIMAL_JSON"][1])
+
+        # Create some files in the assets dir
+        asset_contents = {
+            "asset-1.txt": "This is asset 1",
+            "somedir/asset-2.txt": "Asset 2",
+            "somedir/asset-3.bat": "@echo asset 3",
+        }
+        _write_asset_files(temp_assets_dir, asset_contents)
+
+        # Write the asset_references file
+        asset_references = {
+            "inputs": {
+                "filenames": [os.path.join(temp_assets_dir, "asset-1.txt")],
+                "directories": [os.path.join(temp_assets_dir, "somedir")],
+            },
+            "outputs": {"directories": [os.path.join(temp_assets_dir, "somedir")]},
+        }
+        with open(
+            os.path.join(temp_job_bundle_dir, "asset_references.json"), "w", encoding="utf8"
+        ) as f:
+            json.dump({"assetReferences": asset_references}, f)
+
+        def fake_hashing_callback(metadata: ProgressReportMetadata) -> bool:
+            return True
+
+        def fake_upload_callback(metadata: ProgressReportMetadata) -> bool:
+            return True
+
+        def fake_print_callback(msg: str) -> None:
+            pass
+
+        # This is the function we're testing
+        api.create_job_from_job_bundle(
+            temp_job_bundle_dir,
+            print_function_callback=fake_print_callback,
+            hashing_progress_callback=fake_hashing_callback,
+            upload_progress_callback=fake_upload_callback,
+            queue_parameter_definitions=[],
+        )
+
+        mock_prepare_paths.assert_called_once_with(
+            job_bundle_path=temp_job_bundle_dir,
+            input_paths=sorted(
+                [
+                    os.path.join(temp_assets_dir, "asset-1.txt"),
+                    os.path.join(temp_assets_dir, os.path.normpath("somedir/asset-2.txt")),
+                    os.path.join(temp_assets_dir, os.path.normpath("somedir/asset-3.bat")),
+                ]
+            ),
+            output_paths=[os.path.join(temp_assets_dir, "somedir")],
+            referenced_paths=[],
+            storage_profile_id=MOCK_STORAGE_PROFILE_ID,
+        )
+        mock_hash_attachments.assert_not_called()
+        mock_upload_assets.assert_not_called()
+        # Should not be called with Job Attachments
+        client_mock().create_job.assert_called_once_with(
+            farmId=MOCK_FARM_ID,
+            queueId=MOCK_QUEUE_ID,
+            template=ANY,
+            templateType=ANY,
+            priority=50,
+            storageProfileId=MOCK_STORAGE_PROFILE_ID,
         )
 
 
@@ -621,7 +728,9 @@ def test_create_job_from_job_bundle_with_single_asset_file(
         client_mock().create_job.side_effect = [MOCK_CREATE_JOB_RESPONSE]
         client_mock().get_queue.side_effect = [MOCK_GET_QUEUE_RESPONSE]
         client_mock().get_job.side_effect = [MOCK_GET_JOB_RESPONSE]
-        expected_upload_group = AssetUploadGroup(total_input_files=1, total_input_bytes=1)
+        expected_upload_group = AssetUploadGroup(
+            total_input_files=1, total_input_bytes=1, asset_groups=[AssetRootGroup()]
+        )
         mock_prepare_paths.return_value = expected_upload_group
         mock_upload_assets.return_value = [
             SummaryStatistics(),
@@ -690,7 +799,7 @@ def test_create_job_from_job_bundle_with_single_asset_file(
         )
         mock_hash_attachments.assert_called_once_with(
             asset_manager=ANY,
-            asset_groups=[],
+            asset_groups=[AssetRootGroup()],
             total_input_files=1,
             total_input_bytes=1,
             print_function_callback=fake_print_callback,

--- a/test/unit/deadline_client/api/test_job_bundle_submission_asset_refs.py
+++ b/test/unit/deadline_client/api/test_job_bundle_submission_asset_refs.py
@@ -14,6 +14,7 @@ from deadline.client.api import _submit_job_bundle
 from deadline.client.exceptions import DeadlineOperationError
 from deadline.job_attachments.models import (
     Attachments,
+    AssetRootGroup,
     AssetUploadGroup,
     JobAttachmentsFileSystem,
     AssetRootManifest,
@@ -262,7 +263,7 @@ def test_create_job_from_job_bundle_with_all_asset_ref_variants(
         client_mock().create_job.side_effect = [MOCK_CREATE_JOB_RESPONSE]
         client_mock().get_queue.side_effect = [MOCK_GET_QUEUE_RESPONSE]
         client_mock().get_job.side_effect = [MOCK_GET_JOB_RESPONSE]
-        mock_prepare_paths.return_value = AssetUploadGroup()
+        mock_prepare_paths.return_value = AssetUploadGroup(asset_groups=[AssetRootGroup()])
         mock_hash_assets.return_value = [SummaryStatistics(), AssetRootManifest()]
         mock_upload_assets.return_value = [
             SummaryStatistics(),
@@ -382,7 +383,7 @@ def test_create_job_from_job_bundle_with_all_asset_ref_variants(
             storage_profile_id="",
         )
         mock_hash_assets.assert_called_once_with(
-            asset_groups=[],
+            asset_groups=[AssetRootGroup()],
             total_input_files=0,
             total_input_bytes=0,
             hash_cache_dir=os.path.expanduser(os.path.join("~", ".deadline", "cache")),


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
If customers have SHARED Storage Profiles configured for their Queue and are using Job Attachments, they can get into a state where they have no Job Attachments to upload. This hit an edge case where an empty `Attachments` object is passed to the CreateJob API, causing a submission error.

### What was the solution? (How)
The `S3AssetManager.prepare_assets_for_upload` function returns a [AssetUploadGroup](https://github.com/casillas2/deadline-cloud/blob/mainline/src/deadline/job_attachments/models.py#L54) object that can contain a list of [AssetRootGroups](https://github.com/casillas2/deadline-cloud/blob/mainline/src/deadline/job_attachments/models.py#L43). These AssetRootGroups are what ultimately become the `attachments.manifests` objects in the CreateJob API call. So if the list of AssetRootGroups in the AssetUploadGroup is empty, we know we don't have any Job Attachments, so we don't continue down any Job Attachments code paths, as there's no work to do.

### What is the impact of this change?
Customers submitting jobs with SHARED storage profiles configured with their Queue should be able to submit successfully without needing Job Attachments.

### How was this change tested?
- Confirmed unit and integration tests passed
- Set up a SHARED storage profile location, and submitted a job bundle with files under that location with both CLI and GUI submit methods
  - with changes from mainline, confirmed submit job failed with "Error Occurred: Parameter validation failed:
Invalid length for parameter attachments.manifests, value: 0, valid min length: 1"
  - resubmitted with these changes, confirmed it submitted successfully, without any Job Attachments prompts (as there were no Job Attachments)
  - resubmitted AGAIN with an output directory set outside of the Storage Profile, and confirmed Job Attachments were created

### Was this change documented?
N/A

### Is this a breaking change?
No