### PR TITLE
fix: Removing overridden AWS_CONFIG_FILE path and base environment variabl…

### DIFF
--- a/src/deadline/job_attachments/vfs.py
+++ b/src/deadline/job_attachments/vfs.py
@@ -266,7 +266,7 @@ class VFSProcessManager(object):
         executable = VFSProcessManager.find_vfs_launch_script()
 
         command = (
-            f"sudo -u {self._os_user}"
+            f"sudo -E -u {self._os_user}"
             f" {executable} {mount_point} -f --clienttype=deadline"
             f" --bucket={self._asset_bucket}"
             f" --manifest={self._manifest_path}"
@@ -403,11 +403,9 @@ class VFSProcessManager(object):
         Get the environment variables we'll pass to the launch command.
         :returns: dictionary of default environment variables with VFS changes applied
         """
-        my_env = {**os.environ, **self._os_env_vars}
+        my_env = {**self._os_env_vars}
         my_env["PATH"] = f"{VFSProcessManager.find_vfs_link_dir()}{os.pathsep}{os.environ['PATH']}"
         my_env["LD_LIBRARY_PATH"] = VFSProcessManager.get_library_path()  # type: ignore[assignment]
-
-        my_env["AWS_CONFIG_FILE"] = str(Path(f"~{self._os_user}/.aws/config").expanduser())
 
         return my_env
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
AWS_CONFIG_FILE was overridden in vfs.py's launch environment to be the "default" config file rather than the session created config file which we want to provide the VFS.

We were passing through the base os.environ variables unnecessarily, potentially exposing things we don't intend to even though the VFS is a trusted process we own.

Using POpen with sudo requires the -E option to properly persist the environment variables we pass through to the launched process.

### What was the solution? (How)
Removing overridden AWS_CONFIG_FILE and base environment variables.

Launch VFS with -E option when using sudo -u to run as job-user

### What is the impact of this change?
VFS should properly pick up provided credentials through installed config file's credential_process setting.

### How was this change tested?
New tests added, all unit tests pass.  Reenabled BealineWorkerImageTesting tests, ran with new deadline-cloud, all tests pass.

### Was this change documented?
No

### Is this a breaking change?
No