### PR TITLE
ci: remove formatting check for python 3.7

### DIFF
--- a/.github/workflows/reuse_python_build.yml
+++ b/.github/workflows/reuse_python_build.yml
@@ -52,8 +52,10 @@ jobs:
         echo "::add-mask::$CODEARTIFACT_AUTH_TOKEN"
         echo CODEARTIFACT_AUTH_TOKEN=$CODEARTIFACT_AUTH_TOKEN >> $GITHUB_ENV
         pip install --upgrade hatch
-
+    
     - name: Run Linting
+      # Skipping formatting check due black 23.3 security risks on python 3.7
+      if: ${{ matrix.python-version != 3.7 }}
       run: hatch -v run lint
 
     - name: Run Build

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -9,8 +9,7 @@ freezegun == 1.*
 types-pyyaml == 6.*
 twine == 4.*; python_version == '3.7'
 twine == 5.*; python_version > '3.7'
-black == 23.3.*; python_version == '3.7'
-black == 23.*; python_version > '3.7'
+black == 24.3.*; python_version > '3.7'
 mypy == 1.4.*; python_version == '3.7'
 mypy == 1.*; python_version > '3.7'
 ruff == 0.3.*

--- a/src/deadline/client/ui/dialogs/deadline_config_dialog.py
+++ b/src/deadline/client/ui/dialogs/deadline_config_dialog.py
@@ -546,9 +546,9 @@ class DeadlineWorkstationConfigWidget(QWidget):
         """
 
         # We need to retrieve here as changing Queue's won't update.
-        self.changes[
-            "settings.storage_profile_id"
-        ] = self.default_storage_profile_box.box.currentData()
+        self.changes["settings.storage_profile_id"] = (
+            self.default_storage_profile_box.box.currentData()
+        )
 
         for setting_name, value in self.changes.items():
             if value.startswith(NOT_VALID_MARKER):

--- a/src/deadline/job_attachments/caches/hash_cache.py
+++ b/src/deadline/job_attachments/caches/hash_cache.py
@@ -49,7 +49,9 @@ class HashCache(CacheDB):
 
     def __init__(self, cache_dir: Optional[str] = None) -> None:
         table_name: str = f"hashesV{self.CACHE_DB_VERSION}"
-        create_query: str = f"CREATE TABLE hashesV{self.CACHE_DB_VERSION}(file_path text primary key, hash_algorithm text secondary key, file_hash text, last_modified_time timestamp)"
+        create_query: str = (
+            f"CREATE TABLE hashesV{self.CACHE_DB_VERSION}(file_path text primary key, hash_algorithm text secondary key, file_hash text, last_modified_time timestamp)"
+        )
         super().__init__(
             cache_name=self.CACHE_NAME,
             table_name=table_name,

--- a/src/deadline/job_attachments/caches/s3_check_cache.py
+++ b/src/deadline/job_attachments/caches/s3_check_cache.py
@@ -48,7 +48,9 @@ class S3CheckCache(CacheDB):
 
     def __init__(self, cache_dir: Optional[str] = None) -> None:
         table_name: str = f"s3checkV{self.CACHE_DB_VERSION}"
-        create_query: str = f"CREATE TABLE s3checkV{self.CACHE_DB_VERSION}(s3_key text primary key, last_seen_time timestamp)"
+        create_query: str = (
+            f"CREATE TABLE s3checkV{self.CACHE_DB_VERSION}(s3_key text primary key, last_seen_time timestamp)"
+        )
         super().__init__(
             cache_name=self.CACHE_NAME,
             table_name=table_name,

--- a/test/unit/deadline_job_attachments/test_vfs.py
+++ b/test/unit/deadline_job_attachments/test_vfs.py
@@ -330,9 +330,9 @@ class TestVFSProcessmanager:
             f"{deadline.__package__}.job_attachments.vfs.os.path.exists"
         ) as mock_os_path_exists:
             mock_os_path_exists.return_value = True
-            deadline_vfs_launch_script_path: Union[
-                os.PathLike, str
-            ] = process_manager.find_vfs_launch_script()
+            deadline_vfs_launch_script_path: Union[os.PathLike, str] = (
+                process_manager.find_vfs_launch_script()
+            )
             assert (
                 str(deadline_vfs_launch_script_path)
                 == vfs_test_path + DEADLINE_VFS_EXECUTABLE_SCRIPT
@@ -372,9 +372,9 @@ class TestVFSProcessmanager:
             f"{deadline.__package__}.job_attachments.vfs.os.path.exists"
         ) as mock_os_path_exists:
             mock_os_path_exists.return_value = True
-            deadline_vfs_launch_script_path: Union[
-                os.PathLike, str
-            ] = process_manager.find_vfs_launch_script()
+            deadline_vfs_launch_script_path: Union[os.PathLike, str] = (
+                process_manager.find_vfs_launch_script()
+            )
 
             # Will return preset vfs install path with exe script path appended since env is not set
             assert (


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

black 23.* is a security risk. Bumping to 24 and skipping the formatting check for 3.7

### What was the solution? (How)
update black dep for 3.8+, and remove 23.*. Skip linting for python 3.7 unit tests.

### What is the impact of this change?
no longer running linting on 3.7, resolved a security finding:

https://github.com/casillas2/deadline-cloud/security/dependabot/1

### How was this change tested?
```
hatch run lint
hatch run test
```

### Was this change documented?
yes

### Is this a breaking change?
no

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*