### PR TITLE
feat: Allow pre-submit and post-submit callbacks

### DIFF
--- a/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
@@ -428,7 +428,7 @@ class SubmitJobToDeadlineDialog(QDialog):
                         queue_parameters,
                         asset_references,
                         requirements,
-                        purpose=JobBundlePurpose.SUBMISSION
+                        purpose=JobBundlePurpose.SUBMISSION,
                     )
 
                 self.on_create_job_bundle_callback(
@@ -449,7 +449,7 @@ class SubmitJobToDeadlineDialog(QDialog):
                         settings,
                         queue_parameters,
                         asset_references,
-                        purpose=JobBundlePurpose.SUBMISSION
+                        purpose=JobBundlePurpose.SUBMISSION,
                     )
                 # Maintaining backward compatibility for submitters that do not support host_requirements yet
                 self.on_create_job_bundle_callback(
@@ -519,7 +519,7 @@ class SubmitJobToDeadlineDialog(QDialog):
                     queue_parameters,
                     asset_references,
                     requirements,
-                    purpose=JobBundlePurpose.SUBMISSION
+                    purpose=JobBundlePurpose.SUBMISSION,
                 )
         except UserInitiatedCancel as uic:
             logger.info("Canceling submission.")

--- a/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
@@ -67,6 +67,13 @@ class SubmitJobToDeadlineDialog(QDialog):
         attachments: (FlatAssetReferences): The job attachments that have been added to the job by the user.
         on_create_job_bundle_callback: A function to call when the dialog needs to create a Job Bundle. It
             is called with arguments (widget, job_bundle_dir, settings, queue_parameters, asset_references)
+        on_pre_submit_callback: A function to call just prior to the dialog submitting the Job Bundle. It is
+            called with arguments (widget, job_bundle_dir, settings, queue_parameters, asset_references).
+            This callback can be used to validate or modify a scene file before submitting.
+        on_post_submit_callback: A function to call just after the dialog has submitted the Job Bundle. It
+            is called with arguments (widget, job_bundle_dir, settings, queue_parameters, asset_references).
+            This callback may may be required if the `on_pre_submit_callback` modifies the scene file to
+            prepare it for submission and work needs to be done to modify the scene back to a working state.
         parent: parent of the widget
         f: Qt Window Flags
         show_host_requirements_tab: Display the host requirements tab in dialog if set to True. Default
@@ -82,6 +89,8 @@ class SubmitJobToDeadlineDialog(QDialog):
         auto_detected_attachments: AssetReferences,
         attachments: AssetReferences,
         on_create_job_bundle_callback,
+        on_pre_submit_callback=None,
+        on_post_submit_callback=None,
         parent=None,
         f=Qt.WindowFlags(),
         show_host_requirements_tab=False,
@@ -93,6 +102,8 @@ class SubmitJobToDeadlineDialog(QDialog):
 
         self.job_settings_type = type(initial_job_settings)
         self.on_create_job_bundle_callback = on_create_job_bundle_callback
+        self.on_pre_submit_callback = on_pre_submit_callback
+        self.on_post_submit_callback = on_post_submit_callback
         self.create_job_response: Optional[Dict[str, Any]] = None
         self.deadline_authentication_status = DeadlineAuthenticationStatus.getInstance()
         self.show_host_requirements_tab = show_host_requirements_tab
@@ -400,6 +411,18 @@ class SubmitJobToDeadlineDialog(QDialog):
 
         # Submit the job
         try:
+            # Execute any PreSubmission function defined.
+            if self.on_pre_submit_callback:
+                self.on_pre_submit_callback(
+                    self,
+                    job_history_bundle_dir,
+                    settings,
+                    queue_parameters,
+                    asset_references,
+                    purpose=JobBundlePurpose.SUBMISSION
+                )
+
+
             deadline = api.get_boto3_client("deadline")
 
             job_history_bundle_dir = create_job_history_bundle_dir(
@@ -476,6 +499,17 @@ class SubmitJobToDeadlineDialog(QDialog):
                 deadline,
                 auto_accept=str2bool(get_setting("settings.auto_accept")),
             )
+
+            # Execute any PostSubmission function defined.
+            if self.on_post_submit_callback:
+                self.on_post_submit_callback(
+                    self,
+                    job_history_bundle_dir,
+                    settings,
+                    queue_parameters,
+                    asset_references,
+                    purpose=JobBundlePurpose.SUBMISSION
+                )
         except UserInitiatedCancel as uic:
             logger.info("Canceling submission.")
             QMessageBox.information(self, f"{settings.submitter_name} Job Submission", str(uic))

