### PR TITLE
refactor(job_attachments)!: rename OperatingSystemFamily to StorageProfileOperatingSystemFamily

### DIFF
--- a/src/deadline/job_attachments/_aws/deadline.py
+++ b/src/deadline/job_attachments/_aws/deadline.py
@@ -15,7 +15,7 @@ from ..models import (
     Job,
     JobAttachmentS3Settings,
     ManifestProperties,
-    OperatingSystemFamily,
+    StorageProfileOperatingSystemFamily,
     PathFormat,
     Queue,
     StorageProfile,
@@ -131,7 +131,7 @@ def get_storage_profile_for_queue(
     return StorageProfile(
         storageProfileId=response["storageProfileId"],
         displayName=response["displayName"],
-        osFamily=OperatingSystemFamily(response["osFamily"]),
+        osFamily=StorageProfileOperatingSystemFamily(response["osFamily"]),
         fileSystemLocations=[
             FileSystemLocation(
                 name=file_system_location["name"],

--- a/src/deadline/job_attachments/models.py
+++ b/src/deadline/job_attachments/models.py
@@ -110,7 +110,7 @@ class OutputFile:
     in_s3: bool  # If the file already exists in the CAS
 
 
-class OperatingSystemFamily(str, Enum):
+class StorageProfileOperatingSystemFamily(str, Enum):
     WINDOWS = "windows"
     LINUX = "linux"
     MACOS = "macos"
@@ -294,7 +294,7 @@ class StorageProfile:
 
     storageProfileId: str
     displayName: str
-    osFamily: OperatingSystemFamily
+    osFamily: StorageProfileOperatingSystemFamily
     fileSystemLocations: List[FileSystemLocation] = field(default_factory=list)  # type: ignore
 
 

--- a/test/unit/deadline_job_attachments/data/boto_module/deadline/2020-08-21/service-2.json
+++ b/test/unit/deadline_job_attachments/data/boto_module/deadline/2020-08-21/service-2.json
@@ -2,7 +2,7 @@
   "version": "2.0",
   "metadata": {
     "apiVersion": "2023-10-12",
-    "endpointPrefix": "btpdb6qczg.execute-api",
+    "endpointPrefix": "beta.bealine-dev",
     "jsonVersion": "1.1",
     "protocol": "rest-json",
     "serviceFullName": "AmazonDeadlineCloud",
@@ -45,6 +45,9 @@
           "shape": "ServiceQuotaExceededException"
         }
       ],
+      "endpoint": {
+        "hostPrefix": "management."
+      },
       "idempotent": true
     },
     "AssociateMemberToFleet": {
@@ -80,6 +83,9 @@
           "shape": "ServiceQuotaExceededException"
         }
       ],
+      "endpoint": {
+        "hostPrefix": "management."
+      },
       "idempotent": true
     },
     "AssociateMemberToJob": {
@@ -115,6 +121,9 @@
           "shape": "ServiceQuotaExceededException"
         }
       ],
+      "endpoint": {
+        "hostPrefix": "management."
+      },
       "idempotent": true
     },
     "AssociateMemberToQueue": {
@@ -150,6 +159,9 @@
           "shape": "ServiceQuotaExceededException"
         }
       ],
+      "endpoint": {
+        "hostPrefix": "management."
+      },
       "idempotent": true
     },
     "AssumeFleetRoleForRead": {
@@ -181,7 +193,10 @@
         {
           "shape": "ValidationException"
         }
-      ]
+      ],
+      "endpoint": {
+        "hostPrefix": "management."
+      }
     },
     "AssumeFleetRoleForWorker": {
       "name": "AssumeFleetRoleForWorker",
@@ -215,7 +230,10 @@
         {
           "shape": "ValidationException"
         }
-      ]
+      ],
+      "endpoint": {
+        "hostPrefix": "scheduling."
+      }
     },
     "AssumeQueueRoleForRead": {
       "name": "AssumeQueueRoleForRead",
@@ -246,7 +264,10 @@
         {
           "shape": "ValidationException"
         }
-      ]
+      ],
+      "endpoint": {
+        "hostPrefix": "management."
+      }
     },
     "AssumeQueueRoleForUser": {
       "name": "AssumeQueueRoleForUser",
@@ -277,7 +298,10 @@
         {
           "shape": "ValidationException"
         }
-      ]
+      ],
+      "endpoint": {
+        "hostPrefix": "management."
+      }
     },
     "AssumeQueueRoleForWorker": {
       "name": "AssumeQueueRoleForWorker",
@@ -311,7 +335,10 @@
         {
           "shape": "ValidationException"
         }
-      ]
+      ],
+      "endpoint": {
+        "hostPrefix": "scheduling."
+      }
     },
     "BatchGetJobEntity": {
       "name": "BatchGetJobEntity",
@@ -342,7 +369,10 @@
         {
           "shape": "ValidationException"
         }
-      ]
+      ],
+      "endpoint": {
+        "hostPrefix": "scheduling."
+      }
     },
     "CopyJobTemplate": {
       "name": "CopyJobTemplate",
@@ -373,7 +403,10 @@
         {
           "shape": "ValidationException"
         }
-      ]
+      ],
+      "endpoint": {
+        "hostPrefix": "management."
+      }
     },
     "CreateBudget": {
       "name": "CreateBudget",
@@ -408,6 +441,9 @@
           "shape": "ServiceQuotaExceededException"
         }
       ],
+      "endpoint": {
+        "hostPrefix": "management."
+      },
       "idempotent": true
     },
     "CreateFarm": {
@@ -443,6 +479,9 @@
           "shape": "ServiceQuotaExceededException"
         }
       ],
+      "endpoint": {
+        "hostPrefix": "management."
+      },
       "idempotent": true
     },
     "CreateFleet": {
@@ -478,6 +517,9 @@
           "shape": "ServiceQuotaExceededException"
         }
       ],
+      "endpoint": {
+        "hostPrefix": "management."
+      },
       "idempotent": true
     },
     "CreateJob": {
@@ -513,6 +555,9 @@
           "shape": "ServiceQuotaExceededException"
         }
       ],
+      "endpoint": {
+        "hostPrefix": "management."
+      },
       "idempotent": true
     },
     "CreateLicenseEndpoint": {
@@ -548,6 +593,9 @@
           "shape": "ServiceQuotaExceededException"
         }
       ],
+      "endpoint": {
+        "hostPrefix": "management."
+      },
       "idempotent": true
     },
     "CreateQueue": {
@@ -583,6 +631,9 @@
           "shape": "ServiceQuotaExceededException"
         }
       ],
+      "endpoint": {
+        "hostPrefix": "management."
+      },
       "idempotent": true
     },
     "CreateQueueEnvironment": {
@@ -618,6 +669,9 @@
           "shape": "ServiceQuotaExceededException"
         }
       ],
+      "endpoint": {
+        "hostPrefix": "management."
+      },
       "idempotent": true
     },
     "CreateQueueFleetAssociation": {
@@ -650,6 +704,9 @@
           "shape": "ValidationException"
         }
       ],
+      "endpoint": {
+        "hostPrefix": "management."
+      },
       "idempotent": true
     },
     "CreateStorageProfile": {
@@ -685,6 +742,9 @@
           "shape": "ServiceQuotaExceededException"
         }
       ],
+      "endpoint": {
+        "hostPrefix": "management."
+      },
       "idempotent": true
     },
     "CreateWorker": {
@@ -720,6 +780,9 @@
           "shape": "ValidationException"
         }
       ],
+      "endpoint": {
+        "hostPrefix": "scheduling."
+      },
       "idempotent": true
     },
     "DeleteBudget": {
@@ -752,6 +815,9 @@
           "shape": "ValidationException"
         }
       ],
+      "endpoint": {
+        "hostPrefix": "management."
+      },
       "idempotent": true
     },
     "DeleteFarm": {
@@ -784,6 +850,9 @@
           "shape": "ValidationException"
         }
       ],
+      "endpoint": {
+        "hostPrefix": "management."
+      },
       "idempotent": true
     },
     "DeleteFleet": {
@@ -819,6 +888,9 @@
           "shape": "ValidationException"
         }
       ],
+      "endpoint": {
+        "hostPrefix": "management."
+      },
       "idempotent": true
     },
     "DeleteLicenseEndpoint": {
@@ -854,6 +926,9 @@
           "shape": "ValidationException"
         }
       ],
+      "endpoint": {
+        "hostPrefix": "management."
+      },
       "idempotent": true
     },
     "DeleteMeteredProduct": {
@@ -886,6 +961,9 @@
           "shape": "ValidationException"
         }
       ],
+      "endpoint": {
+        "hostPrefix": "management."
+      },
       "idempotent": true
     },
     "DeleteQueue": {
@@ -921,6 +999,9 @@
           "shape": "ValidationException"
         }
       ],
+      "endpoint": {
+        "hostPrefix": "management."
+      },
       "idempotent": true
     },
     "DeleteQueueEnvironment": {
@@ -950,6 +1031,9 @@
           "shape": "ValidationException"
         }
       ],
+      "endpoint": {
+        "hostPrefix": "management."
+      },
       "idempotent": true
     },
     "DeleteQueueFleetAssociation": {
@@ -985,6 +1069,9 @@
           "shape": "ValidationException"
         }
       ],
+      "endpoint": {
+        "hostPrefix": "management."
+      },
       "idempotent": true
     },
     "DeleteStorageProfile": {
@@ -1014,6 +1101,9 @@
           "shape": "ValidationException"
         }
       ],
+      "endpoint": {
+        "hostPrefix": "management."
+      },
       "idempotent": true
     },
     "DeleteWorker": {
@@ -1049,6 +1139,9 @@
           "shape": "ValidationException"
         }
       ],
+      "endpoint": {
+        "hostPrefix": "scheduling."
+      },
       "idempotent": true
     },
     "DisassociateMemberFromFarm": {
@@ -1081,6 +1174,9 @@
           "shape": "ValidationException"
         }
       ],
+      "endpoint": {
+        "hostPrefix": "management."
+      },
       "idempotent": true
     },
     "DisassociateMemberFromFleet": {
@@ -1116,6 +1212,9 @@
           "shape": "ValidationException"
         }
       ],
+      "endpoint": {
+        "hostPrefix": "management."
+      },
       "idempotent": true
     },
     "DisassociateMemberFromJob": {
@@ -1148,6 +1247,9 @@
           "shape": "ValidationException"
         }
       ],
+      "endpoint": {
+        "hostPrefix": "management."
+      },
       "idempotent": true
     },
     "DisassociateMemberFromQueue": {
@@ -1183,6 +1285,9 @@
           "shape": "ValidationException"
         }
       ],
