### PR TITLE
fix(job_attachments): improvements to nonvalid error messages

### DIFF
--- a/src/deadline/job_attachments/_aws/aws_clients.py
+++ b/src/deadline/job_attachments/_aws/aws_clients.py
@@ -94,7 +94,7 @@ def get_s3_max_pool_connections() -> int:
         ) from ve
     if s3_max_pool_connections <= 0:
         raise AssetSyncError(
-            f"s3_max_pool_connections ({s3_max_pool_connections}) must be positive integer."
+            f"Nonvalid value for configuration setting: 's3_max_pool_connections' ({s3_max_pool_connections}) must be positive integer."
         )
     return s3_max_pool_connections
 

--- a/src/deadline/job_attachments/upload.py
+++ b/src/deadline/job_attachments/upload.py
@@ -123,13 +123,13 @@ class S3AssetUploader:
         # Confirm that the settings values are all positive.
         error_msg = ""
         if small_file_threshold_multiplier <= 0:
-            error_msg = f"small_file_threshold_multiplier ({small_file_threshold_multiplier}) must be positive integer."
+            error_msg = f"'small_file_threshold_multiplier' ({small_file_threshold_multiplier}) must be positive integer."
         elif s3_max_pool_connections <= 0:
             error_msg = (
-                f"s3_max_pool_connections ({s3_max_pool_connections}) must be positive integer."
+                f"'s3_max_pool_connections' ({s3_max_pool_connections}) must be positive integer."
             )
         if error_msg:
-            raise AssetSyncError("Invalid value for configuration setting: " + error_msg)
+            raise AssetSyncError("Nonvalid value for configuration setting: " + error_msg)
 
     def upload_assets(
         self,

--- a/test/unit/deadline_job_attachments/test_upload.py
+++ b/test/unit/deadline_job_attachments/test_upload.py
@@ -1278,37 +1278,50 @@ class TestUpload:
         assert "Failed to parse configuration settings." in str(err.value)
 
     @pytest.mark.parametrize(
-        "setting_name, invalid_value",
+        "setting_name, nonvalid_value, expected_error_msg",
         [
             pytest.param(
                 "s3_max_pool_connections",
                 "-100",
-                id="Invalid s3_max_pool_connections value: negative",
+                "'s3_max_pool_connections' (-100) must be positive integer.",
+                id="s3_max_pool_connections value is negative.",
             ),
             pytest.param(
                 "s3_max_pool_connections",
                 "0",
-                id="Invalid s3_max_pool_connections value: 0",
+                "'s3_max_pool_connections' (0) must be positive integer.",
+                id="s3_max_pool_connections value is 0.",
+            ),
+            pytest.param(
+                "s3_max_pool_connections",
+                "some string",
+                "Failed to parse configuration settings. Please ensure that the following settings in the config file are integers",
+                id="s3_max_pool_connections value is not a number.",
             ),
             pytest.param(
                 "small_file_threshold_multiplier",
                 "-12",
-                id="Invalid small_file_threshold_multiplier value: negative",
+                "'small_file_threshold_multiplier' (-12) must be positive integer.",
+                id="small_file_threshold_multiplier value is negative.",
+            ),
+            pytest.param(
+                "small_file_threshold_multiplier",
+                "some string",
+                "Failed to parse configuration settings. Please ensure that the following settings in the config file are integers",
+                id="small_file_threshold_multiplier value is not a number.",
             ),
         ],
     )
-    def test_asset_uploader_constructor_with_invalid_config_settings(
-        self, setting_name, invalid_value, fresh_deadline_config
+    def test_asset_uploader_constructor_with_nonvalid_config_settings(
+        self, setting_name, nonvalid_value, expected_error_msg, fresh_deadline_config
     ):
         """
-        Tests that when the asset uploader is created with invalid config settings, an AssetSyncError is raised.
+        Tests that when the asset uploader is created with nonvalid config settings, an AssetSyncError is raised.
         """
-        config.set_setting(f"settings.{setting_name}", invalid_value)
+        config.set_setting(f"settings.{setting_name}", nonvalid_value)
         with pytest.raises(AssetSyncError) as err:
             _ = S3AssetUploader()
-        assert (
-            f"Invalid value for configuration setting: {setting_name} ({invalid_value}) must be positive integer."
-        ) in str(err.value)
+        assert expected_error_msg in str(err.value)
 
     @mock_sts
     def test_file_already_uploaded_bucket_in_different_account(self):


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We noticed a flaky unit test in the job attachments part of the package: https://github.com/casillas2/deadline-cloud/actions/runs/8165059251/job/22321551354
The reason it was flakey is because (I think) it sometimes throw this [AssetSyncError](https://github.com/casillas2/deadline-cloud/blob/66126a1864dfed81e7c8b3187c1fe51090d23731/src/deadline/job_attachments/upload.py#L132), and sometimes it throws this [AssetSyncError](https://github.com/casillas2/deadline-cloud/blob/66126a1864dfed81e7c8b3187c1fe51090d23731/src/deadline/job_attachments/_aws/aws_clients.py#L96) from different place, and the former includes the phrase “Invalid value for configuration setting: ” in the error message, but the latter does not. So it can fail in the [assert](https://github.com/casillas2/deadline-cloud/blob/66126a1864dfed81e7c8b3187c1fe51090d23731/test/unit/deadline_job_attachments/test_upload.py#L1310) that checks if the phrase is included in the error message.

### What was the solution? (How)
1. Added the phrase "Nonvalid value for configuration setting: ” in the AssetSyncError thrown by the `get_s3_max_pool_connections()`.
2. Added a couple more test cases.
3. Fixed the term "invalid" to "nonvalid" to avoid using non-Inclusive language.

### What is the impact of this change?
The tests should be less flaky.

### How was this change tested?
Ran `hatch run lint && hatch run test` and made sure all passed.

### Was this change documented?
No.

### Is this a breaking change?
No.