### PR TITLE
fix: Fix storage profiles list broken osFamily matching

### DIFF
--- a/src/deadline/client/ui/dialogs/deadline_config_dialog.py
+++ b/src/deadline/client/ui/dialogs/deadline_config_dialog.py
@@ -802,7 +802,7 @@ class DeadlineStorageProfileNameListComboBox(_DeadlineResourceListComboBox):
                 [
                     (item["displayName"], item["storageProfileId"])
                     for item in storage_profiles
-                    if self._get_current_os() == item["osFamily"]
+                    if self._get_current_os() == item["osFamily"].lower()
                 ],
                 key=lambda item: (item[0].casefold(), item[1]),
             )


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Storage profiles no longer displayed in the config gui. The API had changed from using lower case "windows" to uppercase "WINDOWS" for the `osFamily` field of the storage profiles. 

### What was the solution? (How)
Convert to lower case when comparing against the current os to determine if a Storage Profile should be included in the list. 

### What is the impact of this change?
Storage Profile configuration works again. 

### How was this change tested?
Build and run locally. 

### Was this change documented?
no.

### Is this a breaking change?

no.
