### PR TITLE
fix!: always prompt user about misconfigured inputs

### DIFF
--- a/src/deadline/client/ui/dialogs/deadline_config_dialog.py
+++ b/src/deadline/client/ui/dialogs/deadline_config_dialog.py
@@ -280,7 +280,7 @@ class DeadlineWorkstationConfigWidget(QWidget):
 
     def _build_general_settings_ui(self, group, layout):
         self.auto_accept = self._init_checkbox_setting(
-            group, layout, "settings.auto_accept", "Auto Accept Confirmation Prompts"
+            group, layout, "settings.auto_accept", "Auto Accept Prompt Defaults"
         )
         self.telemetry_opt_out = self._init_checkbox_setting(
             group, layout, "telemetry.opt_out", "Telemetry Opt Out"

--- a/src/deadline/client/ui/dialogs/submit_job_progress_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_progress_dialog.py
@@ -23,6 +23,7 @@ from qtpy.QtWidgets import (  # pylint: disable=import-error; type: ignore
     QGroupBox,
     QLabel,
     QMessageBox,
+    QPushButton,
     QProgressBar,
     QTextEdit,
     QVBoxLayout,
@@ -52,7 +53,12 @@ from deadline.client.job_bundle.submission import (
     split_parameter_args,
 )
 from deadline.job_attachments.exceptions import AssetSyncCancelledError, MisconfiguredInputsError
-from deadline.job_attachments.models import AssetRootGroup, AssetRootManifest, StorageProfile
+from deadline.job_attachments.models import (
+    AssetRootGroup,
+    AssetRootManifest,
+    AssetUploadGroup,
+    StorageProfile,
+)
 from deadline.job_attachments.progress_tracker import ProgressReportMetadata, SummaryStatistics
 from deadline.job_attachments.upload import S3AssetManager
 from deadline.job_attachments._utils import _human_readable_file_size
@@ -105,6 +111,7 @@ class SubmitJobProgressDialog(QDialog):
         asset_manager: Optional[S3AssetManager],
         deadline_client: BaseClient,
         auto_accept: bool = False,
+        require_paths_exist: bool = False,
     ) -> Optional[Dict[str, Any]]:
         """
         Starts a submission. Returns the response from calling create job. If an error occurs
@@ -131,6 +138,7 @@ class SubmitJobProgressDialog(QDialog):
         self._asset_manager = asset_manager
         self._deadline_client = deadline_client
         self._auto_accept = auto_accept
+        self._require_paths_exist = require_paths_exist
 
         self._start_submission()
         return self.exec_()
@@ -240,10 +248,15 @@ class SubmitJobProgressDialog(QDialog):
         ):
             # Extend input_filenames with all the files in the input_directories
             missing_directories: set[str] = set()
-            empty_directories: set[str] = set()
             for directory in self.asset_references.input_directories:
                 if not os.path.isdir(directory):
-                    missing_directories.add(directory)
+                    if self._require_paths_exist:
+                        missing_directories.add(directory)
+                    else:
+                        logging.warning(
+                            f"Input directory '{directory}' does not exist. Adding to referenced paths."
+                        )
+                        self.asset_references.referenced_paths.add(directory)
                     continue
 
                 is_dir_empty = True
@@ -254,46 +267,33 @@ class SubmitJobProgressDialog(QDialog):
                     self.asset_references.input_filenames.update(
                         os.path.normpath(os.path.join(root, file)) for file in files
                     )
+                # Empty directories just become references since there's nothing to upload
                 if is_dir_empty:
-                    empty_directories.add(directory)
+                    logging.info(
+                        f"Input directory '{directory}' is empty. Adding to referenced paths."
+                    )
+                    self.asset_references.referenced_paths.add(directory)
             self.asset_references.input_directories.clear()
 
-            misconfigured_directories = missing_directories or empty_directories
-            if misconfigured_directories:
+            if missing_directories:
                 sample_size = 3
-                sample_of_misconfigured_inputs = ""
-                all_misconfigured_inputs = ""
                 misconfigured_directories_msg = (
                     "Job submission contains misconfigured input directories and cannot be submitted."
-                    " All input directories must exist and cannot be empty."
+                    " All input directories must exist."
                 )
 
-                if missing_directories:
-                    missing_directory_list = sorted(list(missing_directories))
-                    sample_of_missing_directories = "\n\t".join(
-                        missing_directory_list[:sample_size]
-                    )
-                    sample_of_misconfigured_inputs += (
-                        f"\nNon-existent directories:\n\t{sample_of_missing_directories}\n"
-                    )
-                    all_missing_directories = "\n\t".join(missing_directory_list)
-                    all_misconfigured_inputs += (
-                        f"\nNon-existent directories:\n\t{all_missing_directories}"
-                    )
-                if empty_directories:
-                    empty_directory_list = sorted(list(empty_directories))
-                    sample_of_empty_directories = "\n\t".join(empty_directory_list[:sample_size])
-                    sample_of_misconfigured_inputs += (
-                        f"\nEmpty directories:\n\t{sample_of_empty_directories}"
-                    )
-                    all_empty_directories = "\n\t".join(empty_directory_list)
-                    all_misconfigured_inputs += f"\nEmpty directories:\n\t{all_empty_directories}"
+                missing_directory_list = sorted(list(missing_directories))
+                sample_of_missing_directories = "\n\t".join(missing_directory_list[:sample_size])
+                sample_of_misconfigured_inputs = (
+                    f"\nNon-existent directories:\n\t{sample_of_missing_directories}\n"
+                )
+                all_missing_directories = "\n\t".join(missing_directory_list)
+                all_misconfigured_inputs = (
+                    f"\nNon-existent directories:\n\t{all_missing_directories}"
+                )
 
                 logging.error(misconfigured_directories_msg + all_misconfigured_inputs)
-                just_a_sample = (
-                    len(missing_directories) > sample_size or len(empty_directories) > sample_size
-                )
-                if just_a_sample:
+                if len(missing_directories) > sample_size:
                     misconfigured_directories_msg += (
                         " Check logs for all occurrences, here's a sample:\n"
                     )
@@ -302,19 +302,15 @@ class SubmitJobProgressDialog(QDialog):
                 raise MisconfiguredInputsError(misconfigured_directories_msg)
 
             upload_group = self._asset_manager.prepare_paths_for_upload(
-                job_bundle_path=self._job_bundle_dir,
                 input_paths=sorted(self.asset_references.input_filenames),
                 output_paths=sorted(self.asset_references.output_directories),
                 referenced_paths=sorted(self.asset_references.referenced_paths),
                 storage_profile=self._storage_profile,
+                require_paths_exist=self._require_paths_exist,
             )
             # If we find any Job Attachments, start a background thread
             if upload_group.asset_groups:
-                if not self._confirm_asset_references_outside_storage_profile(
-                    upload_group.num_outside_files_by_root,
-                    upload_group.total_input_files,
-                    upload_group.total_input_bytes,
-                ):
+                if not self._confirm_asset_references_outside_storage_profile(upload_group):
                     raise UserInitiatedCancel("Submission canceled.")
 
                 self._start_hashing(
@@ -595,37 +591,67 @@ class SubmitJobProgressDialog(QDialog):
         logger.error(str(e))
 
     def _confirm_asset_references_outside_storage_profile(
-        self,
-        deviated_file_count_by_root: dict[str, int],
-        num_files: int,
-        upload_size: int,
+        self, upload_group: AssetUploadGroup
     ) -> bool:
         """
         Creates a dialog to prompt the user to confirm that they want to proceed
         with uploading when files were found outside of the configured storage profile locations.
         """
-        message_box = QMessageBox(self)
         message_text = (
-            f"Job submission contains {num_files} files totaling {_human_readable_file_size(upload_size)}. "
-            " All files will be uploaded to S3 if they are not already present in the job attachments bucket."
+            f"Job submission contains {upload_group.total_input_files} input files totaling {_human_readable_file_size(upload_group.total_input_bytes)}. "
+            " All input files will be uploaded to S3 if they are not already present in the job attachments bucket."
         )
-        if deviated_file_count_by_root:
-            root_by_count_message = "\n\n".join(
-                [
-                    f"{file_count} files from: '{directory}'"
-                    for directory, file_count in deviated_file_count_by_root.items()
-                ]
-            )
+        warning_message = ""
+        for group in upload_group.asset_groups:
+            if not group.file_system_location_name:
+                warning_message += f"\n\nUnder the directory '{group.root_path}':"
+                warning_message += (
+                    f"\n\t{len(group.inputs)} input file{'' if len(group.inputs) == 1 else 's'}"
+                    if len(group.inputs) > 0
+                    else ""
+                )
+                warning_message += (
+                    f"\n\t{len(group.outputs)} output director{'y' if len(group.outputs) == 1 else 'ies'}"
+                    if len(group.outputs) > 0
+                    else ""
+                )
+                warning_message += (
+                    f"\n\t{len(group.references)} referenced file{'' if len(group.references) == 1 else 's'} and/or director{'y' if len(group.outputs) == 1 else 'ies'}"
+                    if len(group.references) > 0
+                    else ""
+                )
+
+        # Exit early if we've set auto accept and there are no warnings
+        if not warning_message and self._auto_accept:
+            return True
+
+        # Build the UI
+        message_box = QMessageBox(self)
+        if warning_message:
+            if self._storage_profile:
+                fs_locations_text = "\n\t".join(
+                    [fs_location.path for fs_location in self._storage_profile.fileSystemLocations]
+                )
+                message_text += f"\n\nFiles were specified outside of the configured storage profile location(s):\n{fs_locations_text}\n"
+            else:
+                message_text += "\n\nNo storage profile locations are configured for this queue."
             message_text += (
-                f"\n\nFiles were found outside of the configured storage profile location(s). "
-                " Please confirm that you intend to upload files from the following directories:\n\n"
-                f"{root_by_count_message}\n\n"
-                "To remove this warning you must only upload files located within a storage profile location."
+                "\nPlease confirm that you intend to submit a job that uses files from the following directories:"
+                f"{warning_message}\n\n"
+                "To permanently remove this warning you must only use files located within a storage profile location."
             )
             message_box.setIcon(QMessageBox.Warning)
+
         message_box.setText(message_text)
         message_box.setStandardButtons(QMessageBox.Ok | QMessageBox.Cancel)
         message_box.setDefaultButton(QMessageBox.Ok)
+
+        if not warning_message:
+            # If we don't have any warnings, add the "Do not ask again" button that acts like 'OK' but sets the config
+            # setting to always auto-accept similar prompts in the future.
+            dont_ask_button = QPushButton("Do not ask again", self)
+            dont_ask_button.clicked.connect(lambda: set_setting("settings.auto_accept", "true"))
+            message_box.addButton(dont_ask_button, QMessageBox.ActionRole)
 
         message_box.setWindowTitle("Job Attachments Valid Files Confirmation")
         selection = message_box.exec()

--- a/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
@@ -475,6 +475,7 @@ class SubmitJobToDeadlineDialog(QDialog):
                 asset_manager,
                 deadline,
                 auto_accept=str2bool(get_setting("settings.auto_accept")),
+                require_paths_exist=self.job_attachments.get_require_paths_exist(),
             )
         except UserInitiatedCancel as uic:
             logger.info("Canceling submission.")

--- a/src/deadline/client/ui/widgets/job_attachments_tab.py
+++ b/src/deadline/client/ui/widgets/job_attachments_tab.py
@@ -58,11 +58,19 @@ class JobAttachmentsWidget(QWidget):
     def _build_ui(self) -> None:
         tab_layout = QVBoxLayout(self)
 
+        # Create a group box for general settings
+        size_policy = QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        size_policy.setVerticalStretch(10)
+        self.general_group = QGroupBox("General Submission Settings", self)
+        tab_layout.addWidget(self.general_group)
+        self.general_group.setSizePolicy(size_policy)
+        general_layout = QVBoxLayout(self.general_group)
+
         # Create a group box for each type of attachment
         self.input_files_group = QGroupBox("Attach Input Files", self)
-        tab_layout.addWidget(self.input_files_group)
         size_policy = QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         size_policy.setVerticalStretch(80)
+        tab_layout.addWidget(self.input_files_group)
         self.input_files_group.setSizePolicy(size_policy)
         input_files_layout = QVBoxLayout(self.input_files_group)
 
@@ -79,6 +87,10 @@ class JobAttachmentsWidget(QWidget):
         self.output_directories_group.setSizePolicy(size_policy)
         tab_layout.addWidget(self.output_directories_group)
         output_directories_layout = QVBoxLayout(self.output_directories_group)
+
+        # General settings
+        self.general_settings = JobAttachmentsGeneralWidget(self)
+        general_layout.addWidget(self.general_settings)
 
         # The "Attach Input Files" attachments
         self.input_files_controls = JobAttachmentsControlsWidget(self)
@@ -307,6 +319,27 @@ class JobAttachmentsWidget(QWidget):
         asset_references.json|yaml file in a Job Bundle.
         """
         return self.auto_detected_attachments.union(self.attachments)
+
+    def get_require_paths_exist(self) -> bool:
+        """
+        Returns the checkbox value of whether to allow empty paths or not.
+        """
+        return self.general_settings.require_paths_exist.isChecked()
+
+
+class JobAttachmentsGeneralWidget(QWidget):
+    """
+    A Widget that contains general settings for a specific submission.
+    """
+
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent=parent)
+
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        self.require_paths_exist = QCheckBox("Require all input paths exist", parent=self)
+        layout.addWidget(self.require_paths_exist)
 
 
 class JobAttachmentsControlsWidget(QWidget):

