### PR TITLE
fix: Uses botocore ssl context for telemetry requests

### DIFF
--- a/src/deadline/client/api/_telemetry.py
+++ b/src/deadline/client/api/_telemetry.py
@@ -7,10 +7,9 @@ import os
 import platform
 import uuid
 import random
-import ssl
 import time
 
-from botocore.httpsession import get_cert_path
+from botocore.httpsession import create_urllib3_context, get_cert_path
 from configparser import ConfigParser
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
@@ -93,12 +92,8 @@ class TelemetryClient:
         self._initialized: bool = False
         self.package_name = package_name
         self.package_ver = ".".join(package_ver.split(".")[:3])
-
-        # Need to set up a valid SSL context so requests can make it through
-        self._urllib3_context = ssl.SSLContext(ssl.PROTOCOL_TLS)
-        self._urllib3_context.verify_mode = ssl.CERT_REQUIRED
-        self._urllib3_context.check_hostname = True
-        self._urllib3_context.load_default_certs()
+        # Some environments might not have SSL, so we'll use the vendored botocore SSL context
+        self._urllib3_context = create_urllib3_context()
         self._urllib3_context.load_verify_locations(cafile=get_cert_path(True))
 
         # IDs for this session


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
In https://github.com/casillas2/deadline-cloud/pull/230 I added a workaround for telemetry requests that were hitting SSL issues. Turns out some contexts don't have access to SSL at all, which was causing failures in some integrated submitters.

### What was the solution? (How)
Steal more stuff from botocore! I just grabbed the [create_urllib3_context](https://github.com/boto/botocore/blob/develop/botocore/httpsession.py#L102) function, and set the cert path using the corresponding botocore function. This uses all of the vendored ssl stuff from botocore, so we shouldn't hit any more SSL issues when sending telemetry. Regardless, any SSL failures should happen when we try to send the telemetry, which is in a background thread, so it at least won't interrupt user behaviour. 

### What is the impact of this change?
Fix crashes for environments without SSL.

### How was this change tested?
Submitted a job with telemetry enabled, confirmed that it was sent successfully. Without setting the cert path, I confirmed that I was getting SSL errors attempting to send telemetry, and adding in the cert path allowed requests to go through.

### Was this change documented?
N/A

### Is this a breaking change?
No