### PR TITLE
fix(job_attachments): fix integration test exception

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ __pycache__/
 *_version.py
 .attach_pid*
 .DS_Store
+.idea/

--- a/test/integ/deadline_job_attachments/test_job_attachments.py
+++ b/test/integ/deadline_job_attachments/test_job_attachments.py
@@ -1333,7 +1333,7 @@ def test_upload_bucket_wrong_account(external_bucket: str, job_attachment_test: 
 
     # WHEN
     with pytest.raises(
-        AssetSyncError, match=f"Error checking if object exists in bucket '{external_bucket}'"
+        JobAttachmentsS3ClientError, match=".*when calling the PutObject operation: Access Denied"
     ):
         upload_group = asset_manager.prepare_paths_for_upload(
             job_bundle_path=str(job_attachment_test.ASSET_ROOT),


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Integration test failure in `test_upload_bucket_wrong_account`

```
E           deadline.job_attachments.exceptions.JobAttachmentsS3ClientError: Error uploading binary file in bucket 'job-attachment-bucket-snipe-test', Target key or prefix: 'root/Manifests/farm-f04d68d177184646ad0d527964e6f9ba/queue-3495b8b2f71a40c09f0d72267805ab86/Inputs/10ca0ac8feb34af999e13bc0e0715e7f/92b571571820100103aedfc230a145c8_input', HTTP Status Code: 403, Forbidden or Access denied. Please check your AWS credentials, and ensure that your AWS IAM Role or User has the 's3:PutObject' permission for this bucket.  An error occurred (AccessDenied) when calling the PutObject operation: Access Denied

/home/chocecil/.local/share/mise/installs/python/latest/lib/python3.12/site-packages/deadline/job_attachments/upload.py:645: JobAttachmentsS3ClientError
```

### What was the solution? (How)
changed the exception type and message


### What is the impact of this change?
Integ tests pass, no logic changes

### How was this change tested?
`hatch run integ:test`

### Was this change documented?

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*