--- a/src/deadline/job_attachments/exceptions.py
+++ b/src/deadline/job_attachments/exceptions.py
@@ -92,6 +92,13 @@ class AssetOutsideOfRootError(JobAttachmentsError):
     """
 
 
+class MisconfiguredInputsError(JobAttachmentsError):
+    """
+    Exception for errors related to missing input directories, empty input directories,
+    missing input files, and input directories classified as files
+    """
+
+
 class ManifestDecodeValidationError(JobAttachmentsError):
     """
     Exception for errors related to asset manifest decoding.

--- a/src/deadline/job_attachments/models.py
+++ b/src/deadline/job_attachments/models.py
@@ -55,7 +55,6 @@ class AssetUploadGroup:
     """Represents all of the information needed to prepare to upload assets"""
 
     asset_groups: List[AssetRootGroup] = field(default_factory=list)
-    num_outside_files_by_root: dict[str, int] = field(default_factory=dict)
     total_input_files: int = 0
     total_input_bytes: int = 0
 

--- a/src/deadline/job_attachments/upload.py
+++ b/src/deadline/job_attachments/upload.py
@@ -824,6 +824,7 @@ class S3AssetManager:
         referenced_paths: set[str],
         local_type_locations: dict[str, str] = {},
         shared_type_locations: dict[str, str] = {},
