### PR TITLE
feat(job_attachment): reject files on non-Windows systems that do not support O_NOFOLLOW

### DIFF
--- a/test/unit/deadline_job_attachments/test_upload.py
+++ b/test/unit/deadline_job_attachments/test_upload.py
@@ -2420,7 +2420,10 @@ class TestUpload:
         with a3_asset_uploader._open_non_symlink_file_binary(str(symlink_path)) as file_obj:
             # THEN
             assert file_obj is None
-            assert f"Failed to open file {symlink_path}" in caplog.text
+            assert (
+                f"Failed to open file. The following file will be skipped: {symlink_path}"
+                in caplog.text
+            )
             if hasattr(os, "O_NOFOLLOW") is False:
                 # Windows or other platforms that don't support O_NOFOLLOW
                 assert "Mismatch between path and its final path" in caplog.text


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
In the previous PR: https://github.com/casillas2/deadline-cloud/pull/225, we implemented a mitigation against symlink attacks for Job Attachments. However, for non-Windows systems that do not support the `O_NOFOLLOW` flag for the `open` system call, we still need to address the potential security risk of symlink attacks.

### What was the solution? (How)
Added a check to detect operating systems that do not support `O_NOFOLLOW` and are not Windows. On such systems, when encountering a symbolic link, we now log a warning message and reject the file.

### What is the impact of this change?
This ensures that Job Attachments does not leave customers vulnerable to symlink attacks on these systems.

### How was this change tested?
- Ran unit tests and ensured that all passed.
- Ran Integration tests and ensured that all passed.

### Was this change documented?
Yes.

### Is this a breaking change?
No.
