### PR TITLE
fix: Use correct paths on windows for local manifest file

### DIFF
--- a/src/deadline/job_attachments/README.md
+++ b/src/deadline/job_attachments/README.md
@@ -41,7 +41,7 @@ These snapshots are encapsulated in one or more [`asset_manifests`](asset_manife
 
 When starting work, the worker downloads the manifest associated with your job, and recreates the file structure of your submission locally, either downloading all files at once, or as needed if using the [virtual][vfs] job attachments filesystem type. When a task completes, the worker creates a new manifest for any outputs that were specified in the job submission, and uploads the manifest and the outputs back to your S3 bucket.
 
-Manifest files are written to a `manifests` directory within each job bundle that is added to the job history if submitted through the GUI (default: `~/.deadline/job_history`). The file path inside the `manifests` directory corresponds to the S3 manifest path in the submitted job's job attachments metadata.
+Manifest files are written to a `manifests` directory within each job bundle that is added to the job history if submitted through the GUI (default: `~/.deadline/job_history`). A corresponding `manifest_s3_mapping` file is created alongside manifests, which specifies each local manifest file with the S3 manifest path in the submitted job's job attachments metadata.
 
 [vfs]: https://docs.aws.amazon.com/deadline-cloud/latest/userguide/storage-virtual.html
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Windows submissions would sometimes fail, due to a [recent change](https://github.com/aws-deadline/deadline-cloud/pull/291) that writes manifest files locally. This was narrowed down to file name lengths being too long.

### What was the solution? (How)
While there are workarounds to file length issues in Windows, such as prepending `\\?\` to the start of file names, or forcing users to set a registry key ([see Windows documentation](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry)), both didn't seem like ideal solutions. Prepending `\\?\` was leading to weird behaviour with the `~/.deadline` directory, since we run [icacls](https://github.com/aws-deadline/deadline-cloud/blob/mainline/src/deadline/client/config/config_file.py#L196) to refresh the config file. I tried modifying the `icacls` call to append `\\?\` as well, but it was still causing issues with file permissions for the manifest files themselves, not allowing users to open them. Finally, job bundles are intended to be portable, so if the history bundle has a file path too long that kind of defeats the purpose for portability's sake.

So, the decided upon solution is to trim the file path of the manifest, simply writing it to the `manifests` subdirectory in the configured job history directory, and creating a mapping file alongside it (called `manifest_s3_mapping`, which would store the local file name with its associated S3 object key. For the mapping file, I opted for simple Python dicts being written on each line to avoid a larger refactor, while still allowing users to easily script consuming the mapping file by reading one line at a time.

### What is the impact of this change?
Users can see which manifests were submitted with their GUI submissions, and have a way of seeing where they were uploaded to in their S3 bucket.

### How was this change tested?
- modified unit tests
- On Windows, did a manual job submission through the GUI with multiple asset roots (i.e. assets on multiple drives), verified:
  - a `manifests` directory was created in my job history directory
  - two manifest files were created in this directory:
```
Directory of D:\Users\<username>\.deadline\job_history\<profile_name>\2024-04\2024-04-16-02-JobBundle-Name\manifests

16d9cf86f3c8222777ebc39881ad0183_input
1cae1d782cfd85a000d8d2ab601cccb4_input
manifest_s3_mapping
```
  - a `manifest_s3_mapping` file was created locally with the following contents:
```
{'local_file': '1cae1d782cfd85a000d8d2ab601cccb4_input', 's3_key': 'DeadlineCloud/Manifests/farm-0a85287445134eeb9ea6efbde1e9684e/queue-9e71016b3fae48aca5ee9a5a2648ce76/Inputs/8c8e64f7d72b4831b9a5527ff94bd9b8/1cae1d782cfd85a000d8d2ab601cccb4_input'}
{'local_file': '16d9cf86f3c8222777ebc39881ad0183_input', 's3_key': 'DeadlineCloud/Manifests/farm-0a85287445134eeb9ea6efbde1e9684e/queue-9e71016b3fae48aca5ee9a5a2648ce76/Inputs/6725422794af44b18cd43ab783e191ce/16d9cf86f3c8222777ebc39881ad0183_input'}
```
  - and verified that the contents of the manifests were correct
- also submitted a GUI job on a Mac machine, confirmed it created a manifest file locally and the `manifest_s3_mapping` file as well

### Was this change documented?
Updated Readme

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*