+        require_paths_exist: bool = False,
     ) -> list[AssetRootGroup]:
         """
         For the given input paths and output paths, a list of groups is returned, where paths sharing
@@ -847,7 +848,13 @@ class S3AssetManager:
             # Need to use absolute to not resolve symlinks, but need normpath to get rid of relative paths, i.e. '..'
             abs_path = Path(os.path.normpath(Path(_path).absolute()))
             if not abs_path.exists():
-                missing_input_paths.add(abs_path)
+                if require_paths_exist:
+                    missing_input_paths.add(abs_path)
+                else:
+                    logger.warning(
+                        f"Input path '{_path}' resolving to '{abs_path}' does not exist. Adding to referenced paths."
+                    )
+                    referenced_paths.add(_path)
                 continue
             if abs_path.is_dir():
                 misconfigured_directories.add(abs_path)
@@ -1042,30 +1049,13 @@ class S3AssetManager:
                 shared_type_locations[fs_loc.path] = fs_loc.name
         return local_type_locations, shared_type_locations
 
-    def _get_deviated_file_count_by_root(
-        self, groups: list[AssetRootGroup], root_path: str
-    ) -> dict[str, int]:
-        """
-        Given a list of AssetRootGroups and a root directory, return a dict of root paths and file counts that
-        are outside of that root path, and aren't in any storage profile locations.
-        """
-        real_root_path = Path(root_path).resolve()
-        deviated_file_count_by_root: dict[str, int] = {}
-        for group in groups:
-            if (
-                not str(Path(group.root_path).resolve()).startswith(str(real_root_path))
-                and not group.file_system_location_name
-                and group.inputs
-            ):
-                deviated_file_count_by_root[group.root_path] = len(group.inputs)
-        return deviated_file_count_by_root
-
     def _group_asset_paths(
         self,
         input_paths: list[str],
         output_paths: list[str],
         referenced_paths: list[str],
         storage_profile: Optional[StorageProfile] = None,
+        require_paths_exist: bool = False,
     ) -> list[AssetRootGroup]:
         """
         Resolves all of the paths that will be uploaded, sorting by storage profile location.
