### PR TITLE
feat: keep standalone gui open after submission

### DIFF
--- a/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
@@ -483,5 +483,7 @@ class SubmitJobToDeadlineDialog(QDialog):
             job_progress_dialog.close()
 
         if self.create_job_response:
-            # Close the submitter window to signal the submission is done
-            self.close()
+            # Close the submitter window to signal the submission is done but
+            # keep the standalone gui submitter open
+            if settings.submitter_name != "JobBundle":
+                self.close()


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The standalone gui to submit from closes after each submission. This makes it hard to iterate and submit multiple jobs while varying the parameters for a job bundle without having to reopen each time.
### What was the solution? (How)
Added a check to only close the submission dialog if the submitter is not the standalone "JobBundle" submitter.
### What is the impact of this change?
- Standalone job bundle submitter will stay open after submissions
- Other submitters will still close after submission
### How was this change tested?
- Submitted a job from the standalone submitter and verified it stayed open and could be used for another submission after
- Ran the Nuke submitter using my changes to this package and verified that it still closed after submission
### Was this change documented?
No
### Is this a breaking change?
Shouldn't be