--- a/src/deadline/client/util/__init__.py
+++ b/src/deadline/client/util/__init__.py
@@ -1,0 +1,5 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+__all__ = ["import_module_function", "validate_function_signature"]
+
+from .callback_loader import import_module_function, validate_function_signature

--- a/src/deadline/client/util/callback_loader.py
+++ b/src/deadline/client/util/callback_loader.py
@@ -1,5 +1,30 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 import importlib.util
+import inspect
 import sys
+from typing import Any, Optional, get_type_hints
+
+from deadline.client.ui.dialogs.submit_job_to_deadline_dialog import (  # type: ignore
+    SubmitJobToDeadlineDialog,
+    JobBundlePurpose,
+)
+from deadline.client.job_bundle.submission import AssetReferences
+
+
+def _reference_callback_signature(
+    widget: SubmitJobToDeadlineDialog,
+    job_bundle_dir: str,
+    settings: object,
+    queue_parameters: list[dict[str, Any]],
+    asset_references: AssetReferences,
+    host_requirements: Optional[dict[str, Any]] = None,
+    purpose: JobBundlePurpose = JobBundlePurpose.SUBMISSION,
+):
+    pass
+
+
+CALLBACK_REFERENCE_SIGNATURE = inspect.signature(_reference_callback_signature).parameters
+CALLBACK_REFERENCE_HINTS = get_type_hints(_reference_callback_signature)
 
 
 def import_module_function(module_path, module_name, function_name):
@@ -8,3 +33,29 @@ def import_module_function(module_path, module_name, function_name):
     sys.modules[module_name] = mod
     spec.loader.exec_module(mod)
     return getattr(mod, function_name)
+
+
+def _validate_parameter_type(parameter_type, other_type):
+    if parameter_type == other_type:
+        return True
+
+    if parameter_type in other_type.__bases__:
+        return True
+    return False
+
+
+def validate_function_signature(function, reference_signature=CALLBACK_REFERENCE_SIGNATURE):
+    parameters = inspect.signature(function).parameters
+    if parameters == reference_signature:
+        return True
+
+    function_hints = get_type_hints(function)
+
+    for param_name in CALLBACK_REFERENCE_HINTS:
+        if not function_hints.get(param_name):
+            return False
+        if not _validate_parameter_type(
+            CALLBACK_REFERENCE_HINTS[param_name], function_hints[param_name]
+        ):
+            return False
+    return True

--- a/src/deadline/client/util/callback_loader.py
+++ b/src/deadline/client/util/callback_loader.py
@@ -1,0 +1,10 @@
+import importlib.util
+import sys
+
+
+def import_module_function(module_path, module_name, function_name):
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = mod
+    spec.loader.exec_module(mod)
+    return getattr(mod, function_name)

--- a/test/unit/deadline_client/util/__init__.py
+++ b/test/unit/deadline_client/util/__init__.py
@@ -1,0 +1,1 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/test/unit/deadline_client/util/_callback_loader_invalid_signature_config.py
+++ b/test/unit/deadline_client/util/_callback_loader_invalid_signature_config.py
@@ -1,0 +1,29 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+from typing import Any, Optional
+
+from deadline.client.ui.dialogs.submit_job_to_deadline_dialog import (  # type: ignore
+    SubmitJobToDeadlineDialog,
+    JobBundlePurpose,
+)
+from deadline.client.job_bundle.submission import AssetReferences
+
+
+def on_pre_submit_callback(
+    widget: SubmitJobToDeadlineDialog,
+    job_bundle_dir: str,
+    settings: int,
+    asset_references: AssetReferences,
+    host_requirements: Optional[dict[str, Any]] = None,
+    purpose: JobBundlePurpose = JobBundlePurpose.SUBMISSION,
+):
+    return True
+
+
+def on_post_submit_callback(
+    widget: SubmitJobToDeadlineDialog,
+    job_bundle_dir: str,
+    settings: object,
+    queue_parameters: list[dict[str, Any]],
+    asset_references: AssetReferences,
+):
+    return True