@@ -1085,17 +1075,18 @@ class S3AssetManager:
             {rf_path for rf_path in referenced_paths if rf_path},
             local_type_locations,
             shared_type_locations,
+            require_paths_exist,
         )
 
         return asset_groups
 
     def prepare_paths_for_upload(
         self,
-        job_bundle_path: str,
         input_paths: list[str],
         output_paths: list[str],
         referenced_paths: list[str],
         storage_profile: Optional[StorageProfile] = None,
+        require_paths_exist: bool = False,
     ) -> AssetUploadGroup:
         """
         Processes all of the paths required for upload, grouping them by asset root and local storage profile locations.
@@ -1103,15 +1094,15 @@ class S3AssetManager:
         for files that were not under the root path or any local storage profile locations.
         """
         asset_groups = self._group_asset_paths(
-            input_paths, output_paths, referenced_paths, storage_profile
+            input_paths,
+            output_paths,
+            referenced_paths,
+            storage_profile,
+            require_paths_exist,
         )
         (input_file_count, input_bytes) = self._get_total_input_size_from_asset_group(asset_groups)
-        num_outside_files_by_bundle_path = self._get_deviated_file_count_by_root(
-            asset_groups, job_bundle_path
-        )
         return AssetUploadGroup(
             asset_groups=asset_groups,
-            num_outside_files_by_root=num_outside_files_by_bundle_path,
             total_input_files=input_file_count,
             total_input_bytes=input_bytes,
         )

