### PR TITLE
feat: prevent uploading files outside session directory via symlinks

### DIFF
--- a/src/deadline/client/job_bundle/parameters.py
+++ b/src/deadline/client/job_bundle/parameters.py
@@ -104,7 +104,7 @@ def validate_job_parameter(
     input : Any
         The input to validate
     type_required : bool = False
-        Whether the "type" field is required. This is imporant for job bundles which may contain
+        Whether the "type" field is required. This is important for job bundles which may contain
         app-specific parameter values without accompanying metadata such as the parameter type.
     default_required : bool = False
         Whether the "default" field is required. In queue environments, defaults are required. In

--- a/src/deadline/job_attachments/models.py
+++ b/src/deadline/job_attachments/models.py
@@ -102,12 +102,16 @@ class ManifestPathGroup:
 class OutputFile:
     """Files for output"""
 
-    file_size: int  # File size in Bytes
+    # File size in Bytes
+    file_size: int
     file_hash: str
     rel_path: str
     full_path: str
     s3_key: str
-    in_s3: bool  # If the file already exists in the CAS
+    # If the file already exists in the CAS
+    in_s3: bool
+    # The base directory path against which file paths are containment-checked
+    base_dir: Optional[str]
 
 
 class StorageProfileOperatingSystemFamily(str, Enum):

--- a/test/integ/deadline_job_attachments/conftest.py
+++ b/test/integ/deadline_job_attachments/conftest.py
@@ -1,7 +1,8 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
+import getpass
 import json
-
+import sys
 import pytest
 
 
@@ -98,3 +99,7 @@ def external_bucket() -> str:
     Return a bucket that all developers and test accounts have access to, but isn't in the testers account.
     """
     return "job-attachment-bucket-snipe-test"
+
+
+def is_windows_non_admin():
+    return sys.platform == "win32" and getpass.getuser() != "Administrator"

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -1,5 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
+import getpass
+import sys
 import pytest
 import tempfile
 
@@ -28,3 +30,7 @@ def fresh_deadline_config():
             yield str(temp_file_path)
     finally:
         temp_dir.cleanup()
+
+
+def is_windows_non_admin():
+    return sys.platform == "win32" and getpass.getuser() != "Administrator"

--- a/test/unit/deadline_client/job_bundle/test_job_bundle_loader.py
+++ b/test/unit/deadline_client/job_bundle/test_job_bundle_loader.py
@@ -19,6 +19,7 @@ from deadline.client.job_bundle.loader import (
     validate_directory_symlink_containment,
 )
 from deadline.client.job_bundle.parameters import read_job_bundle_parameters
+from ...conftest import is_windows_non_admin
 
 JOB_TEMPLATE_WITH_PARAMETERS_2023_09 = """
 specificationVersion: 'jobtemplate-2023-09'
@@ -194,7 +195,7 @@ def test_parse_yaml_or_json_content_fail(content, type):
 
 
 @pytest.mark.skipif(
-    sys.platform == "win32",
+    is_windows_non_admin(),
     reason="Windows requires Admin to create symlinks, skipping this test.",
 )
 def test_validate_directory_symlink_containment_success(tmpdir):

--- a/test/unit/deadline_job_attachments/test_download.py
+++ b/test/unit/deadline_job_attachments/test_download.py
@@ -76,6 +76,7 @@ from deadline.job_attachments.os_file_permission import (
 from deadline.job_attachments._utils import _human_readable_file_size
 
 from .conftest import has_posix_target_user, has_posix_disjoint_user
+from ..conftest import is_windows_non_admin
 
 
 @dataclass
@@ -1233,7 +1234,7 @@ class TestFullDownload:
         }
 
     @pytest.mark.skipif(
-        sys.platform == "win32",
+        is_windows_non_admin(),
         reason="Windows requires Admin to create symlinks, skipping this test.",
     )
     @mock_sts


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
A potential security threat was identified where an attacker could create a symbolic link within the Session working directory pointing to a file outside the directory, and potentially gain access to files that they should not have access to by identifying the symlink as an output file to be uploaded.

### What was the solution? (How)
1. When identifying output files to be uploaded, we now use `os.path.realpath()` to get the true file location and ensures that it is within the the Session working directory.
2. Files are opened using the `_open_file_binary()` context manager before uploading, which prevents [time-of-check to time-of-use attacks](https://en.wikipedia.org/wiki/Time-of-check_to_time-of-use) by holding the file handle during the upload, making it impossible to modify the symlink while the file is open.
3. Unit/integration tests were added to verify the correct handling of symbolic links pointing outside the Session working directory.

### What is the impact of this change?
Ensures that the Job Attachment is secure against attacks involving symlinks that could lead to unauthorized file access or data leaks. It also adds an additional layer of protection against TOCTOU attacks.

### How was this change tested?
- Added unit tests and an Integration test to cover the cases which involve symlinks pointing inside and outside the Session working directory.
- Manual testing was performed to ensure that legitimate output files are still uploaded correctly, while files outside the Session working directory pointed via symlinks are ignored.

### Was this change documented?
Yes.

### Is this a breaking change?
No.
