### PR TITLE
fix: only load queue environments when connected to a queue

### DIFF
--- a/src/deadline/client/ui/widgets/shared_job_settings_tab.py
+++ b/src/deadline/client/ui/widgets/shared_job_settings_tab.py
@@ -118,7 +118,11 @@ class SharedJobSettingsWidget(QWidget):  # pylint: disable=too-few-public-method
         """
         If the default queue id has changed, refresh the queue parameters.
         """
+        farm_id = get_setting("defaults.farm_id")
         queue_id = get_setting("defaults.queue_id")
+        if not farm_id or not queue_id:
+            self.queue_parameters_box.rebuild_ui(async_loading_state="")
+            return  # If the user has not selected a farm or queue ID, don't try to load
         if self.queue_parameters_box.async_loading_state or queue_id != self.queue_id:
             self.queue_parameters_box.rebuild_ui(
                 async_loading_state="Reloading Queue Environments..."
@@ -156,6 +160,10 @@ class SharedJobSettingsWidget(QWidget):  # pylint: disable=too-few-public-method
         """
         self.farm_id = farm_id = get_setting("defaults.farm_id")
         self.queue_id = queue_id = get_setting("defaults.queue_id")
+        if not self.farm_id or not self.queue_id:
+            # If the user has not selected a farm or queue ID, don't bother starting
+            # the thread.
+            return
         self.__refresh_queue_parameters_id += 1
         self.canceled = CancelationFlag()
         self.__refresh_queue_parameters_thread = threading.Thread(


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Previously, on the first time loading a submitter without the farm/queue set, users would get an error like:

```
Error Traceback: An error occurred (AccessDeniedException) when calling the ListQueueEnvironments operation: User: arn:aws:sts::<account>:assumed-role/AmazonDeadlineCloudStudioUserRole/DeadlineSession-********* is not authorized to perform: deadline:ListQueueEnvironments on resource: arn:aws:deadline:us-west-2:<account>:farm//queue/
```
The error makes it sound like an issue with the IAM role but it's actually an issue with the resource we're trying to access, which does not exist (malformed ARN)

### What was the solution? (How)

Check if we have a queue and farm before looking for queue environments

### What is the impact of this change?

Less errors!

### How was this change tested?

Tested within a DCC context and confirmed the error went away, and that once I selected a farm and queue, the queue environment field was populated

### Was this change documented?

What does this question mean?

### Is this a breaking change?

No!