### PR TITLE
fix: only hookup stdin on windows for dcm login

### DIFF
--- a/src/deadline/client/api/_loginout.py
+++ b/src/deadline/client/api/_loginout.py
@@ -42,12 +42,16 @@ def _login_deadline_cloud_monitor(
 
     # Open Deadline Cloud Monitor, non-blocking the user will keep Deadline Cloud Monitor running in the background.
     try:
-        # We don't hookup to stdin but do this to avoid issues on windows
-        # See https://docs.python.org/3/library/subprocess.html#subprocess.STARTUPINFO.lpAttributeList
-
-        p = subprocess.Popen(
-            args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, stdin=subprocess.PIPE
-        )
+        if sys.platform.startswith("win"):
+            # We don't hookup to stdin but do this to avoid issues on windows
+            # See https://docs.python.org/3/library/subprocess.html#subprocess.STARTUPINFO.lpAttributeList
+            p = subprocess.Popen(
+                args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, stdin=subprocess.PIPE
+            )
+        else:
+            p = subprocess.Popen(
+                args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, stdin=subprocess.DEVNULL
+            )
         # Linux takes time to start DCM binary, which causes the TTY to suspend the process and send it to background job
         # With wait here, the DCM binary starts and TTY does not suspend the deadline process.
         if sys.platform == "linux":

--- a/test/unit/deadline_client/cli/test_cli_auth.py
+++ b/test/unit/deadline_client/cli/test_cli_auth.py
@@ -5,6 +5,8 @@ Tests for the CLI auth commands.
 """
 import json
 import subprocess
+import sys
+
 from unittest.mock import patch
 
 from click.testing import CliRunner
@@ -45,12 +47,20 @@ def test_cli_deadline_cloud_monitor_login_and_logout(fresh_deadline_config):
 
         assert result.exit_code == 0, result.output
 
-        popen_mock.assert_called_once_with(
-            ["/bin/DeadlineCloudMonitor", "login", "--profile", "sandbox-us-west-2"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            stdin=subprocess.PIPE,
-        )
+        if sys.platform.startswith("win"):
+            popen_mock.assert_called_once_with(
+                ["/bin/DeadlineCloudMonitor", "login", "--profile", "sandbox-us-west-2"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                stdin=subprocess.PIPE,
+            )
+        else:
+            popen_mock.assert_called_once_with(
+                ["/bin/DeadlineCloudMonitor", "login", "--profile", "sandbox-us-west-2"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                stdin=subprocess.DEVNULL,
+            )
 
         assert result.exit_code == 0
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
For the login flow, we were hooking into `stdin` on all systems due to a windows specific behavior. This puts us at risk of receiving a `SIGTTIN` on Linux even though we don't need to read from `stdin` when launching in a `TTY`
### What was the solution? (How)
Only hook into `stdin` on Windows operating systems.

### What is the impact of this change?
Login is more robust on non-windows systems
### How was this change tested?
Tested on a RHEL 9 instance and observed that the login/logout flows could be completed successfully with this change
### Is this a breaking change?
No


----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*