--- a/test/integ/deadline_job_attachments/test_job_attachments.py
+++ b/test/integ/deadline_job_attachments/test_job_attachments.py
@@ -147,7 +147,6 @@ def upload_input_files_assets_not_in_cas(job_attachment_test: JobAttachmentTest)
 
     # WHEN
     upload_group = asset_manager.prepare_paths_for_upload(
-        job_bundle_path=str(job_attachment_test.ASSET_ROOT),
         input_paths=[str(job_attachment_test.SCENE_MA_PATH)],
         output_paths=[str(job_attachment_test.OUTPUT_PATH)],
         referenced_paths=[],
@@ -225,7 +224,6 @@ def upload_input_files_one_asset_in_cas(
 
     # WHEN
     upload_group = asset_manager.prepare_paths_for_upload(
-        job_bundle_path=str(job_attachment_test.ASSET_ROOT),
         input_paths=input_paths,
         output_paths=[str(job_attachment_test.OUTPUT_PATH)],
         referenced_paths=[],
@@ -321,7 +319,6 @@ def test_upload_input_files_all_assets_in_cas(
 
     # WHEN
     upload_group = asset_manager.prepare_paths_for_upload(
-        job_bundle_path=str(job_attachment_test.ASSET_ROOT),
         input_paths=input_paths,
         output_paths=[str(job_attachment_test.OUTPUT_PATH)],
         referenced_paths=[],
@@ -1153,7 +1150,6 @@ def upload_input_files_no_input_paths(
 
     # WHEN
     upload_group = asset_manager.prepare_paths_for_upload(
-        job_bundle_path=str(job_attachment_test.ASSET_ROOT),
         input_paths=[],
         output_paths=[str(job_attachment_test.OUTPUT_PATH)],
         referenced_paths=[],
@@ -1221,7 +1217,6 @@ def test_upload_input_files_no_download_paths(job_attachment_test: JobAttachment
 
     # WHEN
     upload_group = asset_manager.prepare_paths_for_upload(
-        job_bundle_path=str(job_attachment_test.ASSET_ROOT),
         input_paths=[str(job_attachment_test.SCENE_MA_PATH)],
         output_paths=[],
         referenced_paths=[],
@@ -1337,7 +1332,6 @@ def test_upload_bucket_wrong_account(external_bucket: str, job_attachment_test: 
     ):
         # The attempt to upload the asset manifest should be blocked.
         upload_group = asset_manager.prepare_paths_for_upload(
-            job_bundle_path=str(job_attachment_test.ASSET_ROOT),
             input_paths=[str(job_attachment_test.SCENE_MA_PATH)],
             output_paths=[str(job_attachment_test.OUTPUT_PATH)],
             referenced_paths=[],

--- a/test/unit/deadline_client/api/test_job_bundle_submission_asset_refs.py
+++ b/test/unit/deadline_client/api/test_job_bundle_submission_asset_refs.py
@@ -376,11 +376,11 @@ def test_create_job_from_job_bundle_with_all_asset_ref_variants(
             ]
         )
         mock_prepare_paths.assert_called_once_with(
-            job_bundle_path=temp_job_bundle_dir,
             input_paths=input_paths,
             output_paths=output_paths,
             referenced_paths=referenced_paths,
             storage_profile=None,
+            require_paths_exist=False,
         )
         mock_hash_assets.assert_called_once_with(
             asset_groups=[AssetRootGroup()],

--- a/test/unit/deadline_client/cli/test_cli_bundle.py
+++ b/test/unit/deadline_client/cli/test_cli_bundle.py
@@ -18,6 +18,7 @@ from deadline.client.cli import main
 from deadline.client.cli._groups import bundle_group
 from deadline.client.api import _submit_job_bundle
 from deadline.client.config.config_file import set_setting
+from deadline.job_attachments.upload import S3AssetManager
 from deadline.job_attachments.models import JobAttachmentsFileSystem
 from deadline.job_attachments.progress_tracker import SummaryStatistics
 
@@ -326,6 +327,9 @@ def test_cli_bundle_asset_load_method(fresh_deadline_config, temp_job_bundle_dir
         }
         json.dump(data, f)
 
+    upload_group_mock = Mock()
+    upload_group_mock.asset_groups = [Mock()]
+    upload_group_mock.total_input_files = 0
     attachment_mock = Mock()
     attachment_mock.total_bytes = 0
     attachment_mock.total_files.return_value = 0
@@ -344,6 +348,8 @@ def test_cli_bundle_asset_load_method(fresh_deadline_config, temp_job_bundle_dir
         _submit_job_bundle.api, "get_queue_user_boto3_session"
     ), patch.object(
         bundle_group.api, "get_deadline_cloud_library_telemetry_client"
+    ), patch.object(
+        S3AssetManager, "prepare_paths_for_upload", return_value=upload_group_mock
     ):
         bundle_boto3_client_mock().create_job.return_value = MOCK_CREATE_JOB_RESPONSE
         bundle_boto3_client_mock().get_job.return_value = MOCK_GET_JOB_RESPONSE


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We need to better handle some job attachments paths (inputs, outputs, references), specifically around empty/non-existent and misconfigured (i.e. files marked as directories and vice-versa)

### What was the solution? (How)
Validate paths better. If any inputs are specified that do not exist, we add them to referenced paths, or fail submission if the new option `require_paths_exist` is used (either through the CLI flag `--require-paths-exist` or a checkbox in the Job Attachments tab). Empty input directories are likewise added as referenced paths. Throw an error for any paths that were marked as files but are actually directories.

### What is the impact of this change?
Users submitting jobs can be confident all of their expected inputs have been uploaded/included, and have more insight into what is actually being included in their submissions.

### How was this change tested?
```
hatch run fmt
hatch run lint
hatch build
hatch run test
```

#### Setup
- I crafted two different kinds of job bundles which I used for various job submissions
  1. Defined IN, INOUT, and OUT parameters, added asset_references and parameter_values that referenced files that did and did not exist, and some directories that were empty
  2. Defined OUT parameters, and added asset_references for input directories that were empty and some that did not exist

#### Test 1: Submitting Within A Configured Storage Profile Location

1.   (GUI) Successful Submission With Confirmation Popup

  <details>

  ![Test1](https://github.com/aws-deadline/deadline-cloud/assets/132690522/6deddc61-a28f-4594-9a7d-54c7b7c10106)

  </details>

2.   (GUI) Unsuccessful Submission when setting 'Require Paths Exist' checkbox 

  <details>

  ![Test2](https://github.com/aws-deadline/deadline-cloud/assets/132690522/1b399a75-cfc3-4d0e-ad04-dd8c34088fe2)

  </details>

3. (CLI) Successful Submission With Confirmation Prompt

```
marofke@ Desktop % deadline bundle submit test_bundle_1    
Submitting to Queue: CMF
INFO:deadline.client.api._submit_job_bundle:Input path './other_input_dir' does not exist. Adding to referenced paths.
INFO:deadline.client.api._submit_job_bundle:Input path '/Users/marofke/Desktop/asset_ref_dir/does_not_exist' does not exist. Adding to referenced paths.
INFO:deadline.job_attachments.upload:Input path './other.txt' resolving to '/Users/marofke/Desktop/other.txt' does not exist. Adding to referenced paths.
INFO:deadline.job_attachments.upload:Input path 'Users/marofke/Desktop/asset_ref_dir/test.txt' resolving to '/Users/marofke/Desktop/Users/marofke/Desktop/asset_ref_dir/test.txt' does not exist. Adding to referenced paths.
INFO:deadline.job_attachments.upload:Input path 'Users/marofke/Desktop/asset_ref_dir/test copy.txt' resolving to '/Users/marofke/Desktop/Users/marofke/Desktop/asset_ref_dir/test copy.txt' does not exist. Adding to referenced paths.
INFO:deadline.job_attachments.upload:Input path 'Users/marofke/Desktop/asset_ref_dir/does not exist.txt' resolving to '/Users/marofke/Desktop/Users/marofke/Desktop/asset_ref_dir/does not exist.txt' does not exist. Adding to referenced paths.
Job submission contains 18 input files totaling 20.8 KB.  All input files will be uploaded to S3 if they are not already present in the job attachments bucket.

Do you wish to proceed? [Y/n]: 
```

4. (CLI) Unsuccessful Submission when using `--require-paths-exist` flag

```
marofke@ Desktop % deadline bundle submit test_bundle_1 --yes --require-paths-exist
Submitting to Queue: CMF
Job submission contains misconfigured input directories and cannot be submitted. All input directories must exist.
Non-existent directories:
	./other_input_dir
	/Users/marofke/Desktop/asset_ref_dir/does_not_exist
Job submission canceled.
```

5. (GUI and CLI) Successfully Submitted my second job bundle that only had output directories

#### Test 2: Submitting With No Configured Storage Profile Location

1. (GUI) Successful Submission With Confirmation Popup
  - confirmed setting the `auto-accept` config setting still showed this prompt
  <details>
  
  ![Test3](https://github.com/aws-deadline/deadline-cloud/assets/132690522/48adf805-a386-4ccf-9284-cadeb819e607)

  </details>

2. (CLI) Successful Submission With Confirmation Popup
  - confirmed setting the `auto-accept` config setting still showed this prompt

```
marofke@ Desktop % deadline bundle submit test_bundle_1
Submitting to Queue: CMF
INFO:deadline.client.api._submit_job_bundle:Input path './other_input_dir' does not exist. Adding to referenced paths.
INFO:deadline.client.api._submit_job_bundle:Input path '/Users/marofke/Desktop/asset_ref_dir/does_not_exist' does not exist. Adding to referenced paths.
INFO:deadline.job_attachments.upload:Input path 'Users/marofke/Desktop/asset_ref_dir/test.txt' resolving to '/Users/marofke/Desktop/Users/marofke/Desktop/asset_ref_dir/test.txt' does not exist. Adding to referenced paths.
INFO:deadline.job_attachments.upload:Input path './other.txt' resolving to '/Users/marofke/Desktop/other.txt' does not exist. Adding to referenced paths.
INFO:deadline.job_attachments.upload:Input path 'Users/marofke/Desktop/asset_ref_dir/does not exist.txt' resolving to '/Users/marofke/Desktop/Users/marofke/Desktop/asset_ref_dir/does not exist.txt' does not exist. Adding to referenced paths.
INFO:deadline.job_attachments.upload:Input path 'Users/marofke/Desktop/asset_ref_dir/test copy.txt' resolving to '/Users/marofke/Desktop/Users/marofke/Desktop/asset_ref_dir/test copy.txt' does not exist. Adding to referenced paths.
Job submission contains 18 input files totaling 20.8 KB.  All input files will be uploaded to S3 if they are not already present in the job attachments bucket.

Files were specified outside of the configured storage profile location(s).  Please confirm that you intend to submit a job that uses files from the following directories:

Under the directory '/Users/marofke/Desktop':
	18 input files
	2 output directories
	6 referenced files and/or directories

To permanently remove this warning you must only use files located within a storage profile location.

Do you wish to proceed? [y/N]: 
```

3. (GUI and CLI) Submitted my second job bundle, confirming it also prompted when output paths fell outside of a storage profile filesystem location

#### Test 3: Submitting Job with Directory Marked as File

1. (GUI) Confirmed it failed to submit
  <details>
  
  ![Test16](https://github.com/aws-deadline/deadline-cloud/assets/132690522/c6b74606-aa77-4f3e-8c35-267a89b6786d)

  </details>

2. (CLI) Confirmed it failed to submit
  <details>

```
marofke@ Desktop % deadline bundle submit test_bundle_1    
Submitting to Queue: CMF
INFO:deadline.client.api._submit_job_bundle:Input path './other_input_dir' does not exist. Adding to referenced paths.
INFO:deadline.client.api._submit_job_bundle:Input path '/Users/marofke/Desktop/asset_ref_dir/does_not_exist' does not exist. Adding to referenced paths.
INFO:deadline.job_attachments.upload:Input path './other.txt' resolving to '/Users/marofke/Desktop/other.txt' does not exist. Adding to referenced paths.
INFO:deadline.job_attachments.upload:Input path '/Users/marofke/Desktop/asset_ref_dir/does not exist.txt' resolving to '/Users/marofke/Desktop/asset_ref_dir/does not exist.txt' does not exist. Adding to referenced paths.
Job submission contains missing input files or directories specified as files. All inputs must exist and be classified properly.
Directories classified as files:
	/Users/marofke/Desktop/asset_ref_dir/nested
Job submission canceled.
```

  </details>

### UI Changes
- Here's the new UI setting that allows users to enforce all paths exist:
  <details><summary>Show / Hide</summary>

  ![NewCheckbox](https://github.com/aws-deadline/deadline-cloud/assets/132690522/634119f0-e081-4823-869e-366af49eb56b)

  </details>

### Was this change documented?
No

### Is this a breaking change?
Yes, added new CLI flag and reworked the public interface of the Job Attachments S3AssetUploader

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*