### PR TITLE
fix(job_attachments): use TransferManager for upload and download

### DIFF
--- a/src/deadline/client/config/config_file.py
+++ b/src/deadline/client/config/config_file.py
@@ -109,13 +109,13 @@ SETTINGS: Dict[str, Dict[str, Any]] = {
     "telemetry.opt_out": {"default": "false"},
     "telemetry.identifier": {"default": ""},
     "defaults.job_attachments_file_system": {"default": "COPIED", "depend": "defaults.farm_id"},
-    "settings.multipart_upload_chunk_size": {
-        "default": "8388608",  # 8 MB (Default chunk size for multipart upload)
-        "description": "The chunk size to use when uploading files in multi-parts.",
-    },
-    "settings.multipart_upload_max_workers": {
-        "default": "10",
-        "description": "The maximum number of workers (processes) to use when uploading files in multi-parts.",
+    "settings.s3_max_pool_connections": {
+        "default": "50",
+        "description": (
+            "The maximum number of connections to keep in the connection pool used by the S3's upload/download operations. "
+            "If this value is not set, the default value of 50 is used. "
+            "(Note: It's recommended setting this value above 10 to avoid 'Connection pool is full' warnings during the uploads/downloads.)"
+        ),
     },
     "settings.small_file_threshold_multiplier": {
         "default": "20",  # By default, the small file threshold is 160 MB (since the default S3 multipart-upload chunk size is 8 MB.)

--- a/src/deadline/job_attachments/progress_tracker.py
+++ b/src/deadline/job_attachments/progress_tracker.py
@@ -115,7 +115,7 @@ class ProgressStatus(Enum):
     """The asset manager is hashing files."""
 
     UPLOAD_IN_PROGRESS = ("UPLOAD_IN_PROGRESS", "Uploaded")
-    """The asset manager is uploadng files."""
+    """The asset manager is uploading files."""
 
     DOWNLOAD_IN_PROGRESS = ("DOWNLOAD_IN_PROGRESS", "Downloaded")
     """Downloading files"""

--- a/test/unit/deadline_client/cli/test_cli_config.py
+++ b/test/unit/deadline_client/cli/test_cli_config.py
@@ -35,7 +35,7 @@ def test_cli_config_show_defaults(fresh_deadline_config):
     assert fresh_deadline_config in result.output
 
     # Assert the expected number of settings
-    assert len(settings.keys()) == 16
+    assert len(settings.keys()) == 15
 
     for setting_name in settings.keys():
         assert setting_name in result.output
@@ -102,8 +102,7 @@ def test_cli_config_show_modified_config(fresh_deadline_config):
     config.set_setting("settings.log_level", "DEBUG")
     config.set_setting("telemetry.opt_out", "True")
     config.set_setting("telemetry.identifier", "user-id-123abc-456def")
-    config.set_setting("settings.multipart_upload_chunk_size", "10000000")
-    config.set_setting("settings.multipart_upload_max_workers", "16")
+    config.set_setting("settings.s3_max_pool_connections", "100")
     config.set_setting("settings.small_file_threshold_multiplier", "15")
 
     runner = CliRunner()

--- a/test/unit/deadline_job_attachments/test_asset_sync.py
+++ b/test/unit/deadline_job_attachments/test_asset_sync.py
@@ -8,7 +8,7 @@ import shutil
 from math import trunc
 from pathlib import Path
 from typing import Optional, Dict
-from unittest.mock import ANY, MagicMock, call, mock_open, patch
+from unittest.mock import ANY, MagicMock, mock_open, patch
 
 import boto3
 from deadline.job_attachments.progress_tracker import ProgressStatus
@@ -18,7 +18,7 @@ from moto import mock_sts
 import deadline
 from deadline.job_attachments.asset_sync import AssetSync
 from deadline.job_attachments.os_file_permission import PosixFileSystemPermissionSettings
-from deadline.job_attachments.download import _progress_logger
+
 from deadline.job_attachments.exceptions import (
     VFSExecutableMissingError,
     JobAttachmentsS3ClientError,
@@ -69,29 +69,6 @@ class TestAssetSync:
         asset_sync = AssetSync(farm_id)
         asset_sync.s3_uploader._s3 = client
         return asset_sync
-
-    def test_progress_logger_one_file(self) -> None:
-        """
-        Asserts that task runs are getting updated with the appropriate progress
-        when only one file is being uploaded.
-        """
-        # GIVEN
-        mock_progress_tracker_callback = MagicMock()
-        mock_progress_tracker_callback.return_value = True
-        callback = _progress_logger(
-            file_size_in_bytes=10,
-            progress_tracker_callback=mock_progress_tracker_callback,
-        )
-
-        # WHEN
-        for _ in range(1, 11):
-            callback(1)
-
-        # THEN
-        assert mock_progress_tracker_callback.call_count == 10
-        calls = [call(1, False) for _ in range(1, 10)]
-        calls.append(call(1, True))
-        mock_progress_tracker_callback.assert_has_calls(calls)
 
     @pytest.mark.parametrize(
         ("file_size", "expected_output"),


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
- Originally, Job Attachment's upload was implemented using an approach of manually managing multipart uploads (by calling `create_multipart_upload`, `upload_part`, `complete_multipart_upload`, ...) This way of using low-level APIs was primarily to meet the requirement to be able to cancel the upload of a single, potentially large, file in the middle.
However, this approach introduced unnecessary complexity by directly handling multipart upload operations. It was suggested that using a `TransferManager` could offer a better solution while still supporting the cancellation of uploads midway.
- We were seeing `urllib3.connectionpool:Connection pool is full` warnings messages when uploading job attachments.
- The interruption/cancellation of download (input syncing in workers) was not very responsive. It takes way too long to complete the cancellation of download, especially when the number of files is very big, over 1000.

### What was the solution? (How)
- Refactored the upload implementation to leverage boto3's `TransferManager`. This change allows us to maintain the capability to cancel file uploads midway while simplifying the upload process by replacing the low-level multipart upload management.
  - Performance tests were done to compare the old approach and the new `TransferManager`-based approach
    - It showed not much differences in upload speeds across various file sizes and quantities.
    - There was one notable improvement, though: When a job bundle consists of a large number of small files (< 8 MB, which is a default chunk size for multipart upload).
- To address the issue of "connection pool is full" warning messages showing up during job submissions, I increased the default `max_pool_connections` for the S3 client from **10** to **50**. This adjustment helps prevent exceeding the max pool size limit when uploading or downloading files concurrently. Also, I made it configurable through the client's `config` file. Users can now configure this max_pool_connection value by setting:

  ```
  [settings]
  s3_max_pool_connections = 50
  ```
  in the config file.
  The number of thread workers (`max_workers` for `concurrent.futures.ThreadPoolExecutor()`) for upload and download are now determined as follows:
  - the number of thread workers for upload = `max_pool_connections` / min(`k`, `S3_UPLOAD_MAX_CONCURRENCY`)  where k is `small_file_threshold_multiplier`
  - the number of thread workers for download = `max_pool_connections` / `S3_DOWNLOAD_MAX_CONCURRENCY`

### What is the impact of this change?
This refactoring introduces several improvements:
- Simplifies the upload implementation by using `TransferManager`. Maintains or improves upload performance, especially in scenarios with many small files.
- Reduces the time to cancel downloads, particularly for a large number of files, improving user experience during long-running download.
- Resolves the issue of "connection pool is full" warnings by adjusting the S3 client's max pool connections size.

### How was this change tested?
- Made sure that all unit tests passed by running `hatch run test`
- Made sure that the Job Attachment integ tests passed by running `hatch run integ:test`
- The change was tested by performing job submissions with various combinations of file sizes and amounts. I compared upload speeds between the old approach and the new TransferManager-based approach, revealing minimal performance differences with a significant improvement in handling a large number of small files.
- Confirmed that "connection pool is full" warnings are not showing up during concurrent file uploads and downloads.
- The download cancellation was tested by running [scripted_tests/download_cancel_test.py](https://github.com/casillas2/deadline-cloud/blob/mainline/scripted_tests/download_cancel_test.py). With a job bundle of a large number of files, showing a drastic reduction in cancellation times. For example, from approximately 8-10 minutes to 1-2 minutes for 5000 files.

### Was this change documented?
No.

### Is this a breaking change?
No.