### PR TITLE
chore: add python 3.7 and 3.8 classifiers

### DIFF
--- a/.github/workflows/release_bump.yml
+++ b/.github/workflows/release_bump.yml
@@ -63,6 +63,7 @@ jobs:
           # Run semantic-release to generate new changelog
           pip install --upgrade hatch
           hatch env create release
+          hatch run release:deps
           NEXT_SEMVER=$(hatch run release:bump $BUMP_ARGS)
 
           # Grab the new version's changelog and prepend it to the original changelog contents

--- a/hatch.toml
+++ b/hatch.toml
@@ -67,10 +67,8 @@ make_exe = "python scripts/pyinstaller/make_exe.py --output {env:OUT_FILE}"
 
 [envs.release]
 detached = true
-dependencies = [
-  "python-semantic-release == 8.7.*"
-]
 
 [envs.release.scripts]
+deps = "pip install -r requirements-release.txt"
 bump = "semantic-release -v --strict version --no-push --no-commit --no-tag --skip-build {args}"
 version = "semantic-release -v --strict version --print {args}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,8 @@ classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.7",
+  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",

--- a/requirements-release.txt
+++ b/requirements-release.txt
@@ -1,3 +1,1 @@
-# HACK: This file solely exists for dependabot checks. The actual dependencies are in `hatch.toml` in the `release` environment.
-# If dependabot opens a PR that modifies this file, please make sure to update the coresponding dependency in `hatch.toml` as well.
 python-semantic-release == 9.2.*


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Missed adding 3.7 and 3.8 classifiers.

### What was the solution? (How)
* Add 3.7 and 3.8
* Install and track pytho-semantic-release via requirements file

### What is the impact of this change?
adds classifiers

### How was this change tested?
```
hatch run fmt
hatch run lint
hatch run test
hatch build
```

### Was this change documented?
Yes

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*