### PR TITLE
fix: Write manifests locally when submitting

### DIFF
--- a/src/deadline/client/ui/dialogs/submit_job_progress_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_progress_dialog.py
@@ -339,6 +339,7 @@ class SubmitJobProgressDialog(QDialog):
                 manifests=manifests,
                 on_uploading_assets=_update_upload_progress,
                 s3_check_cache_dir=config_file.get_cache_directory(),
+                manifest_write_dir=self._job_bundle_dir,
             )
 
             logger.info("Finished uploading job attachments files.")

--- a/src/deadline/job_attachments/README.md
+++ b/src/deadline/job_attachments/README.md
@@ -41,6 +41,8 @@ These snapshots are encapsulated in one or more [`asset_manifests`](asset_manife
 
 When starting work, the worker downloads the manifest associated with your job, and recreates the file structure of your submission locally, either downloading all files at once, or as needed if using the [virtual][vfs] job attachments filesystem type. When a task completes, the worker creates a new manifest for any outputs that were specified in the job submission, and uploads the manifest and the outputs back to your S3 bucket.
 
+Manifest files are written to a `manifests` directory within each job bundle that is added to the job history if submitted through the GUI (default: `~/.deadline/job_history`). The file path inside the `manifests` directory corresponds to the S3 manifest path in the submitted job's job attachments metadata.
+
 [vfs]: https://docs.aws.amazon.com/deadline-cloud/latest/userguide/storage-virtual.html
 
 ## Local Cache Files

--- a/test/unit/deadline_job_attachments/test_upload.py
+++ b/test/unit/deadline_job_attachments/test_upload.py
@@ -127,6 +127,18 @@ class TestUpload:
         output_dir1 = tmpdir.join("outputs")
         output_dir2 = tmpdir.join("outputs").join("textures")
 
+        history_dir = tmpdir.join("history")
+        expected_manifest_file = (
+            history_dir.join("manifests")
+            .join(farm_id)
+            .join(queue_id)
+            .join("Inputs")
+            .join("0000")
+            .join("e_input")
+        )
+        assert not os.path.exists(history_dir)
+        assert not os.path.exists(expected_manifest_file)
+
         expected_total_input_bytes = (
             scene_file.size() + texture_file.size() + normal_file.size() + meta_file.size()
         )
@@ -196,6 +208,7 @@ class TestUpload:
                 manifests=asset_root_manifests,
                 on_uploading_assets=mock_on_uploading_assets,
                 s3_check_cache_dir=str(cache_dir),
+                manifest_write_dir=str(history_dir),
             )
 
             # Then
@@ -235,6 +248,10 @@ class TestUpload:
             }
 
             assert f"assetRoot/Manifests/{farm_id}/{queue_id}/Inputs/0000/e_input" in caplog.text
+
+            # Ensure we wrote our manifest file locally
+            assert os.path.exists(expected_manifest_file)
+            assert os.path.isfile(expected_manifest_file)
 
             assert_progress_report_last_callback(
                 num_input_files=4,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
When making job submissions with Job Attachments, it isn't easy to see what actual manifests were submitted with your job. You'd have to call `deadline job get` to see your manifest paths, and then call `aws s3 cp` to download that file locally.

### What was the solution? (How)
Write the manifest files locally in the job bundle history directory, in a `manifests` sub-directory. Note that currently only GUI submissions create job history directories, so we aren't saving manifests for CLI submissions.

### What is the impact of this change?
It'll be a lot easier to debug Job Attachments submission issues now that customers can just look at what assets were collected for the job submission by looking through their manifest files.

### How was this change tested?
- Updated unit test
- Did multiple job submissions from GUI and confirmed the manifests directory was created in each job bundle history submission.
- Did a CLI submission and confirmed it worked as expected, and did not write a manifest file locally

### Was this change documented?
Updated the readme

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*