### PR TITLE
fix(job_attachments):  Use files' last modification time to identify output files to be synced

### DIFF
--- a/test/integ/deadline_job_attachments/test_data/outputs/not_for_sync_outputs.txt
+++ b/test/integ/deadline_job_attachments/test_data/outputs/not_for_sync_outputs.txt
@@ -1,0 +1,1 @@
+Although it is in the output directory, it is actually an input file. It should be downloaded (to the worker's session working directory) during sync_inputs, and should not be captured as an output file when sync_outputs.


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
There was a bug where the output files of a session were not synced (uploaded) to the Job Attachment bucket. The issue was traced back to the way how we identify output files: to be recognized as an output file to be uploaded, its last modification time (`lstat().st_mtime`) must be later than the start time of the Session Action (the `TASK_RUN` action). There were some cases where the output file's last mod time was slightly (1 - 10 milliseconds) before the session action's start time.
Based on this [StackExchange post](https://unix.stackexchange.com/a/759891), it seemed that there is some inherent misalignment / discrepancy between the filesystem time and the system time, with the filesystem time being up to 10 milliseconds ahead.

### What was the solution? (How)
Shifted our approach to leveraging the asset manifests in identifying any files modified during the session. Manifests already have each file's last modification time (`mtime`). So, we can compare the `mtime`(initial mtime when the input file is being uploaded) retrieved from manifests vs. the file's `mtime` when we do output syncing. This allows us no longer need to rely on the session start time (which was recorded by `datetime.now()`) to filter output files.

### What is the impact of this change?
We resolve the boundary value bug.

### How was this change tested?
- Fixed existing unit tests and integ tests to be in line with the change, and made sure all passed successfully.
- E2E tests: Run the job bundles below and made sure the expected output files were successfully synced.
  - a job with step-step dependencies
  - a job without step-step dependencies, creating a new file in the OUT directory --> The new file was synced.
  - a job that has INOUT directory, modifying the existing file in that directory --> The modified file was synced.

### Was this change documented?
No.

### Is this a breaking change?
No.
