### PR TITLE
feat!: prep for rootPathFormat becoming ALL UPPERS

### DIFF
--- a/src/deadline/client/api/_session.py
+++ b/src/deadline/client/api/_session.py
@@ -9,7 +9,7 @@ import logging
 from configparser import ConfigParser
 from contextlib import contextmanager
 from enum import Enum
-from typing import Optional
+from typing import Any, Optional
 import boto3  # type: ignore[import]
 from botocore.client import BaseClient  # type: ignore[import]
 from botocore.credentials import CredentialProvider, RefreshableCredentials
@@ -17,7 +17,6 @@ from botocore.exceptions import (  # type: ignore[import]
     ClientError,
     ProfileNotFound,
 )
-
 from botocore.session import get_session as get_botocore_session
 
 from ..config import get_setting
@@ -110,6 +109,9 @@ def get_boto3_client(service_name: str, config: Optional[ConfigParser] = None) -
         config (ConfigParser, optional): If provided, the AWS Deadline Cloud config to use.
     """
     session = get_boto3_session(config=config)
+
+    if service_name == "deadline":
+        return DeadlineClient(session.client(service_name))
     return session.client(service_name)
 
 
@@ -279,6 +281,50 @@ def check_authentication_status(config: Optional[ConfigParser] = None) -> AwsAut
             if get_credentials_source(config) == AwsCredentialsSource.DEADLINE_CLOUD_MONITOR_LOGIN:
                 return AwsAuthenticationStatus.NEEDS_LOGIN
             return AwsAuthenticationStatus.CONFIGURATION_ERROR
+
+
+class DeadlineClient:
+    """
+    A shim layer for boto Deadline client.
+
+    If a method doesn't exist here, it calls the real client
+    """
+
+    _real_client: Any
+
+    def __init__(self, real_client: Any) -> None:
+        self._real_client = real_client
+        self.meta = self._real_client.meta
+
+    def create_job(self, *args, **kwargs) -> Any:
+        deadline_service_model = self._real_client.meta.service_model
+
+        # revert to service model style if old service model is used, entries
+        # here can then be deleted after their migration period
+        path_format_enums = deadline_service_model.shape_for("PathFormat").metadata.get("enum")
+        if path_format_enums[0] == path_format_enums[0].lower():
+            # old enums are 'windows', and 'posix'
+            # new enums are 'WINDOWS', and 'POSIX'
+            if "attachments" in kwargs:
+                for manifest in kwargs["attachments"]["manifests"]:
+                    manifest["rootPathFormat"] = manifest["rootPathFormat"].lower()
+
+        return self._real_client.create_job(*args, **kwargs)
+
+    def __getattr__(self, __name: str) -> Any:
+        """
+        Respond to unknown method calls by calling the underlying _real_client
+        If the underlying _real_client does not have a given method, an AttributeError
+        will be raised.
+        Note that __getattr__ is only called if the attribute cannot otherwise be found,
+        so if this class alread has the called method defined, __getattr__ will not be called.
+        This is in opposition to __getattribute__ which is called by default.
+        """
+
+        def method(*args, **kwargs) -> Any:
+            return getattr(self._real_client, __name)(*args, **kwargs)
+
+        return method
 
 
 class QueueUserCredentialProvider(CredentialProvider):

--- a/src/deadline/client/cli/_groups/job_group.py
+++ b/src/deadline/client/cli/_groups/job_group.py
@@ -273,7 +273,7 @@ def _download_job_output(
     if job_attachments:
         job_attachments_manifests = job_attachments["manifests"]
         for manifest in job_attachments_manifests:
-            root_path_format_mapping[manifest["rootPath"]] = manifest["rootPathFormat"]
+            root_path_format_mapping[manifest["rootPath"]] = manifest["rootPathFormat"].upper()
 
     job_output_downloader = OutputDownloader(
         s3_settings=JobAttachmentS3Settings(**queue["jobAttachmentSettings"]),

--- a/src/deadline/job_attachments/models.py
+++ b/src/deadline/job_attachments/models.py
@@ -127,8 +127,16 @@ class StorageProfileOperatingSystemFamily(str, Enum):
 
 
 class PathFormat(str, Enum):
-    WINDOWS = "windows"
-    POSIX = "posix"
+    WINDOWS = "WINDOWS"
+    POSIX = "POSIX"
+
+    @classmethod
+    def _missing_(cls, value) -> Optional[PathFormat]:
+        value = value.upper()
+        for member in cls:
+            if member == value:
+                return member
+        return None
 
     @classmethod
     def get_host_path_format(cls) -> PathFormat:

--- a/test/unit/deadline_job_attachments/test_asset_sync.py
+++ b/test/unit/deadline_job_attachments/test_asset_sync.py
@@ -145,9 +145,9 @@ class TestAssetSync:
 
             # THEN
             expected_source_path_format = (
-                "windows"
+                "WINDOWS"
                 if default_job.attachments.manifests[0].rootPathFormat == PathFormat.WINDOWS
-                else "posix"
+                else "POSIX"
             )
             assert result_pathmap_rules == [
                 {
@@ -243,9 +243,9 @@ class TestAssetSync:
 
             # THEN
             expected_source_path_format = (
-                "windows"
+                "WINDOWS"
                 if job.attachments.manifests[0].rootPathFormat == PathFormat.WINDOWS
-                else "posix"
+                else "POSIX"
             )
             assert result_pathmap_rules == [
                 {
@@ -373,9 +373,9 @@ class TestAssetSync:
 
             # THEN
             expected_source_path_format = (
-                "windows"
+                "WINDOWS"
                 if default_job.attachments.manifests[0].rootPathFormat == PathFormat.WINDOWS
-                else "posix"
+                else "POSIX"
             )
             assert result_pathmap_rules == [
                 {
@@ -449,9 +449,9 @@ class TestAssetSync:
             # THEN
             merge_manifests_mock.assert_called()
             expected_source_path_format = (
-                "windows"
+                "WINDOWS"
                 if job.attachments.manifests[0].rootPathFormat == PathFormat.WINDOWS
-                else "posix"
+                else "POSIX"
             )
 
             assert result_pathmap_rules == [
@@ -758,7 +758,7 @@ class TestAssetSync:
             # THEN
             assert result_pathmap_rules == [
                 {
-                    "source_path_format": "posix",
+                    "source_path_format": "POSIX",
                     "source_path": default_job.attachments.manifests[0].rootPath,
                     "destination_path": local_root,
                 }
@@ -843,9 +843,9 @@ class TestAssetSync:
 
             # THEN
             expected_source_path_format = (
-                "windows"
+                "WINDOWS"
                 if job.attachments.manifests[0].rootPathFormat == PathFormat.WINDOWS
-                else "posix"
+                else "POSIX"
             )
             assert result_pathmap_rules == [
                 {

--- a/test/unit/deadline_job_attachments/test_models.py
+++ b/test/unit/deadline_job_attachments/test_models.py
@@ -9,7 +9,7 @@ import pytest
 class TestModels:
     @pytest.mark.parametrize(
         ("sys_os", "expected_output"),
-        [("win32", "windows"), ("darwin", "posix"), ("linux", "posix")],
+        [("win32", "WINDOWS"), ("darwin", "POSIX"), ("linux", "POSIX")],
     )
     def test_get_host_path_format_string(self, sys_os: str, expected_output: str):
         """
