### PR TITLE
fix: Update config help text

### DIFF
--- a/src/deadline/client/cli/_groups/config_group.py
+++ b/src/deadline/client/cli/_groups/config_group.py
@@ -19,32 +19,47 @@ def cli_config():
     The available AWS Deadline Cloud settings are:
 
     defaults.aws_profile_name:
-        The default AWS profile to use for AWS Deadline Cloud commands.
+
+        The default AWS profile to use for AWS Deadline Cloud commands. Set to '' to use the default credentials. Other settings are saved with the profile.
 
     defaults.farm_id:
+
         The default farm ID to use for job submissions or CLI operations.
 
     defaults.queue_id:
+
         The default queue ID to use for job submissions or CLI operations.
 
     settings.storage_profile_id:
+
         The storage profile that this workstation conforms to. It specifies
         where shared file systems are mounted, and where named job attachments
         should go.
 
+    defaults.job_id:
+
+        The Job ID to use by default. This gets updated by job submission so is normally the most recently submitted job.
+
     settings.job_history_dir:
-        The directory in which to create new job bundles for
-        submitting to AWS Deadline Cloud, to produce a history of job submissions.
+
+        The directory in which to create new job bundles for submitting to AWS Deadline Cloud, to produce a history of job submissions.
 
     settings.auto_accept:
-        Flag to automatically confirm any confirmation prompts
+
+        Flag to automatically confirm any confirmation prompts.
 
     settings.log_level:
+
         Setting to change the log level. Must be one of ["ERROR", "WARNING", "INFO", "DEBUG"]
 
     defaults.job_attachments_file_system:
+
         Setting to determine if attachments are copied on to workers before a job executes
         or fetched in realtime. Must be one of ["COPIED", "VIRTUAL"]
+
+    telemetry.opt_out:
+
+        Flag to specify opting out of telemetry data collection.
     """
 
 
@@ -52,7 +67,7 @@ def cli_config():
 @_handle_error
 def config_show():
     """
-    Show AWS Deadline Cloud's current workstation configuration settings.
+    Show AWS Deadline Cloud's current workstation configuration.
     """
     click.echo(f"AWS Deadline Cloud configuration file:\n   {config_file.get_config_file_path()}")
     click.echo()


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Our CLI config help text (i.e. `deadline config -h`) was missing telemetry opt out information.

### What was the solution? (How)
Update the help text (we're just using a big comment block), also made the formatting look better. I chose not to include some other config settings that aren't necessary to show to the user (imo).

### What is the impact of this change?
Customers that use the CLI are more aware of their config options.

### How was this change tested?
Previous:
```
deadline config
Usage: deadline config [OPTIONS] COMMAND [ARGS]...

  Manage AWS Deadline Cloud's workstation configuration.

  The available AWS Deadline Cloud settings are:

  defaults.aws_profile_name:     The default AWS profile to use for AWS
  Deadline Cloud commands.

  defaults.farm_id:     The default farm ID to use for job submissions or CLI
  operations.

  defaults.queue_id:     The default queue ID to use for job submissions or
  CLI operations.

  settings.storage_profile_id:     The storage profile that this workstation
  conforms to. It specifies     where shared file systems are mounted, and
  where named job attachments     should go.

  settings.job_history_dir:     The directory in which to create new job
  bundles for     submitting to AWS Deadline Cloud, to produce a history of
  job submissions.

  settings.auto_accept:     Flag to automatically confirm any confirmation
  prompts

  settings.log_level:     Setting to change the log level. Must be one of
  ["ERROR", "WARNING", "INFO", "DEBUG"]

  defaults.job_attachments_file_system:     Setting to determine if
  attachments are copied on to workers before a job executes     or fetched in
  realtime. Must be one of ["COPIED", "VIRTUAL"]

Options:
  -h, --help  Show this message and exit.

Commands:
  get   Gets an AWS Deadline Cloud workstation configuration setting.
  gui   Open the workstation configuration settings GUI.
  set   Sets an AWS Deadline Cloud workstation configuration setting.
  show  Show AWS Deadline Cloud's current workstation configuration...
```

Now:
```
deadline config
Usage: deadline config [OPTIONS] COMMAND [ARGS]...

  Manage AWS Deadline Cloud's workstation configuration.

  The available AWS Deadline Cloud settings are:

  defaults.aws_profile_name:

      The default AWS profile to use for AWS Deadline Cloud commands. Set to
      '' to use the default credentials. Other settings are saved with the
      profile.

  defaults.farm_id:

      The default farm ID to use for job submissions or CLI operations.

  defaults.queue_id:

      The default queue ID to use for job submissions or CLI operations.

  settings.storage_profile_id:

      The storage profile that this workstation conforms to. It specifies
      where shared file systems are mounted, and where named job attachments
      should go.

  defaults.job_id:

      The Job ID to use by default. This gets updated by job submission so is
      normally the most recently submitted job.

  settings.job_history_dir:

      The directory in which to create new job bundles for submitting to AWS
      Deadline Cloud, to produce a history of job submissions.

  settings.auto_accept:

      Flag to automatically confirm any confirmation prompts.

  settings.log_level:

      Setting to change the log level. Must be one of ["ERROR", "WARNING",
      "INFO", "DEBUG"]

  defaults.job_attachments_file_system:

      Setting to determine if attachments are copied on to workers before a
      job executes     or fetched in realtime. Must be one of ["COPIED",
      "VIRTUAL"]

  telemetry.opt_out:

      Flag to specify opting out of telemetry data collection.

Options:
  -h, --help  Show this message and exit.

Commands:
  get   Gets an AWS Deadline Cloud workstation configuration setting.
  gui   Open the workstation configuration settings GUI.
  set   Sets an AWS Deadline Cloud workstation configuration setting.
  show  Show AWS Deadline Cloud's current workstation configuration.

```

### Was this change documented?
The change IS the documentation

### Is this a breaking change?
No