### PR TITLE
ci: add mainline integration test workflow

### DIFF
--- a/.github/workflows/mainline_integration_test.yml
+++ b/.github/workflows/mainline_integration_test.yml
@@ -1,0 +1,32 @@
+name: Mainline Integration Test
+
+on:
+  workflow_dispatch:
+
+jobs:  
+  MainlineIntegrationTest:
+    name: Integration Test
+    runs-on: ubuntu-latest
+    environment: mainline
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: mainline
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_CODEBUILD_MAINLINE_INTEG_ROLE }}
+          aws-region: us-west-2
+          mask-aws-account-id: true
+      - name: Run CodeBuild
+        uses: aws-actions/aws-codebuild-run-build@v1
+        with:
+          project-name: deadline-cloud-dev-IntegTest
+          hide-cloudwatch-logs: true
+          env-vars-for-codebuild: |
+            TEST_TYPE
+        env:
+          TEST_TYPE: WHEEL


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Add a workflow dispatch for running the deadline cloud integration tests on mainline

### What was the solution? (How)
Add the workflow

### What is the impact of this change?
We can run the integration tests in CI

### How was this change tested?
n/a - this will be tests after it has been merged

### Was this change documented?
n/a

### Is this a breaking change?
no

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*