### PR TITLE
fix(job_attachments): handle case-insensitive path extraction on Windows

### DIFF
--- a/test/unit/deadline_job_attachments/test_upload.py
+++ b/test/unit/deadline_job_attachments/test_upload.py
@@ -1981,6 +1981,28 @@ class TestUpload:
                 [],
             ),
             (
+                {
+                    "/home/username/DOCS/inputs/input1.txt",
+                    "/HOME/username/DOCS/inputs/input2.txt",
+                },  # input paths
+                {"/home/username/docs/outputs"},  # output paths
+                set(),  # referenced paths
+                {},  # File System Location (LOCAL type)
+                {},  # File System Location (SHARED type)
+                [
+                    AssetRootGroup(
+                        root_path="/",
+                        inputs={
+                            Path("/home/username/DOCS/inputs/input1.txt"),
+                            Path("/HOME/username/DOCS/inputs/input2.txt"),
+                        },
+                        outputs={
+                            Path("/home/username/docs/outputs"),
+                        },
+                    ),
+                ],
+            ),
+            (
                 {"/home/username/docs/inputs/input1.txt"},  # input paths
                 {"/home/username/docs/outputs"},  # output paths
                 set(),  # referenced paths
@@ -2123,6 +2145,42 @@ class TestUpload:
                 [],
             ),
             (
+                {"d:\\USERNAME\\DOCS\\inputs\\input1.txt"},  # input paths
+                {"D:\\username\\docs\\outputs"},  # output paths
+                set(),  # referenced paths
+                {},  # File System Location (LOCAL type)
+                {},  # File System Location (SHARED type)
+                [
+                    AssetRootGroup(
+                        root_path="D:\\username\\docs",
+                        inputs={
+                            Path("d:\\USERNAME\\DOCS\\inputs\\input1.txt"),
+                        },
+                        outputs={
+                            Path("D:\\username\\docs\\outputs"),
+                        },
+                    ),
+                ],
+            ),
+            (
+                {"D:\\username\\docs\\inputs\\input1.txt"},  # input paths
+                {"d:\\USERNAME\\DOCS\\outputs"},  # output paths
+                set(),  # referenced paths
+                {},  # File System Location (LOCAL type)
+                {},  # File System Location (SHARED type)
+                [
+                    AssetRootGroup(
+                        root_path="D:\\username\\docs",
+                        inputs={
+                            Path("D:\\username\\docs\\inputs\\input1.txt"),
+                        },
+                        outputs={
+                            Path("d:\\USERNAME\\DOCS\\outputs"),
+                        },
+                    ),
+                ],
+            ),
+            (
                 {"C:\\username\\docs\\inputs\\input1.txt"},  # input paths
                 {"C:\\username\\docs\\outputs"},  # output paths
                 set(),  # referenced paths
@@ -2250,7 +2308,11 @@ class TestUpload:
         sorted_result = sorted(result, key=lambda x: x.root_path)
         sorted_expected_result = sorted(expected_result, key=lambda x: x.root_path)
 
-        assert sorted_result == sorted_expected_result
+        assert len(sorted_result) == len(sorted_expected_result)
+        for i in range(len(sorted_result)):
+            assert sorted_result[i].root_path.upper() == sorted_expected_result[i].root_path.upper()
+            assert sorted_result[i].inputs == sorted_expected_result[i].inputs
+            assert sorted_result[i].outputs == sorted_expected_result[i].outputs
 
     @pytest.mark.skipif(
         sys.platform != "win32",


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
On Windows, asset paths are not treated as case-insensitive, leading to incorrect grouping of assets with paths that differ only in case. For example, if two paths "C:\Username\user\test1.txt" and "c:\uSerNaMe\user\test2.txt" exist, their shared root path should be extracted as "C:\Username\user". However, currently, these paths are treated as having different root paths due to the case-sensitivity issue.

### What was the solution? (How)
The `_get_asset_groups` function has been modified to ensure that the root path extraction is case-insensitive on Windows. 

### What is the impact of this change?
Resolves the issue of incorrect asset grouping on Windows due to case-sensitivity

### How was this change tested?
- A new unit test case has been added to validate the case-insensitive root path extraction.
- Existing unit tests and integration tests pass successfully.
- Manual end-to-end testing: submitting a job with a following parameter:
  ```
  name: AssetsDir1
  type: PATH
  objectType: DIRECTORY
  dataFlow: IN
  default: ./INPUTS_1
  ```
Where the actual input directory's name on the file system is `inputs_1`. The job submission and job execution on a worker was working, and generated output files as expected.

### Was this change documented?
No.

### Is this a breaking change?
No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*