### PR TITLE
chore: add revert as semantic allowed tag

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,6 +181,7 @@ allowed_tags = [
     "style",
     "refactor",
     "test",
+    "revert",
 ]
 minor_tags = []
 patch_tags = [


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
revert is missing from semantic allowed tags.

### What was the solution? (How)
Add revert to allowed tags

### What is the impact of this change?
revert will now be tracked when we do versioning

### How was this change tested?
Confirmed that `revert!` caused a version bump.
```
hatch run release:bump
```

### Was this change documented?
No

### Is this a breaking change?
No