### PR TITLE
chore: revise the squashed commit message for #309 in Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 ## 0.48.0 (2024-04-25)
 
 ### BREAKING CHANGES
-* always prompt user about misconfigured inputs (#309) ([`f8d5826`](https://github.com/aws-deadline/deadline-cloud/commit/f8d5826316cbaae1a41d11c2decad38a4ab5ca5d))
+* Improve handling of misconfigured input job attachments (that are not within any locations for the submission machines’s configured storage profile), handle empty/non-existent paths and add them to asset references, add `require_paths_exist` option (#309) ([`f8d5826`](https://github.com/aws-deadline/deadline-cloud/commit/f8d5826316cbaae1a41d11c2decad38a4ab5ca5d))
 * **job_attachments**: use correct profile for GetStorageProfileForQueue API (#296) ([`a8de5f6`](https://github.com/aws-deadline/deadline-cloud/commit/a8de5f679a7b7da53ce83ab1ba25cacded06773f))
 
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The previous squashed commit message for https://github.com/aws-deadline/deadline-cloud/pull/309 should reflect the breaking changes related to input path handling and the new `require_paths_exist` option.

### What was the solution? (How)
Update the squashed commit message to:
```
Improve handling of misconfigured input job attachments (that are not within any locations for the submission machines’s configured storage profile), handle empty/non-existent paths and add them to asset references, add `require_paths_exist` option
```

### What is the impact of this change?
The updated commit message clearly communicates the changes.

### How was this change tested?
This is just an update to the commit message, so no testing is required. 

### Was this change documented?
No.

### Is this a breaking change?
No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*