### PR TITLE
feat: Adds common data to telemetry events

### DIFF
--- a/src/deadline/client/api/_submit_job_bundle.py
+++ b/src/deadline/client/api/_submit_job_bundle.py
@@ -276,6 +276,11 @@ def create_job_from_job_bundle(
     if logging.DEBUG >= logger.getEffectiveLevel():
         logger.debug(json.dumps(create_job_args, indent=1))
 
+    api.get_deadline_cloud_library_telemetry_client().record_event(
+        event_type="com.amazon.rum.deadline.submission",
+        event_details={},
+    )
+
     create_job_response = deadline.create_job(**create_job_args)
     logger.debug(f"CreateJob Response {create_job_response}")
 
@@ -300,6 +305,10 @@ def create_job_from_job_bundle(
             job_id,
             deadline,
             create_job_result_callback,
+        )
+
+        api.get_deadline_cloud_library_telemetry_client().record_event(
+            event_type="com.amazon.rum.deadline.create_job", event_details={"is_success": success}
         )
 
         if not success:

--- a/src/deadline/client/cli/_groups/bundle_group.py
+++ b/src/deadline/client/cli/_groups/bundle_group.py
@@ -191,6 +191,12 @@ def bundle_submit(
         raise DeadlineOperationError(
             f"Failed to submit the job bundle to Amazon Deadline Cloud:\n{exc}"
         ) from exc
+    except Exception as exc:
+        api.get_deadline_cloud_library_telemetry_client().record_error(
+            event_details={"exception_scope": "on_submit"},
+            exception_type=str(type(exc)),
+        )
+        raise
 
 
 @cli_bundle.command(name="gui-submit")

--- a/src/deadline/client/ui/dialogs/submit_job_progress_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_progress_dialog.py
@@ -509,7 +509,9 @@ class SubmitJobProgressDialog(QDialog):
         job creation has finished.
         """
         api.get_deadline_cloud_library_telemetry_client().record_event(
-            event_type="com.amazon.rum.deadline.create_job", event_details={"is_success": success}
+            event_type="com.amazon.rum.deadline.create_job",
+            event_details={"is_success": success},
+            from_gui=True,
         )
 
         if success:

--- a/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
@@ -457,6 +457,7 @@ class SubmitJobToDeadlineDialog(QDialog):
                 event_details={
                     "submitter_name": settings.submitter_name,
                 },
+                from_gui=True,
             )
 
             self.create_job_response = job_progress_dialog.start_submission(
@@ -476,8 +477,9 @@ class SubmitJobToDeadlineDialog(QDialog):
         except Exception as exc:
             logger.exception("error submitting job")
             api.get_deadline_cloud_library_telemetry_client().record_error(
-                event_details={"submitter_name": settings.submitter_name},
+                event_details={"exception_scope": "on_submit"},
                 exception_type=str(type(exc)),
+                from_gui=True,
             )
             QMessageBox.warning(self, f"{settings.submitter_name} Job Submission", str(exc))
             job_progress_dialog.close()

--- a/test/unit/deadline_client/api/test_api_telemetry.py
+++ b/test/unit/deadline_client/api/test_api_telemetry.py
@@ -24,7 +24,7 @@ def fixture_telemetry_client(fresh_deadline_config):
         side_effect=[("user-id", "identity-store-id")],
     ):
         return TelemetryClient(
-            "test-library", "0.1.2.1234", config=config.config_file.read_config()
+            "deadline-cloud-library", "0.1.2.1234", config=config.config_file.read_config()
         )
 
 
@@ -170,7 +170,11 @@ def test_record_error(telemetry_client):
     queue_mock = MagicMock()
     test_error_details = {"some_field": "some_value"}
     test_exc = Exception("some exception")
-    expected_event_details = {"some_field": "some_value", "exception_type": str(type(test_exc))}
+    expected_event_details = {
+        "some_field": "some_value",
+        "exception_type": str(type(test_exc)),
+        "usage_mode": "CLI",
+    }
     expected_event = TelemetryEvent(
         event_type="com.amazon.rum.deadline.error", event_details=expected_event_details
     )


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We need to refine our telemetry metrics to better isolate events.

### What was the solution? (How)
Be more descriptive of event types, and add common data that is included in every request (the intent is to capture package versions of other libraries that use this library, such as our integrated submitters and adaptors)

See these other PRs for how we'll build off of these changes:
- https://github.com/casillas2/deadline-cloud-for-nuke/pull/103
- https://github.com/casillas2/deadline-cloud-worker-agent/pull/203

### What is the impact of this change?
We can more clearly pinpoint what kind of flows users are using, and on what versions of our software they are using.

### How was this change tested?
Manually tested against my own deployment, confirmed test data showed up.

### Was this change documented?
N/A

### Is this a breaking change?
No