+      "endpoint": {
+        "hostPrefix": "management."
+      },
       "idempotent": true
     },
     "GetAggregatedStatisticsForSessions": {
@@ -1214,7 +1319,10 @@
         {
           "shape": "ValidationException"
         }
-      ]
+      ],
+      "endpoint": {
+        "hostPrefix": "management."
+      }
     },
     "GetBudget": {
       "name": "GetBudget",
@@ -1245,7 +1353,10 @@
         {
           "shape": "ValidationException"
         }
-      ]
+      ],
+      "endpoint": {
+        "hostPrefix": "management."
+      }
     },
     "GetFarm": {
       "name": "GetFarm",
@@ -1276,7 +1387,10 @@
         {
           "shape": "ValidationException"
         }
-      ]
+      ],
+      "endpoint": {
+        "hostPrefix": "management."
+      }
     },
     "GetFleet": {
       "name": "GetFleet",
@@ -1307,7 +1421,10 @@
         {
           "shape": "ValidationException"
         }
-      ]
+      ],
+      "endpoint": {
+        "hostPrefix": "management."
+      }
     },
     "GetJob": {
       "name": "GetJob",
@@ -1338,7 +1455,10 @@
         {
           "shape": "ValidationException"
         }
-      ]
+      ],
+      "endpoint": {
+        "hostPrefix": "management."
+      }
     },
     "GetLicenseEndpoint": {
       "name": "GetLicenseEndpoint",
@@ -1369,7 +1489,10 @@
         {
           "shape": "ValidationException"
         }
-      ]
+      ],
+      "endpoint": {
+        "hostPrefix": "management."
+      }
     },
     "GetQueue": {
       "name": "GetQueue",
@@ -1400,7 +1523,10 @@
         {
           "shape": "ValidationException"
         }
-      ]
+      ],
+      "endpoint": {
+        "hostPrefix": "management."
+      }
     },
     "GetQueueEnvironment": {
       "name": "GetQueueEnvironment",
@@ -1431,7 +1557,10 @@
         {
           "shape": "ValidationException"
         }
-      ]
+      ],
+      "endpoint": {
+        "hostPrefix": "management."
+      }
     },
     "GetQueueFleetAssociation": {
       "name": "GetQueueFleetAssociation",
@@ -1462,7 +1591,10 @@
         {
           "shape": "ValidationException"
         }
-      ]
+      ],
+      "endpoint": {
+        "hostPrefix": "management."
+      }
     },
     "GetSession": {
       "name": "GetSession",
@@ -1493,13 +1625,16 @@
         {
           "shape": "ValidationException"
         }
-      ]
+      ],
+      "endpoint": {
+        "hostPrefix": "management."
+      }
     },
     "GetSessionAction": {
       "name": "GetSessionAction",
       "http": {
         "method": "GET",
-        "requestUri": "/2023-10-12/farms/{farmId}/queues/{queueId}/jobs/{jobId}/sessionactions/{sessionActionId}",
+        "requestUri": "/2023-10-12/farms/{farmId}/queues/{queueId}/jobs/{jobId}/session-actions/{sessionActionId}",
         "responseCode": 200
       },
       "input": {
@@ -1524,7 +1659,44 @@
         {
           "shape": "ValidationException"
         }
-      ]
+      ],
+      "endpoint": {
+        "hostPrefix": "management."
+      }
+    },
+    "GetSessionsStatisticsAggregation": {
+      "name": "GetSessionsStatisticsAggregation",
+      "http": {
+        "method": "GET",
+        "requestUri": "/2023-10-12/farms/{farmId}/sessions-statistics-aggregation",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "GetSessionsStatisticsAggregationRequest"
+      },
+      "output": {
+        "shape": "GetSessionsStatisticsAggregationResponse"
+      },
+      "errors": [
+        {
+          "shape": "AccessDeniedException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "ResourceNotFoundException"
+        },
+        {
+          "shape": "ThrottlingException"
+        },
+        {
+          "shape": "ValidationException"
+        }
+      ],
+      "endpoint": {
+        "hostPrefix": "management."
+      }
     },
     "GetStep": {
       "name": "GetStep",
@@ -1555,7 +1727,10 @@
         {
           "shape": "ValidationException"
         }
-      ]
+      ],
+      "endpoint": {
+        "hostPrefix": "management."
+      }
     },
     "GetStorageProfile": {
       "name": "GetStorageProfile",
@@ -1586,7 +1761,10 @@
         {
           "shape": "ValidationException"
         }
-      ]
+      ],
+      "endpoint": {
+        "hostPrefix": "management."
+      }
     },
     "GetStorageProfileForQueue": {
       "name": "GetStorageProfileForQueue",
@@ -1617,7 +1795,10 @@
         {
           "shape": "ValidationException"
         }
-      ]
+      ],
+      "endpoint": {
+        "hostPrefix": "management."
+      }
     },
     "GetTask": {
       "name": "GetTask",
@@ -1648,7 +1829,10 @@
         {
           "shape": "ValidationException"
         }
-      ]
+      ],
+      "endpoint": {
+        "hostPrefix": "management."
+      }
     },
     "GetWorker": {
       "name": "GetWorker",
@@ -1679,7 +1863,10 @@
         {
           "shape": "ValidationException"
         }
-      ]
+      ],
+      "endpoint": {
+        "hostPrefix": "management."
+      }
     },
     "ListAvailableMeteredProducts": {
       "name": "ListAvailableMeteredProducts",
@@ -1701,7 +1888,10 @@
         {
           "shape": "ThrottlingException"
         }
-      ]
+      ],
+      "endpoint": {
+        "hostPrefix": "management."
+      }
     },
     "ListBudgets": {
       "name": "ListBudgets",
@@ -1732,7 +1922,10 @@
         {
           "shape": "ValidationException"
         }
-      ]
+      ],
+      "endpoint": {
+        "hostPrefix": "management."
+      }
     },
     "ListFarmMembers": {
       "name": "ListFarmMembers",
@@ -1763,7 +1956,10 @@
         {
           "shape": "ValidationException"
         }
-      ]
+      ],
+      "endpoint": {
+        "hostPrefix": "management."
+      }
     },
     "ListFarms": {
       "name": "ListFarms",
@@ -1791,7 +1987,10 @@
         {
           "shape": "ValidationException"
         }
-      ]
+      ],
+      "endpoint": {
+        "hostPrefix": "management."
+      }
     },
     "ListFleetMembers": {
       "name": "ListFleetMembers",
@@ -1822,7 +2021,10 @@
         {
           "shape": "ValidationException"
         }
-      ]
+      ],
+      "endpoint": {
+        "hostPrefix": "management."
+      }
     },
     "ListFleets": {
       "name": "ListFleets",
@@ -1853,7 +2055,10 @@
         {
           "shape": "ValidationException"
         }
-      ]
+      ],
+      "endpoint": {
+        "hostPrefix": "management."
+      }
     },
     "ListJobMembers": {
       "name": "ListJobMembers",
@@ -1884,7 +2089,10 @@
         {
           "shape": "ValidationException"
         }
-      ]
+      ],
+      "endpoint": {
+        "hostPrefix": "management."
+      }
     },
     "ListJobs": {
       "name": "ListJobs",
@@ -1915,7 +2123,10 @@
         {
           "shape": "ValidationException"
         }
-      ]
+      ],
+      "endpoint": {
+        "hostPrefix": "management."
+      }
     },
     "ListLicenseEndpoints": {
       "name": "ListLicenseEndpoints",
@@ -1946,7 +2157,10 @@
         {
           "shape": "ValidationException"
         }
-      ]
+      ],
+      "endpoint": {
+        "hostPrefix": "management."
+      }
     },
     "ListMeteredProducts": {
       "name": "ListMeteredProducts",
@@ -1977,7 +2191,10 @@
         {
           "shape": "ValidationException"
         }
-      ]
+      ],
+      "endpoint": {
+        "hostPrefix": "management."
+      }
     },
     "ListQueueEnvironments": {
       "name": "ListQueueEnvironments",
@@ -2008,7 +2225,10 @@
         {
           "shape": "ValidationException"
         }
-      ]
+      ],
+      "endpoint": {
+        "hostPrefix": "management."
+      }
     },
     "ListQueueFleetAssociations": {
       "name": "ListQueueFleetAssociations",
@@ -2036,7 +2256,10 @@
         {
           "shape": "ThrottlingException"
         }
-      ]
+      ],
+      "endpoint": {
+        "hostPrefix": "management."
+      }
     },
     "ListQueueMembers": {
       "name": "ListQueueMembers",
@@ -2067,7 +2290,10 @@
         {
           "shape": "ValidationException"
         }
-      ]
+      ],
+      "endpoint": {
+        "hostPrefix": "management."
+      }
     },
     "ListQueues": {
       "name": "ListQueues",
@@ -2098,13 +2324,16 @@
         {
           "shape": "ValidationException"
         }
-      ]
+      ],
+      "endpoint": {
+        "hostPrefix": "management."
+      }
     },
     "ListSessionActions": {
       "name": "ListSessionActions",
       "http": {
         "method": "GET",
-        "requestUri": "/2023-10-12/farms/{farmId}/queues/{queueId}/jobs/{jobId}/sessionactions",
+        "requestUri": "/2023-10-12/farms/{farmId}/queues/{queueId}/jobs/{jobId}/session-actions",
         "responseCode": 200
       },
       "input": {
@@ -2129,7 +2358,10 @@
         {
           "shape": "ValidationException"
         }
-      ]
+      ],
+      "endpoint": {
+        "hostPrefix": "management."
+      }
     },
     "ListSessions": {
       "name": "ListSessions",
@@ -2160,7 +2392,44 @@
         {
           "shape": "ValidationException"
         }
-      ]
+      ],
+      "endpoint": {
+        "hostPrefix": "management."
+      }
+    },
+    "ListSessionsForWorker": {
+      "name": "ListSessionsForWorker",
+      "http": {
+        "method": "GET",
+        "requestUri": "/2023-10-12/farms/{farmId}/fleets/{fleetId}/workers/{workerId}/sessions",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "ListSessionsForWorkerRequest"
+      },
+      "output": {
+        "shape": "ListSessionsForWorkerResponse"
+      },
+      "errors": [
+        {
+          "shape": "AccessDeniedException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "ResourceNotFoundException"
+        },
+        {
+          "shape": "ThrottlingException"
+        },
+        {
+          "shape": "ValidationException"
+        }
+      ],
+      "endpoint": {
+        "hostPrefix": "management."
+      }
     },
     "ListStepConsumers": {
       "name": "ListStepConsumers",
@@ -2191,7 +2460,10 @@
         {
           "shape": "ValidationException"
         }
-      ]
+      ],
+      "endpoint": {
+        "hostPrefix": "management."
+      }
     },
     "ListStepDependencies": {
       "name": "ListStepDependencies",
@@ -2222,7 +2494,10 @@
         {
           "shape": "ValidationException"
         }
-      ]
+      ],
+      "endpoint": {
+        "hostPrefix": "management."
+      }
     },
     "ListSteps": {
       "name": "ListSteps",
@@ -2253,7 +2528,10 @@
         {
           "shape": "ValidationException"
         }
-      ]
+      ],
+      "endpoint": {
+        "hostPrefix": "management."
+      }
     },
     "ListStorageProfiles": {
       "name": "ListStorageProfiles",
@@ -2284,7 +2562,10 @@
         {
           "shape": "ValidationException"
         }
-      ]
+      ],
+      "endpoint": {
+        "hostPrefix": "management."
+      }
     },
     "ListStorageProfilesForQueue": {
       "name": "ListStorageProfilesForQueue",
@@ -2315,7 +2596,10 @@
         {
           "shape": "ValidationException"
         }
-      ]
+      ],
+      "endpoint": {
+        "hostPrefix": "management."
+      }
     },
     "ListTagsForResource": {
       "name": "ListTagsForResource",
@@ -2346,7 +2630,10 @@
         {
           "shape": "ValidationException"
         }
-      ]
+      ],
+      "endpoint": {
+        "hostPrefix": "management."
+      }
     },
     "ListTasks": {
       "name": "ListTasks",
@@ -2377,38 +2664,10 @@
         {
           "shape": "ValidationException"
         }
-      ]
-    },
-    "ListWorkerSessions": {
-      "name": "ListWorkerSessions",
-      "http": {
-        "method": "GET",
-        "requestUri": "/2023-10-12/farms/{farmId}/fleets/{fleetId}/workers/{workerId}/sessions",
-        "responseCode": 200
-      },
-      "input": {
-        "shape": "ListWorkerSessionsRequest"
-      },
-      "output": {
-        "shape": "ListWorkerSessionsResponse"
-      },
-      "errors": [
-        {
-          "shape": "AccessDeniedException"
-        },
-        {
-          "shape": "InternalServerErrorException"
-        },
-        {
-          "shape": "ResourceNotFoundException"
-        },
-        {
-          "shape": "ThrottlingException"
-        },
-        {
-          "shape": "ValidationException"
-        }
-      ]
+      ],
+      "endpoint": {
+        "hostPrefix": "management."
+      }
     },
     "ListWorkers": {
       "name": "ListWorkers",
@@ -2439,7 +2698,10 @@
         {
           "shape": "ValidationException"
         }
-      ]
+      ],
+      "endpoint": {
+        "hostPrefix": "management."
+      }
     },
     "PutMeteredProduct": {
       "name": "PutMeteredProduct",
@@ -2471,6 +2733,9 @@
           "shape": "ValidationException"
         }
       ],
+      "endpoint": {
+        "hostPrefix": "management."
+      },
       "idempotent": true
     },
     "SearchJobs": {
@@ -2502,7 +2767,10 @@
         {
           "shape": "ValidationException"
         }
-      ]
+      ],
+      "endpoint": {
+        "hostPrefix": "management."
+      }
     },
     "SearchSteps": {
       "name": "SearchSteps",
@@ -2533,7 +2801,10 @@
         {
           "shape": "ValidationException"
         }
-      ]
+      ],
+      "endpoint": {
+        "hostPrefix": "management."
+      }
     },
     "SearchTasks": {
       "name": "SearchTasks",
@@ -2564,7 +2835,10 @@
         {
           "shape": "ValidationException"
         }
-      ]
+      ],
+      "endpoint": {
+        "hostPrefix": "management."
+      }
     },
     "SearchWorkers": {
       "name": "SearchWorkers",
@@ -2595,7 +2869,44 @@
         {
           "shape": "ValidationException"
         }
-      ]
+      ],
+      "endpoint": {
+        "hostPrefix": "management."
+      }
+    },
+    "StartSessionsStatisticsAggregation": {
+      "name": "StartSessionsStatisticsAggregation",
+      "http": {
+        "method": "POST",
+        "requestUri": "/2023-10-12/farms/{farmId}/sessions-statistics-aggregation",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "StartSessionsStatisticsAggregationRequest"
+      },
+      "output": {
+        "shape": "StartSessionsStatisticsAggregationResponse"
+      },
+      "errors": [
+        {
+          "shape": "AccessDeniedException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "ResourceNotFoundException"
+        },
+        {
+          "shape": "ThrottlingException"
+        },
+        {
+          "shape": "ValidationException"
+        }
+      ],
+      "endpoint": {
+        "hostPrefix": "management."
+      }
     },
     "TagResource": {
       "name": "TagResource",
@@ -2629,7 +2940,10 @@
         {
           "shape": "ValidationException"
         }
-      ]
+      ],
+      "endpoint": {
+        "hostPrefix": "management."
+      }
     },
     "UntagResource": {
       "name": "UntagResource",
@@ -2664,6 +2978,9 @@
           "shape": "ValidationException"
         }
       ],
+      "endpoint": {
+        "hostPrefix": "management."
+      },
       "idempotent": true
     },
     "UpdateBudget": {
@@ -2696,6 +3013,9 @@
           "shape": "ValidationException"
         }
       ],
+      "endpoint": {
+        "hostPrefix": "management."
+      },
       "idempotent": true
     },
     "UpdateFarm": {
@@ -2728,6 +3048,9 @@
           "shape": "ValidationException"
         }
       ],
+      "endpoint": {
+        "hostPrefix": "management."
+      },
       "idempotent": true
     },
     "UpdateFleet": {
@@ -2763,6 +3086,9 @@
           "shape": "ServiceQuotaExceededException"
         }
       ],
+      "endpoint": {
+        "hostPrefix": "management."
+      },
       "idempotent": true
     },
     "UpdateJob": {
@@ -2798,6 +3124,9 @@
           "shape": "ValidationException"
         }
       ],
+      "endpoint": {
+        "hostPrefix": "management."
+      },
       "idempotent": true
     },
     "UpdateQueue": {
@@ -2830,6 +3159,9 @@
           "shape": "ValidationException"
         }
       ],
+      "endpoint": {
+        "hostPrefix": "management."
+      },
       "idempotent": true
     },
     "UpdateQueueEnvironment": {
@@ -2861,7 +3193,10 @@
         {
           "shape": "ValidationException"
         }
-      ]
+      ],
+      "endpoint": {
+        "hostPrefix": "management."
+      }
     },
     "UpdateQueueFleetAssociation": {
       "name": "UpdateQueueFleetAssociation",
@@ -2893,6 +3228,9 @@
           "shape": "ValidationException"
         }
       ],
+      "endpoint": {
+        "hostPrefix": "management."
+      },
       "idempotent": true
     },
     "UpdateSession": {
@@ -2922,9 +3260,15 @@
           "shape": "ThrottlingException"
         },
         {
+          "shape": "ConflictException"
+        },
+        {
           "shape": "ValidationException"
         }
       ],
+      "endpoint": {
+        "hostPrefix": "management."
+      },
       "idempotent": true
     },
     "UpdateStep": {
@@ -2960,6 +3304,9 @@
           "shape": "ValidationException"
         }
       ],
+      "endpoint": {
+        "hostPrefix": "management."
+      },
       "idempotent": true
     },
     "UpdateStorageProfile": {
@@ -2992,6 +3339,9 @@
           "shape": "ValidationException"
         }
       ],
+      "endpoint": {
+        "hostPrefix": "management."
+      },
       "idempotent": true
     },
     "UpdateTask": {
@@ -3027,6 +3377,9 @@
           "shape": "ValidationException"
         }
       ],
+      "endpoint": {
+        "hostPrefix": "management."
+      },
       "idempotent": true
     },
     "UpdateWorker": {
@@ -3062,6 +3415,9 @@
           "shape": "ValidationException"
         }
       ],
+      "endpoint": {
+        "hostPrefix": "scheduling."
+      },
       "idempotent": true
     },
     "UpdateWorkerSchedule": {
@@ -3091,16 +3447,24 @@
           "shape": "ThrottlingException"
         },
         {
+          "shape": "ConflictException"
+        },
+        {
           "shape": "ValidationException"
         }
       ],
