### PR TITLE
fix: swap exec to exec_

### DIFF
--- a/src/deadline/client/ui/dialogs/deadline_config_dialog.py
+++ b/src/deadline/client/ui/dialogs/deadline_config_dialog.py
@@ -69,7 +69,7 @@ class DeadlineConfigDialog(QDialog):
         Returns True if any changes were applied, False otherwise.
         """
         deadline_config = DeadlineConfigDialog(parent=parent)
-        deadline_config.exec()
+        deadline_config.exec_()
         return deadline_config.changes_were_applied
 
     def __init__(self, parent=None) -> None:

--- a/src/deadline/client/ui/dialogs/deadline_login_dialog.py
+++ b/src/deadline/client/ui/dialogs/deadline_login_dialog.py
@@ -71,7 +71,7 @@ class DeadlineLoginDialog(QMessageBox):
             close_on_success=close_on_success,
             config=config,
         )
-        return deadline_login.exec()
+        return deadline_login.exec_()
 
     def __init__(
         self,
@@ -173,9 +173,9 @@ class DeadlineLoginDialog(QMessageBox):
                 while self.__login_thread.is_alive():
                     QApplication.instance().processEvents()  # type: ignore[union-attr]
 
-    def exec(self) -> bool:
+    def exec_(self) -> bool:
         """
         Runs the modal login dialog, returning True if the login was
         successful, False otherwise.
         """
-        return super().exec() == QMessageBox.Ok
+        return super().exec_() == QMessageBox.Ok

--- a/src/deadline/client/ui/dialogs/submit_job_progress_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_progress_dialog.py
@@ -134,7 +134,7 @@ class SubmitJobProgressDialog(QDialog):
         self._auto_accept = auto_accept
 
         self._start_submission()
-        return self.exec()
+        return self.exec_()
 
     def _build_ui(self):
         """Builds up the Dialog UI"""
@@ -613,12 +613,12 @@ class SubmitJobProgressDialog(QDialog):
                 while thread.is_alive():
                     QApplication.instance().processEvents()  # type: ignore[union-attr]
 
-    def exec(self) -> Optional[Dict[str, Any]]:  # type: ignore[override]
+    def exec_(self) -> Optional[Dict[str, Any]]:  # type: ignore[override]
         """
         Runs the modal job progress dialog, returns the response from calling
         create job if the dialog was accepted. Otherwise returns None
         """
-        if super().exec() == QDialog.Accepted:
+        if super().exec_() == QDialog.Accepted:
             return self._create_job_response
         return None
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Some mishandled pyside2 vs pyside6 exec compatibility went in when adding qtpy. Previously in python2, exec was a reserved word, however in python3 exec is just a built-in statement, so python bindings in PySide6/PyQt6 and later can now match the C++ layer exactly by exposing `exec`. Since PySide2 used to support python2, it still just uses `exec_`, but PySide6 which only supported python3 has both `exec_` and `exec`. 

Thus when the job attachments submission dialog tried to pop up it would error with:

```
'super' object has no attribute 'exec'
```

This wasn't caught originally when testing against pyside2 due to what is believed to be a polluted test environment that had both pyside6 and pyside2, so qtpy used pyside6.

### What was the solution? (How)

Use exec_() everywhere for now since it just works for both versions. The previous version where we redirected exec/exec_ caused infinite recursion in pyside6, but not pyside2.

### What is the impact of this change?

1. PySide6 still works
1. PySide2 works again

### How was this change tested?

```
hatch run fmt
hatch build
hatch run lint
hatch run test
```

#### PySide6

```
hatch shell
(deadline) bash-3.2$ deadline bundle gui-submit .
Optional GUI components for deadline are unavailable. Would you like to install PySide? [y/N]: y
Looking in indexes: https://aws:****@amazon-deadline-cloud-938076848303.d.codeartifact.us-west-2.amazonaws.com/pypi/amazon-deadline-cloud-client-software/simple/
Collecting PySide6-essentials==6.6.*
  Using cached https://amazon-deadline-cloud-938076848303.d.codeartifact.us-west-2.amazonaws.com/pypi/amazon-deadline-cloud-client-software/simple/pyside6-essentials/6.6.2/PySide6_Essentials-6.6.2-cp38-abi3-macosx_11_0_universal2.whl (147.1 MB)
Collecting shiboken6==6.6.2 (from PySide6-essentials==6.6.*)
  Using cached https://amazon-deadline-cloud-938076848303.d.codeartifact.us-west-2.amazonaws.com/pypi/amazon-deadline-cloud-client-software/simple/shiboken6/6.6.2/shiboken6-6.6.2-cp38-abi3-macosx_11_0_universal2.whl (345 kB)
Installing collected packages: shiboken6, PySide6-essentials
Successfully installed PySide6-essentials-6.6.2 shiboken6-6.6.2
```
The gui then launched and I was able to submit a job, have the job attachments pop up, and successfully hash and upload and create the job

#### PySide2

Ran through the same thing by using the Maya integration (PySide2)

##### Latest release

```
cd ../deadline-cloud-for-maya
rm -rf ./plugin_env && hatch env prune && hatch run install --maya-version 2023
hatch shell
open /Applications/Autodesk/maya2023/Maya.app/
```

Confirmed I was hitting the PySide2 issue on submit

<img width="516" alt="image" src="https://github.com/casillas2/deadline-cloud/assets/60796713/4df879cc-93e5-4989-a83c-20aaaae69b84">

##### Current changes

```
cd ../deadline-cloud-for-maya
# prep the env
rm -rf ./plugin_env && hatch env prune && hatch run install --maya-version 2023
pushd ../deadline-cloud && rm -rf ./dist && hatch build && popd && rm -rf ./dist && hatch build
hatch shell
pip install ./dist/deadline_cloud_for_maya-0.13.1*.whl ../deadline-cloud/dist/deadline-0.44.*.whl --python-version 3.9 --only-binary=:all: --platform macosx_10_9_x86_64 --upgrade -t ./plugin_env/scripts
open /Applications/Autodesk/maya2023/Maya.app/
```

Proceeded to submit another job, and had no issues with the job attachments dialog

### Was this change documented?

N/A

### Is this a breaking change?

fixing :)