### PR TITLE
feat: Add telemetry opt-out env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,17 @@ You can download this package from:
 
 See instructions in DEVELOPMENT.md
 
+## Telemetry
+
+This library collects telemetry data by default. Telemetry events contain non-personally-identifiable information that helps us understand how users interact with our software so we know what features our customers use, and/or what existing pain points are.
+
+You can opt out of telemetry data collection by either:
+
+1. Setting the environment variable: `DEADLINE_CLOUD_TELEMETRY_OPT_OUT=true`
+2. Setting the config file: `deadline config set telemetry.opt_out true`
+
+Note that setting the environment variable supersedes the config file setting.
+
 # Build / Test / Release
 
 ## Setup Code Artifact

--- a/test/unit/deadline_client/api/test_job_bundle_submission.py
+++ b/test/unit/deadline_client/api/test_job_bundle_submission.py
@@ -270,7 +270,9 @@ def test_create_job_from_job_bundle(
         "deadline.client.api._session.DeadlineClient._get_deadline_api_input_shape"
     ) as input_shape_mock:
         input_shape_mock.return_value = {"template": ""}
-        with patch.object(api._session, "get_boto3_session") as session_mock:
+        with patch.object(api._session, "get_boto3_session") as session_mock, patch.object(
+            _submit_job_bundle.api, "get_deadline_cloud_library_telemetry_client"
+        ):
             session_mock().client("deadline").create_job.side_effect = [MOCK_CREATE_JOB_RESPONSE]
             session_mock().client("deadline").get_job.return_value = MOCK_GET_JOB_RESPONSE
 
