### PR TITLE
fix: make GUI installs more robust and provide helpful messages

### DIFF
--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,17 +1,18 @@
+black == 24.3.*; python_version > '3.7'
 coverage[toml] ~= 7.2; python_version == '3.7'
 coverage[toml] == 7.*; python_version > '3.7'
 coverage-conditional-plugin == 0.9.*
+freezegun == 1.*
+jsondiff == 2.*
+moto == 4.*
+mypy == 1.4.*; python_version == '3.7'
+mypy == 1.*; python_version > '3.7'
 pytest == 7.*
-pytest-cov == 4.*
+pytest-cov == 4.*; python_version == '3.7'
+pytest-cov == 5.*; python_version > '3.7'
 pytest-timeout == 2.*
 pytest-xdist == 3.*
-freezegun == 1.*
+ruff == 0.3.*
 types-pyyaml == 6.*
 twine == 4.*; python_version == '3.7'
 twine == 5.*; python_version > '3.7'
-black == 24.3.*; python_version > '3.7'
-mypy == 1.4.*; python_version == '3.7'
-mypy == 1.*; python_version > '3.7'
-ruff == 0.3.*
-moto == 4.*
-jsondiff == 2.*

--- a/src/deadline/client/ui/__init__.py
+++ b/src/deadline/client/ui/__init__.py
@@ -107,13 +107,13 @@ def _ensure_pyside():
     In a nutshell, it does this via 2 different, yet similar methods:
         * if it's a standard python installation:
             * start a sys.executable `python -m pip install` subprocess
-        * if it's a pyinstaller builder:
+        * if it's a pyinstaller build:
             * check PATH for python, and
             * use `/path/to/python -m to pip install` subprocess
 
-    There's a lot of error-cases to potentially deal with this:
+    There's a lot of error-cases to potentially deal with:
         * does a python install exist
-        * do the process have write access to the location we're targeting
+        * does the process have write access to the target location
         * is python an alias to the microsoft store
         * are there any other missing system libraries a user has to install
         * etc.
@@ -145,7 +145,8 @@ def _ensure_pyside():
 
     # TODO: swap to deadline[gui]=={this_client_version} once published
     pyside6_pypi = "PySide6-essentials==6.6.*"
-    if "deadline" not in basename(sys.executable).lower():
+    # Check if not pyinstaller (https://pyinstaller.org/en/stable/runtime-information.html)
+    if not (getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS")):
         # standard python sys.executable
         # TODO: consider local editables `pip install .[gui]` for a dev env
         command = [sys.executable, "-m", "pip", "install", pyside6_pypi]
@@ -185,7 +186,7 @@ def _ensure_pyside():
     python_executable = shutil.which("python3") or shutil.which("python")
     if sys.platform == "win32":
         # reverse the order for Windows, since a standard install of python will have
-        # python.exe, but not nessarily python3. python3 might still be an alias to
+        # python.exe, but not necessarily python3. python3 might still be an alias to
         # the windows store.
         python_executable = shutil.which("python") or shutil.which("python3")
         if python_executable and all(
@@ -221,9 +222,7 @@ def _ensure_pyside():
     test_file = Path(deps_folder) / "test_file"
     try:
         test_file.parent.mkdir(parents=True, exist_ok=True)
-        with test_file.open("w", encoding="utf-8"):
-            # successfully created file
-            pass
+        test_file.touch()
     except Exception:
         click.echo(
             f"Unable to install GUI dependencies, you do not have the permissions to write to '{deps_folder}'."


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

We've been encountering some edge-cases with the lazy installs of pyside on both Windows and Linux.
1. Failure without a helpful error message if you don't have write permissions
2. Finding a windows store installation before an actual installation
3. Failure if the python.exe points to the Windows Store alias
4. Failure if the python.exe was installed from the Windows Store
5. Failure to install when using the system linux install (might not be fully accurate)

Failures we aren't fixing in here:
On Linux:
```
qt.qpa.plugin: From 6.5.0, xcb-cursor0 or libxcb-cursor0 is needed to load the Qt xcb platform plugin.
qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "" even though it was found.
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

Available platform plugins are: eglfs, linuxfb, minimal, minimalegl, offscreen, vkkhrdisplay, vnc, wayland-egl, wayland, xcb.
```

The QApplication is aborting, thus we can't catch this and provide helpful advice. The message isn't too bad, and there's lots of posts online. A user must install xcb-cursors as appropriate on their linux distro. The submitter installer may be able to bundle this in the future, but pypi users will need to do this regardless.

### What was the solution? (How)

I've moved all the installation logic to an internal `_ensure_pyside` function that adds checks for all these different scenarios. If the executable appears to be a microsoft store executable, we add the `--no-user` flag so that we can install to a target

### What is the impact of this change?

Users should hopefully be able to help themselves get the GUI components onto their machine!

### How was this change tested?

On Linux:

1. Didn't have permissions:

```
$ ./deadline config gui
Optional GUI components for deadline are unavailable. Would you like to install PySide? [y/N]: y
Unable to install GUI dependencies, you do not have the permissions to write to '/home/ec2-user/Downloads/deadline-cloud-robust_windows_gui_install/out/cli'.
You can finish the install by running the following command as a user who can write to that folder

	/usr/bin/python3 -m pip install 'PySide6-essentials==6.6.*' --python-version 3.9 --only-binary=:all: --target /home/ec2-user/Downloads/deadline-cloud-robust_windows_gui_install/out/cli
```
Running that command with `sudo` allowed me to launch the deadline gui

On Windows:

1. Didn't have permissions:
```
C:\Program Files\Locked Down Test>deadline config gui
Optional GUI components for deadline are unavailable. Would you like to install PySide? [y/N]: y
Unable to install GUI dependencies, you do not have the permissions to write to 'C:\Program Files\Locked Down Test\cli'.
You can finish the install by running the following command as a user who can write to that folder:

        C:\Users\epmog\AppData\Local\Microsoft\WindowsApps\python.EXE -m pip install PySide6-essentials==6.6.* --python-version 3.11 --only-binary=:all: --target C:\Program Files\Locked Down Test\cli --no-user
```
running that command as Admin allowed me to install the dependencies, and then I was able to launch the gui as the original user.

2. microsoft store alias
```
$ ./deadline config gui
Optional GUI components for deadline are unavailable. Would you like to install PySide? [y/N]: y
running command: C:\Users\morgane\AppData\Local\Microsoft\WindowsApps\python.EXE -m pip install PySide6-essentials=
=6.6.* --python-version 3.11 --only-binary=:all: --target C:\users\morgane\dev\deadline-cloud\tmp\cli --no-user
The python install, C:\Users\morgane\AppData\Local\Microsoft\WindowsApps\python.EXE, is an alias to the Microsoft store.
To install AWS Deadline Cloud's GUI dependencies, install python and re-run this command.
```
after installing python from the windows store, I was able to re-run the command use the GUI

### Was this change documented?

For the most part it is documentation.

### Is this a breaking change?

Fixing!

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*