@@ -17,6 +17,23 @@ class TestModels:
         """
         with patch("sys.platform", sys_os):
             assert PathFormat.get_host_path_format_string() == expected_output
+
+    @pytest.mark.parametrize(
+        ("input", "output"),
+        [
+            ("windows", PathFormat.WINDOWS),
+            ("WINDOWS", PathFormat.WINDOWS),
+            ("wInDoWs", PathFormat.WINDOWS),
+            ("posix", PathFormat.POSIX),
+            ("POSIX", PathFormat.POSIX),
+            ("PoSiX", PathFormat.POSIX),
+        ],
+    )
+    def test_path_format_case(self, input: str, output: PathFormat) -> None:
+        """
+        Tests that the correct enum types are created regardless of input string casing.
+        """
+        assert PathFormat(input) == output
 
     @pytest.mark.parametrize(
         ("input", "output"),


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

API model for rootPathFormat is changing from lowercase to uppercase, so we need to prep ahead of time so that we support both when the swap happens.

### What was the solution? (How)

* Re-added the shim to deadline.client to ensure that create_job uses the correct version of rootPathFormat.
* Modified deadline.job_attachments to switch the enum to ALL UPPERS, and if the enum can't be found (ie. `windows`) that it would see if the uppercase version exists.
* get_job is also affected, but we only use this on download, so we can just swap that usage to ALL UPPERS all the time.
* Downstream dependencies worker agent and openjd handle PathFormats regardless of lowers or uppers (they use uppers), so this doesn't actually break them.

### What is the impact of this change?

* If a model exists that uses lowercase enums, it will use that on create_job
* Regardless of what model exists for get_job, it'll work.

### How was this change tested?

Added tests around the `_missing_` feature of the enum, as well as the DeadlineClient create_job shim

```
hatch run fmt
hatch build
hatch run lint
hatch run test
```

I then attempted to submit job bundles using the old model, and confirmed that it changed the request to use the lowercase version.

### Was this change documented?

N/A

### Is this a breaking change?

This is a breaking change since we're changing the PathFormat enum's values and the format of the strings returned for the path mapping rules in `sync_inputs` (even though the only known dependency handles this already).