### PR TITLE
ci: remove merge back from release workflow

### DIFF
--- a/.github/workflows/release_bump.yml
+++ b/.github/workflows/release_bump.yml
@@ -17,15 +17,15 @@ concurrency:
   group: release
 
 jobs:
-  TestMainline:
-    name: Test Mainline
+  UnitTests:
+    name: Unit Tests
     uses: ./.github/workflows/code_quality.yml
     with:
       branch: mainline
     secrets: inherit
 
   Bump:
-    needs: TestMainline
+    needs: UnitTests
     runs-on: ubuntu-latest
     environment: release
     permissions:
@@ -35,7 +35,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: release
+          ref: mainline
           fetch-depth: 0
           token: ${{ secrets.CI_TOKEN }}
 
@@ -48,11 +48,6 @@ jobs:
         run: |
           git config --local user.email "129794699+client-software-ci@users.noreply.github.com"
           git config --local user.name "client-software-ci"
-
-      - name: MergePushRelease
-        run: |
-          git merge --ff-only origin/mainline -v
-          git push origin release
 
       - name: Bump
         run: |
@@ -93,4 +88,4 @@ jobs:
           git push -u origin bump/$NEXT_SEMVER
 
           # Needs "Allow GitHub Actions to create and approve pull requests" under Settings > Actions
-          gh pr create --base release --title "chore(release): $NEXT_SEMVER" --body "$RELEASE_NOTES"
+          gh pr create --base mainline --title "chore(release): $NEXT_SEMVER" --body "$RELEASE_NOTES"

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -52,21 +52,23 @@ jobs:
         with:
           ref: release
           fetch-depth: 0
-
-      - name: VerifyReleaseBranch
-        run: |
-          RELEASE_HEAD=$(git show -s --format='%H')
-          if [[ $RELEASE_HEAD != ${{ github.sha }} ]]; then
-            echo "ERROR: tip of release branch ($RELEASE_HEAD) does not match the commit that started this release (${{ github.sha }}). Aborting release."
-            exit 1
-          else
-            echo "Verified tip of release branch ($RELEASE_HEAD) matches the commit that started this release (${{ github.sha }})"
-          fi
-
+          token: ${{ secrets.CI_TOKEN }}
+      
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.9'
+
+      - name: ConfigureGit
+        run: |
+          git config --local user.email "129794699+client-software-ci@users.noreply.github.com"
+          git config --local user.name "client-software-ci"
+
+      
+      - name: MergePushRelease
+        run: |
+          git merge --ff-only origin/mainline -v
+          git push origin release 
 
       - name: PrepRelease
         id: prep-release
@@ -76,9 +78,6 @@ jobs:
 
           # The format of the tag must match the pattern in pyproject.toml -> tool.semantic_release.tag_format
           TAG="$NEXT_SEMVER"
-
-          git config --local user.email "129794699+client-software-ci@users.noreply.github.com"
-          git config --local user.name "client-software-ci"
 
           git tag -a $TAG -m "Release $TAG"
 
@@ -134,25 +133,6 @@ jobs:
         run: |
           git push origin $TAG
           gh release create $TAG dist/* --notes "$RELEASE_NOTES"
-
-  MergeBack:
-    needs: Release
-    runs-on: ubuntu-latest
-    environment: release
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          ref: mainline
-          fetch-depth: 0
-          token: ${{ secrets.CI_TOKEN }}
-
-      - name: MergeBackMainline
-        run: |
-          git merge --ff-only origin/release
-          git push origin mainline
 
   PublishToRepository:
     needs: Release


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
1. Using merge back requires a removal of a security feature
2. Pushing to release before merging the change log makes rolling back awkward if there is an issue found in the changelog PR.

### What was the solution? (How)
release:bump no longer merges, it only create the PR for the change log. release:publish now runs when a push is made to mainline with a modification to CHANGELOG.md. If the commit was made by ci, then it will merge mainline to release and follow with the release and publish jobs.

### What is the impact of this change?
Should make release process smoother

### How was this change tested?
Tested in a developer github account

### Was this change documented?
no

### Is this a breaking change?
no