### PR TITLE
fix(job_attachments)!: use correct profile for GetStorageProfileForQueue API

### DIFF
--- a/src/deadline/client/api/__init__.py
+++ b/src/deadline/client/api/__init__.py
@@ -22,6 +22,7 @@ __all__ = [
     "get_queue_parameter_definitions",
     "get_telemetry_client",
     "get_deadline_cloud_library_telemetry_client",
+    "get_storage_profile_for_queue",
 ]
 
 # The following import is needed to prevent the following sporadic failure:
@@ -57,6 +58,7 @@ from ._telemetry import (
     get_deadline_cloud_library_telemetry_client,
     TelemetryClient,
 )
+from ._get_storage_profile_for_queue import get_storage_profile_for_queue
 
 logger = getLogger(__name__)
 

--- a/src/deadline/client/api/_get_storage_profile_for_queue.py
+++ b/src/deadline/client/api/_get_storage_profile_for_queue.py
@@ -1,0 +1,44 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+from __future__ import annotations
+
+__all__ = ["get_storage_profile_for_queue"]
+
+from configparser import ConfigParser
+from typing import Optional
+from botocore.client import BaseClient  # type: ignore[import]
+
+from ._session import get_boto3_client
+from ...job_attachments.models import (
+    FileSystemLocation,
+    FileSystemLocationType,
+    StorageProfile,
+    StorageProfileOperatingSystemFamily,
+)
+
+
+def get_storage_profile_for_queue(
+    farm_id: str,
+    queue_id: str,
+    storage_profile_id: str,
+    deadline: Optional[BaseClient] = None,
+    config: Optional[ConfigParser] = None,
+) -> StorageProfile:
+    if deadline is None:
+        deadline = get_boto3_client("deadline", config=config)
+
+    storage_profile_response = deadline.get_storage_profile_for_queue(
+        farmId=farm_id, queueId=queue_id, storageProfileId=storage_profile_id
+    )
+    return StorageProfile(
+        storageProfileId=storage_profile_response["storageProfileId"],
+        displayName=storage_profile_response["displayName"],
+        osFamily=StorageProfileOperatingSystemFamily(storage_profile_response["osFamily"]),
+        fileSystemLocations=[
+            FileSystemLocation(
+                name=file_system_location["name"],
+                path=file_system_location["path"],
+                type=FileSystemLocationType(file_system_location["type"]),
+            )
+            for file_system_location in storage_profile_response.get("fileSystemLocations", [])
+        ],
+    )

--- a/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
@@ -432,6 +432,12 @@ class SubmitJobToDeadlineDialog(QDialog):
             queue_id = get_setting("defaults.queue_id")
             storage_profile_id = get_setting("settings.storage_profile_id")
 
