### PR TITLE
feat!: remove py37 from official support

### DIFF
--- a/.github/workflows/reuse_python_build.yml
+++ b/.github/workflows/reuse_python_build.yml
@@ -15,7 +15,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
         os: [ubuntu-latest, windows-latest, macOS-latest]
     env:
       PYTHON: ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "deadline"
 dynamic = ["version"]
 readme = "README.md"
 license = "Apache-2.0"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 
 # Note: All deps should be using >= since this is a *library* as well as an application.
 # Applications that consume this library should be the ones that are more strictly
@@ -17,8 +17,7 @@ dependencies = [
     "click >= 8.1.7",
     "pyyaml >= 6.0",
     # Job Attachments
-    "typing_extensions == 4.7.*; python_version == '3.7'",
-    "typing_extensions >= 4.8; python_version > '3.7'",
+    "typing_extensions >= 4.8",
     # Pinning due to 3.4 not being available upstream
     "xxhash == 3.4.*",
     # Pinning due to new 4.18 dependencies breaking pyinstaller implementation

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,18 +1,14 @@
-coverage[toml] ~= 7.2; python_version == '3.7'
-coverage[toml] == 7.*; python_version > '3.7'
+coverage[toml] == 7.*;
 coverage-conditional-plugin == 0.9.*
 pytest == 7.*
-pytest-cov == 4.*
+pytest-cov == 5.*
 pytest-timeout == 2.*
 pytest-xdist == 3.*
 freezegun == 1.*
 types-pyyaml == 6.*
-twine == 4.*; python_version == '3.7'
-twine == 5.*; python_version > '3.7'
-black == 23.3.*; python_version == '3.7'
-black == 23.*; python_version > '3.7'
-mypy == 1.4.*; python_version == '3.7'
-mypy == 1.*; python_version > '3.7'
+twine == 5.*
+black == 24.*
+mypy == 1.*
 ruff == 0.3.*
 moto == 4.*
 jsondiff == 2.*

--- a/src/deadline/client/ui/dialogs/deadline_config_dialog.py
+++ b/src/deadline/client/ui/dialogs/deadline_config_dialog.py
@@ -546,9 +546,9 @@ class DeadlineWorkstationConfigWidget(QWidget):
         """
 
         # We need to retrieve here as changing Queue's won't update.
-        self.changes[
-            "settings.storage_profile_id"
-        ] = self.default_storage_profile_box.box.currentData()
+        self.changes["settings.storage_profile_id"] = (
+            self.default_storage_profile_box.box.currentData()
+        )
 
         for setting_name, value in self.changes.items():
             if value.startswith(NOT_VALID_MARKER):

--- a/src/deadline/job_attachments/caches/hash_cache.py
+++ b/src/deadline/job_attachments/caches/hash_cache.py
@@ -49,7 +49,9 @@ class HashCache(CacheDB):
 
     def __init__(self, cache_dir: Optional[str] = None) -> None:
         table_name: str = f"hashesV{self.CACHE_DB_VERSION}"
-        create_query: str = f"CREATE TABLE hashesV{self.CACHE_DB_VERSION}(file_path text primary key, hash_algorithm text secondary key, file_hash text, last_modified_time timestamp)"
+        create_query: str = (
+            f"CREATE TABLE hashesV{self.CACHE_DB_VERSION}(file_path text primary key, hash_algorithm text secondary key, file_hash text, last_modified_time timestamp)"
+        )
         super().__init__(
             cache_name=self.CACHE_NAME,
             table_name=table_name,

--- a/src/deadline/job_attachments/caches/s3_check_cache.py
+++ b/src/deadline/job_attachments/caches/s3_check_cache.py
@@ -48,7 +48,9 @@ class S3CheckCache(CacheDB):
 
     def __init__(self, cache_dir: Optional[str] = None) -> None:
         table_name: str = f"s3checkV{self.CACHE_DB_VERSION}"
-        create_query: str = f"CREATE TABLE s3checkV{self.CACHE_DB_VERSION}(s3_key text primary key, last_seen_time timestamp)"
+        create_query: str = (
+            f"CREATE TABLE s3checkV{self.CACHE_DB_VERSION}(s3_key text primary key, last_seen_time timestamp)"
+        )
         super().__init__(
             cache_name=self.CACHE_NAME,
             table_name=table_name,

--- a/test/unit/deadline_job_attachments/test_vfs.py
+++ b/test/unit/deadline_job_attachments/test_vfs.py
@@ -342,9 +342,9 @@ class TestVFSProcessmanager:
             f"{deadline.__package__}.job_attachments.vfs.os.path.exists"
         ) as mock_os_path_exists:
             mock_os_path_exists.return_value = True
-            deadline_vfs_launch_script_path: Union[
-                os.PathLike, str
-            ] = process_manager.find_vfs_launch_script()
+            deadline_vfs_launch_script_path: Union[os.PathLike, str] = (
+                process_manager.find_vfs_launch_script()
+            )
             assert (
                 str(deadline_vfs_launch_script_path)
                 == vfs_test_path + DEADLINE_VFS_EXECUTABLE_SCRIPT
@@ -384,9 +384,9 @@ class TestVFSProcessmanager:
             f"{deadline.__package__}.job_attachments.vfs.os.path.exists"
         ) as mock_os_path_exists:
             mock_os_path_exists.return_value = True
-            deadline_vfs_launch_script_path: Union[
-                os.PathLike, str
-            ] = process_manager.find_vfs_launch_script()
+            deadline_vfs_launch_script_path: Union[os.PathLike, str] = (
+                process_manager.find_vfs_launch_script()
+            )
 
             # Will return preset vfs install path with exe script path appended since env is not set
             assert (


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Python 3.7 has been EOL for a while and it's holding us back from updating critical dependencies.

### What was the solution? (How)

Drop python 3.7 support

### What is the impact of this change?

Users can no longer install deadline into a python 3.7 environment

### How was this change tested?

```
hatch run fmt
hatch build
hatch run lint
hatch run test
```

### Was this change documented?

Updated the supported python versions

### Is this a breaking change?

Yep!