### PR TITLE
fix: Move telemetry urllib context to initialize function

### DIFF
--- a/src/deadline/client/api/_telemetry.py
+++ b/src/deadline/client/api/_telemetry.py
@@ -9,7 +9,6 @@ import uuid
 import random
 import time
 
-from botocore.httpsession import create_urllib3_context, get_cert_path
 from configparser import ConfigParser
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
@@ -92,9 +91,6 @@ class TelemetryClient:
         self._initialized: bool = False
         self.package_name = package_name
         self.package_ver = ".".join(package_ver.split(".")[:3])
-        # Some environments might not have SSL, so we'll use the vendored botocore SSL context
-        self._urllib3_context = create_urllib3_context()
-        self._urllib3_context.load_verify_locations(cafile=get_cert_path(True))
 
         # IDs for this session
         self.session_id: str = str(uuid.uuid4())
@@ -139,6 +135,11 @@ class TelemetryClient:
                 f"{get_deadline_endpoint_url(config=config)}/2023-10-12/telemetry",
                 TelemetryClient.ENDPOINT_PREFIX,
             )
+            # Some environments might not have SSL, so we'll use the vendored botocore SSL context
+            from botocore.httpsession import create_urllib3_context, get_cert_path
+
+            self._urllib3_context = create_urllib3_context()
+            self._urllib3_context.load_verify_locations(cafile=get_cert_path(True))
 
             user_id, _ = get_user_and_identity_store_id(config=config)
             if user_id:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We're still seeing some runtime errors in DCC submitters when trying to initialize the telemetry client.

### What was the solution? (How)
Move botocore's urllib3 SSL context logic into the `initialize` function, which safely tries to import botocore's SSL, or silently fails

### What is the impact of this change?
Failing to initialize telemetry shouldn't crash DCC submitters

### How was this change tested?
Submitted a job successfully

### Was this change documented?
N/A

### Is this a breaking change?
No