--- a/test/unit/deadline_client/util/_callback_loader_invalid_syntax_config.py
+++ b/test/unit/deadline_client/util/_callback_loader_invalid_syntax_config.py
@@ -1,0 +1,33 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+from typing import Any, Optional
+
+from deadline.client.ui.dialogs.submit_job_to_deadline_dialog import (  # type: ignore
+    SubmitJobToDeadlineDialog,
+    JobBundlePurpose,
+)
+from deadline.client.job_bundle.submission import AssetReferences
+
+
+def missing_on_pre_submit_callback(
+        widget: SubmitJobToDeadlineDialog,
+        job_bundle_dir: str,
+        settings: object,
+        queue_parameters: list[dict[str, Any]],
+        asset_references: AssetReferences,
+        host_requirements: Optional[dict[str, Any]] = None,
+        purpose: JobBundlePurpose = JobBundlePurpose.SUBMISSION,
+):
+    return True
+
+
+defmissing_on_post_submit_callback(
+        widget: SubmitJobToDeadlineDialog,
+        job_bundle_dir: str,
+        settings: object,
+        queue_parameters: list[dict[str, Any]],
+        asset_references: AssetReferences,
+        host_requirements: Optional[dict[str, Any]] = None,
+        purpose: JobBundlePurpose = JobBundlePurpose.SUBMISSION,
+):
+    return True
+

--- a/test/unit/deadline_client/util/_callback_loader_missing_function_config.py
+++ b/test/unit/deadline_client/util/_callback_loader_missing_function_config.py
@@ -1,0 +1,32 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+from typing import Any, Optional
+
+from deadline.client.ui.dialogs.submit_job_to_deadline_dialog import (  # type: ignore
+    SubmitJobToDeadlineDialog,
+    JobBundlePurpose,
+)
+from deadline.client.job_bundle.submission import AssetReferences
+
+
+def missing_on_pre_submit_callback(
+    widget: SubmitJobToDeadlineDialog,
+    job_bundle_dir: str,
+    settings: object,
+    queue_parameters: list[dict[str, Any]],
+    asset_references: AssetReferences,
+    host_requirements: Optional[dict[str, Any]] = None,
+    purpose: JobBundlePurpose = JobBundlePurpose.SUBMISSION,
+):
+    return True
+
+
+def missing_on_post_submit_callback(
+    widget: SubmitJobToDeadlineDialog,
+    job_bundle_dir: str,
+    settings: object,
+    queue_parameters: list[dict[str, Any]],
+    asset_references: AssetReferences,
+    host_requirements: Optional[dict[str, Any]] = None,
+    purpose: JobBundlePurpose = JobBundlePurpose.SUBMISSION,
+):
+    return True

--- a/test/unit/deadline_client/util/_callback_loader_valid_config.py
+++ b/test/unit/deadline_client/util/_callback_loader_valid_config.py
@@ -1,0 +1,32 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+from typing import Any, Optional
+
+from deadline.client.ui.dialogs.submit_job_to_deadline_dialog import (  # type: ignore
+    SubmitJobToDeadlineDialog,
+    JobBundlePurpose,
+)
+from deadline.client.job_bundle.submission import AssetReferences
+
+
+def on_pre_submit_callback(
+    widget: SubmitJobToDeadlineDialog,
+    job_bundle_dir: str,
+    settings: object,
+    queue_parameters: list[dict[str, Any]],
+    asset_references: AssetReferences,
+    host_requirements: Optional[dict[str, Any]] = None,
+    purpose: JobBundlePurpose = JobBundlePurpose.SUBMISSION,
+):
+    return True
+
+
+def on_post_submit_callback(
+    widget: SubmitJobToDeadlineDialog,
+    job_bundle_dir: str,
+    settings: object,
+    queue_parameters: list[dict[str, Any]],
+    asset_references: AssetReferences,
+    host_requirements: Optional[dict[str, Any]] = None,
+    purpose: JobBundlePurpose = JobBundlePurpose.SUBMISSION,
+):
+    return True

