### PR TITLE
feat: use AWS CRT for faster transfers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,9 @@ classifiers = [
 # Applications that consume this library should be the ones that are more strictly
 # limiting dependencies if they want/need to.
 dependencies = [
-    "boto3[crt] >= 1.34.75",
+    # See CR platform and Python version support here: https://pypi.org/project/awscrt/#files
+    "boto3[crt] >= 1.34.75; python_version >= '3.7' and python_version <= '3.11'",
+    "boto3 >= 1.34.75; python_version < '3.7' or python_version > '3.11'",
     "click >= 8.1.7",
     "pyyaml >= 6.0",
     # Job Attachments

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
 # Applications that consume this library should be the ones that are more strictly
 # limiting dependencies if they want/need to.
 dependencies = [
-    "boto3 >= 1.34.75",
+    "boto3[crt] >= 1.34.75",
     "click >= 8.1.7",
     "pyyaml >= 6.0",
     # Job Attachments

--- a/src/deadline/job_attachments/_aws/aws_clients.py
+++ b/src/deadline/job_attachments/_aws/aws_clients.py
@@ -7,11 +7,7 @@ from functools import lru_cache
 from typing import Optional
 
 import boto3
-<<<<<<< HEAD
-from boto3.s3.transfer import create_crt_transfer_manager
-=======
 from boto3.s3.transfer import create_crt_transfer_manager, create_transfer_manager
->>>>>>> 203eff5 (feat: support AWS CRT for faster transfers)
 
 import botocore
 from botocore.client import BaseClient, Config

--- a/src/deadline/job_attachments/_aws/aws_clients.py
+++ b/src/deadline/job_attachments/_aws/aws_clients.py
@@ -7,8 +7,9 @@ from functools import lru_cache
 from typing import Optional
 
 import boto3
+from boto3.s3.transfer import create_crt_transfer_manager
+
 import botocore
-from boto3.s3.transfer import create_transfer_manager
 from botocore.client import BaseClient, Config
 
 from deadline.client.config import config_file
@@ -104,7 +105,7 @@ def get_s3_max_pool_connections() -> int:
 @lru_cache(maxsize=MAX_SIZE_CACHE)
 def get_s3_transfer_manager(s3_client: BaseClient):
     transfer_config = boto3.s3.transfer.TransferConfig()
-    return create_transfer_manager(client=s3_client, config=transfer_config)
+    return create_crt_transfer_manager(client=s3_client, config=transfer_config)
 
 
 @lru_cache(maxsize=MAX_SIZE_CACHE)

--- a/src/deadline/job_attachments/_aws/aws_clients.py
+++ b/src/deadline/job_attachments/_aws/aws_clients.py
@@ -7,7 +7,11 @@ from functools import lru_cache
 from typing import Optional
 
 import boto3
+<<<<<<< HEAD
 from boto3.s3.transfer import create_crt_transfer_manager
+=======
+from boto3.s3.transfer import create_crt_transfer_manager, create_transfer_manager
+>>>>>>> 203eff5 (feat: support AWS CRT for faster transfers)
 
 import botocore
 from botocore.client import BaseClient, Config
@@ -105,7 +109,14 @@ def get_s3_max_pool_connections() -> int:
 @lru_cache(maxsize=MAX_SIZE_CACHE)
 def get_s3_transfer_manager(s3_client: BaseClient):
     transfer_config = boto3.s3.transfer.TransferConfig()
-    return create_crt_transfer_manager(client=s3_client, config=transfer_config)
+
+    crt_transfer_manager = create_crt_transfer_manager(client=s3_client, config=transfer_config)
+    if crt_transfer_manager:
+        return crt_transfer_manager
+
+    # Fallback to regular transfer manager if CRT transfer manager does not support the configuration, which can happen if the client
+    # and bucket are in different regions.
+    return create_transfer_manager(client=s3_client, config=transfer_config)
 
 
 @lru_cache(maxsize=MAX_SIZE_CACHE)

--- a/test/unit/deadline_job_attachments/test_asset_sync.py
+++ b/test/unit/deadline_job_attachments/test_asset_sync.py
@@ -44,6 +44,10 @@ from deadline.job_attachments._utils import _human_readable_file_size
 from ..conftest import is_windows_non_admin
 
 
+@patch(
+    f"{deadline.__package__}.job_attachments._aws.aws_clients.create_crt_transfer_manager",
+    MagicMock(return_value=None),
+)
 class TestAssetSync:
     @pytest.fixture(autouse=True)
     def before_test(

--- a/test/unit/deadline_job_attachments/test_download.py
+++ b/test/unit/deadline_job_attachments/test_download.py
@@ -566,6 +566,10 @@ def assert_get_job_input_output_paths_by_asset_root(
 
 @pytest.mark.docker
 @pytest.mark.parametrize("manifest_version", [ManifestVersion.v2023_03_03])
+@patch(
+    f"{deadline.__package__}.job_attachments._aws.aws_clients.create_crt_transfer_manager",
+    MagicMock(return_value=None),
+)
 class TestFullDownload:
     """
     Tests for downloads from cas.
@@ -1965,6 +1969,10 @@ class TestFullDownload:
 
 
 @pytest.mark.parametrize("manifest_version", [ManifestVersion.v2023_03_03])
+@patch(
+    f"{deadline.__package__}.job_attachments._aws.aws_clients.create_crt_transfer_manager",
+    MagicMock(return_value=None),
+)
 class TestFullDownloadPrefixesWithSlashes:
     """
     Tests for downloads from cas when the queue prefixes are created.

--- a/test/unit/deadline_job_attachments/test_upload.py
+++ b/test/unit/deadline_job_attachments/test_upload.py
@@ -57,6 +57,10 @@ from deadline.job_attachments._utils import _human_readable_file_size
 from ..conftest import is_windows_non_admin
 
 
+@patch(
+    f"{deadline.__package__}.job_attachments._aws.aws_clients.create_crt_transfer_manager",
+    MagicMock(return_value=None),
+)
 class TestUpload:
     """
     Tests for handling uploading assets.


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Transfers to and from S3 can be slow and do not use all available bandwidth.

### What was the solution? (How)
Use AWS CRT ([more info](https://aws.amazon.com/blogs/storage/improving-amazon-s3-throughput-for-the-aws-cli-and-boto3-with-the-aws-common-runtime/)) which uses optimized low level libraries under the hood to gain dramatic boosts in performance. Boto3 abstracts away the differences invisibly.

If CRT is installed, the S3 transfer manager will automatically use the CRT flavor of manager when running on some EC2 instances, but its performance boosts are useful in non-EC2 contexts too so this PR opts into the CRT transfer manager unless it's not compatible.

### What is the impact of this change?
I submitted jobs with 10GB attachments and compared transfer speeds. Before this change, transfers went at ~260MB/s. After this change, they went at ~960MB/s. My machine is an EC2 instance in a different region from the S3 bucket. The connection to S3 was over the internet.

### How was this change tested?
Submitting jobs and observing the job attachment speed. I ran `hatch run test` and `hatch run test_docker`.

### Was this change documented?
No change to documentation.

### Is this a breaking change?
No. CRT for boto is compatible will all Unix/Linux, Mac, and Windows.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*