### PR TITLE
fix: include python3.dll in windows pyinstaller builds

### DIFF
--- a/scripts/pyinstaller/deadline_cli.spec
+++ b/scripts/pyinstaller/deadline_cli.spec
@@ -36,6 +36,22 @@ cli_a = Analysis(
     cipher=BLOCK_CIPHER,
 )
 
+# Need to ensure we bundle python3.dll to ensure Shiboken works on windows
+if sys.platform == "win32":
+    python3_dll = None
+    for name, path, _ in cli_a.binaries:
+        if name == "python3.dll":
+            break
+        if not (name.startswith("python") and name.endswith(".dll")):
+            continue 
+        python3_dll = str(Path(path).parent / "python3.dll")
+        break
+
+    if not python3_dll:
+        raise RuntimeError("python3.dll was not added to binaries, but is required for windows to download pyside. Failing build")
+    
+    cli_a.binaries += [('python3.dll', python3_dll, 'BINARY')]
+
 # Filter out the UI submodule for now
 deadline_ui = os.path.join('deadline', 'ui')
 cli_a.datas = [item for item in cli_a.datas if not item[0].startswith(deadline_ui)]


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Windows pyinstaller builds were not able to pip install pyside6 after the fact. This was due to Shiboken failing to load it's dependent modules:

```
DLL load failed while importing Shiboken: The specified module could not be found.
PySide6/__init__.py: Unable to import Shiboken from C:\Users\epmog\DeadlineCloudSubmitter\DeadlineClient\cli\base_library.zip, C:\Users\epmog\DeadlineCloudSubmitter\DeadlineClient\cli\lib-dynload, C:\Users\epmog\DeadlineCloudSubmitter\DeadlineClient\cli, C:\Users\epmog\DeadlineCloudSubmitter\DeadlineClient\cli\win32, C:\Users\epmog\DeadlineCloudSubmitter\DeadlineClient\cli\pywin32_system32
Failed to import qtpy/PySide/Qt, which is required to show the GUI:
No Qt bindings could be found
```

Unfortunately it doesn't tell us the missing DLL!

### What was the solution? (How)

Long story short, found out that python3.dll was the missing link! So we force that include for Windows pyinstaller builds by checking the binaries and adding it if it isn't there.

### What is the impact of this change?

Windows users of pyinstaller can now download pyside/qt!

### How was this change tested?

On a windows instance:
```
$ export OUT_FILE=./pyinstall_fix.zip
$ hatch run codebuild-installer:make_exe
$ unzip ./pyinstall_fix.zip
$ cd pyinstall_fix
$ deadline.exe config gui
Optional GUI components for deadline are unavailable. Would you like to install PySide? [y/N]: y
...
# GUI pops up!
```

### Was this change documented?

n/a

### Is this a breaking change?

n/a