--- a/test/unit/deadline_client/util/test_callback_loader.py
+++ b/test/unit/deadline_client/util/test_callback_loader.py
@@ -1,0 +1,115 @@
+import os
+
+from deadline.client import util
+
+
+def _asset_not_raises(fn, *args, **kwargs):
+    try:
+        ret = fn(*args, **kwargs)
+        return ret
+    except Exception as err:
+        assert "Did raise unexpected exception. {}".format(str(err))
+
+
+def _asset_raises(fn, exception_type, *args, **kwargs):
+    try:
+        fn(*args, **kwargs)
+        assert False is True
+    except exception_type:
+        return True
+    except Exception as err:
+        assert "Did not raise expected {} type. {}".format(exception_type, str(err))
+
+
+def test_loading_valid_config(fresh_deadline_config):
+    on_pre_submit_callback = _asset_not_raises(
+        util.callback_loader.import_module_function,
+        module_path=os.path.join(os.path.dirname(__file__), "_callback_loader_valid_config.py"),
+        module_name="test_loading_valid_config",
+        function_name="on_pre_submit_callback",
+    )
+
+    assert util.callback_loader.validate_function_signature(function=on_pre_submit_callback)
+
+    on_post_submit_callback = _asset_not_raises(
+        util.callback_loader.import_module_function,
+        module_path=os.path.join(os.path.dirname(__file__), "_callback_loader_valid_config.py"),
+        module_name="test_loading_valid_config",
+        function_name="on_post_submit_callback",
+    )
+
+    assert util.callback_loader.validate_function_signature(function=on_post_submit_callback)
+
+
+def test_loading_invalid_signature_config(fresh_deadline_config):
+    on_pre_submit_callback = _asset_not_raises(
+        util.callback_loader.import_module_function,
+        module_path=os.path.join(
+            os.path.dirname(__file__), "_callback_loader_invalid_signature_config.py"
+        ),
+        module_name="test_loading_invalid_signature_config",
+        function_name="on_pre_submit_callback",
+    )
+
+    valid_signature_pre = util.callback_loader.validate_function_signature(
+        function=on_pre_submit_callback
+    )
+    assert valid_signature_pre is False
+
+    on_post_submit_callback = _asset_not_raises(
+        util.callback_loader.import_module_function,
+        module_path=os.path.join(
+            os.path.dirname(__file__), "_callback_loader_invalid_signature_config.py"
+        ),
+        module_name="test_loading_invalid_signature_config",
+        function_name="on_post_submit_callback",
+    )
+
+    valid_signature_post = util.callback_loader.validate_function_signature(
+        function=on_post_submit_callback
+    )
+    assert valid_signature_post is False
+
+
+def test_loading_missing_function_config(fresh_deadline_config):
+    _asset_raises(
+        util.callback_loader.import_module_function,
+        exception_type=AttributeError,
+        module_path=os.path.join(
+            os.path.dirname(__file__), "_callback_loader_missing_function_config.py"
+        ),
+        module_name="test_loading_missing_function_config",
+        function_name="on_pre_submit_callback",
+    )
+
+    _asset_raises(
+        util.callback_loader.import_module_function,
+        exception_type=AttributeError,
+        module_path=os.path.join(
+            os.path.dirname(__file__), "_callback_loader_missing_function_config.py"
+        ),
+        module_name="test_loading_missing_function_config",
+        function_name="on_post_submit_callback",
+    )
+
+
+def test_loading_invalid_syntax_config(fresh_deadline_config):
+    _asset_raises(
+        util.callback_loader.import_module_function,
+        exception_type=SyntaxError,
+        module_path=os.path.join(
+            os.path.dirname(__file__), "_callback_loader_invalid_syntax_config.py"
+        ),
+        module_name="test_loading_invalid_syntax_config",
+        function_name="on_pre_submit_callback",
+    )
+
+    _asset_raises(
+        util.callback_loader.import_module_function,
+        exception_type=SyntaxError,
+        module_path=os.path.join(
+            os.path.dirname(__file__), "_callback_loader_invalid_syntax_config.py"
+        ),
+        module_name="test_loading_invalid_syntax_config",
+        function_name="on_post_submit_callback",
+    )


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
When working in a studio, we often want to execute local validation of scene files before we allow a submission to the render farm. In other scenarios we may need to modify or transform the scene to prepare if for the render farm.

These two hooks allow for studio specified modification hooks to be optionally run before and after a submission completes.

### What was the solution? (How)
This solution implements an `on_pre_submit_callback` and a `on_post_submit_callback` that take the same parameters as the `on_create_job_bundle_callback`.
The parameters match `on_create_job_bundle_callback` solely to provide flexibility in case the hook needs access to any of the settings of the job.

### What is the impact of this change?
The impact of this change as it stands would be non-breaking. I would consider adding functionality in the deadline-cloud-for-XX adaptor packages to provide a developer friendly way to provide hooks externally (Out of the scope of this PR probably, but it could be environment variables pointing to hook files, or an import of a pre-determined package name for example)

### How was this change tested?
Untested

### Was this change documented?
Not currently documented

### Is this a breaking change?
No it is a feature addition
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*