### PR TITLE
fix(job_attachment)!: use username instead of group for Windows file permissions setting

### DIFF
--- a/scripted_tests/set_file_permission_for_windows.py
+++ b/scripted_tests/set_file_permission_for_windows.py
@@ -12,33 +12,33 @@ import win32security
 from deadline.job_attachments.os_file_permission import (
     WindowsFileSystemPermissionSettings,
     WindowsPermissionEnum,
-    _set_fs_group_for_windows,
+    _set_fs_permission_for_windows,
 )
 
 """
-This script is to test a `_set_fs_group_for_windows()` function in Job Attachment module,
-which is for setting file permissions and group ownership on Windows.
+This script is to test a `_set_fs_permission_for_windows()` function in Job Attachment module,
+which is for setting file permissions and ownership on Windows.
 
 Prerequisites
 -------------
-Before running the test, prepare the target group, target user (a user who is a member of
-the target group), and disjoint user (not a member of the target group.)
+Before running the test, prepare a target user and a disjoint user.
 
 How to Run
 ----------
 To execute this script, run the following command from the root location:
 python ./scripted_tests/set_file_permission_for_windows.py \
     -n <the_number_of_files_to_create_for_test> \
-    -g <target_group_name> \
-    -f <file_permission> -d <directory_permission> \
-    -u <target_user_name> -du <disjoint_user_name>
+    -f <file_permission> \
+    -d <directory_permission> \
+    -u <target_user_name> \
+    -du <disjoint_user_name>
 
 Note: The `-f` and `-d` flags are optional.
 
 Then, the command will do the following:
 1. Installs `pywin32`, which is a required package for the testing.
 2. Creates a temporary directory and creates the specified number of files in it.
-2. The script will add the given target group to the owner list for the specified files.
+2. The script will add the given target user to the owner list for the specified files.
 3. It will then verify (1) whether the target user has Read/Write access to these files,
    and (2) that the disjoint user does not have access.
 
@@ -60,7 +60,6 @@ End of test execution.
 def run_test():
     parser = argparse.ArgumentParser()
     parser.add_argument("-n", "--num_files", type=int, required=True)
-    parser.add_argument("-g", "--group", required=True, type=str)
     parser.add_argument("-f", "--file_permission", required=False, type=str, default="FULL_CONTROL")
     parser.add_argument("-d", "--dir_permission", required=False, type=str, default="FULL_CONTROL")
     parser.add_argument("-u", "--target_user", required=True, type=str)
@@ -90,21 +89,20 @@ def run_test():
             files.append(str(file_path))
 
         print("Temporary files created.")
-        print("Running test: Setting file permissions and group ownership...")
+        print("Running test: Setting file permissions...")
         start_time = time.perf_counter()
 
         fs_permission_settings = WindowsFileSystemPermissionSettings(
             os_user=args.target_user,
-            os_group=args.group,
             dir_mode=dir_permission,
             file_mode=file_permission,
         )
-        _set_fs_group_for_windows(
+        _set_fs_permission_for_windows(
             file_paths=files,
             local_root=temp_root_dir,
             fs_permission_settings=fs_permission_settings,
         )
-        print("File permissions and group ownership set.")
+        print("File permissions set.")
         print(f"Total running time for {num_files} files: {time.perf_counter() - start_time}")
 
         print("Checking file permissions...")

--- a/src/deadline/job_attachments/download.py
+++ b/src/deadline/job_attachments/download.py
@@ -56,7 +56,7 @@ from .os_file_permission import (
     PosixFileSystemPermissionSettings,
     WindowsFileSystemPermissionSettings,
     _set_fs_group_for_posix,
-    _set_fs_group_for_windows,
+    _set_fs_permission_for_windows,
 )
 from ._utils import _is_relative_to, _join_s3_paths
 
@@ -791,7 +791,7 @@ def _set_fs_group(
     else:  # if os.name is not "posix"
         if not isinstance(fs_permission_settings, WindowsFileSystemPermissionSettings):
             raise TypeError("The file system permission settings must be specific to Windows.")
-        _set_fs_group_for_windows(
+        _set_fs_permission_for_windows(
             file_paths=file_paths,
             local_root=local_root,
             fs_permission_settings=fs_permission_settings,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The use of group names in permission settings for Windows file system was identified as unnecessary for our needs. Windows uses [ACLs](https://learn.microsoft.com/en-us/windows/win32/secauthz/access-control-lists) for controlling access to directories and files, and it offers flexibility to assign specific permissions directly to individual trustees (users), so the use of group name seemed to be redundant.

### What was the solution? (How)
1. In the `WindowsFileSystemPermissionSettings` class, made the `os_group` field Optional.
   - Later, once the Worker Agent that instantiate this class ([here](https://github.com/casillas2/deadline-cloud-worker-agent/blob/04448d558714b99c99cd70026646887a9ddeaa09/src/deadline_worker_agent/sessions/session.py#L845)) is updated to not pass the `os_group` field, we can completely remove this optional field from Job Attachment code.
3. Updated the permission setting logic to use usernames instead of group names for ACL settings.

### What is the impact of this change?
This change simplifies the permission setting process in Windows by removing unnecessary `os_group`.

### How was this change tested?
- Unit tests: fix a few existing tests to accommodate the changes, ensuring all tests passed.
- Scripted test: run [scripted_tests/set_file_permission_for_windows.py](https://github.com/casillas2/deadline-cloud/blob/mainline/scripted_tests/set_file_permission_for_windows.py) to verify that the specified permissions were correctly applied to files, with the permissions being granted to the specified user.

### Was this change documented?
Yes, we have a written document that justifies this change.

### Is this a breaking change?
No.
