### PR TITLE
fix(job_attachments)!: remove local storage of manifest files

### DIFF
--- a/requirements-integ-testing.txt
+++ b/requirements-integ-testing.txt
@@ -1,1 +1,1 @@
-deadline-cloud-test-fixtures ~= 0.5.0
+deadline-cloud-test-fixtures ~= 0.5.5

--- a/scripted_tests/upload_scale_test.py
+++ b/scripted_tests/upload_scale_test.py
@@ -8,7 +8,6 @@ import sys
 import time
 
 from deadline.job_attachments._aws.deadline import get_queue
-from deadline.job_attachments.asset_manifests.decode import decode_manifest
 from deadline.job_attachments.download import download_files_from_manifests, get_manifest_from_s3
 from deadline.job_attachments.models import S3_MANIFEST_FOLDER_NAME
 from deadline.job_attachments.upload import S3AssetManager
@@ -132,9 +131,10 @@ if __name__ == "__main__":
         print("\nStarting download test...")
         start = time.perf_counter()
         manifest_key = f"{queue.jobAttachmentSettings.rootPrefix}/{S3_MANIFEST_FOLDER_NAME}/{attachment_settings.manifests[0].inputManifestPath}"
-        manifest = get_manifest_from_s3(manifest_key, queue.jobAttachmentSettings.s3BucketName)
-        with open(manifest) as manifest_file:
-            asset_manifest = decode_manifest(manifest_file.read())
+        asset_manifest = get_manifest_from_s3(
+            manifest_key, queue.jobAttachmentSettings.s3BucketName
+        )
+
         download_files_from_manifests(
             s3_bucket=queue.jobAttachmentSettings.s3BucketName,
             manifests_by_root={"/tmp/test_download": asset_manifest},

--- a/test/unit/deadline_job_attachments/test_asset_sync.py
+++ b/test/unit/deadline_job_attachments/test_asset_sync.py
@@ -8,7 +8,7 @@ import shutil
 from math import trunc
 from pathlib import Path
 from typing import Optional, Dict
-from unittest.mock import ANY, MagicMock, mock_open, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import boto3
 from deadline.job_attachments.progress_tracker import ProgressStatus
@@ -213,10 +213,7 @@ class TestAssetSync:
         # WHEN
         with patch(
             f"{deadline.__package__}.job_attachments.asset_sync.get_manifest_from_s3",
-            side_effect=[f"{local_root}/manifest.json"],
-        ), patch("builtins.open", mock_open(read_data="test_manifest_file")), patch(
-            f"{deadline.__package__}.job_attachments.asset_sync.decode_manifest",
-            side_effect=["test_manifest_data"],
+            return_value="test_manifest_data",
         ), patch(
             f"{deadline.__package__}.job_attachments.asset_sync.download_files_from_manifests",
             side_effect=[DownloadSummaryStatistics()],
@@ -287,18 +284,13 @@ class TestAssetSync:
         job: Job = request.getfixturevalue(job_fixture_name)
         s3_settings: JobAttachmentS3Settings = request.getfixturevalue(s3_settings_fixture_name)
         default_queue.jobAttachmentSettings = s3_settings
-        session_dir = str(tmp_path)
         dest_dir = "assetroot-27bggh78dd2b568ab123"
-        local_root = str(Path(session_dir) / dest_dir)
         assert job.attachments
 
         # WHEN
         with patch(
             f"{deadline.__package__}.job_attachments.asset_sync.get_manifest_from_s3",
-            side_effect=[f"{local_root}/manifest.json"],
-        ), patch("builtins.open", mock_open(read_data="test_manifest_file")), patch(
-            f"{deadline.__package__}.job_attachments.asset_sync.decode_manifest",
-            side_effect=["test_manifest_data"],
+            return_value="test_manifest_data",
         ), patch(
             f"{deadline.__package__}.job_attachments.asset_sync._get_unique_dest_dir_name",
             side_effect=[dest_dir],
@@ -349,10 +341,7 @@ class TestAssetSync:
         # WHEN
         with patch(
             f"{deadline.__package__}.job_attachments.asset_sync.get_manifest_from_s3",
-            side_effect=[f"{local_root}/manifest.json"],
-        ), patch("builtins.open", mock_open(read_data="test_manifest_file")), patch(
-            f"{deadline.__package__}.job_attachments.asset_sync.decode_manifest",
-            side_effect=["test_manifest_data"],
+            return_value="test_manifest_data",
         ), patch(
             f"{deadline.__package__}.job_attachments.asset_sync.download_files_from_manifests",
             side_effect=[DownloadSummaryStatistics()],
@@ -420,8 +409,8 @@ class TestAssetSync:
         # WHEN
         with patch(
             f"{deadline.__package__}.job_attachments.asset_sync.get_manifest_from_s3",
-            side_effect=[f"{local_root}/manifest.json"],
-        ), patch("builtins.open", mock_open(read_data=json.dumps(test_manifest_one))), patch(
+            return_value=json.dumps(test_manifest_one),
+        ), patch(
             f"{deadline.__package__}.job_attachments.asset_sync.download_files_from_manifests",
             side_effect=[DownloadSummaryStatistics()],
         ), patch(
@@ -735,12 +724,6 @@ class TestAssetSync:
         # WHEN
         with patch(
             f"{deadline.__package__}.job_attachments.asset_sync.get_manifest_from_s3",
-            side_effect=[
-                f"{local_root}/manifest_input",
-                f"{local_root}/manifest-movie1_input",
-            ],
-        ), patch("builtins.open", mock_open(read_data="test_manifest_file")), patch(
-            f"{deadline.__package__}.job_attachments.asset_sync.decode_manifest",
             return_value="test_manifest_data",
         ), patch(
             f"{deadline.__package__}.job_attachments.asset_sync.download_files_from_manifests",
@@ -817,10 +800,7 @@ class TestAssetSync:
         # WHEN
         with patch(
             f"{deadline.__package__}.job_attachments.asset_sync.get_manifest_from_s3",
-            side_effect=[f"{local_root}/manifest.json"],
-        ), patch("builtins.open", mock_open(read_data="test_manifest_file")), patch(
-            f"{deadline.__package__}.job_attachments.asset_sync.decode_manifest",
-            side_effect=["test_manifest_data"],
+            return_value="test_manifest_data",
         ), patch(
             f"{deadline.__package__}.job_attachments.asset_sync.download_files_from_manifests",
             side_effect=[DownloadSummaryStatistics()],


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
During the sync_inputs, we were downloading an asset manifest files from the Job Attachment bucket and storing it under `/tmp` as `deadline-manifest-*.json`. This file was then opened, read, and decoded into a manifest object. However, we noticed a leakage issue where the manifest files are not being deleted and remained in the `/tmp` even after the session ended and was no longer needed.

### What was the solution? (How)
It is actually unnecessary to locally saving the manifest files. Instead, the `get_manifest_from_s3()` now call the `download_fileobj` API with `io.BytesIO()` buffer, decodes it and returns the `BaseAssetManifest` object. So this approach reads the manifest data directly into memory, avoiding the intermediate step of creating temporary files.

### What is the impact of this change?
- Prevents the leakage of temporary manifest files under the `/tmp` directory.
- Simplifies the process by removing unnecessary file I/O operations. 

### How was this change tested?
- Updated unit tests to reflect this change. Confirmed that all tests passed.
- Ran integration tests and confirmed all tests passed.
- Manual testing
  - submitted a job and let a worker agent process the job to verify that `sync_inputs` correctly gets manifest and downloads expected input files.
  - Also tested with a job with step-step dependencies to ensure the job is handled as expected.

### Was this change documented?
No.

### Is this a breaking change?
No.
