### PR TITLE
fix(job_attachments): fix output syncing when using identically named local File System Locations across different OS

### DIFF
--- a/src/deadline/job_attachments/asset_sync.py
+++ b/src/deadline/job_attachments/asset_sync.py
@@ -562,6 +562,7 @@ class AssetSync:
         storage_profiles_source_paths = list(storage_profiles_path_mapping_rules.keys())
 
         for manifest_properties in attachments.manifests:
+            session_root = session_dir
             local_root: Path = Path()
             if (
                 len(storage_profiles_path_mapping_rules) > 0
@@ -571,6 +572,10 @@ class AssetSync:
                     local_root = Path(
                         storage_profiles_path_mapping_rules[manifest_properties.rootPath]
                     )
+                    # We use session_root to filter out any files resolved to a location outside
+                    # of that directory. If storage profile's path mapping rules are available,
+                    # we can consider the session_root to be the mapped-storage profile path.
+                    session_root = local_root
                 else:
                     raise AssetSyncError(
                         "Error occurred while attempting to sync output files: "
@@ -584,7 +589,7 @@ class AssetSync:
                 manifest_properties,
                 s3_settings,
                 local_root,
-                session_dir,
+                session_root,
             )
             if output_files:
                 output_manifest = self._generate_output_manifest(output_files)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We have identified a bug related to output syncing when using identically named local File System Locations across Windows submitter and Linux workers.

The issue occurs in the following scenario:
1. A queue has storage profiles attached with identically named File System Locations (e.g., FSL1) of the LOCAL type.
2. A job bundle is submitted on Windows, and the bundle is located under the FSL1 path.
3. The job runs on a Linux worker. In this case, the input assets are downloaded to the Linux worker's FSL1 as the root path, and the output files are generated under the same root path.

However, our current implementation (see [this PR](https://github.com/aws-deadline/deadline-cloud/pull/225)) skips files outside the session directory during output syncing. As a result, the output files generated on the Linux worker are skipped because they are outside the session directory.

### What was the solution? (How)
we updated the output syncing logic, adding the line `session_dir = local_root` when a storage profile path is available. We use this `session_dir` to filter out any files resolved to a location outside of that directory. If storage profile path is available, we can consider the `session_dir` to be the storage profile path.

### What is the impact of this change?
Ensures that output files generated under the identically named FSL path are properly synced back to S3.

### How was this change tested?
Manual E2E testing on both Linux and Windows, and made sure generated output are synced correctly.

### Was this change documented?
No.

### Is this a breaking change?
No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*