### PR TITLE
revert!: "feat!: prep for rootPathFormat becoming ALL UPPERS (#222)"

### DIFF
--- a/src/deadline/client/cli/_groups/job_group.py
+++ b/src/deadline/client/cli/_groups/job_group.py
@@ -273,7 +273,7 @@ def _download_job_output(
     if job_attachments:
         job_attachments_manifests = job_attachments["manifests"]
         for manifest in job_attachments_manifests:
-            root_path_format_mapping[manifest["rootPath"]] = manifest["rootPathFormat"].upper()
+            root_path_format_mapping[manifest["rootPath"]] = manifest["rootPathFormat"]
 
     job_output_downloader = OutputDownloader(
         s3_settings=JobAttachmentS3Settings(**queue["jobAttachmentSettings"]),

--- a/src/deadline/job_attachments/models.py
+++ b/src/deadline/job_attachments/models.py
@@ -131,16 +131,8 @@ class StorageProfileOperatingSystemFamily(str, Enum):
 
 
 class PathFormat(str, Enum):
-    WINDOWS = "WINDOWS"
-    POSIX = "POSIX"
-
-    @classmethod
-    def _missing_(cls, value) -> Optional[PathFormat]:
-        value = value.upper()
-        for member in cls:
-            if member == value:
-                return member
-        return None
+    WINDOWS = "windows"
+    POSIX = "posix"
 
     @classmethod
     def get_host_path_format(cls) -> PathFormat:

--- a/test/unit/deadline_client/api/test_api_session.py
+++ b/test/unit/deadline_client/api/test_api_session.py
@@ -4,14 +4,10 @@
 tests the deadline.client.api functions relating to boto3.Client
 """
 
-from typing import Dict, List
 from unittest.mock import call, patch, MagicMock, ANY
 
 import boto3  # type: ignore[import]
 from deadline.client import api, config
-from deadline.client.api._session import DeadlineClient
-
-import pytest
 
 
 def test_get_boto3_session(fresh_deadline_config):
@@ -175,72 +171,3 @@ def test_check_deadline_api_available_fails(fresh_deadline_config):
         assert result is False
         # It should have called list_farms with to check the API
         session_mock().client("deadline").list_farms.assert_called_once_with(maxResults=1)
-
-
-@pytest.mark.parametrize(
-    "model_enums, manifests_input, manifests_output",
-    [
-        pytest.param(
-            (["windows", "posix"]),
-            (
-                [
-                    {"rootPathFormat": "WINDOWS"},
-                    {"rootPathFormat": "POSIX"},
-                ]
-            ),
-            (
-                [
-                    {"rootPathFormat": "windows"},
-                    {"rootPathFormat": "posix"},
-                ]
-            ),
-            id="old service model - all lowers",
-        ),
-        pytest.param(
-            (["WINDOWS", "POSIX"]),
-            (
-                [
-                    {"rootPathFormat": "WINDOWS", "rootPath": ""},
-                    {"rootPathFormat": "POSIX", "rootPath": ""},
-                ]
-            ),
-            (
-                [
-                    {"rootPathFormat": "WINDOWS", "rootPath": ""},
-                    {"rootPathFormat": "POSIX", "rootPath": ""},
-                ]
-            ),
-            id="new service model - ALL UPPERS",
-        ),
-    ],
-)
-def test_create_job_root_path_format_compat(
-    model_enums: List[str],
-    manifests_input: List[Dict[str, str]],
-    manifests_output: List[Dict[str, str]],
-) -> None:
-    """
-    create_job will eventually be updated so that rootPathFormat is all UPPERS.
-
-    Here we make sure that the shim is doing its job of:
-    1. Calling the underlying client method
-    2. Replacing all rootPathFormats to be the right casing
-    """
-    # GIVEN
-    fake_client = MagicMock()
-    fake_path_format_shape = MagicMock()
-    fake_path_format_shape.metadata.get.return_value = model_enums
-    fake_client.meta.service_model.shape_for.return_value = fake_path_format_shape
-    deadline_client = DeadlineClient(fake_client)
-
-    def create_job_manifests(manifests):
-        return {"attachments": {"manifests": manifests}}
-
-    kwargs_input = create_job_manifests(manifests_input)
-    kwargs_output = create_job_manifests(manifests_output)
-
-    # WHEN
-    deadline_client.create_job(**kwargs_input)
-
-    # THEN
-    fake_client.create_job.assert_called_once_with(**kwargs_output)

--- a/test/unit/deadline_job_attachments/test_asset_sync.py
+++ b/test/unit/deadline_job_attachments/test_asset_sync.py
@@ -148,9 +148,9 @@ class TestAssetSync:
 
             # THEN
             expected_source_path_format = (
-                "WINDOWS"
+                "windows"
                 if default_job.attachments.manifests[0].rootPathFormat == PathFormat.WINDOWS
-                else "POSIX"
+                else "posix"
             )
             assert result_pathmap_rules == [
                 {
@@ -246,9 +246,9 @@ class TestAssetSync:
 
             # THEN
             expected_source_path_format = (
-                "WINDOWS"
+                "windows"
                 if job.attachments.manifests[0].rootPathFormat == PathFormat.WINDOWS
-                else "POSIX"
+                else "posix"
             )
             assert result_pathmap_rules == [
                 {
@@ -376,9 +376,9 @@ class TestAssetSync:
 
             # THEN
             expected_source_path_format = (
-                "WINDOWS"
+                "windows"
                 if default_job.attachments.manifests[0].rootPathFormat == PathFormat.WINDOWS
-                else "POSIX"
+                else "posix"
             )
             assert result_pathmap_rules == [
                 {
@@ -452,9 +452,9 @@ class TestAssetSync:
             # THEN
             merge_manifests_mock.assert_called()
             expected_source_path_format = (
-                "WINDOWS"
+                "windows"
                 if job.attachments.manifests[0].rootPathFormat == PathFormat.WINDOWS
-                else "POSIX"
+                else "posix"
             )
 
             assert result_pathmap_rules == [
@@ -814,7 +814,7 @@ class TestAssetSync:
             # THEN
             assert result_pathmap_rules == [
                 {
-                    "source_path_format": "POSIX",
+                    "source_path_format": "posix",
                     "source_path": default_job.attachments.manifests[0].rootPath,
                     "destination_path": local_root,
                 }
@@ -899,9 +899,9 @@ class TestAssetSync:
 
             # THEN
             expected_source_path_format = (
-                "WINDOWS"
+                "windows"
                 if job.attachments.manifests[0].rootPathFormat == PathFormat.WINDOWS
-                else "POSIX"
+                else "posix"
             )
             assert result_pathmap_rules == [
                 {

--- a/test/unit/deadline_job_attachments/test_models.py
+++ b/test/unit/deadline_job_attachments/test_models.py
@@ -9,7 +9,7 @@ import pytest
 class TestModels:
     @pytest.mark.parametrize(
         ("sys_os", "expected_output"),
-        [("win32", "WINDOWS"), ("darwin", "POSIX"), ("linux", "POSIX")],
+        [("win32", "windows"), ("darwin", "posix"), ("linux", "posix")],
     )
     def test_get_host_path_format_string(self, sys_os: str, expected_output: str):
         """
@@ -17,23 +17,6 @@ class TestModels:
         """
         with patch("sys.platform", sys_os):
             assert PathFormat.get_host_path_format_string() == expected_output
-
-    @pytest.mark.parametrize(
-        ("input", "output"),
-        [
-            ("windows", PathFormat.WINDOWS),
-            ("WINDOWS", PathFormat.WINDOWS),
-            ("wInDoWs", PathFormat.WINDOWS),
-            ("posix", PathFormat.POSIX),
-            ("POSIX", PathFormat.POSIX),
-            ("PoSiX", PathFormat.POSIX),
-        ],
-    )
-    def test_path_format_case(self, input: str, output: PathFormat) -> None:
-        """
-        Tests that the correct enum types are created regardless of input string casing.
-        """
-        assert PathFormat(input) == output
 
     @pytest.mark.parametrize(
         ("input", "output"),


### PR DESCRIPTION
This reverts commit d49c885efe3b97b79d1eca3dfaaac472bf85aaf2. PR #222 

### What was the problem/requirement? (What/Why)

service change is no longer going through, so this commit is no longer needed.

### What was the solution? (How)

git revert!

### What is the impact of this change?

posix will forever be whispered

### How was this change tested?

```
hatch run fmt
hatch build
hatch run lint
hatch run test
```

### Was this change documented?

N/A

### Is this a breaking change?

technically, since PathFormats are returned as lowercased from sync_inputs