### PR TITLE
fix(job_attachment)!: remove `os_group` field from Windows filesystem permission settings

### DIFF
--- a/src/deadline/job_attachments/models.py
+++ b/src/deadline/job_attachments/models.py
@@ -317,24 +317,3 @@ class FileConflictResolution(Enum):
     SKIP = 1
     OVERWRITE = 2
     CREATE_COPY = 3
-
-
-# TODO: remove once we fixed worker agent to import PosixFileSystemPermissionSettings from os_file_permission
-@dataclass
-class PosixFileSystemPermissionSettings:
-    """
-    A dataclass representing file system permission-related information
-    for Posix. The specified permission modes will be bitwise-OR'ed with
-    the directory or file's existing permissions.
-
-    Attributes:
-        os_user (str): The target operating system user for ownership.
-        os_group (str): The target operating system group for ownership.
-        dir_mode (int): The permission mode to be added to directories.
-        file_mode (int): The permission mode to be added to files.
-    """
-
-    os_user: str
-    os_group: str
-    dir_mode: int
-    file_mode: int

--- a/src/deadline/job_attachments/os_file_permission.py
+++ b/src/deadline/job_attachments/os_file_permission.py
@@ -4,9 +4,9 @@ import os
 from pathlib import Path
 import shutil
 import sys
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from enum import Enum
-from typing import List, Optional, Set, Union
+from typing import List, Set, Union
 
 from .exceptions import AssetSyncError, PathOutsideDirectoryError
 from ._utils import _is_relative_to
@@ -58,12 +58,9 @@ class WindowsFileSystemPermissionSettings:
         file_mode (WindowsPermissionEnum): The permission mode to be added to files.
     """
 
-    # TODO: Remove the optional `os_group` once the jobRunAsUser - windows - group field
-    # is removed from our APIs
     os_user: str
     dir_mode: WindowsPermissionEnum
     file_mode: WindowsPermissionEnum
-    os_group: Optional[str] = field(default=None)
 
 
 # A union of different file system permission settings that are based on the underlying OS.


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The `os_group` field in the `WindowsFileSystemPermissionSettings` was identified as unnecessary and marked for removal to simplify the interface.

### What was the solution? (How)
To keep backward compatibility, we planned 3-phase removal:
1. Make the file Optional (PR: https://github.com/casillas2/deadline-cloud/pull/196)
2. Update the dependent package to stop passing `os_group` when creating `WindowsFileSystemPermissionSettings` object. (PR: https://github.com/casillas2/deadline-cloud-worker-agent/pull/213)
3. Completely remove the field.

Steps 1 and 2 had been done. This PR is for Step 3.

Also, removed the `PosixFileSystemPermissionSettings` in the `models.py`. This whole class was moved to `os_file_permissions.py`, and we already fixed worker agent to import PosixFileSystemPermissionSettings from os_file_permission. (PR: https://github.com/casillas2/deadline-cloud-worker-agent/pull/81)

### What is the impact of this change?
We simplify the interface. 

### How was this change tested?
- Unit tests: `hatch run lint && hatch run test`
- Integ tests: `hatch run integ:test`
- Ran a quick E2E test to make sure that removing `PosixFileSystemPermissionSettings` in the `models.py` does not break anything, and job submission & worker's input syncing are working as usual.

### Was this change documented?

### Is this a breaking change?
This is breaking change for any package that still uses the `os_group` field in the `WindowsFileSystemPermissionSettings` class. The only place is was being used was deadline-cloud-worker-agent, and we have already done the Step 2 to remove that usage.