### PR TITLE
fix: catch on correct exception type if downloading with no outputs

### DIFF
--- a/src/deadline/job_attachments/download.py
+++ b/src/deadline/job_attachments/download.py
@@ -217,6 +217,8 @@ def _get_tasks_manifests_keys_from_s3(
             action="listing bucket contents",
             error_details=str(bce),
         ) from bce
+    except JobAttachmentsError:
+        raise  # pass along JobAttachmentsErrors if we get them
     except Exception as e:
         raise AssetSyncError from e
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We were still seeing a cryptic error message when trying to download outputs for a job that has no outputs (either because the job hasn't completed or there are no expected outputs).

Turns out we were catching on all exceptions and raising an `AssetSyncError`, when the function we were catching on raised a `JobAttachmentsError` if no outputs were found.

### What was the solution? (How)
Catch on the `JobAttachmentsError` and raise it since we expect that error and handle it up the chain.

### What is the impact of this change?
It's clearer to customers that there are no outputs for their job

### How was this change tested?
Before fix:
```
deadline job download-output
Downloading output from Job 'Test'
Failed to download output from job group:

```

After fix:
```
deadline job download-output
Downloading output from Job 'Test'
There are no output files available for download at this moment. Please verify that the Job/Step/Task you are trying to download output from has completed successfully.
```


### Was this change documented?
N/A

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*