+            storage_profile = None
+            if storage_profile_id:
+                storage_profile = api.get_storage_profile_for_queue(
+                    farm_id, queue_id, storage_profile_id, deadline
+                )
+
             queue = deadline.get_queue(farmId=farm_id, queueId=queue_id)
 
             queue_role_session = api.get_queue_user_boto3_session(
@@ -463,7 +469,7 @@ class SubmitJobToDeadlineDialog(QDialog):
             self.create_job_response = job_progress_dialog.start_submission(
                 farm_id,
                 queue_id,
-                storage_profile_id,
+                storage_profile,
                 job_history_bundle_dir,
                 queue_parameters,
                 asset_manager,

--- a/src/deadline/job_attachments/_aws/deadline.py
+++ b/src/deadline/job_attachments/_aws/deadline.py
@@ -10,15 +10,11 @@ from ..exceptions import JobAttachmentsError
 from ..models import (
     Attachments,
     JobAttachmentsFileSystem,
-    FileSystemLocation,
-    FileSystemLocationType,
     Job,
     JobAttachmentS3Settings,
     ManifestProperties,
-    StorageProfileOperatingSystemFamily,
     PathFormat,
     Queue,
-    StorageProfile,
 )
 from .aws_clients import get_deadline_client
 
@@ -109,39 +105,4 @@ def get_job(
             if "attachments" in response and response["attachments"]
             else None
         ),
-    )
-
-
-def get_storage_profile_for_queue(
-    farm_id: str,
-    queue_id: str,
-    storage_profile_id: str,
-    session: Optional[boto3.Session] = None,
-    deadline_endpoint_url: Optional[str] = None,
-) -> StorageProfile:
-    """
-    Retrieves a specific storage profile for queue from AWS Deadline Cloud.
-    """
-    try:
-        response = get_deadline_client(
-            session=session, endpoint_url=deadline_endpoint_url
-        ).get_storage_profile_for_queue(
-            farmId=farm_id, queueId=queue_id, storageProfileId=storage_profile_id
-        )
-    except ClientError as exc:
-        raise JobAttachmentsError(
-            f'Failed to get Storage profile "{storage_profile_id}" from Deadline'
-        ) from exc
-    return StorageProfile(
-        storageProfileId=response["storageProfileId"],
-        displayName=response["displayName"],
-        osFamily=StorageProfileOperatingSystemFamily(response["osFamily"]),
-        fileSystemLocations=[
-            FileSystemLocation(
-                name=file_system_location["name"],
-                path=file_system_location["path"],
-                type=FileSystemLocationType(file_system_location["type"]),
-            )
-            for file_system_location in response.get("fileSystemLocations", [])
-        ],
     )

--- a/test/integ/deadline_job_attachments/test_job_attachments.py
+++ b/test/integ/deadline_job_attachments/test_job_attachments.py
@@ -1335,6 +1335,7 @@ def test_upload_bucket_wrong_account(external_bucket: str, job_attachment_test: 
     with pytest.raises(
         JobAttachmentsS3ClientError, match=".*when calling the PutObject operation: Access Denied"
     ):
+        # The attempt to upload the asset manifest should be blocked.
         upload_group = asset_manager.prepare_paths_for_upload(
             job_bundle_path=str(job_attachment_test.ASSET_ROOT),
             input_paths=[str(job_attachment_test.SCENE_MA_PATH)],

--- a/test/unit/deadline_client/api/test_job_bundle_submission_asset_refs.py
+++ b/test/unit/deadline_client/api/test_job_bundle_submission_asset_refs.py
@@ -380,7 +380,7 @@ def test_create_job_from_job_bundle_with_all_asset_ref_variants(
             input_paths=input_paths,
             output_paths=output_paths,
             referenced_paths=referenced_paths,
-            storage_profile_id="",
+            storage_profile=None,
         )
         mock_hash_assets.assert_called_once_with(
             asset_groups=[AssetRootGroup()],

--- a/test/unit/deadline_job_attachments/test_upload.py
+++ b/test/unit/deadline_job_attachments/test_upload.py
@@ -1967,21 +1967,17 @@ class TestUpload:
             fileSystemLocations=mock_file_system_locations,
         )
 
-        with patch(
-            f"{deadline.__package__}.job_attachments.upload.get_storage_profile_for_queue",
-            side_effect=[mock_storage_profile_for_queue],
-        ):
-            asset_manager = S3AssetManager(
-                farm_id=farm_id,
-                queue_id=queue_id,
-                job_attachment_settings=self.job_attachment_s3_settings,
-            )
+        asset_manager = S3AssetManager(
+            farm_id=farm_id,
+            queue_id=queue_id,
+            job_attachment_settings=self.job_attachment_s3_settings,
+        )
 
-            result = asset_manager._get_file_system_locations_by_type(
-                storage_profile_id="sp-0123456789"
-            )
+        result = asset_manager._get_file_system_locations_by_type(
+            storage_profile_for_queue=mock_storage_profile_for_queue
+        )
 
-            assert result == expected_result
+        assert result == expected_result
 
     @pytest.mark.skipif(
         sys.platform == "win32",


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
When submitting a job with a Storage Profile ID, the `GetStorageProfileForQueue` API was using the default AWS profile instead of the Deadline Cloud submitter's configured profile. If the two profiles pointed to different regions, the API couldn't find the storage profile resource, resulting in a job submission failure

### What was the solution? (How)
Modified the code to use the correct boto3 session (using the Deadline Cloud submitter's profile) when calling the `GetStorageProfileForQueue` API. The API is no longer called from `src/deadline/job_attachments/upload.py`. Instead, the API is called from the below places:
1. src/deadline/client/api/_submit_job_bundle.py
2. src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
and the `prepare_paths_for_upload()` function now receives `storage_profile` object itself instead of `storage_profile_id`.

### What is the impact of this change?
Fixes the job submission issue when involving a Storage Profile in a different region than the default AWS profile. 

### How was this change tested?
1. I created AWS CLI's `[default]` profile and Deadline Cloud default profile, where each profile is pointing to different regions.
2. Before the change, job submission to a queue with a Storage Profile failed with a "storage profile does not exist" error.
2. After the change, job submission to the same queue succeeded, and the job could be created.
3. A new job was submitted to a Queue with a Storage Profile, and I executed a worker (CMF) to verify that asset sync and output downloads worked as expected.

### Was this change documented?
No.

### Is this a breaking change?
Yes, there are changes in the public interface (`S3AssetManager`'s `prepare_paths_for_upload()`).

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*