### PR TITLE
fix: Mock STS calls for some JA upload tests

### DIFF
--- a/test/unit/deadline_job_attachments/test_upload.py
+++ b/test/unit/deadline_job_attachments/test_upload.py
@@ -2348,6 +2348,7 @@ class TestUpload:
         )
         assert actual_queues == expected_queues
 
+    @mock_sts
     @pytest.mark.parametrize(
         "manifest_version",
         [
@@ -2395,6 +2396,7 @@ class TestUpload:
             assert file_size == 5
             s3_cache.put_entry.assert_not_called()
 
+    @mock_sts
     @pytest.mark.parametrize(
         "manifest_version",
         [


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Some unit tests were failing to pass since we weren't mocking the STS calls.

### What was the solution? (How)
Add the `@mocksts` attribute to the missed unit tests.

### What is the impact of this change?
Tests pass.

### How was this change tested?
Ran unit tests from mainline, confirmed they failed. With these changes, confirmed they passed.

### Was this change documented?
N/A

### Is this a breaking change?
Unbreaking