### PR TITLE
fix: Make StorageProfileOperatingSystemFamily enum case-insensitive

### DIFF
--- a/src/deadline/job_attachments/models.py
+++ b/src/deadline/job_attachments/models.py
@@ -111,9 +111,19 @@ class OutputFile:
 
 
 class StorageProfileOperatingSystemFamily(str, Enum):
+    """Case-insensitive enum for the storage profile operating system family type."""
+
     WINDOWS = "windows"
     LINUX = "linux"
     MACOS = "macos"
+
+    @classmethod
+    def _missing_(cls, value):
+        value = value.lower()
+        for member in cls:
+            if member == value:
+                return member
+        return None
 
 
 class PathFormat(str, Enum):

--- a/test/unit/deadline_job_attachments/test_models.py
+++ b/test/unit/deadline_job_attachments/test_models.py
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 from unittest.mock import patch
 
-from deadline.job_attachments.models import PathFormat
+from deadline.job_attachments.models import PathFormat, StorageProfileOperatingSystemFamily
 
 import pytest
 
@@ -17,3 +17,34 @@ class TestModels:
         """
         with patch("sys.platform", sys_os):
             assert PathFormat.get_host_path_format_string() == expected_output
+
+    @pytest.mark.parametrize(
+        ("input", "output"),
+        [
+            ("windows", StorageProfileOperatingSystemFamily.WINDOWS),
+            ("WINDOWS", StorageProfileOperatingSystemFamily.WINDOWS),
+            ("wInDoWs", StorageProfileOperatingSystemFamily.WINDOWS),
+            ("linux", StorageProfileOperatingSystemFamily.LINUX),
+            ("LINUX", StorageProfileOperatingSystemFamily.LINUX),
+            ("LiNuX", StorageProfileOperatingSystemFamily.LINUX),
+            ("macos", StorageProfileOperatingSystemFamily.MACOS),
+            ("MACOS", StorageProfileOperatingSystemFamily.MACOS),
+            ("maCOs", StorageProfileOperatingSystemFamily.MACOS),
+        ],
+    )
+    def test_storage_profile_operating_system_family_case(
+        self, input: str, output: StorageProfileOperatingSystemFamily
+    ) -> None:
+        """
+        Tests that the correct enum types are created regardless of input string casing.
+        """
+        assert StorageProfileOperatingSystemFamily(input) == output
+
+    @pytest.mark.parametrize(("input"), [("linuxx"), ("darwin"), ("oSx"), ("MSDOS")])
+    def test_storage_profile_operating_system_raises_type_error(self, input):
+        """
+        Tests that a ValueError is raised when a non-valid string is given.
+        I.e. our case-insensitivity isn't causing false-positives.
+        """
+        with pytest.raises(ValueError):
+            StorageProfileOperatingSystemFamily(input)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The API model for StorageProfileOperatingSystemFamily requires all caps for the enum values.

### What was the solution? (How)
Make the enum case-insensitive.

### What is the impact of this change?
Nothing should break once we update the API model.

### How was this change tested?
Created new unit tests and confirmed they passed.

### Was this change documented?
N/A

### Is this a breaking change?
No