@@ -325,7 +327,9 @@ def test_create_job_from_job_bundle_error_missing_template(
     """
     Test a job bundle with missing template.
     """
-    with patch.object(api._session, "get_boto3_session") as session_mock:
+    with patch.object(api._session, "get_boto3_session") as session_mock, patch.object(
+        _submit_job_bundle.api, "get_deadline_cloud_library_telemetry_client"
+    ):
         session_mock().client("deadline").create_job.side_effect = [MOCK_CREATE_JOB_RESPONSE]
 
         config.set_setting("defaults.farm_id", MOCK_FARM_ID)
@@ -353,7 +357,9 @@ def test_create_job_from_job_bundle_error_duplicate_template(
     """
     Test a job bundle with both a JSON and YAML template.
     """
-    with patch.object(api._session, "get_boto3_session") as session_mock:
+    with patch.object(api._session, "get_boto3_session") as session_mock, patch.object(
+        _submit_job_bundle.api, "get_deadline_cloud_library_telemetry_client"
+    ):
         session_mock().client("deadline").create_job.side_effect = [MOCK_CREATE_JOB_RESPONSE]
 
         config.set_setting("defaults.farm_id", MOCK_FARM_ID)
@@ -385,7 +391,9 @@ def test_create_job_from_job_bundle_error_duplicate_parameters(
     """
     Test a job bundle with an incorrect Amazon Deadline Cloud parameter
     """
-    with patch.object(api._session, "get_boto3_session") as session_mock:
+    with patch.object(api._session, "get_boto3_session") as session_mock, patch.object(
+        _submit_job_bundle.api, "get_deadline_cloud_library_telemetry_client"
+    ):
         session_mock().client("deadline").create_job.side_effect = [MOCK_CREATE_JOB_RESPONSE]
 
         config.set_setting("defaults.farm_id", MOCK_FARM_ID)
@@ -448,7 +456,7 @@ def test_create_job_from_job_bundle_job_attachments(
     ) as mock_prepare_paths, patch.object(
         S3AssetManager, "upload_assets"
     ) as mock_upload_assets, patch.object(
-        _submit_job_bundle.api, "get_telemetry_client"
+        _submit_job_bundle.api, "get_deadline_cloud_library_telemetry_client"
     ):
         client_mock().get_queue.side_effect = [MOCK_GET_QUEUE_RESPONSE]
         client_mock().create_job.side_effect = [MOCK_CREATE_JOB_RESPONSE]
@@ -565,7 +573,7 @@ def test_create_job_from_job_bundle_empty_job_attachments(
     ) as mock_prepare_paths, patch.object(
         S3AssetManager, "upload_assets"
     ) as mock_upload_assets, patch.object(
-        _submit_job_bundle.api, "get_telemetry_client"
+        _submit_job_bundle.api, "get_deadline_cloud_library_telemetry_client"
     ):
         client_mock().get_queue.side_effect = [MOCK_GET_QUEUE_RESPONSE]
         client_mock().create_job.side_effect = [MOCK_CREATE_JOB_RESPONSE]
@@ -657,7 +665,9 @@ def test_create_job_from_job_bundle_with_empty_asset_references(
     job_template_type, job_template = MOCK_JOB_TEMPLATE_CASES["MINIMAL_JSON"]
     with patch(
         "deadline.client.api._session.DeadlineClient._get_deadline_api_input_shape"
-    ) as input_shape_mock:
+    ) as input_shape_mock, patch.object(
+        _submit_job_bundle.api, "get_deadline_cloud_library_telemetry_client"
+    ):
         input_shape_mock.return_value = {}
         with patch.object(api._session, "get_boto3_session") as session_mock:
             session_mock().client("deadline").create_job.side_effect = [MOCK_CREATE_JOB_RESPONSE]
@@ -723,7 +733,7 @@ def test_create_job_from_job_bundle_with_single_asset_file(
     ) as mock_prepare_paths, patch.object(
         S3AssetManager, "upload_assets"
     ) as mock_upload_assets, patch.object(
-        _submit_job_bundle.api, "get_telemetry_client"
+        _submit_job_bundle.api, "get_deadline_cloud_library_telemetry_client"
     ):
         client_mock().create_job.side_effect = [MOCK_CREATE_JOB_RESPONSE]
         client_mock().get_queue.side_effect = [MOCK_GET_QUEUE_RESPONSE]

--- a/test/unit/deadline_client/api/test_job_bundle_submission_asset_refs.py
+++ b/test/unit/deadline_client/api/test_job_bundle_submission_asset_refs.py
@@ -258,7 +258,7 @@ def test_create_job_from_job_bundle_with_all_asset_ref_variants(
     ) as mock_hash_assets, patch.object(
         S3AssetManager, "upload_assets"
     ) as mock_upload_assets, patch.object(
-        _submit_job_bundle.api, "get_telemetry_client"
+        _submit_job_bundle.api, "get_deadline_cloud_library_telemetry_client"
     ):
         client_mock().create_job.side_effect = [MOCK_CREATE_JOB_RESPONSE]
         client_mock().get_queue.side_effect = [MOCK_GET_QUEUE_RESPONSE]

--- a/test/unit/deadline_client/cli/test_cli_bundle.py
+++ b/test/unit/deadline_client/cli/test_cli_bundle.py
@@ -123,7 +123,7 @@ def test_cli_bundle_submit(fresh_deadline_config, temp_job_bundle_dir):
     ), patch.object(
         _submit_job_bundle, "_upload_attachments"
     ), patch.object(
-        bundle_group.api, "get_telemetry_client"
+        bundle_group.api, "get_deadline_cloud_library_telemetry_client"
     ):
         get_boto3_client_mock().create_job.return_value = MOCK_CREATE_JOB_RESPONSE
         get_boto3_client_mock().get_job.return_value = MOCK_GET_JOB_RESPONSE
@@ -158,7 +158,9 @@ def test_cli_bundle_explicit_parameters(fresh_deadline_config):
     # Use a temporary directory for the job bundle
     with patch(
         "deadline.client.api._session.DeadlineClient._get_deadline_api_input_shape"
-    ) as input_shape_mock:
+    ) as input_shape_mock, patch.object(
+        bundle_group.api, "get_deadline_cloud_library_telemetry_client"
+    ):
         input_shape_mock.return_value = {}
         with tempfile.TemporaryDirectory() as tmpdir, patch.object(
             boto3, "Session"
@@ -209,7 +211,9 @@ def test_cli_bundle_priority_retries(fresh_deadline_config):
     # Use a temporary directory for the job bundle
     with patch(
         "deadline.client.api._session.DeadlineClient._get_deadline_api_input_shape"
-    ) as input_shape_mock:
+    ) as input_shape_mock, patch.object(
+        bundle_group.api, "get_deadline_cloud_library_telemetry_client"
+    ):
         input_shape_mock.return_value = {}
         with tempfile.TemporaryDirectory() as tmpdir, patch.object(
             boto3, "Session"
@@ -264,7 +268,9 @@ def test_cli_bundle_job_name(fresh_deadline_config):
     # Use a temporary directory for the job bundle
     with patch(
         "deadline.client.api._session.DeadlineClient._get_deadline_api_input_shape"
-    ) as input_shape_mock:
+    ) as input_shape_mock, patch.object(
+        bundle_group.api, "get_deadline_cloud_library_telemetry_client"
+    ):
         input_shape_mock.return_value = {}
         with tempfile.TemporaryDirectory() as tmpdir, patch.object(
             boto3, "Session"
@@ -361,7 +367,7 @@ def test_cli_bundle_asset_load_method(fresh_deadline_config, temp_job_bundle_dir
     ), patch.object(
         _submit_job_bundle.api, "get_queue_user_boto3_session"
     ), patch.object(
-        bundle_group.api, "get_telemetry_client"
+        bundle_group.api, "get_deadline_cloud_library_telemetry_client"
     ):
         bundle_boto3_client_mock().create_job.return_value = MOCK_CREATE_JOB_RESPONSE
         bundle_boto3_client_mock().get_job.return_value = MOCK_GET_JOB_RESPONSE
@@ -413,7 +419,9 @@ def test_cli_bundle_job_parameter_from_cli(fresh_deadline_config):
     # Use a temporary directory for the job bundle
     with patch(
         "deadline.client.api._session.DeadlineClient._get_deadline_api_input_shape"
-    ) as input_shape_mock:
+    ) as input_shape_mock, patch.object(
+        bundle_group.api, "get_deadline_cloud_library_telemetry_client"
+    ):
         input_shape_mock.return_value = {}
         with tempfile.TemporaryDirectory() as tmpdir, patch.object(
             boto3, "Session"
@@ -468,7 +476,9 @@ def test_cli_bundle_empty_job_parameter_from_cli(fresh_deadline_config):
     # Use a temporary directory for the job bundle
     with patch(
         "deadline.client.api._session.DeadlineClient._get_deadline_api_input_shape"
-    ) as input_shape_mock:
+    ) as input_shape_mock, patch.object(
+        bundle_group.api, "get_deadline_cloud_library_telemetry_client"
+    ):
         input_shape_mock.return_value = {}
         with tempfile.TemporaryDirectory() as tmpdir, patch.object(
             boto3, "Session"
@@ -585,7 +595,7 @@ def test_cli_bundle_accept_upload_confirmation(fresh_deadline_config, temp_job_b
     ), patch.object(
         _submit_job_bundle.api, "get_queue_user_boto3_session"
     ), patch.object(
-        bundle_group.api, "get_telemetry_client"
+        bundle_group.api, "get_deadline_cloud_library_telemetry_client"
     ):
         get_boto3_client_mock().create_job.return_value = MOCK_CREATE_JOB_RESPONSE
         get_boto3_client_mock().get_job.return_value = MOCK_GET_JOB_RESPONSE
@@ -661,7 +671,7 @@ def test_cli_bundle_reject_upload_confirmation(fresh_deadline_config, temp_job_b
     ), patch.object(
         _submit_job_bundle.api, "get_queue_user_boto3_session"
     ), patch.object(
-        bundle_group.api, "get_telemetry_client"
+        bundle_group.api, "get_deadline_cloud_library_telemetry_client"
     ):
         get_boto3_client_mock().get_queue.return_value = {
             "displayName": "Test Queue",


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We need an easy way for customers to opt-out of telemetry data collection for our adaptors, ideally through a Queue environment so the amount of configuration is minimal.

### What was the solution? (How)
Add an opt-out env var, `DEADLINE_CLOUD_TELEMETRY_OPT_OUT`, which will override the config file setting if it exists. Customers can define this env var in their queue environment to opt out of telemetry data collection.

I also noticed some tests were throwing background errors, as telemetry wasn't mocked out in some tests, I've fixed those tests.

### What is the impact of this change?
Customers can now easily opt-out. Also updated the readme to instruct users on opt-out instructions.

### How was this change tested?
Tested manually, confirming telemetry was not sent went the env var was set to true/yes/1/on, and it did send if set to false/no/0/off (or didn't exist).

Tested with adaptors, confirming they didn't send telemetry when the env var was set.

### Was this change documented?
There is a readme change.

### Is this a breaking change?
No