+      "endpoint": {
+        "hostPrefix": "scheduling."
+      },
       "idempotent": true
     }
   },
   "shapes": {
     "AccessDeniedException": {
       "type": "structure",
-      "required": ["message"],
+      "required": [
+        "message"
+      ],
       "members": {
         "message": {
           "shape": "String"
@@ -3133,13 +3497,11 @@
       "min": 1,
       "pattern": "([a-zA-Z][a-zA-Z0-9]{0,63}:)?amount(\\.[a-zA-Z][a-zA-Z0-9]{0,63})+"
     },
-    "JobAttachmentsFileSystem": {
-      "type": "string",
-      "enum": ["COPIED", "VIRTUAL"]
-    },
     "AssignedEnvironmentEnterSessionActionDefinition": {
       "type": "structure",
-      "required": ["environmentId"],
+      "required": [
+        "environmentId"
+      ],
       "members": {
         "environmentId": {
           "shape": "EnvironmentId"
@@ -3148,7 +3510,9 @@
     },
     "AssignedEnvironmentExitSessionActionDefinition": {
       "type": "structure",
-      "required": ["environmentId"],
+      "required": [
+        "environmentId"
+      ],
       "members": {
         "environmentId": {
           "shape": "EnvironmentId"
@@ -3157,7 +3521,12 @@
     },
     "AssignedSession": {
       "type": "structure",
-      "required": ["queueId", "jobId", "sessionActions", "logConfiguration"],
+      "required": [
+        "queueId",
+        "jobId",
+        "sessionActions",
+        "logConfiguration"
+      ],
       "members": {
         "queueId": {
           "shape": "QueueId"
@@ -3175,7 +3544,10 @@
     },
     "AssignedSessionAction": {
       "type": "structure",
-      "required": ["sessionActionId", "definition"],
+      "required": [
+        "sessionActionId",
+        "definition"
+      ],
       "members": {
         "sessionActionId": {
           "shape": "SessionActionId"
@@ -3228,7 +3600,11 @@
     },
     "AssignedTaskRunSessionActionDefinition": {
       "type": "structure",
-      "required": ["taskId", "stepId", "parameters"],
+      "required": [
+        "taskId",
+        "stepId",
+        "parameters"
+      ],
       "members": {
         "taskId": {
           "shape": "TaskId"
@@ -3427,7 +3803,10 @@
     },
     "AssumeFleetRoleForReadRequest": {
       "type": "structure",
-      "required": ["farmId", "fleetId"],
+      "required": [
+        "farmId",
+        "fleetId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -3448,17 +3827,23 @@
     },
     "AssumeFleetRoleForReadResponse": {
       "type": "structure",
-      "required": ["credentials"],
+      "required": [
+        "credentials"
+      ],
       "members": {
         "credentials": {
-          "shape": "IamCredentials"
+          "shape": "AwsCredentials"
         }
       },
       "sensitive": true
     },
     "AssumeFleetRoleForWorkerRequest": {
       "type": "structure",
-      "required": ["farmId", "fleetId", "workerId"],
+      "required": [
+        "farmId",
+        "fleetId",
+        "workerId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -3484,17 +3869,22 @@
     },
     "AssumeFleetRoleForWorkerResponse": {
       "type": "structure",
-      "required": ["credentials"],
+      "required": [
+        "credentials"
+      ],
       "members": {
         "credentials": {
-          "shape": "IamCredentials"
+          "shape": "AwsCredentials"
         }
       },
       "sensitive": true
     },
     "AssumeQueueRoleForReadRequest": {
       "type": "structure",
-      "required": ["farmId", "queueId"],
+      "required": [
+        "farmId",
+        "queueId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -3515,17 +3905,22 @@
     },
     "AssumeQueueRoleForReadResponse": {
       "type": "structure",
-      "required": ["credentials"],
+      "required": [
+        "credentials"
+      ],
       "members": {
         "credentials": {
-          "shape": "IamCredentials"
+          "shape": "AwsCredentials"
         }
       },
       "sensitive": true
     },
     "AssumeQueueRoleForUserRequest": {
       "type": "structure",
-      "required": ["farmId", "queueId"],
+      "required": [
+        "farmId",
+        "queueId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -3546,17 +3941,24 @@
     },
     "AssumeQueueRoleForUserResponse": {
       "type": "structure",
-      "required": ["credentials"],
+      "required": [
+        "credentials"
+      ],
       "members": {
         "credentials": {
-          "shape": "IamCredentials"
+          "shape": "AwsCredentials"
         }
       },
       "sensitive": true
     },
     "AssumeQueueRoleForWorkerRequest": {
       "type": "structure",
-      "required": ["farmId", "fleetId", "workerId", "queueId"],
+      "required": [
+        "farmId",
+        "fleetId",
+        "workerId",
+        "queueId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -3589,14 +3991,16 @@
       "type": "structure",
       "members": {
         "credentials": {
-          "shape": "IamCredentials"
+          "shape": "AwsCredentials"
         }
       },
       "sensitive": true
     },
     "Attachments": {
       "type": "structure",
-      "required": ["manifests"],
+      "required": [
+        "manifests"
+      ],
       "members": {
         "manifests": {
           "shape": "ManifestPropertiesList"
@@ -3626,28 +4030,44 @@
       "max": 10,
       "min": 1
     },
-    "AutoScalingConfiguration": {
-      "type": "structure",
-      "required": ["mode", "maxFleetSize"],
-      "members": {
-        "mode": {
-          "shape": "AutoScalingMode"
-        },
-        "minFleetSize": {
-          "shape": "MinZeroMaxInteger"
-        },
-        "maxFleetSize": {
-          "shape": "MinZeroMaxInteger"
-        }
-      }
-    },
     "AutoScalingMode": {
       "type": "string",
-      "enum": ["NO_SCALING", "EVENT_BASED_AUTO_SCALING"]
+      "enum": [
+        "NO_SCALING",
+        "EVENT_BASED_AUTO_SCALING"
+      ]
     },
     "AutoScalingStatus": {
       "type": "string",
-      "enum": ["GROWING", "STEADY", "SHRINKING"]
+      "enum": [
+        "GROWING",
+        "STEADY",
+        "SHRINKING"
+      ]
+    },
+    "AwsCredentials": {
+      "type": "structure",
+      "required": [
+        "accessKeyId",
+        "secretAccessKey",
+        "sessionToken",
+        "expiration"
+      ],
+      "members": {
+        "accessKeyId": {
+          "shape": "AccessKeyId"
+        },
+        "secretAccessKey": {
+          "shape": "SecretAccessKey"
+        },
+        "sessionToken": {
+          "shape": "SessionToken"
+        },
+        "expiration": {
+          "shape": "SyntheticTimestamp_date_time"
+        }
+      },
+      "sensitive": true
     },
     "BatchGetJobEntityErrors": {
       "type": "list",
@@ -3665,7 +4085,12 @@
     },
     "BatchGetJobEntityRequest": {
       "type": "structure",
-      "required": ["farmId", "fleetId", "workerId", "identifiers"],
+      "required": [
+        "farmId",
+        "fleetId",
+        "workerId",
+        "identifiers"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -3694,7 +4119,10 @@
     },
     "BatchGetJobEntityResponse": {
       "type": "structure",
-      "required": ["entities", "errors"],
+      "required": [
+        "entities",
+        "errors"
+      ],
       "members": {
         "entities": {
           "shape": "BatchGetJobEntityList"
@@ -3711,7 +4139,10 @@
     },
     "BudgetActionToAdd": {
       "type": "structure",
-      "required": ["type", "thresholdPercentage"],
+      "required": [
+        "type",
+        "thresholdPercentage"
+      ],
       "members": {
         "type": {
           "shape": "BudgetActionType"
@@ -3720,13 +4151,16 @@
           "shape": "ThresholdPercentage"
         },
         "description": {
-          "shape": "String"
+          "shape": "Description"
         }
       }
     },
     "BudgetActionToRemove": {
       "type": "structure",
-      "required": ["type", "thresholdPercentage"],
+      "required": [
+        "type",
+        "thresholdPercentage"
+      ],
       "members": {
         "type": {
           "shape": "BudgetActionType"
@@ -3774,7 +4208,10 @@
     },
     "BudgetStatus": {
       "type": "string",
-      "enum": ["ACTIVE", "INACTIVE"]
+      "enum": [
+        "ACTIVE",
+        "INACTIVE"
+      ]
     },
     "BudgetSummaries": {
       "type": "list",
@@ -3789,7 +4226,7 @@
         "usageTrackingResource",
         "status",
         "displayName",
-        "approximateDollarsLimit",
+        "approximateDollarLimit",
         "usages",
         "createdBy",
         "createdAt"
@@ -3810,7 +4247,7 @@
         "description": {
           "shape": "Description"
         },
-        "approximateDollarsLimit": {
+        "approximateDollarLimit": {
           "shape": "ConsumedUsageLimit"
         },
         "usages": {
@@ -3872,7 +4309,12 @@
     },
     "ConflictException": {
       "type": "structure",
-      "required": ["message", "reason", "resourceId", "resourceType"],
+      "required": [
+        "message",
+        "reason",
+        "resourceId",
+        "resourceType"
+      ],
       "members": {
         "message": {
           "shape": "String"
@@ -3913,16 +4355,23 @@
     },
     "ConsumedUsages": {
       "type": "structure",
-      "required": ["approximateDollarsUsage"],
+      "required": [
+        "approximateDollarUsage"
+      ],
       "members": {
-        "approximateDollarsUsage": {
+        "approximateDollarUsage": {
           "shape": "Float"
         }
       }
     },
     "CopyJobTemplateRequest": {
       "type": "structure",
-      "required": ["farmId", "jobId", "queueId", "targetS3Location"],
+      "required": [
+        "farmId",
+        "jobId",
+        "queueId",
+        "targetS3Location"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -3951,7 +4400,9 @@
     },
     "CopyJobTemplateResponse": {
       "type": "structure",
-      "required": ["templateType"],
+      "required": [
+        "templateType"
+      ],
       "members": {
         "templateType": {
           "shape": "JobTemplateType"
@@ -3960,7 +4411,10 @@
     },
     "CpuArchitectureType": {
       "type": "string",
-      "enum": ["x86_64", "arm64"]
+      "enum": [
+        "x86_64",
+        "arm64"
+      ]
     },
     "CreateBudgetRequest": {
       "type": "structure",
@@ -3968,7 +4422,7 @@
         "farmId",
         "usageTrackingResource",
         "displayName",
-        "approximateDollarsLimit",
+        "approximateDollarLimit",
         "actions",
         "schedule"
       ],
@@ -3998,7 +4452,7 @@
         "description": {
           "shape": "Description"
         },
-        "approximateDollarsLimit": {
+        "approximateDollarLimit": {
           "shape": "ConsumedUsageLimit"
         },
         "actions": {
@@ -4011,7 +4465,9 @@
     },
     "CreateBudgetResponse": {
       "type": "structure",
-      "required": ["budgetId"],
+      "required": [
+        "budgetId"
+      ],
       "members": {
         "budgetId": {
           "shape": "BudgetId"
@@ -4020,7 +4476,9 @@
     },
     "CreateFarmRequest": {
       "type": "structure",
-      "required": ["displayName"],
+      "required": [
+        "displayName"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -4052,7 +4510,9 @@
     },
     "CreateFarmResponse": {
       "type": "structure",
-      "required": ["farmId"],
+      "required": [
+        "farmId"
+      ],
       "members": {
         "farmId": {
           "shape": "FarmId"
@@ -4061,7 +4521,13 @@
     },
     "CreateFleetRequest": {
       "type": "structure",
-      "required": ["farmId", "displayName", "roleArn", "configuration"],
+      "required": [
+        "farmId",
+        "displayName",
+        "roleArn",
+        "maxWorkerCount",
+        "configuration"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -4088,6 +4554,12 @@
         "roleArn": {
           "shape": "IamRoleArn"
         },
+        "minWorkerCount": {
+          "shape": "MinZeroMaxInteger"
+        },
+        "maxWorkerCount": {
+          "shape": "MinZeroMaxInteger"
+        },
         "configuration": {
           "shape": "FleetConfiguration"
         },
@@ -4098,7 +4570,9 @@
     },
     "CreateFleetResponse": {
       "type": "structure",
-      "required": ["fleetId"],
+      "required": [
+        "fleetId"
+      ],
       "members": {
         "fleetId": {
           "shape": "FleetId"
@@ -4107,7 +4581,13 @@
     },
     "CreateJobRequest": {
       "type": "structure",
-      "required": ["farmId", "queueId", "template", "templateType", "priority"],
+      "required": [
+        "farmId",
+        "queueId",
+        "template",
+        "templateType",
+        "priority"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -4161,7 +4641,9 @@
     },
     "CreateJobResponse": {
       "type": "structure",
-      "required": ["jobId"],
+      "required": [
+        "jobId"
+      ],
       "members": {
         "jobId": {
           "shape": "JobId"
@@ -4170,11 +4652,18 @@
     },
     "CreateJobTargetTaskRunStatus": {
       "type": "string",
-      "enum": ["READY", "SUSPENDED"]
+      "enum": [
+        "READY",
+        "SUSPENDED"
+      ]
     },
     "CreateLicenseEndpointRequest": {
       "type": "structure",
-      "required": ["vpcId", "subnetIds", "securityGroupIds"],
+      "required": [
+        "vpcId",
+        "subnetIds",
+        "securityGroupIds"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -4219,7 +4708,9 @@
     },
     "CreateLicenseEndpointResponse": {
       "type": "structure",
-      "required": ["licenseEndpointId"],
+      "required": [
+        "licenseEndpointId"
+      ],
       "members": {
         "licenseEndpointId": {
           "shape": "LicenseEndpointId"
@@ -4228,7 +4719,13 @@
     },
     "CreateQueueEnvironmentRequest": {
       "type": "structure",
-      "required": ["farmId", "queueId", "priority", "templateType", "template"],
+      "required": [
+        "farmId",
+        "queueId",
+        "priority",
+        "templateType",
+        "template"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -4264,7 +4761,9 @@
     },
     "CreateQueueEnvironmentResponse": {
       "type": "structure",
-      "required": ["queueEnvironmentId"],
+      "required": [
+        "queueEnvironmentId"
+      ],
       "members": {
         "queueEnvironmentId": {
           "shape": "QueueEnvironmentId"
@@ -4273,7 +4772,11 @@
     },
     "CreateQueueFleetAssociationRequest": {
       "type": "structure",
-      "required": ["farmId", "queueId", "fleetId"],
+      "required": [
+        "farmId",
+        "queueId",
+        "fleetId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -4299,7 +4802,10 @@
     },
     "CreateQueueRequest": {
       "type": "structure",
-      "required": ["farmId", "displayName"],
+      "required": [
+        "farmId",
+        "displayName"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -4323,9 +4829,6 @@
         "description": {
           "shape": "Description"
         },
-        "status": {
-          "shape": "QueueStatus"
-        },
         "defaultBudgetAction": {
           "shape": "DefaultQueueBudgetAction"
         },
@@ -4335,8 +4838,8 @@
         "roleArn": {
           "shape": "IamRoleArn"
         },
-        "jobsRunAs": {
-          "shape": "JobsRunAs"
+        "jobRunAsUser": {
+          "shape": "JobRunAsUser"
         },
         "requiredFileSystemLocationNames": {
           "shape": "RequiredFileSystemLocationNames"
@@ -4351,7 +4854,9 @@
     },
     "CreateQueueResponse": {
       "type": "structure",
-      "required": ["queueId"],
+      "required": [
+        "queueId"
+      ],
       "members": {
         "queueId": {
           "shape": "QueueId"
@@ -4360,7 +4865,11 @@
     },
     "CreateStorageProfileRequest": {
       "type": "structure",
-      "required": ["farmId", "displayName", "osFamily"],
+      "required": [
+        "farmId",
+        "displayName",
+        "osFamily"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -4382,7 +4891,7 @@
           "shape": "ResourceName"
         },
         "osFamily": {
-          "shape": "OperatingSystemFamily"
+          "shape": "StorageProfileOperatingSystemFamily"
         },
         "fileSystemLocations": {
           "shape": "FileSystemLocationsList"
@@ -4391,7 +4900,9 @@
     },
     "CreateStorageProfileResponse": {
       "type": "structure",
-      "required": ["storageProfileId"],
+      "required": [
+        "storageProfileId"
+      ],
       "members": {
         "storageProfileId": {
           "shape": "StorageProfileId"
@@ -4400,7 +4911,10 @@
     },
     "CreateWorkerRequest": {
       "type": "structure",
-      "required": ["farmId", "fleetId"],
+      "required": [
+        "farmId",
+        "fleetId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -4430,7 +4944,9 @@
     },
     "CreateWorkerResponse": {
       "type": "structure",
-      "required": ["workerId"],
+      "required": [
+        "workerId"
+      ],
       "members": {
         "workerId": {
           "shape": "WorkerId"
@@ -4446,10 +4962,13 @@
     },
     "CustomerManagedFleetConfiguration": {
       "type": "structure",
-      "required": ["autoScalingConfiguration", "workerRequirements"],
+      "required": [
+        "mode",
+        "workerRequirements"
+      ],
       "members": {
-        "autoScalingConfiguration": {
-          "shape": "AutoScalingConfiguration"
+        "mode": {
+          "shape": "AutoScalingMode"
         },
         "workerRequirements": {
           "shape": "CustomerManagedWorkerRequirements"
@@ -4459,9 +4978,22 @@
         }
       }
     },
+    "CustomerManagedFleetOperatingSystemFamily": {
+      "type": "string",
+      "enum": [
+        "windows",
+        "linux",
+        "macos"
+      ]
+    },
     "CustomerManagedWorkerRequirements": {
       "type": "structure",
-      "required": ["vCpuCount", "memoryMiB", "osFamily", "cpuArchitectureType"],
+      "required": [
+        "vCpuCount",
+        "memoryMiB",
+        "osFamily",
+        "cpuArchitectureType"
+      ],
       "members": {
         "vCpuCount": {
           "shape": "VCpuCountRange"
@@ -4470,7 +5002,7 @@
           "shape": "MemoryMiBRange"
         },
         "osFamily": {
-          "shape": "OperatingSystemFamily"
+          "shape": "CustomerManagedFleetOperatingSystemFamily"
         },
         "cpuArchitectureType": {
           "shape": "CpuArchitectureType"
@@ -4485,7 +5017,11 @@
     },
     "DateTimeFilterExpression": {
       "type": "structure",
-      "required": ["name", "operator", "dateTime"],
+      "required": [
+        "name",
+        "operator",
+        "dateTime"
+      ],
       "members": {
         "name": {
           "shape": "String"
@@ -4508,7 +5044,10 @@
     },
     "DeleteBudgetRequest": {
       "type": "structure",
-      "required": ["farmId", "budgetId"],
+      "required": [
+        "farmId",
+        "budgetId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -4533,7 +5072,9 @@
     },
     "DeleteFarmRequest": {
       "type": "structure",
-      "required": ["farmId"],
+      "required": [
+        "farmId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -4553,7 +5094,10 @@
     },
     "DeleteFleetRequest": {
       "type": "structure",
-      "required": ["farmId", "fleetId"],
+      "required": [
+        "farmId",
+        "fleetId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -4584,7 +5128,9 @@
     },
     "DeleteLicenseEndpointRequest": {
       "type": "structure",
-      "required": ["licenseEndpointId"],
+      "required": [
+        "licenseEndpointId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -4604,7 +5150,10 @@
     },
     "DeleteMeteredProductRequest": {
       "type": "structure",
-      "required": ["licenseEndpointId", "productId"],
+      "required": [
+        "licenseEndpointId",
+        "productId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -4629,7 +5178,11 @@
     },
     "DeleteQueueEnvironmentRequest": {
       "type": "structure",
-      "required": ["farmId", "queueId", "queueEnvironmentId"],
+      "required": [
+        "farmId",
+        "queueId",
+        "queueEnvironmentId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -4659,7 +5212,11 @@
     },
     "DeleteQueueFleetAssociationRequest": {
       "type": "structure",
-      "required": ["farmId", "queueId", "fleetId"],
+      "required": [
+        "farmId",
+        "queueId",
+        "fleetId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -4689,7 +5246,10 @@
     },
     "DeleteQueueRequest": {
       "type": "structure",
-      "required": ["farmId", "queueId"],
+      "required": [
+        "farmId",
+        "queueId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -4714,7 +5274,10 @@
     },
     "DeleteStorageProfileRequest": {
       "type": "structure",
-      "required": ["farmId", "storageProfileId"],
+      "required": [
+        "farmId",
+        "storageProfileId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -4739,7 +5302,11 @@
     },
     "DeleteWorkerRequest": {
       "type": "structure",
-      "required": ["farmId", "fleetId", "workerId"],
+      "required": [
+        "farmId",
+        "fleetId",
+        "workerId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -4775,7 +5342,10 @@
     },
     "DependencyConsumerResolutionStatus": {
       "type": "string",
-      "enum": ["RESOLVED", "UNRESOLVED"]
+      "enum": [
+        "RESOLVED",
+        "UNRESOLVED"
+      ]
     },
     "DependencyCounts": {
       "type": "structure",
@@ -4803,15 +5373,21 @@
     "Description": {
       "type": "string",
       "max": 100,
-      "min": 0
+      "min": 0,
+      "sensitive": true
     },
     "DesiredWorkerStatus": {
       "type": "string",
-      "enum": ["STOPPED"]
+      "enum": [
+        "STOPPED"
+      ]
     },
     "DisassociateMemberFromFarmRequest": {
       "type": "structure",
-      "required": ["farmId", "principalId"],
+      "required": [
+        "farmId",
+        "principalId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -4836,7 +5412,11 @@
     },
     "DisassociateMemberFromFleetRequest": {
       "type": "structure",
-      "required": ["farmId", "fleetId", "principalId"],
+      "required": [
+        "farmId",
+        "fleetId",
+        "principalId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -4866,7 +5446,12 @@
     },
     "DisassociateMemberFromJobRequest": {
       "type": "structure",
-      "required": ["farmId", "queueId", "jobId", "principalId"],
+      "required": [
+        "farmId",
+        "queueId",
+        "jobId",
+        "principalId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -4901,7 +5486,11 @@
     },
     "DisassociateMemberFromQueueRequest": {
       "type": "structure",
-      "required": ["farmId", "queueId", "principalId"],
+      "required": [
+        "farmId",
+        "queueId",
+        "principalId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -4936,7 +5525,8 @@
     "Document": {
       "type": "structure",
       "members": {},
-      "document": true
+      "document": true,
+      "sensitive": true
     },
     "Double": {
       "type": "double",
@@ -4974,7 +5564,10 @@
     },
     "Ec2MarketType": {
       "type": "string",
-      "enum": ["on-demand", "spot"]
+      "enum": [
+        "on-demand",
+        "spot"
+      ]
     },
     "EndedAt": {
       "type": "timestamp",
@@ -4986,7 +5579,12 @@
     },
     "EnvironmentDetailsEntity": {
       "type": "structure",
-      "required": ["jobId", "environmentId", "schemaVersion", "template"],
+      "required": [
+        "jobId",
+        "environmentId",
+        "schemaVersion",
+        "template"
+      ],
       "members": {
         "jobId": {
           "shape": "JobId"
@@ -5004,7 +5602,12 @@
     },
     "EnvironmentDetailsError": {
       "type": "structure",
-      "required": ["jobId", "environmentId", "code", "message"],
+      "required": [
+        "jobId",
+        "environmentId",
+        "code",
+        "message"
+      ],
       "members": {
         "jobId": {
           "shape": "JobId"
@@ -5022,7 +5625,10 @@
     },
     "EnvironmentDetailsIdentifiers": {
       "type": "structure",
-      "required": ["jobId", "environmentId"],
+      "required": [
+        "jobId",
+        "environmentId"
+      ],
       "members": {
         "jobId": {
           "shape": "JobId"
@@ -5034,7 +5640,9 @@
     },
     "EnvironmentEnterSessionActionDefinition": {
       "type": "structure",
-      "required": ["environmentId"],
+      "required": [
+        "environmentId"
+      ],
       "members": {
         "environmentId": {
           "shape": "EnvironmentId"
@@ -5043,7 +5651,9 @@
     },
     "EnvironmentEnterSessionActionDefinitionSummary": {
       "type": "structure",
-      "required": ["environmentId"],
+      "required": [
+        "environmentId"
+      ],
       "members": {
         "environmentId": {
           "shape": "EnvironmentId"
@@ -5052,7 +5662,9 @@
     },
     "EnvironmentExitSessionActionDefinition": {
       "type": "structure",
-      "required": ["environmentId"],
+      "required": [
+        "environmentId"
+      ],
       "members": {
         "environmentId": {
           "shape": "EnvironmentId"
@@ -5061,7 +5673,9 @@
     },
     "EnvironmentExitSessionActionDefinitionSummary": {
       "type": "structure",
-      "required": ["environmentId"],
+      "required": [
+        "environmentId"
+      ],
       "members": {
         "environmentId": {
           "shape": "EnvironmentId"
@@ -5078,11 +5692,17 @@
       "type": "string"
     },
     "EnvironmentTemplate": {
-      "type": "string"
+      "type": "string",
+      "max": 15000,
+      "min": 1,
+      "sensitive": true
     },
     "EnvironmentTemplateType": {
       "type": "string",
-      "enum": ["JSON", "YAML"]
+      "enum": [
+        "JSON",
+        "YAML"
+      ]
     },
     "ExceptionContext": {
       "type": "map",
@@ -5138,16 +5758,18 @@
     },
     "FarmSummary": {
       "type": "structure",
-      "required": ["farmId", "displayName", "createdAt", "createdBy"],
+      "required": [
+        "farmId",
+        "displayName",
+        "createdAt",
+        "createdBy"
+      ],
       "members": {
         "farmId": {
           "shape": "FarmId"
         },
         "displayName": {
           "shape": "ResourceName"
-        },
-        "description": {
-          "shape": "Description"
         },
         "kmsKeyArn": {
           "shape": "KmsKeyArn"
@@ -5171,7 +5793,10 @@
     },
     "FieldSortExpression": {
       "type": "structure",
-      "required": ["sortOrder", "name"],
+      "required": [
+        "sortOrder",
+        "name"
+      ],
       "members": {
         "sortOrder": {
           "shape": "SortOrder"
@@ -5183,7 +5808,11 @@
     },
     "FileSystemLocation": {
       "type": "structure",
-      "required": ["name", "path", "type"],
+      "required": [
+        "name",
+        "path",
+        "type"
+      ],
       "members": {
         "name": {
           "shape": "FileSystemLocationName"
@@ -5194,17 +5823,22 @@
         "type": {
           "shape": "FileSystemLocationType"
         }
-      }
+      },
+      "sensitive": true
     },
     "FileSystemLocationName": {
       "type": "string",
       "max": 64,
       "min": 1,
-      "pattern": "[0-9A-Za-z ]*"
+      "pattern": "[0-9A-Za-z ]*",
+      "sensitive": true
     },
     "FileSystemLocationType": {
       "type": "string",
-      "enum": ["SHARED", "LOCAL"]
+      "enum": [
+        "SHARED",
+        "LOCAL"
+      ]
     },
     "FileSystemLocationsList": {
       "type": "list",
@@ -5216,7 +5850,10 @@
     },
     "FixedBudgetSchedule": {
       "type": "structure",
-      "required": ["startTime", "endTime"],
+      "required": [
+        "startTime",
+        "endTime"
+      ],
       "members": {
         "startTime": {
           "shape": "StartsAt"
@@ -5228,7 +5865,10 @@
     },
     "FleetAmountCapability": {
       "type": "structure",
-      "required": ["name", "min"],
+      "required": [
+        "name",
+        "min"
+      ],
       "members": {
         "name": {
           "shape": "AmountCapabilityName"
@@ -5251,7 +5891,10 @@
     },
     "FleetAttributeCapability": {
       "type": "structure",
-      "required": ["name", "values"],
+      "required": [
+        "name",
+        "values"
+      ],
       "members": {
         "name": {
           "shape": "AttributeCapabilityName"
@@ -5357,6 +6000,8 @@
         "displayName",
         "status",
         "workerCount",
+        "minWorkerCount",
+        "maxWorkerCount",
         "configuration",
         "createdAt",
         "createdBy"
@@ -5371,9 +6016,6 @@
         "displayName": {
           "shape": "ResourceName"
         },
-        "description": {
-          "shape": "Description"
-        },
         "status": {
           "shape": "FleetStatus"
         },
@@ -5385,6 +6027,12 @@
         },
         "workerCount": {
           "shape": "Integer"
+        },
+        "minWorkerCount": {
+          "shape": "MinZeroMaxInteger"
+        },
+        "maxWorkerCount": {
+          "shape": "MinZeroMaxInteger"
         },
         "configuration": {
           "shape": "FleetConfiguration"
@@ -5415,7 +6063,13 @@
     },
     "GetAggregatedStatisticsForSessionsRequest": {
       "type": "structure",
-      "required": ["farmId", "startTime", "endTime", "groupBy", "statistics"],
+      "required": [
+        "farmId",
+        "startTime",
+        "endTime",
+        "groupBy",
+        "statistics"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -5438,6 +6092,9 @@
         },
         "endTime": {
           "shape": "SyntheticTimestamp_date_time"
+        },
+        "timezone": {
+          "shape": "Timezone"
         },
         "period": {
           "shape": "Period"
@@ -5473,7 +6130,9 @@
     },
     "GetAggregatedStatisticsForSessionsResponse": {
       "type": "structure",
-      "required": ["statistics"],
+      "required": [
+        "statistics"
+      ],
       "members": {
         "statistics": {
           "shape": "StatisticsList"
@@ -5485,7 +6144,10 @@
     },
     "GetBudgetRequest": {
       "type": "structure",
-      "required": ["farmId", "budgetId"],
+      "required": [
+        "farmId",
+        "budgetId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -5511,7 +6173,7 @@
         "usageTrackingResource",
         "status",
         "displayName",
-        "approximateDollarsLimit",
+        "approximateDollarLimit",
         "usages",
         "actions",
         "schedule",
@@ -5534,7 +6196,7 @@
         "description": {
           "shape": "Description"
         },
-        "approximateDollarsLimit": {
+        "approximateDollarLimit": {
           "shape": "ConsumedUsageLimit"
         },
         "usages": {
@@ -5565,7 +6227,9 @@
     },
     "GetFarmRequest": {
       "type": "structure",
-      "required": ["farmId"],
+      "required": [
+        "farmId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -5620,7 +6284,10 @@
     },
     "GetFleetRequest": {
       "type": "structure",
-      "required": ["farmId", "fleetId"],
+      "required": [
+        "farmId",
+        "fleetId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -5647,6 +6314,8 @@
         "displayName",
         "status",
         "workerCount",
+        "minWorkerCount",
+        "maxWorkerCount",
         "configuration",
         "roleArn",
         "createdAt",
@@ -5676,6 +6345,12 @@
         },
         "workerCount": {
           "shape": "Integer"
+        },
+        "minWorkerCount": {
+          "shape": "MinZeroMaxInteger"
+        },
+        "maxWorkerCount": {
+          "shape": "MinZeroMaxInteger"
         },
         "configuration": {
           "shape": "FleetConfiguration"
@@ -5720,7 +6395,11 @@
     },
     "GetJobRequest": {
       "type": "structure",
-      "required": ["farmId", "jobId", "queueId"],
+      "required": [
+        "farmId",
+        "jobId",
+        "queueId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -5820,7 +6499,9 @@
     },
     "GetLicenseEndpointRequest": {
       "type": "structure",
-      "required": ["licenseEndpointId"],
+      "required": [
+        "licenseEndpointId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -5836,7 +6517,11 @@
     },
     "GetLicenseEndpointResponse": {
       "type": "structure",
-      "required": ["licenseEndpointId", "status", "statusMessage"],
+      "required": [
+        "licenseEndpointId",
+        "status",
+        "statusMessage"
+      ],
       "members": {
         "licenseEndpointId": {
           "shape": "LicenseEndpointId"
@@ -5854,16 +6539,36 @@
           "shape": "DnsName"
         },
         "subnetIds": {
-          "shape": "SubnetIdList"
+          "shape": "GetLicenseEndpointResponseSubnetIdsList"
         },
         "securityGroupIds": {
-          "shape": "SecurityGroupIdList"
+          "shape": "GetLicenseEndpointResponseSecurityGroupIdsList"
         }
       }
     },
+    "GetLicenseEndpointResponseSecurityGroupIdsList": {
+      "type": "list",
+      "member": {
+        "shape": "SecurityGroupId"
+      },
+      "max": 10,
+      "min": 1
+    },
+    "GetLicenseEndpointResponseSubnetIdsList": {
+      "type": "list",
+      "member": {
+        "shape": "SubnetId"
+      },
+      "max": 10,
+      "min": 1
+    },
     "GetQueueEnvironmentRequest": {
       "type": "structure",
-      "required": ["farmId", "queueId", "queueEnvironmentId"],
+      "required": [
+        "farmId",
+        "queueId",
+        "queueEnvironmentId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -5930,7 +6635,11 @@
     },
     "GetQueueFleetAssociationRequest": {
       "type": "structure",
-      "required": ["farmId", "queueId", "fleetId"],
+      "required": [
+        "farmId",
+        "queueId",
+        "fleetId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -5956,7 +6665,13 @@
     },
     "GetQueueFleetAssociationResponse": {
       "type": "structure",
-      "required": ["queueId", "fleetId", "status", "createdAt", "createdBy"],
+      "required": [
+        "queueId",
+        "fleetId",
+        "status",
+        "createdAt",
+        "createdBy"
+      ],
       "members": {
         "queueId": {
           "shape": "QueueId"
@@ -5983,7 +6698,10 @@
     },
     "GetQueueRequest": {
       "type": "structure",
-      "required": ["farmId", "queueId"],
+      "required": [
+        "farmId",
+        "queueId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -6041,14 +6759,14 @@
         "roleArn": {
           "shape": "IamRoleArn"
         },
-        "jobsRunAs": {
-          "shape": "JobsRunAs"
-        },
         "requiredFileSystemLocationNames": {
           "shape": "RequiredFileSystemLocationNames"
         },
         "allowedStorageProfileIds": {
           "shape": "AllowedStorageProfileIds"
+        },
+        "jobRunAsUser": {
+          "shape": "JobRunAsUser"
         },
         "createdAt": {
           "shape": "CreatedAt"
@@ -6066,7 +6784,12 @@
     },
     "GetSessionActionRequest": {
       "type": "structure",
-      "required": ["farmId", "queueId", "jobId", "sessionActionId"],
+      "required": [
+        "farmId",
+        "queueId",
+        "jobId",
+        "sessionActionId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -6097,7 +6820,12 @@
     },
     "GetSessionActionResponse": {
       "type": "structure",
-      "required": ["sessionActionId", "status", "sessionId", "definition"],
+      "required": [
+        "sessionActionId",
+        "status",
+        "sessionId",
+        "definition"
+      ],
       "members": {
         "sessionActionId": {
           "shape": "SessionActionId"
@@ -6110,6 +6838,9 @@
         },
         "endedAt": {
           "shape": "EndedAt"
+        },
+        "updatedAt": {
+          "shape": "UpdatedAt"
         },
         "progressPercent": {
           "shape": "SessionActionProgressPercent"
@@ -6130,7 +6861,12 @@
     },
     "GetSessionRequest": {
       "type": "structure",
-      "required": ["farmId", "queueId", "jobId", "sessionId"],
+      "required": [
+        "farmId",
+        "queueId",
+        "jobId",
+        "sessionId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -6208,9 +6944,68 @@
         }
       }
     },
+    "GetSessionsStatisticsAggregationRequest": {
+      "type": "structure",
+      "required": [
+        "farmId",
+        "aggregationId"
+      ],
+      "members": {
+        "dryRun": {
+          "shape": "DryRun",
+          "location": "header",
+          "locationName": "X-Amz-Dryrun"
+        },
+        "farmId": {
+          "shape": "FarmId",
+          "location": "uri",
+          "locationName": "farmId"
+        },
+        "aggregationId": {
+          "shape": "String",
+          "location": "querystring",
+          "locationName": "aggregationId"
+        },
+        "maxResults": {
+          "shape": "MaxResults",
+          "location": "querystring",
+          "locationName": "maxResults"
+        },
+        "nextToken": {
+          "shape": "String",
+          "location": "querystring",
+          "locationName": "nextToken"
+        }
+      }
+    },
+    "GetSessionsStatisticsAggregationResponse": {
+      "type": "structure",
+      "required": [
+        "status"
+      ],
+      "members": {
+        "statistics": {
+          "shape": "StatisticsList"
+        },
+        "nextToken": {
+          "shape": "String"
+        },
+        "status": {
+          "shape": "SessionsStatisticsAggregationStatus"
+        },
+        "statusMessage": {
+          "shape": "String"
+        }
+      }
+    },
     "GetStepRequest": {
       "type": "structure",
-      "required": ["farmId", "queueId", "jobId", "stepId"],
+      "required": [
+        "farmId",
+        "queueId",
+        "jobId",
+        "stepId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -6260,6 +7055,9 @@
         "lifecycleStatus": {
           "shape": "StepLifecycleStatus"
         },
+        "lifecycleStatusMessage": {
+          "shape": "String"
+        },
         "taskRunStatus": {
           "shape": "TaskRunStatus"
         },
@@ -6303,7 +7101,11 @@
     },
     "GetStorageProfileForQueueRequest": {
       "type": "structure",
-      "required": ["farmId", "queueId", "storageProfileId"],
+      "required": [
+        "farmId",
+        "queueId",
+        "storageProfileId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -6329,7 +7131,11 @@
     },
     "GetStorageProfileForQueueResponse": {
       "type": "structure",
-      "required": ["storageProfileId", "displayName", "osFamily"],
+      "required": [
+        "storageProfileId",
+        "displayName",
+        "osFamily"
+      ],
       "members": {
         "storageProfileId": {
           "shape": "StorageProfileId"
@@ -6338,7 +7144,7 @@
           "shape": "ResourceName"
         },
         "osFamily": {
-          "shape": "OperatingSystemFamily"
+          "shape": "StorageProfileOperatingSystemFamily"
         },
         "fileSystemLocations": {
           "shape": "FileSystemLocationsList"
@@ -6347,7 +7153,10 @@
     },
     "GetStorageProfileRequest": {
       "type": "structure",
-      "required": ["farmId", "storageProfileId"],
+      "required": [
+        "farmId",
+        "storageProfileId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -6383,7 +7192,7 @@
           "shape": "ResourceName"
         },
         "osFamily": {
-          "shape": "OperatingSystemFamily"
+          "shape": "StorageProfileOperatingSystemFamily"
         },
         "createdAt": {
           "shape": "CreatedAt"
@@ -6404,7 +7213,13 @@
     },
     "GetTaskRequest": {
       "type": "structure",
-      "required": ["farmId", "queueId", "jobId", "stepId", "taskId"],
+      "required": [
+        "farmId",
+        "queueId",
+        "jobId",
+        "stepId",
+        "taskId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -6440,7 +7255,12 @@
     },
     "GetTaskResponse": {
       "type": "structure",
-      "required": ["taskId", "createdAt", "createdBy", "runStatus"],
+      "required": [
+        "taskId",
+        "createdAt",
+        "createdBy",
+        "runStatus"
+      ],
       "members": {
         "taskId": {
           "shape": "TaskId"
@@ -6457,7 +7277,7 @@
         "targetRunStatus": {
           "shape": "TaskTargetRunStatus"
         },
-        "retryCount": {
+        "failureRetryCount": {
           "shape": "TaskRetryCount"
         },
         "parameters": {
@@ -6482,7 +7302,11 @@
     },
     "GetWorkerRequest": {
       "type": "structure",
-      "required": ["farmId", "fleetId", "workerId"],
+      "required": [
+        "farmId",
+        "fleetId",
+        "workerId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -6567,30 +7391,6 @@
         }
       }
     },
-    "IamCredentials": {
-      "type": "structure",
-      "required": [
-        "accessKeyId",
-        "secretAccessKey",
-        "sessionToken",
-        "expiration"
-      ],
-      "members": {
-        "accessKeyId": {
-          "shape": "AccessKeyId"
-        },
-        "secretAccessKey": {
-          "shape": "SecretAccessKey"
-        },
-        "sessionToken": {
-          "shape": "SessionToken"
-        },
-        "expiration": {
-          "shape": "SyntheticTimestamp_date_time"
-        }
-      },
-      "sensitive": true
-    },
     "IamRoleArn": {
       "type": "string",
       "pattern": "arn:(aws[a-zA-Z-]*):iam::\\d{12}:role(/[!-.0-~]+)*/[\\w+=,.@-]+"
@@ -6616,7 +7416,7 @@
       "member": {
         "shape": "InstanceType"
       },
-      "max": 10,
+      "max": 100,
       "min": 1
     },
     "IntString": {
@@ -6631,7 +7431,9 @@
     },
     "InternalServerErrorException": {
       "type": "structure",
-      "required": ["message"],
+      "required": [
+        "message"
+      ],
       "members": {
         "message": {
           "shape": "String"
@@ -6684,7 +7486,10 @@
     },
     "JobAttachmentDetailsEntity": {
       "type": "structure",
-      "required": ["jobId", "attachments"],
+      "required": [
+        "jobId",
+        "attachments"
+      ],
       "members": {
         "jobId": {
           "shape": "JobId"
@@ -6696,7 +7501,11 @@
     },
     "JobAttachmentDetailsError": {
       "type": "structure",
-      "required": ["jobId", "code", "message"],
+      "required": [
+        "jobId",
+        "code",
+        "message"
+      ],
       "members": {
         "jobId": {
           "shape": "JobId"
@@ -6711,7 +7520,9 @@
     },
     "JobAttachmentDetailsIdentifiers": {
       "type": "structure",
-      "required": ["jobId"],
+      "required": [
+        "jobId"
+      ],
       "members": {
         "jobId": {
           "shape": "JobId"
@@ -6720,7 +7531,10 @@
     },
     "JobAttachmentSettings": {
       "type": "structure",
-      "required": ["s3BucketName", "rootPrefix"],
+      "required": [
+        "s3BucketName",
+        "rootPrefix"
+      ],
       "members": {
         "s3BucketName": {
           "shape": "S3BucketName"
@@ -6730,14 +7544,26 @@
         }
       }
     },
+    "JobAttachmentsFileSystem": {
+      "type": "string",
+      "enum": [
+        "COPIED",
+        "VIRTUAL"
+      ]
+    },
     "JobDescription": {
       "type": "string",
       "max": 2048,
-      "min": 1
+      "min": 1,
+      "sensitive": true
     },
     "JobDetailsEntity": {
       "type": "structure",
-      "required": ["jobId", "logGroupName", "schemaVersion"],
+      "required": [
+        "jobId",
+        "logGroupName",
+        "schemaVersion"
+      ],
       "members": {
         "jobId": {
           "shape": "JobId"
@@ -6745,8 +7571,8 @@
         "jobAttachmentSettings": {
           "shape": "JobAttachmentSettings"
         },
-        "jobsRunAs": {
-          "shape": "JobsRunAs"
+        "jobRunAsUser": {
+          "shape": "JobRunAsUser"
         },
         "logGroupName": {
           "shape": "String"
@@ -6767,7 +7593,11 @@
     },
     "JobDetailsError": {
       "type": "structure",
-      "required": ["jobId", "code", "message"],
+      "required": [
+        "jobId",
+        "code",
+        "message"
+      ],
       "members": {
         "jobId": {
           "shape": "JobId"
@@ -6782,7 +7612,9 @@
     },
     "JobDetailsIdentifiers": {
       "type": "structure",
-      "required": ["jobId"],
+      "required": [
+        "jobId"
+      ],
       "members": {
         "jobId": {
           "shape": "JobId"
@@ -6810,6 +7642,7 @@
     "JobEntityErrorCode": {
       "type": "string",
       "enum": [
+        "AccessDeniedException",
         "InternalServerException",
         "ValidationException",
         "ResourceNotFoundException",
@@ -6853,11 +7686,12 @@
         "CREATE_IN_PROGRESS",
         "CREATE_FAILED",
         "CREATE_COMPLETE",
-        "UPLOADING",
+        "UPLOAD_IN_PROGRESS",
         "UPLOAD_FAILED",
         "UPDATE_IN_PROGRESS",
         "UPDATE_FAILED",
-        "UPDATE_SUCCEEDED"
+        "UPDATE_SUCCEEDED",
+        "ARCHIVED"
       ]
     },
     "JobMember": {
@@ -6903,7 +7737,7 @@
     },
     "JobName": {
       "type": "string",
-      "max": 64,
+      "max": 128,
       "min": 1
     },
     "JobParameter": {
@@ -6931,13 +7765,28 @@
       },
       "value": {
         "shape": "JobParameter"
-      }
+      },
+      "sensitive": true
     },
     "JobPriority": {
       "type": "integer",
       "box": true,
       "max": 100,
       "min": 0
+    },
+    "JobRunAsUser": {
+      "type": "structure",
+      "required": [
+        "runAs"
+      ],
+      "members": {
+        "posix": {
+          "shape": "PosixUser"
+        },
+        "runAs": {
+          "shape": "RunAs"
+        }
+      }
     },
     "JobSearchSummaries": {
       "type": "list",
@@ -7068,24 +7917,26 @@
     },
     "JobTargetTaskRunStatus": {
       "type": "string",
-      "enum": ["READY", "FAILED", "SUCCEEDED", "CANCELED", "SUSPENDED"]
+      "enum": [
+        "READY",
+        "FAILED",
+        "SUCCEEDED",
+        "CANCELED",
+        "SUSPENDED"
+      ]
     },
     "JobTemplate": {
       "type": "string",
       "max": 300000,
-      "min": 1
+      "min": 1,
+      "sensitive": true
     },
     "JobTemplateType": {
       "type": "string",
-      "enum": ["JSON", "YAML"]
-    },
-    "JobsRunAs": {
-      "type": "structure",
-      "members": {
-        "posix": {
-          "shape": "PosixUser"
-        }
-      }
+      "enum": [
+        "JSON",
+        "YAML"
+      ]
     },
     "KmsKeyArn": {
       "type": "string",
@@ -7097,7 +7948,12 @@
     },
     "LicenseEndpointStatus": {
       "type": "string",
-      "enum": ["CREATE_IN_PROGRESS", "DELETE_IN_PROGRESS", "READY", "NOT_READY"]
+      "enum": [
+        "CREATE_IN_PROGRESS",
+        "DELETE_IN_PROGRESS",
+        "READY",
+        "NOT_READY"
+      ]
     },
     "LicenseEndpointSummaries": {
       "type": "list",
@@ -7153,7 +8009,9 @@
     },
     "ListAvailableMeteredProductsResponse": {
       "type": "structure",
-      "required": ["meteredProducts"],
+      "required": [
+        "meteredProducts"
+      ],
       "members": {
         "meteredProducts": {
           "shape": "MeteredProductSummaryList"
@@ -7165,7 +8023,9 @@
     },
     "ListBudgetsRequest": {
       "type": "structure",
-      "required": ["farmId"],
+      "required": [
+        "farmId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -7196,7 +8056,9 @@
     },
     "ListBudgetsResponse": {
       "type": "structure",
-      "required": ["budgets"],
+      "required": [
+        "budgets"
+      ],
       "members": {
         "nextToken": {
           "shape": "String"
@@ -7208,7 +8070,9 @@
     },
     "ListFarmMembersRequest": {
       "type": "structure",
-      "required": ["farmId"],
+      "required": [
+        "farmId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -7234,7 +8098,9 @@
     },
     "ListFarmMembersResponse": {
       "type": "structure",
-      "required": ["members"],
+      "required": [
+        "members"
+      ],
       "members": {
         "members": {
           "shape": "FarmMembers"
@@ -7276,7 +8142,9 @@
     },
     "ListFarmsResponse": {
       "type": "structure",
-      "required": ["farms"],
+      "required": [
+        "farms"
+      ],
       "members": {
         "nextToken": {
           "shape": "String"
@@ -7288,7 +8156,10 @@
     },
     "ListFleetMembersRequest": {
       "type": "structure",
-      "required": ["farmId", "fleetId"],
+      "required": [
+        "farmId",
+        "fleetId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -7319,7 +8190,9 @@
     },
     "ListFleetMembersResponse": {
       "type": "structure",
-      "required": ["members"],
+      "required": [
+        "members"
+      ],
       "members": {
         "members": {
           "shape": "FleetMembers"
@@ -7331,7 +8204,9 @@
     },
     "ListFleetsRequest": {
       "type": "structure",
-      "required": ["farmId"],
+      "required": [
+        "farmId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -7372,7 +8247,9 @@
     },
     "ListFleetsResponse": {
       "type": "structure",
-      "required": ["fleets"],
+      "required": [
+        "fleets"
+      ],
       "members": {
         "fleets": {
           "shape": "FleetSummaries"
@@ -7384,7 +8261,11 @@
     },
     "ListJobMembersRequest": {
       "type": "structure",
-      "required": ["farmId", "queueId", "jobId"],
+      "required": [
+        "farmId",
+        "queueId",
+        "jobId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -7420,7 +8301,9 @@
     },
     "ListJobMembersResponse": {
       "type": "structure",
-      "required": ["members"],
+      "required": [
+        "members"
+      ],
       "members": {
         "members": {
           "shape": "JobMembers"
@@ -7432,7 +8315,10 @@
     },
     "ListJobsRequest": {
       "type": "structure",
-      "required": ["farmId", "queueId"],
+      "required": [
+        "farmId",
+        "queueId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -7468,7 +8354,9 @@
     },
     "ListJobsResponse": {
       "type": "structure",
-      "required": ["jobs"],
+      "required": [
+        "jobs"
+      ],
       "members": {
         "jobs": {
           "shape": "JobSummaries"
@@ -7500,7 +8388,9 @@
     },
     "ListLicenseEndpointsResponse": {
       "type": "structure",
-      "required": ["licenseEndpoints"],
+      "required": [
+        "licenseEndpoints"
+      ],
       "members": {
         "licenseEndpoints": {
           "shape": "LicenseEndpointSummaries"
@@ -7512,7 +8402,9 @@
     },
     "ListMeteredProductsRequest": {
       "type": "structure",
-      "required": ["licenseEndpointId"],
+      "required": [
+        "licenseEndpointId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -7538,7 +8430,9 @@
     },
     "ListMeteredProductsResponse": {
       "type": "structure",
-      "required": ["meteredProducts"],
+      "required": [
+        "meteredProducts"
+      ],
       "members": {
         "meteredProducts": {
           "shape": "MeteredProductSummaryList"
@@ -7550,7 +8444,10 @@
     },
     "ListQueueEnvironmentsRequest": {
       "type": "structure",
-      "required": ["farmId", "queueId"],
+      "required": [
+        "farmId",
+        "queueId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -7581,7 +8478,9 @@
     },
     "ListQueueEnvironmentsResponse": {
       "type": "structure",
-      "required": ["environments"],
+      "required": [
+        "environments"
+      ],
       "members": {
         "environments": {
           "shape": "QueueEnvironmentSummaries"
@@ -7593,18 +8492,14 @@
     },
     "ListQueueFleetAssociationsRequest": {
       "type": "structure",
-      "required": ["farmId"],
+      "required": [
+        "farmId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
           "location": "header",
           "locationName": "X-Amz-Dryrun"
-        },
-        "clientToken": {
-          "shape": "ClientToken",
-          "idempotencyToken": true,
-          "location": "header",
-          "locationName": "X-Amz-Client-Token"
         },
         "farmId": {
           "shape": "FarmId",
@@ -7635,7 +8530,9 @@
     },
     "ListQueueFleetAssociationsResponse": {
       "type": "structure",
-      "required": ["queueFleetAssociations"],
+      "required": [
+        "queueFleetAssociations"
+      ],
       "members": {
         "queueFleetAssociations": {
           "shape": "QueueFleetAssociationSummaries"
@@ -7647,7 +8544,10 @@
     },
     "ListQueueMembersRequest": {
       "type": "structure",
-      "required": ["farmId", "queueId"],
+      "required": [
+        "farmId",
+        "queueId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -7678,7 +8578,9 @@
     },
     "ListQueueMembersResponse": {
       "type": "structure",
-      "required": ["members"],
+      "required": [
+        "members"
+      ],
       "members": {
         "members": {
           "shape": "QueueMemberList"
@@ -7690,7 +8592,9 @@
     },
     "ListQueuesRequest": {
       "type": "structure",
-      "required": ["farmId"],
+      "required": [
+        "farmId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -7726,7 +8630,9 @@
     },
     "ListQueuesResponse": {
       "type": "structure",
-      "required": ["queues"],
+      "required": [
+        "queues"
+      ],
       "members": {
         "queues": {
           "shape": "QueueSummaries"
@@ -7738,7 +8644,11 @@
     },
     "ListSessionActionsRequest": {
       "type": "structure",
-      "required": ["farmId", "queueId", "jobId"],
+      "required": [
+        "farmId",
+        "queueId",
+        "jobId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -7784,9 +8694,11 @@
     },
     "ListSessionActionsResponse": {
       "type": "structure",
-      "required": ["sessionactions"],
+      "required": [
+        "sessionActions"
+      ],
       "members": {
-        "sessionactions": {
+        "sessionActions": {
           "shape": "SessionActionSummaries"
         },
         "nextToken": {
@@ -7794,9 +8706,73 @@
         }
       }
     },
+    "ListSessionsForWorkerRequest": {
+      "type": "structure",
+      "required": [
+        "farmId",
+        "fleetId",
+        "workerId"
+      ],
+      "members": {
+        "dryRun": {
+          "shape": "DryRun",
+          "location": "header",
+          "locationName": "X-Amz-Dryrun"
+        },
+        "farmId": {
+          "shape": "FarmId",
+          "location": "uri",
+          "locationName": "farmId"
+        },
+        "fleetId": {
+          "shape": "FleetId",
+          "location": "uri",
+          "locationName": "fleetId"
+        },
+        "workerId": {
+          "shape": "WorkerId",
+          "location": "uri",
+          "locationName": "workerId"
+        },
+        "nextToken": {
+          "shape": "String",
+          "location": "querystring",
+          "locationName": "nextToken"
+        },
+        "maxResults": {
+          "shape": "MaxResults",
+          "location": "querystring",
+          "locationName": "maxResults"
+        }
+      }
+    },
+    "ListSessionsForWorkerResponse": {
+      "type": "structure",
+      "required": [
+        "sessions"
+      ],
+      "members": {
+        "sessions": {
+          "shape": "ListSessionsForWorkerSummaries"
+        },
+        "nextToken": {
+          "shape": "String"
+        }
+      }
+    },
+    "ListSessionsForWorkerSummaries": {
+      "type": "list",
+      "member": {
+        "shape": "WorkerSessionSummary"
+      }
+    },
     "ListSessionsRequest": {
       "type": "structure",
-      "required": ["farmId", "queueId", "jobId"],
+      "required": [
+        "farmId",
+        "queueId",
+        "jobId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -7832,7 +8808,9 @@
     },
     "ListSessionsResponse": {
       "type": "structure",
-      "required": ["sessions"],
+      "required": [
+        "sessions"
+      ],
       "members": {
         "sessions": {
           "shape": "SessionSummaries"
@@ -7844,7 +8822,12 @@
     },
     "ListStepConsumersRequest": {
       "type": "structure",
-      "required": ["farmId", "queueId", "jobId", "stepId"],
+      "required": [
+        "farmId",
+        "queueId",
+        "jobId",
+        "stepId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -7891,7 +8874,9 @@
     },
     "ListStepConsumersResponse": {
       "type": "structure",
-      "required": ["consumers"],
+      "required": [
+        "consumers"
+      ],
       "members": {
         "consumers": {
           "shape": "StepConsumers"
@@ -7903,7 +8888,12 @@
     },
     "ListStepDependenciesRequest": {
       "type": "structure",
-      "required": ["farmId", "queueId", "jobId", "stepId"],
+      "required": [
+        "farmId",
+        "queueId",
+        "jobId",
+        "stepId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -7950,7 +8940,9 @@
     },
     "ListStepDependenciesResponse": {
       "type": "structure",
-      "required": ["dependencies"],
+      "required": [
+        "dependencies"
+      ],
       "members": {
         "dependencies": {
           "shape": "StepDependencies"
@@ -7962,7 +8954,11 @@
     },
     "ListStepsRequest": {
       "type": "structure",
-      "required": ["farmId", "queueId", "jobId"],
+      "required": [
+        "farmId",
+        "queueId",
+        "jobId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -7998,7 +8994,9 @@
     },
     "ListStepsResponse": {
       "type": "structure",
-      "required": ["steps"],
+      "required": [
+        "steps"
+      ],
       "members": {
         "steps": {
           "shape": "StepSummaries"
@@ -8010,7 +9008,10 @@
     },
     "ListStorageProfilesForQueueRequest": {
       "type": "structure",
-      "required": ["farmId", "queueId"],
+      "required": [
+        "farmId",
+        "queueId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -8041,7 +9042,9 @@
     },
     "ListStorageProfilesForQueueResponse": {
       "type": "structure",
-      "required": ["storageProfiles"],
+      "required": [
+        "storageProfiles"
+      ],
       "members": {
         "storageProfiles": {
           "shape": "StorageProfileSummaries"
@@ -8053,7 +9056,9 @@
     },
     "ListStorageProfilesRequest": {
       "type": "structure",
-      "required": ["farmId"],
+      "required": [
+        "farmId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -8079,7 +9084,9 @@
     },
     "ListStorageProfilesResponse": {
       "type": "structure",
-      "required": ["storageProfiles"],
+      "required": [
+        "storageProfiles"
+      ],
       "members": {
         "storageProfiles": {
           "shape": "StorageProfileSummaries"
@@ -8091,7 +9098,9 @@
     },
     "ListTagsForResourceRequest": {
       "type": "structure",
-      "required": ["resourceArn"],
+      "required": [
+        "resourceArn"
+      ],
       "members": {
         "resourceArn": {
           "shape": "String",
@@ -8110,7 +9119,12 @@
     },
     "ListTasksRequest": {
       "type": "structure",
-      "required": ["farmId", "queueId", "jobId", "stepId"],
+      "required": [
+        "farmId",
+        "queueId",
+        "jobId",
+        "stepId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -8151,7 +9165,9 @@
     },
     "ListTasksResponse": {
       "type": "structure",
-      "required": ["tasks"],
+      "required": [
+        "tasks"
+      ],
       "members": {
         "tasks": {
           "shape": "TaskSummaries"
@@ -8161,96 +9177,12 @@
         }
       }
     },
-    "ListWorkerSessionSummaries": {
-      "type": "list",
-      "member": {
-        "shape": "ListWorkerSessionSummary"
-      }
-    },
-    "ListWorkerSessionSummary": {
-      "type": "structure",
-      "required": [
-        "sessionId",
-        "queueId",
-        "jobId",
-        "startedAt",
-        "lifecycleStatus"
-      ],
-      "members": {
-        "sessionId": {
-          "shape": "SessionId"
-        },
-        "queueId": {
-          "shape": "QueueId"
-        },
-        "jobId": {
-          "shape": "JobId"
-        },
-        "startedAt": {
-          "shape": "StartedAt"
-        },
-        "lifecycleStatus": {
-          "shape": "SessionLifecycleStatus"
-        },
-        "endedAt": {
-          "shape": "EndedAt"
-        },
-        "targetLifecycleStatus": {
-          "shape": "SessionLifecycleTargetStatus"
-        }
-      }
-    },
-    "ListWorkerSessionsRequest": {
-      "type": "structure",
-      "required": ["farmId", "fleetId", "workerId"],
-      "members": {
-        "dryRun": {
-          "shape": "DryRun",
-          "location": "header",
-          "locationName": "X-Amz-Dryrun"
-        },
-        "farmId": {
-          "shape": "FarmId",
-          "location": "uri",
-          "locationName": "farmId"
-        },
-        "fleetId": {
-          "shape": "FleetId",
-          "location": "uri",
-          "locationName": "fleetId"
-        },
-        "workerId": {
-          "shape": "WorkerId",
-          "location": "uri",
-          "locationName": "workerId"
-        },
-        "nextToken": {
-          "shape": "String",
-          "location": "querystring",
-          "locationName": "nextToken"
-        },
-        "maxResults": {
-          "shape": "MaxResults",
-          "location": "querystring",
-          "locationName": "maxResults"
-        }
-      }
-    },
-    "ListWorkerSessionsResponse": {
-      "type": "structure",
-      "required": ["sessions"],
-      "members": {
-        "sessions": {
-          "shape": "ListWorkerSessionSummaries"
-        },
-        "nextToken": {
-          "shape": "String"
-        }
-      }
-    },
     "ListWorkersRequest": {
       "type": "structure",
-      "required": ["farmId", "fleetId"],
+      "required": [
+        "farmId",
+        "fleetId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -8281,7 +9213,9 @@
     },
     "ListWorkersResponse": {
       "type": "structure",
-      "required": ["workers"],
+      "required": [
+        "workers"
+      ],
       "members": {
         "nextToken": {
           "shape": "String"
@@ -8293,7 +9227,9 @@
     },
     "LogConfiguration": {
       "type": "structure",
-      "required": ["logDriver"],
+      "required": [
+        "logDriver"
+      ],
       "members": {
         "logDriver": {
           "shape": "LogDriver"
@@ -8339,11 +9275,17 @@
     },
     "LogicalOperator": {
       "type": "string",
-      "enum": ["AND", "OR"]
+      "enum": [
+        "AND",
+        "OR"
+      ]
     },
     "ManifestProperties": {
       "type": "structure",
-      "required": ["rootPath", "osType"],
+      "required": [
+        "rootPath",
+        "rootPathFormat"
+      ],
       "members": {
         "fileSystemLocationName": {
           "shape": "FileSystemLocationName"
@@ -8351,8 +9293,8 @@
         "rootPath": {
           "shape": "ManifestPropertiesRootPathString"
         },
-        "osType": {
-          "shape": "OperatingSystemFamily"
+        "rootPathFormat": {
+          "shape": "PathFormat"
         },
         "outputRelativeDirectories": {
           "shape": "OutputRelativeDirectoriesList"
@@ -8363,7 +9305,8 @@
         "inputManifestHash": {
           "shape": "ManifestPropertiesInputManifestHashString"
         }
-      }
+      },
+      "sensitive": true
     },
     "ManifestPropertiesInputManifestHashString": {
       "type": "string",
@@ -8408,7 +9351,12 @@
     },
     "MembershipLevel": {
       "type": "string",
-      "enum": ["VIEWER", "CONTRIBUTOR", "OWNER", "MANAGER"]
+      "enum": [
+        "VIEWER",
+        "CONTRIBUTOR",
+        "OWNER",
+        "MANAGER"
+      ]
     },
     "MemoryAmountMiB": {
       "type": "integer",
@@ -8418,7 +9366,9 @@
     },
     "MemoryMiBRange": {
       "type": "structure",
-      "required": ["min"],
+      "required": [
+        "min"
+      ],
       "members": {
         "min": {
           "shape": "MemoryAmountMiB"
@@ -8434,7 +9384,12 @@
     },
     "MeteredProductSummary": {
       "type": "structure",
-      "required": ["productId", "family", "vendor", "port"],
+      "required": [
+        "productId",
+        "family",
+        "vendor",
+        "port"
+      ],
       "members": {
         "productId": {
           "shape": "MeteredProductId"
@@ -8474,10 +9429,6 @@
       "max": 10000,
       "min": 0
     },
-    "OperatingSystemFamily": {
-      "type": "string",
-      "enum": ["windows", "linux", "macos"]
-    },
     "OutputRelativeDirectoriesList": {
       "type": "list",
       "member": {
@@ -8493,7 +9444,11 @@
     },
     "ParameterFilterExpression": {
       "type": "structure",
-      "required": ["name", "operator", "value"],
+      "required": [
+        "name",
+        "operator",
+        "value"
+      ],
       "members": {
         "name": {
           "shape": "String"
@@ -8508,7 +9463,10 @@
     },
     "ParameterSortExpression": {
       "type": "structure",
-      "required": ["sortOrder", "name"],
+      "required": [
+        "sortOrder",
+        "name"
+      ],
       "members": {
         "sortOrder": {
           "shape": "SortOrder"
@@ -8520,7 +9478,9 @@
     },
     "ParameterSpace": {
       "type": "structure",
-      "required": ["parameters"],
+      "required": [
+        "parameters"
+      ],
       "members": {
         "parameters": {
           "shape": "StepParameterList"
@@ -8540,12 +9500,23 @@
       "max": 256,
       "min": 1
     },
+    "PathFormat": {
+      "type": "string",
+      "enum": [
+        "windows",
+        "posix"
+      ]
+    },
     "PathMappingRule": {
       "type": "structure",
-      "required": ["sourceOs", "sourcePath", "destinationPath"],
+      "required": [
+        "sourcePathFormat",
+        "sourcePath",
+        "destinationPath"
+      ],
       "members": {
-        "sourceOs": {
-          "shape": "SourceOs"
+        "sourcePathFormat": {
+          "shape": "PathFormat"
         },
         "sourcePath": {
           "shape": "String"
@@ -8553,7 +9524,8 @@
         "destinationPath": {
           "shape": "String"
         }
-      }
+      },
+      "sensitive": true
     },
     "PathMappingRules": {
       "type": "list",
@@ -8564,11 +9536,16 @@
     "PathString": {
       "type": "string",
       "max": 1024,
-      "min": 1
+      "min": 0
     },
     "Period": {
       "type": "string",
-      "enum": ["HOURLY", "DAILY", "WEEKLY", "MONTHLY"]
+      "enum": [
+        "HOURLY",
+        "DAILY",
+        "WEEKLY",
+        "MONTHLY"
+      ]
     },
     "PortNumber": {
       "type": "integer",
@@ -8578,7 +9555,10 @@
     },
     "PosixUser": {
       "type": "structure",
-      "required": ["user", "group"],
+      "required": [
+        "user",
+        "group"
+      ],
       "members": {
         "user": {
           "shape": "PosixUserUserString"
@@ -8590,19 +9570,22 @@
     },
     "PosixUserGroupString": {
       "type": "string",
-      "max": 32,
+      "max": 31,
       "min": 0,
-      "pattern": "[a-zA-Z0-9_.][^:]{0,31}$|^"
+      "pattern": "(?:[a-z][a-z0-9-]{0,30})?"
     },
     "PosixUserUserString": {
       "type": "string",
-      "max": 32,
+      "max": 31,
       "min": 0,
-      "pattern": "[a-zA-Z0-9_.][^:]{0,31}$|^"
+      "pattern": "(?:[a-z][a-z0-9-]{0,30})?"
     },
     "PrincipalType": {
       "type": "string",
-      "enum": ["USER", "GROUP"]
+      "enum": [
+        "USER",
+        "GROUP"
+      ]
     },
     "Priority": {
       "type": "integer",
@@ -8618,7 +9601,10 @@
     },
     "PutMeteredProductRequest": {
       "type": "structure",
-      "required": ["licenseEndpointId", "productId"],
+      "required": [
+        "licenseEndpointId",
+        "productId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -8643,7 +9629,10 @@
     },
     "QueueBlockedReason": {
       "type": "string",
-      "enum": ["NO_BUDGET_CONFIGURED", "BUDGET_THRESHOLD_REACHED"]
+      "enum": [
+        "NO_BUDGET_CONFIGURED",
+        "BUDGET_THRESHOLD_REACHED"
+      ]
     },
     "QueueEnvironmentId": {
       "type": "string",
@@ -8657,7 +9646,11 @@
     },
     "QueueEnvironmentSummary": {
       "type": "structure",
-      "required": ["queueEnvironmentId", "name", "priority"],
+      "required": [
+        "queueEnvironmentId",
+        "name",
+        "priority"
+      ],
       "members": {
         "queueEnvironmentId": {
           "shape": "QueueEnvironmentId"
@@ -8687,7 +9680,13 @@
     },
     "QueueFleetAssociationSummary": {
       "type": "structure",
-      "required": ["queueId", "fleetId", "status", "createdAt", "createdBy"],
+      "required": [
+        "queueId",
+        "fleetId",
+        "status",
+        "createdAt",
+        "createdBy"
+      ],
       "members": {
         "queueId": {
           "shape": "QueueId"
@@ -8755,7 +9754,11 @@
     },
     "QueueStatus": {
       "type": "string",
-      "enum": ["ACTIVE", "SCHEDULING", "SCHEDULING_BLOCKED"]
+      "enum": [
+        "IDLE",
+        "SCHEDULING",
+        "SCHEDULING_BLOCKED"
+      ]
     },
     "QueueSummaries": {
       "type": "list",
@@ -8783,9 +9786,6 @@
         },
         "displayName": {
           "shape": "ResourceName"
-        },
-        "description": {
-          "shape": "Description"
         },
         "status": {
           "shape": "QueueStatus"
@@ -8825,7 +9825,11 @@
     },
     "ResourceNotFoundException": {
       "type": "structure",
-      "required": ["message", "resourceId", "resourceType"],
+      "required": [
+        "message",
+        "resourceId",
+        "resourceType"
+      ],
       "members": {
         "message": {
           "shape": "String"
@@ -8848,7 +9852,10 @@
     },
     "ResponseBudgetAction": {
       "type": "structure",
-      "required": ["type", "thresholdPercentage"],
+      "required": [
+        "type",
+        "thresholdPercentage"
+      ],
       "members": {
         "type": {
           "shape": "BudgetActionType"
@@ -8857,7 +9864,7 @@
           "shape": "ThresholdPercentage"
         },
         "description": {
-          "shape": "String"
+          "shape": "Description"
         }
       }
     },
@@ -8868,6 +9875,13 @@
       },
       "max": 10,
       "min": 0
+    },
+    "RunAs": {
+      "type": "string",
+      "enum": [
+        "QUEUE_CONFIGURED_USER",
+        "WORKER_AGENT_USER"
+      ]
     },
     "S3BucketName": {
       "type": "string",
@@ -8882,7 +9896,10 @@
     },
     "S3Location": {
       "type": "structure",
-      "required": ["bucketName", "key"],
+      "required": [
+        "bucketName",
+        "key"
+      ],
       "members": {
         "bucketName": {
           "shape": "S3BucketName"
@@ -8928,7 +9945,10 @@
     },
     "SearchGroupedFilterExpressions": {
       "type": "structure",
-      "required": ["filters", "operator"],
+      "required": [
+        "filters",
+        "operator"
+      ],
       "members": {
         "filters": {
           "shape": "SearchFilterExpressions"
@@ -8940,7 +9960,11 @@
     },
     "SearchJobsRequest": {
       "type": "structure",
-      "required": ["farmId", "queueIds", "itemOffset"],
+      "required": [
+        "farmId",
+        "queueIds",
+        "itemOffset"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -8991,7 +10015,10 @@
     },
     "SearchJobsResponse": {
       "type": "structure",
-      "required": ["jobs", "totalResults"],
+      "required": [
+        "jobs",
+        "totalResults"
+      ],
       "members": {
         "jobs": {
           "shape": "JobSearchSummaries"
@@ -9029,7 +10056,11 @@
     },
     "SearchStepsRequest": {
       "type": "structure",
-      "required": ["farmId", "queueIds", "itemOffset"],
+      "required": [
+        "farmId",
+        "queueIds",
+        "itemOffset"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -9083,7 +10114,10 @@
     },
     "SearchStepsResponse": {
       "type": "structure",
-      "required": ["steps", "totalResults"],
+      "required": [
+        "steps",
+        "totalResults"
+      ],
       "members": {
         "steps": {
           "shape": "StepSearchSummaries"
@@ -9098,7 +10132,11 @@
     },
     "SearchTasksRequest": {
       "type": "structure",
-      "required": ["farmId", "queueIds", "itemOffset"],
+      "required": [
+        "farmId",
+        "queueIds",
+        "itemOffset"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -9152,7 +10190,10 @@
     },
     "SearchTasksResponse": {
       "type": "structure",
-      "required": ["tasks", "totalResults"],
+      "required": [
+        "tasks",
+        "totalResults"
+      ],
       "members": {
         "tasks": {
           "shape": "TaskSearchSummaries"
@@ -9172,7 +10213,9 @@
     },
     "SearchTermFilterExpression": {
       "type": "structure",
-      "required": ["searchTerm"],
+      "required": [
+        "searchTerm"
+      ],
       "members": {
         "searchTerm": {
           "shape": "SearchTerm"
@@ -9181,7 +10224,11 @@
     },
     "SearchWorkersRequest": {
       "type": "structure",
-      "required": ["farmId", "fleetIds", "itemOffset"],
+      "required": [
+        "farmId",
+        "fleetIds",
+        "itemOffset"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -9232,7 +10279,10 @@
     },
     "SearchWorkersResponse": {
       "type": "structure",
-      "required": ["workers", "totalResults"],
+      "required": [
+        "workers",
+        "totalResults"
+      ],
       "members": {
         "workers": {
           "shape": "WorkerSearchSummaries"
@@ -9253,20 +10303,11 @@
       "type": "string",
       "pattern": "sg-[\\w]{1,120}"
     },
-    "SecurityGroupIdList": {
-      "type": "list",
-      "member": {
-        "shape": "SecurityGroupId"
-      },
-      "min": 1
-    },
     "ServiceManagedEc2FleetConfiguration": {
       "type": "structure",
       "required": [
         "instanceRequirements",
-        "instanceMarketOptions",
-        "minFleetSize",
-        "maxFleetSize"
+        "instanceMarketOptions"
       ],
       "members": {
         "instanceRequirements": {
@@ -9274,18 +10315,14 @@
         },
         "instanceMarketOptions": {
           "shape": "ServiceManagedEc2InstanceMarketOptions"
-        },
-        "minFleetSize": {
-          "shape": "MinZeroMaxInteger"
-        },
-        "maxFleetSize": {
-          "shape": "MinZeroMaxInteger"
         }
       }
     },
     "ServiceManagedEc2InstanceMarketOptions": {
       "type": "structure",
-      "required": ["type"],
+      "required": [
+        "type"
+      ],
       "members": {
         "type": {
           "shape": "Ec2MarketType"
@@ -9294,7 +10331,12 @@
     },
     "ServiceManagedEc2InstanceRequirements": {
       "type": "structure",
-      "required": ["vCpuCount", "memoryMiB", "osFamily", "cpuArchitectureType"],
+      "required": [
+        "vCpuCount",
+        "memoryMiB",
+        "osFamily",
+        "cpuArchitectureType"
+      ],
       "members": {
         "vCpuCount": {
           "shape": "VCpuCountRange"
@@ -9303,7 +10345,7 @@
           "shape": "MemoryMiBRange"
         },
         "osFamily": {
-          "shape": "OperatingSystemFamily"
+          "shape": "ServiceManagedFleetOperatingSystemFamily"
         },
         "cpuArchitectureType": {
           "shape": "CpuArchitectureType"
@@ -9324,6 +10366,13 @@
           "shape": "FleetAttributeCapabilityList"
         }
       }
+    },
+    "ServiceManagedFleetOperatingSystemFamily": {
+      "type": "string",
+      "enum": [
+        "windows",
+        "linux"
+      ]
     },
     "ServiceQuotaExceededException": {
       "type": "structure",
@@ -9365,7 +10414,10 @@
     },
     "ServiceQuotaExceededExceptionReason": {
       "type": "string",
-      "enum": ["SERVICE_QUOTA_EXCEEDED_EXCEPTION", "KMS_KEY_LIMIT_EXCEEDED"]
+      "enum": [
+        "SERVICE_QUOTA_EXCEEDED_EXCEPTION",
+        "KMS_KEY_LIMIT_EXCEEDED"
+      ]
     },
     "SessionActionDefinition": {
       "type": "structure",
@@ -9418,7 +10470,8 @@
     "SessionActionProgressMessage": {
       "type": "string",
       "max": 4096,
-      "min": 0
+      "min": 0,
+      "sensitive": true
     },
     "SessionActionProgressPercent": {
       "type": "float",
@@ -9436,7 +10489,10 @@
         "FAILED",
         "INTERRUPTED",
         "CANCELED",
-        "NEVER_ATTEMPTED"
+        "NEVER_ATTEMPTED",
+        "SCHEDULED",
+        "RECLAIMING",
+        "RECLAIMED"
       ]
     },
     "SessionActionSummaries": {
@@ -9447,7 +10503,11 @@
     },
     "SessionActionSummary": {
       "type": "structure",
-      "required": ["sessionActionId", "status", "definition"],
+      "required": [
+        "sessionActionId",
+        "status",
+        "definition"
+      ],
       "members": {
         "sessionActionId": {
           "shape": "SessionActionId"
@@ -9460,6 +10520,9 @@
         },
         "endedAt": {
           "shape": "EndedAt"
+        },
+        "updatedAt": {
+          "shape": "UpdatedAt"
         },
         "progressPercent": {
           "shape": "SessionActionProgressPercent"
@@ -9485,7 +10548,9 @@
     },
     "SessionLifecycleTargetStatus": {
       "type": "string",
-      "enum": ["ENDED"]
+      "enum": [
+        "ENDED"
+      ]
     },
     "SessionSummaries": {
       "type": "list",
@@ -9536,13 +10601,104 @@
       "type": "string",
       "sensitive": true
     },
+    "SessionsStatisticsAggregationStatus": {
+      "type": "string",
+      "enum": [
+        "IN_PROGRESS",
+        "TIMEOUT",
+        "FAILED",
+        "COMPLETED"
+      ]
+    },
+    "SessionsStatisticsResources": {
+      "type": "structure",
+      "members": {
+        "queueIds": {
+          "shape": "SessionsStatisticsResourcesQueueIdsList"
+        },
+        "fleetIds": {
+          "shape": "SessionsStatisticsResourcesFleetIdsList"
+        }
+      },
+      "union": true
+    },
+    "SessionsStatisticsResourcesFleetIdsList": {
+      "type": "list",
+      "member": {
+        "shape": "FleetId"
+      },
+      "max": 10,
+      "min": 1
+    },
+    "SessionsStatisticsResourcesQueueIdsList": {
+      "type": "list",
+      "member": {
+        "shape": "QueueId"
+      },
+      "max": 10,
+      "min": 1
+    },
     "SortOrder": {
       "type": "string",
-      "enum": ["ASCENDING", "DESCENDING"]
+      "enum": [
+        "ASCENDING",
+        "DESCENDING"
+      ]
     },
-    "SourceOs": {
-      "type": "string",
-      "enum": ["windows", "posix"]
+    "StartSessionsStatisticsAggregationRequest": {
+      "type": "structure",
+      "required": [
+        "farmId",
+        "resourceIds",
+        "startTime",
+        "endTime",
+        "groupBy",
+        "statistics"
+      ],
+      "members": {
+        "dryRun": {
+          "shape": "DryRun",
+          "location": "header",
+          "locationName": "X-Amz-Dryrun"
+        },
+        "farmId": {
+          "shape": "FarmId",
+          "location": "uri",
+          "locationName": "farmId"
+        },
+        "resourceIds": {
+          "shape": "SessionsStatisticsResources"
+        },
+        "startTime": {
+          "shape": "SyntheticTimestamp_date_time"
+        },
+        "endTime": {
+          "shape": "SyntheticTimestamp_date_time"
+        },
+        "timezone": {
+          "shape": "Timezone"
+        },
+        "period": {
+          "shape": "Period"
+        },
+        "groupBy": {
+          "shape": "UsageGroupBy"
+        },
+        "statistics": {
+          "shape": "UsageStatistics"
+        }
+      }
+    },
+    "StartSessionsStatisticsAggregationResponse": {
+      "type": "structure",
+      "required": [
+        "aggregationId"
+      ],
+      "members": {
+        "aggregationId": {
+          "shape": "String"
+        }
+      }
     },
     "StartedAt": {
       "type": "timestamp",
@@ -9554,7 +10710,11 @@
     },
     "Statistics": {
       "type": "structure",
-      "required": ["count", "costInUsd", "runtimeInSeconds"],
+      "required": [
+        "count",
+        "costInUsd",
+        "runtimeInSeconds"
+      ],
       "members": {
         "queueId": {
           "shape": "QueueId"
@@ -9633,7 +10793,9 @@
     },
     "StepAmountCapability": {
       "type": "structure",
-      "required": ["name"],
+      "required": [
+        "name"
+      ],
       "members": {
         "name": {
           "shape": "AmountCapabilityName"
@@ -9657,7 +10819,9 @@
     },
     "StepAttributeCapability": {
       "type": "structure",
-      "required": ["name"],
+      "required": [
+        "name"
+      ],
       "members": {
         "name": {
           "shape": "AttributeCapabilityName"
@@ -9672,7 +10836,10 @@
     },
     "StepConsumer": {
       "type": "structure",
-      "required": ["stepId", "status"],
+      "required": [
+        "stepId",
+        "status"
+      ],
       "members": {
         "stepId": {
           "shape": "StepId"
@@ -9696,7 +10863,10 @@
     },
     "StepDependency": {
       "type": "structure",
-      "required": ["stepId", "status"],
+      "required": [
+        "stepId",
+        "status"
+      ],
       "members": {
         "stepId": {
           "shape": "StepId"
@@ -9709,7 +10879,8 @@
     "StepDescription": {
       "type": "string",
       "max": 2048,
-      "min": 1
+      "min": 1,
+      "sensitive": true
     },
     "StepDetailsEntity": {
       "type": "structure",
@@ -9740,7 +10911,12 @@
     },
     "StepDetailsError": {
       "type": "structure",
-      "required": ["jobId", "stepId", "code", "message"],
+      "required": [
+        "jobId",
+        "stepId",
+        "code",
+        "message"
+      ],
       "members": {
         "jobId": {
           "shape": "JobId"
@@ -9758,7 +10934,10 @@
     },
     "StepDetailsIdentifiers": {
       "type": "structure",
-      "required": ["jobId", "stepId"],
+      "required": [
+        "jobId",
+        "stepId"
+      ],
       "members": {
         "jobId": {
           "shape": "JobId"
@@ -9788,7 +10967,10 @@
     },
     "StepParameter": {
       "type": "structure",
-      "required": ["name", "type"],
+      "required": [
+        "name",
+        "type"
+      ],
       "members": {
         "name": {
           "shape": "StepParameterName"
@@ -9811,11 +10993,19 @@
     },
     "StepParameterType": {
       "type": "string",
-      "enum": ["INT", "FLOAT", "STRING", "PATH"]
+      "enum": [
+        "INT",
+        "FLOAT",
+        "STRING",
+        "PATH"
+      ]
     },
     "StepRequiredCapabilities": {
       "type": "structure",
-      "required": ["attributes", "amounts"],
+      "required": [
+        "attributes",
+        "amounts"
+      ],
       "members": {
         "attributes": {
           "shape": "StepAttributeCapabilities"
@@ -9902,6 +11092,9 @@
         "lifecycleStatus": {
           "shape": "StepLifecycleStatus"
         },
+        "lifecycleStatusMessage": {
+          "shape": "String"
+        },
         "taskRunStatus": {
           "shape": "TaskRunStatus"
         },
@@ -9936,11 +11129,25 @@
     },
     "StepTargetTaskRunStatus": {
       "type": "string",
-      "enum": ["READY", "FAILED", "SUCCEEDED", "CANCELED", "SUSPENDED"]
+      "enum": [
+        "READY",
+        "FAILED",
+        "SUCCEEDED",
+        "CANCELED",
+        "SUSPENDED"
+      ]
     },
     "StorageProfileId": {
       "type": "string",
       "pattern": "sp-[0-9a-f]{32}"
+    },
+    "StorageProfileOperatingSystemFamily": {
+      "type": "string",
+      "enum": [
+        "windows",
+        "linux",
+        "macos"
+      ]
     },
     "StorageProfileSummaries": {
       "type": "list",
@@ -9950,7 +11157,11 @@
     },
     "StorageProfileSummary": {
       "type": "structure",
-      "required": ["storageProfileId", "displayName", "osFamily"],
+      "required": [
+        "storageProfileId",
+        "displayName",
+        "osFamily"
+      ],
       "members": {
         "storageProfileId": {
           "shape": "StorageProfileId"
@@ -9959,7 +11170,7 @@
           "shape": "ResourceName"
         },
         "osFamily": {
-          "shape": "OperatingSystemFamily"
+          "shape": "StorageProfileOperatingSystemFamily"
         }
       }
     },
@@ -9973,7 +11184,11 @@
     },
     "StringFilterExpression": {
       "type": "structure",
-      "required": ["name", "operator", "value"],
+      "required": [
+        "name",
+        "operator",
+        "value"
+      ],
       "members": {
         "name": {
           "shape": "String"
@@ -10003,13 +11218,6 @@
       "min": 1,
       "pattern": "subnet-[\\w]{1,120}"
     },
-    "SubnetIdList": {
-      "type": "list",
-      "member": {
-        "shape": "SubnetId"
-      },
-      "min": 1
-    },
     "SyncInputJobAttachmentsSessionActionDefinition": {
       "type": "structure",
       "members": {
@@ -10032,7 +11240,9 @@
     },
     "TagResourceRequest": {
       "type": "structure",
-      "required": ["resourceArn"],
+      "required": [
+        "resourceArn"
+      ],
       "members": {
         "resourceArn": {
           "shape": "String",
@@ -10077,6 +11287,7 @@
           "shape": "PathString"
         }
       },
+      "sensitive": true,
       "union": true
     },
     "TaskParameters": {
@@ -10086,7 +11297,8 @@
       },
       "value": {
         "shape": "TaskParameterValue"
-      }
+      },
+      "sensitive": true
     },
     "TaskRetryCount": {
       "type": "integer",
@@ -10096,7 +11308,11 @@
     },
     "TaskRunSessionActionDefinition": {
       "type": "structure",
-      "required": ["taskId", "stepId", "parameters"],
+      "required": [
+        "taskId",
+        "stepId",
+        "parameters"
+      ],
       "members": {
         "taskId": {
           "shape": "TaskId"
@@ -10111,7 +11327,10 @@
     },
     "TaskRunSessionActionDefinitionSummary": {
       "type": "structure",
-      "required": ["taskId", "stepId"],
+      "required": [
+        "taskId",
+        "stepId"
+      ],
       "members": {
         "taskId": {
           "shape": "TaskId"
@@ -10127,13 +11346,15 @@
         "PENDING",
         "READY",
         "ASSIGNED",
+        "STARTING",
         "SCHEDULED",
         "INTERRUPTING",
         "RUNNING",
         "SUSPENDED",
         "CANCELED",
         "FAILED",
-        "SUCCEEDED"
+        "SUCCEEDED",
+        "NOT_COMPATIBLE"
       ]
     },
     "TaskRunStatusCounts": {
@@ -10175,7 +11396,7 @@
         "parameters": {
           "shape": "TaskParameters"
         },
-        "retryCount": {
+        "failureRetryCount": {
           "shape": "TaskRetryCount"
         },
         "startedAt": {
@@ -10194,7 +11415,12 @@
     },
     "TaskSummary": {
       "type": "structure",
-      "required": ["taskId", "createdAt", "createdBy", "runStatus"],
+      "required": [
+        "taskId",
+        "createdAt",
+        "createdBy",
+        "runStatus"
+      ],
       "members": {
         "taskId": {
           "shape": "TaskId"
@@ -10211,7 +11437,7 @@
         "targetRunStatus": {
           "shape": "TaskTargetRunStatus"
         },
-        "retryCount": {
+        "failureRetryCount": {
           "shape": "TaskRetryCount"
         },
         "parameters": {
@@ -10236,7 +11462,13 @@
     },
     "TaskTargetRunStatus": {
       "type": "string",
-      "enum": ["READY", "FAILED", "SUCCEEDED", "CANCELED", "SUSPENDED"]
+      "enum": [
+        "READY",
+        "FAILED",
+        "SUCCEEDED",
+        "CANCELED",
+        "SUSPENDED"
+      ]
     },
     "ThresholdPercentage": {
       "type": "float",
@@ -10246,7 +11478,9 @@
     },
     "ThrottlingException": {
       "type": "structure",
-      "required": ["message"],
+      "required": [
+        "message"
+      ],
       "members": {
         "message": {
           "shape": "String"
@@ -10275,6 +11509,12 @@
         "throttling": true
       }
     },
+    "Timezone": {
+      "type": "string",
+      "max": 9,
+      "min": 9,
+      "pattern": "UTC[-+][01][0-9]:(30|00)"
+    },
     "TotalResults": {
       "type": "integer",
       "box": true,
@@ -10283,7 +11523,10 @@
     },
     "UntagResourceRequest": {
       "type": "structure",
-      "required": ["resourceArn", "tagKeys"],
+      "required": [
+        "resourceArn",
+        "tagKeys"
+      ],
       "members": {
         "resourceArn": {
           "shape": "String",
@@ -10303,7 +11546,10 @@
     },
     "UpdateBudgetRequest": {
       "type": "structure",
-      "required": ["farmId", "budgetId"],
+      "required": [
+        "farmId",
+        "budgetId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -10335,7 +11581,7 @@
         "status": {
           "shape": "BudgetStatus"
         },
-        "approximateDollarsLimit": {
+        "approximateDollarLimit": {
           "shape": "ConsumedUsageLimit"
         },
         "actionsToAdd": {
@@ -10355,7 +11601,9 @@
     },
     "UpdateFarmRequest": {
       "type": "structure",
-      "required": ["farmId"],
+      "required": [
+        "farmId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -10384,7 +11632,10 @@
     },
     "UpdateFleetRequest": {
       "type": "structure",
-      "required": ["farmId", "fleetId"],
+      "required": [
+        "farmId",
+        "fleetId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -10416,6 +11667,12 @@
         "roleArn": {
           "shape": "IamRoleArn"
         },
+        "minWorkerCount": {
+          "shape": "MinZeroMaxInteger"
+        },
+        "maxWorkerCount": {
+          "shape": "MinZeroMaxInteger"
+        },
         "configuration": {
           "shape": "FleetConfiguration"
         }
@@ -10425,9 +11682,19 @@
       "type": "structure",
       "members": {}
     },
+    "UpdateJobLifecycleStatus": {
+      "type": "string",
+      "enum": [
+        "ARCHIVED"
+      ]
+    },
     "UpdateJobRequest": {
       "type": "structure",
-      "required": ["farmId", "queueId", "jobId"],
+      "required": [
+        "farmId",
+        "queueId",
+        "jobId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -10466,6 +11733,9 @@
         },
         "maxRetriesPerTask": {
           "shape": "MaxRetriesPerTask"
+        },
+        "lifecycleStatus": {
+          "shape": "UpdateJobLifecycleStatus"
         }
       }
     },
@@ -10475,7 +11745,11 @@
     },
     "UpdateQueueEnvironmentRequest": {
       "type": "structure",
-      "required": ["farmId", "queueId", "queueEnvironmentId"],
+      "required": [
+        "farmId",
+        "queueId",
+        "queueEnvironmentId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -10520,7 +11794,12 @@
     },
     "UpdateQueueFleetAssociationRequest": {
       "type": "structure",
-      "required": ["farmId", "queueId", "fleetId", "status"],
+      "required": [
+        "farmId",
+        "queueId",
+        "fleetId",
+        "status"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -10549,7 +11828,9 @@
     },
     "UpdateQueueFleetAssociationResponse": {
       "type": "structure",
-      "required": ["status"],
+      "required": [
+        "status"
+      ],
       "members": {
         "status": {
           "shape": "QueueFleetAssociationStatus"
@@ -10558,7 +11839,10 @@
     },
     "UpdateQueueRequest": {
       "type": "structure",
-      "required": ["farmId", "queueId"],
+      "required": [
+        "farmId",
+        "queueId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -10587,9 +11871,6 @@
         "description": {
           "shape": "Description"
         },
-        "status": {
-          "shape": "QueueStatus"
-        },
         "defaultBudgetAction": {
           "shape": "DefaultQueueBudgetAction"
         },
@@ -10599,8 +11880,8 @@
         "roleArn": {
           "shape": "IamRoleArn"
         },
-        "jobsRunAs": {
-          "shape": "JobsRunAs"
+        "jobRunAsUser": {
+          "shape": "JobRunAsUser"
         },
         "requiredFileSystemLocationNamesToAdd": {
           "shape": "RequiredFileSystemLocationNames"
@@ -10722,7 +12003,10 @@
     },
     "UpdateStorageProfileRequest": {
       "type": "structure",
-      "required": ["farmId", "storageProfileId"],
+      "required": [
+        "farmId",
+        "storageProfileId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -10749,7 +12033,7 @@
           "shape": "ResourceName"
         },
         "osFamily": {
-          "shape": "OperatingSystemFamily"
+          "shape": "StorageProfileOperatingSystemFamily"
         },
         "fileSystemLocationsToAdd": {
           "shape": "FileSystemLocationsList"
@@ -10821,7 +12105,11 @@
     },
     "UpdateWorkerRequest": {
       "type": "structure",
-      "required": ["farmId", "fleetId", "workerId"],
+      "required": [
+        "farmId",
+        "fleetId",
+        "workerId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -10843,7 +12131,7 @@
           "location": "uri",
           "locationName": "workerId"
         },
-        "targetStatus": {
+        "status": {
           "shape": "UpdatedWorkerStatus"
         },
         "capabilities": {
@@ -10869,7 +12157,11 @@
     },
     "UpdateWorkerScheduleRequest": {
       "type": "structure",
-      "required": ["farmId", "fleetId", "workerId"],
+      "required": [
+        "farmId",
+        "fleetId",
+        "workerId"
+      ],
       "members": {
         "dryRun": {
           "shape": "DryRun",
@@ -10943,7 +12235,7 @@
         "endedAt": {
           "shape": "SyntheticTimestamp_date_time"
         },
-        "updateTime": {
+        "updatedAt": {
           "shape": "SyntheticTimestamp_date_time"
         },
         "progressPercent": {
@@ -10962,7 +12254,11 @@
     },
     "UpdatedWorkerStatus": {
       "type": "string",
-      "enum": ["STARTED", "STOPPING", "STOPPED"]
+      "enum": [
+        "STARTED",
+        "STOPPING",
+        "STOPPED"
+      ]
     },
     "UsageGroupBy": {
       "type": "list",
@@ -10986,7 +12282,12 @@
     },
     "UsageStatistic": {
       "type": "string",
-      "enum": ["SUM", "MIN", "MAX", "AVG"]
+      "enum": [
+        "SUM",
+        "MIN",
+        "MAX",
+        "AVG"
+      ]
     },
     "UsageStatistics": {
       "type": "list",
@@ -11007,14 +12308,19 @@
     },
     "UsageType": {
       "type": "string",
-      "enum": ["COMPUTE", "LICENSE"]
+      "enum": [
+        "COMPUTE",
+        "LICENSE"
+      ]
     },
     "UserId": {
       "type": "string"
     },
     "UserJobsFirst": {
       "type": "structure",
-      "required": ["userIdentityId"],
+      "required": [
+        "userIdentityId"
+      ],
       "members": {
         "userIdentityId": {
           "shape": "String"
@@ -11023,7 +12329,9 @@
     },
     "VCpuCountRange": {
       "type": "structure",
-      "required": ["min"],
+      "required": [
+        "min"
+      ],
       "members": {
         "min": {
           "shape": "MinOneMaxTenThousand"
@@ -11035,7 +12343,10 @@
     },
     "ValidationException": {
       "type": "structure",
-      "required": ["message", "reason"],
+      "required": [
+        "message",
+        "reason"
+      ],
       "members": {
         "message": {
           "shape": "String"
@@ -11058,7 +12369,10 @@
     },
     "ValidationExceptionField": {
       "type": "structure",
-      "required": ["name", "message"],
+      "required": [
+        "name",
+        "message"
+      ],
       "members": {
         "name": {
           "shape": "String"
@@ -11091,7 +12405,10 @@
     },
     "WorkerAmountCapability": {
       "type": "structure",
-      "required": ["name", "value"],
+      "required": [
+        "name",
+        "value"
+      ],
       "members": {
         "name": {
           "shape": "AmountCapabilityName"
@@ -11111,7 +12428,10 @@
     },
     "WorkerAttributeCapability": {
       "type": "structure",
-      "required": ["name", "values"],
+      "required": [
+        "name",
+        "values"
+      ],
       "members": {
         "name": {
           "shape": "AttributeCapabilityName"
@@ -11131,7 +12451,10 @@
     },
     "WorkerCapabilities": {
       "type": "structure",
-      "required": ["amounts", "attributes"],
+      "required": [
+        "amounts",
+        "attributes"
+      ],
       "members": {
         "amounts": {
           "shape": "WorkerAmountCapabilityList"
@@ -11143,7 +12466,9 @@
     },
     "WorkerEc2Metadata": {
       "type": "structure",
-      "required": ["instanceType"],
+      "required": [
+        "instanceType"
+      ],
       "members": {
         "instanceType": {
           "shape": "InstanceType"
@@ -11171,7 +12496,6 @@
     },
     "WorkerSearchSummary": {
       "type": "structure",
-      "required": ["createdBy", "createdAt"],
       "members": {
         "fleetId": {
           "shape": "FleetId"
@@ -11196,6 +12520,39 @@
         },
         "updatedAt": {
           "shape": "UpdatedAt"
+        }
+      }
+    },
+    "WorkerSessionSummary": {
+      "type": "structure",
+      "required": [
+        "sessionId",
+        "queueId",
+        "jobId",
+        "startedAt",
+        "lifecycleStatus"
+      ],
+      "members": {
+        "sessionId": {
+          "shape": "SessionId"
+        },
+        "queueId": {
+          "shape": "QueueId"
+        },
+        "jobId": {
+          "shape": "JobId"
+        },
+        "startedAt": {
+          "shape": "StartedAt"
+        },
+        "lifecycleStatus": {
+          "shape": "SessionLifecycleStatus"
+        },
+        "endedAt": {
+          "shape": "EndedAt"
+        },
+        "targetLifecycleStatus": {
+          "shape": "SessionLifecycleTargetStatus"
         }
       }
     },

--- a/test/unit/deadline_job_attachments/test_upload.py
+++ b/test/unit/deadline_job_attachments/test_upload.py
@@ -43,7 +43,7 @@ from deadline.job_attachments.models import (
     FileSystemLocationType,
     ManifestProperties,
     JobAttachmentS3Settings,
-    OperatingSystemFamily,
+    StorageProfileOperatingSystemFamily,
     PathFormat,
     StorageProfile,
 )
@@ -1928,7 +1928,7 @@ class TestUpload:
         mock_storage_profile_for_queue = StorageProfile(
             storageProfileId="sp-0123456789",
             displayName="Storage profile 1",
-            osFamily=OperatingSystemFamily.WINDOWS,
+            osFamily=StorageProfileOperatingSystemFamily.WINDOWS,
             fileSystemLocations=mock_file_system_locations,
         )
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The class named `OperatingSystemFamily`, used for specifying the OS family of `StorageProfile`, had a name that was too generic. 

### What was the solution? (How)
The `OperatingSystemFamily` Enum class was renamed to `StorageProfileOperatingSystemFamily` to provide clearer context within the `StorageProfile`.

### What is the impact of this change?
Makes it clearer what the enum pertains to.

### How was this change tested?
- Ran both unit tests and integ tests to ensure everything passed successfully.
- Verified that job submissions to the Farm/Queue that has Storage Profiles (for both Linux and Windows), and output downloads work correctly without any failures.

### Was this change documented?
No.

### Is this a breaking change?
This class doesn't seem to be used in any other packages (such as `deadline-cloud-worker-agent` and `deadline-cloud-*` packages) other than this one, but since the class name was changed, I think this change could be a breaking change. 