### PR TITLE
fix: set QT_API to pyside6 or pyside2 for deadline-cli

### DIFF
--- a/src/deadline/client/ui/__init__.py
+++ b/src/deadline/client/ui/__init__.py
@@ -60,6 +60,7 @@ def gui_context_for_cli():
         app.exec()
     """
     import importlib
+    import os
     from os.path import basename, dirname, join, normpath
     import shlex
     import shutil
@@ -69,8 +70,9 @@ def gui_context_for_cli():
 
     import click
 
-    has_pyside = importlib.util.find_spec("PySide6") or importlib.util.find_spec("PySide2")
-    if not has_pyside:
+    has_pyside6 = importlib.util.find_spec("PySide6")
+    has_pyside2 = importlib.util.find_spec("PySide2")
+    if not (has_pyside6 or has_pyside2):
         message = "Optional GUI components for deadline are unavailable. Would you like to install PySide?"
         will_install_gui = click.confirm(message, default=False)
         if not will_install_gui:
@@ -120,6 +122,12 @@ def gui_context_for_cli():
             # time consider local editables `pip install .[gui]`
             subprocess.run([sys.executable, "-m", "pip", "install", pyside6_pypi])
 
+    # set QT_API to inform qtpy which dependencies to look for.
+    # default to pyside6 and fallback to pyside2.
+    # Does not work with PyQt5 which is qtpy default
+    os.environ["QT_API"] = "pyside6"
+    if has_pyside2:
+        os.environ["QT_API"] = "pyside2"
     try:
         from qtpy.QtGui import QIcon
         from qtpy.QtWidgets import QApplication, QMessageBox


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

If a user has PyQt5/6 installed in their environment, launching the gui from the deadline client cli will throw an error saying `TypeError: 'f' is an unknown keyword argument`. This is because PyQt5/6 does not define f as a keyword arg in the QDialog constructor, even though Qt, PySide2, and PySide6 do.

This error will occur even if PySide6 or PySide2 are in the environment.

### What was the solution? (How)

For now, set the QT_API environment variable to use/prioritize our supported Qt bindings.

ref: https://github.com/spyder-ide/qtpy/tree/master?tab=readme-ov-file#requirements

Can always add PyQt5/6 support in the future if needed.

### What is the impact of this change?

Users with additional dependencies in their environment will continue to work!

### How was this change tested?

Before the fix:
```
hatch shell
pip install PyQt5 PySide6
deadline config gui
```
received this error, since `f` is not a keyword for a QDialog in PyQt5/6

![image](https://github.com/aws-deadline/deadline-cloud/assets/60796713/49e8365c-d871-4a89-94b5-4f9db7e28e76)


After fix without changing environment:
```
deadline config gui
```

And the gui launched properly

### Was this change documented?

N/A

### Is this a breaking change?

Nope

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*