### PR TITLE
docs: fix pip install optional deps for zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ $ pip install deadline
 
 or if you want the optional gui dependencies:
 ```sh
-pip install deadline[gui]
+$ pip install "deadline[gui]"
 ```
 
 ## Usage


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

pip install command wouldn't work on zsh:

```
% pip install deadline[gui]
zsh: no matches found: deadline[gui]
```

### What was the solution? (How)

quote the install! Now works on windows, mac, linux on the terminals I tried.

```
% pip install "deadline[gui]"
Collecting deadline[gui]
  Using cached deadline-0.47.1-py3-none-any.whl.metadata (7.9 kB)
Requirement already satisfied: boto3>=1.34.75 in /Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages (from deadline[gui]) (1.34.75)
...
Using cached deadline-0.47.1-py3-none-any.whl (216 kB)
Installing collected packages: deadline
Successfully installed deadline-0.47.1
```

### What is the impact of this change?

working docs

### How was this change tested?

### Was this change documented?

it is!

### Is this a breaking change?

nope!

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*