### PR TITLE
fix: Throw error in sync-inputs if total input size is too large

### DIFF
--- a/test/unit/deadline_job_attachments/conftest.py
+++ b/test/unit/deadline_job_attachments/conftest.py
@@ -435,6 +435,29 @@ def fixture_merged_manifest():
     }
 
 
+@pytest.fixture(name="really_big_manifest")
+def fixture_really_big_manifest():
+    return {
+        "hashAlg": "xxh128",
+        "manifestVersion": "2023-03-03",
+        "paths": [
+            {
+                "hash": "a20ddfc33590cd7d2391f1972f66a72a",
+                "mtime": 4444444444444444,
+                "path": "a.txt",
+                "size": 100000000000000000,  # 100 Petabytes
+            },
+            {
+                "hash": "b96ddfc33590cd7d2391f1972f66a72a",
+                "mtime": 2222222222222222,
+                "path": "b.txt",
+                "size": 200000000000000000,  # 200 Petabytes
+            },
+        ],
+        "totalSize": 300000000000000000,
+    }
+
+
 def has_posix_target_user() -> bool:
     """Returns if the testing environment exported the env variables for doing
     cross-account posix target-user tests.


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
When using the [COPIED](https://github.com/aws-deadline/deadline-cloud/blob/mainline/src/deadline/job_attachments/models.py#L156) Job Attachments file system type, a worker could end up getting "disk full" errors because there isn't enough space on the machine to download all of the inputs required for the job.

### What was the solution? (How)
Since we count the total size of all inputs in the manifest file, we'll just check if the free disk space is enough to fit all of the files we're planning to download, and otherwise throw an error so users can see they need to increase their storage, or reduce the size of their job.

### What is the impact of this change?
Jobs should fail fast if there are too many inputs for workers.

### How was this change tested?
- Added new unit test
- spun up a CMF with my changes and did the following tests:
  - confirmed a normal job downloaded inputs successfully
  - modified the input manifest for a job, setting the file sizes really high, and confirmed it failed in the Sync Attachments session action. Here's the log:
```
No older logs at this moment.
2024/04/09 11:32:28-05:00  
2024/04/09 11:32:28-05:00 ==============================================
2024/04/09 11:32:28-05:00 --------- Job Attachments Download for Job
2024/04/09 11:32:28-05:00 ==============================================
2024/04/09 11:32:28-05:00 Syncing inputs using Job Attachments
2024/04/09 11:32:28-05:00 Error occurred while attempting to sync input files: Total file size required for download (100.0 TB) is larger than available disk space (255.15 GB)
Traceback (most recent call last):
  File "/opt/deadline/worker/lib/python3.9/site-packages/deadline_worker_agent/sessions/actions/sync_input_job_attachments.py", line 135, in _on_done
    future.result()
  File "/home/marofke/.local/share/rtx/installs/python/3.9.16/lib/python3.9/concurrent/futures/_base.py", line 439, in result
    return self.__get_result()
  File "/home/marofke/.local/share/rtx/installs/python/3.9.16/lib/python3.9/concurrent/futures/_base.py", line 391, in __get_result
    raise self._exception
  File "/home/marofke/.local/share/rtx/installs/python/3.9.16/lib/python3.9/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/opt/deadline/worker/lib/python3.9/site-packages/deadline_worker_agent/sessions/session.py", line 934, in sync_asset_inputs
    (download_summary_statistics, path_mapping_rules) = self._asset_sync.sync_inputs(
  File "/opt/deadline/worker/lib/python3.9/site-packages/deadline/job_attachments/asset_sync.py", line 502, in sync_inputs
    self._ensure_disk_capacity(session_dir, total_input_size)
  File "/opt/deadline/worker/lib/python3.9/site-packages/deadline/job_attachments/asset_sync.py", line 349, in _ensure_disk_capacity
    raise AssetSyncError(
deadline.job_attachments.exceptions.AssetSyncError: Error occurred while attempting to sync input files: Total file size required for download (100.0 TB) is larger than available disk space (255.15 GB)
No newer logs at this moment.
```

### Was this change documented?
N/A

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*