### PR TITLE
fix(job_attachments): pass original exception to AssetSyncError

### DIFF
--- a/src/deadline/job_attachments/download.py
+++ b/src/deadline/job_attachments/download.py
@@ -122,7 +122,7 @@ def get_manifest_from_s3(
             error_details=str(bce),
         ) from bce
     except Exception as e:
-        raise AssetSyncError from e
+        raise AssetSyncError(e) from e
 
 
 def _get_output_manifest_prefix(
@@ -220,7 +220,7 @@ def _get_tasks_manifests_keys_from_s3(
     except JobAttachmentsError:
         raise  # pass along JobAttachmentsErrors if we get them
     except Exception as e:
-        raise AssetSyncError from e
+        raise AssetSyncError(e) from e
 
     # 2. Select all files in the last subfolder (alphabetically) under each "task-{any}" folder.
     for task_folder, files in task_prefixes.items():
@@ -516,7 +516,7 @@ def download_file(
             error_details=str(bce),
         ) from bce
     except Exception as e:
-        raise AssetSyncError from e
+        raise AssetSyncError(e) from e
 
     download_logger.debug(f"Downloaded {file.path} to {str(local_file_name)}")
     os.utime(local_file_name, (modified_time_override, modified_time_override))  # type: ignore[arg-type]
@@ -646,7 +646,7 @@ def _get_asset_root_from_s3(
             error_details=str(bce),
         ) from bce
     except Exception as e:
-        raise AssetSyncError from e
+        raise AssetSyncError(e) from e
 
     return head["Metadata"].get("asset-root", None)
 

--- a/src/deadline/job_attachments/upload.py
+++ b/src/deadline/job_attachments/upload.py
@@ -432,7 +432,7 @@ class S3AssetUploader:
                     error_details=str(bce),
                 ) from bce
             except Exception as e:
-                raise AssetSyncError from e
+                raise AssetSyncError(e) from e
 
     @contextmanager
     def _open_non_symlink_file_binary(
@@ -590,7 +590,7 @@ class S3AssetUploader:
                 error_details=str(bce),
             ) from bce
         except Exception as e:
-            raise AssetSyncError from e
+            raise AssetSyncError(e) from e
 
     def upload_bytes_to_s3(
         self,
@@ -644,7 +644,7 @@ class S3AssetUploader:
                 error_details=str(bce),
             ) from bce
         except Exception as e:
-            raise AssetSyncError from e
+            raise AssetSyncError(e) from e
 
 
 class S3AssetManager:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
In certain cases, when raising `AssetSyncError` from another exception using 
```
except Exception as e:
    raise AssetSyncError from e
```
the error message was not being displayed correctly. This makes it hard to debug and identify the root cause of the issue.

### What was the solution? (How)
Change `raise AssetSyncError from e` to `raise AssetSyncError(e) from e`, passing the original exception instance `e` to the `AssetSyncError`, so that we can ensure that the error message is preserved and displayed correctly.

### What is the impact of this change?
Improves the overall debugging experience and make it easier to understand the root cause of issues.

### How was this change tested?
- Made sure all unit tests passed by running `hatch run test`
- Made sure all integration tests passed by running`hatch run integ:test`
- Manually tested a scenario where the `[WinError 183] Cannot create a file when that file already exists` error occurred when running the output download command, `deadline job download-output < resource ids >  --output json --conflict-resolution CREATE_COPY`, on windows. Before this change, the download would fail silently without any error message. After the change, the error message was correctly displayed.

### Was this change documented?
No.

### Is this a breaking change?
No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*