### PR TITLE
fix: fix typos in error messages

### DIFF
--- a/src/deadline/client/api/_loginout.py
+++ b/src/deadline/client/api/_loginout.py
@@ -58,7 +58,8 @@ def _login_deadline_cloud_monitor(
             time.sleep(0.5)
     except FileNotFoundError:
         raise DeadlineOperationError(
-            f"Could not find Deadline Cloud Monitor at {deadline_cloud_monitor_path}. Please ensure Deadline Cloud Monitor is installed correctly and setup the {profile_name} profile again."
+            f"Could not find Deadline Cloud Monitor at {deadline_cloud_monitor_path}."
+            f"Please ensure Deadline Cloud Monitor is installed correctly and set up the {profile_name} profile again."
         )
     if on_pending_authorization:
         on_pending_authorization(
@@ -136,11 +137,13 @@ def logout(config: Optional[ConfigParser] = None) -> str:
             output = subprocess.check_output(args)
         except FileNotFoundError:
             raise DeadlineOperationError(
-                f"Could not find Deadline Cloud Monitor at {deadline_cloud_monitor_path}. Please ensure Deadline Cloud Monitor is installed correctly and setup the {profile_name} profile again."
+                f"Could not find Deadline Cloud Monitor at {deadline_cloud_monitor_path}."
+                f"Please ensure Deadline Cloud Monitor is installed correctly and set up the {profile_name} profile again."
             )
         except subprocess.CalledProcessError as e:
             raise DeadlineOperationError(
-                f"Deadline Cloud Monitor was unable to logout the profile {profile_name}. Return code {e.returncode}: {e.output}"
+                f"Deadline Cloud Monitor was unable to log out the profile {profile_name}."
+                f"Return code {e.returncode}: {e.output}"
             )
 
         # Force a refresh of the cached boto3 Session

--- a/src/deadline/client/api/_loginout.py
+++ b/src/deadline/client/api/_loginout.py
@@ -35,12 +35,12 @@ def _login_deadline_cloud_monitor(
     on_cancellation_check: Optional[Callable],
     config: Optional[ConfigParser] = None,
 ):
-    # Deadline Cloud Monitor writes the absolute path to itself to the config file
+    # Deadline Cloud monitor writes the absolute path to itself to the config file
     deadline_cloud_monitor_path = get_setting("deadline-cloud-monitor.path", config=config)
     profile_name = get_setting("defaults.aws_profile_name", config=config)
     args = [deadline_cloud_monitor_path, "login", "--profile", profile_name]
 
-    # Open Deadline Cloud Monitor, non-blocking the user will keep Deadline Cloud Monitor running in the background.
+    # Open Deadline Cloud monitor, non-blocking the user will keep Deadline Cloud monitor running in the background.
     try:
         if sys.platform.startswith("win"):
             # We don't hookup to stdin but do this to avoid issues on windows
@@ -58,8 +58,8 @@ def _login_deadline_cloud_monitor(
             time.sleep(0.5)
     except FileNotFoundError:
         raise DeadlineOperationError(
-            f"Could not find Deadline Cloud Monitor at {deadline_cloud_monitor_path}."
-            f"Please ensure Deadline Cloud Monitor is installed correctly and set up the {profile_name} profile again."
+            f"Could not find Deadline Cloud monitor at {deadline_cloud_monitor_path}. "
+            f"Please ensure Deadline Cloud monitor is installed correctly and set up the {profile_name} profile again."
         )
     if on_pending_authorization:
         on_pending_authorization(
@@ -67,21 +67,21 @@ def _login_deadline_cloud_monitor(
         )
     # And wait for the user to complete login
     while True:
-        # Deadline Cloud Monitor is a GUI app that will keep on running
+        # Deadline Cloud monitor is a GUI app that will keep on running
         # So we sit here and test that profile for validity until it works
         if check_authentication_status(config) == AwsAuthenticationStatus.AUTHENTICATED:
-            return f"Deadline Cloud Monitor Profile: {profile_name}"
+            return f"Deadline Cloud monitor Profile: {profile_name}"
         if on_cancellation_check:
             # Check if the UI has signaled a cancel
             if on_cancellation_check():
                 p.kill()
                 raise Exception()
         if p.poll():
-            # Deadline Cloud Monitor has stopped, we assume it returned us an error on one line on stderr
-            # but let's be specific about Deadline Cloud Monitor failing incase the error is non-obvious
+            # Deadline Cloud monitor has stopped, we assume it returned us an error on one line on stderr
+            # but let's be specific about Deadline Cloud monitor failing incase the error is non-obvious
             # and let's tack on stdout incase it helps
             err_prefix = (
-                f"Deadline Cloud Monitor was not able to log into the {profile_name} profile: "
+                f"Deadline Cloud monitor was not able to log into the {profile_name} profile: "
             )
             out = p.stdout.read().decode("utf-8") if p.stdout else ""
             raise DeadlineOperationError(f"{err_prefix}:\n{out}")
@@ -95,12 +95,12 @@ def login(
     config: Optional[ConfigParser] = None,
 ) -> str:
     """
-    For AWS profiles created by Deadline Cloud Monitor, logs in to provide access to Deadline Cloud.
+    For AWS profiles created by Deadline Cloud monitor, logs in to provide access to Deadline Cloud.
 
     Args:
         on_pending_authorization (Callable): A callback that receives method-specific information to continue login.
             All methods: 'credentials_source' parameter of type AwsCredentialsSource
-            For Deadline Cloud Monitor: No additional parameters
+            For Deadline Cloud monitor: No additional parameters
         on_cancellation_check (Callable): A callback that allows the operation to cancel before login completes
         config (ConfigParser, optional): The AWS Deadline Cloud configuration
                 object to use instead of the config file.
@@ -111,13 +111,13 @@ def login(
             on_pending_authorization, on_cancellation_check, config
         )
     raise UnsupportedProfileTypeForLoginLogout(
-        "Logging in is only supported for AWS Profiles created by Deadline Cloud Monitor."
+        "Logging in is only supported for AWS Profiles created by Deadline Cloud monitor."
     )
 
 
 def logout(config: Optional[ConfigParser] = None) -> str:
     """
-    For AWS profiles created by Deadline Cloud Monitor, logs out of Deadline Cloud.
+    For AWS profiles created by Deadline Cloud monitor, logs out of Deadline Cloud.
 
      Args:
         config (ConfigParser, optional): The AWS Deadline Cloud configuration
@@ -125,24 +125,24 @@ def logout(config: Optional[ConfigParser] = None) -> str:
     """
     credentials_source = get_credentials_source(config)
     if credentials_source == AwsCredentialsSource.DEADLINE_CLOUD_MONITOR_LOGIN:
-        # Deadline Cloud Monitor writes the absolute path to itself to the config file
+        # Deadline Cloud monitor writes the absolute path to itself to the config file
         deadline_cloud_monitor_path = get_setting("deadline-cloud-monitor.path", config=config)
         profile_name = get_setting("defaults.aws_profile_name", config=config)
         args = [deadline_cloud_monitor_path, "logout", "--profile", profile_name]
 
-        # Open Deadline Cloud Monitor, blocking
-        # Unlike login, that opens the regular Deadline Cloud Monitor GUI, logout is a CLI command that clears the profile
+        # Open Deadline Cloud monitor, blocking
+        # Unlike login, that opens the regular Deadline Cloud monitor GUI, logout is a CLI command that clears the profile
         # This makes it easier as we can execute and look at the return cdoe
         try:
             output = subprocess.check_output(args)
         except FileNotFoundError:
             raise DeadlineOperationError(
-                f"Could not find Deadline Cloud Monitor at {deadline_cloud_monitor_path}."
-                f"Please ensure Deadline Cloud Monitor is installed correctly and set up the {profile_name} profile again."
+                f"Could not find Deadline Cloud monitor at {deadline_cloud_monitor_path}. "
+                f"Please ensure Deadline Cloud monitor is installed correctly and set up the {profile_name} profile again."
             )
         except subprocess.CalledProcessError as e:
             raise DeadlineOperationError(
-                f"Deadline Cloud Monitor was unable to log out the profile {profile_name}."
+                f"Deadline Cloud monitor was unable to log out the profile {profile_name}."
                 f"Return code {e.returncode}: {e.output}"
             )
 
@@ -150,5 +150,5 @@ def logout(config: Optional[ConfigParser] = None) -> str:
         invalidate_boto3_session_cache()
         return output.decode("utf8")
     raise UnsupportedProfileTypeForLoginLogout(
-        "Logging out is only supported for AWS Profiles created by Deadline Cloud Monitor."
+        "Logging out is only supported for AWS Profiles created by Deadline Cloud monitor."
     )

--- a/src/deadline/client/api/_session.py
+++ b/src/deadline/client/api/_session.py
@@ -115,7 +115,7 @@ def get_boto3_client(service_name: str, config: Optional[ConfigParser] = None) -
 
 def get_credentials_source(config: Optional[ConfigParser] = None) -> AwsCredentialsSource:
     """
-    Returns DEADLINE_CLOUD_MONITOR_LOGIN if Deadline Cloud Monitor wrote the credentials, HOST_PROVIDED otherwise.
+    Returns DEADLINE_CLOUD_MONITOR_LOGIN if Deadline Cloud monitor wrote the credentials, HOST_PROVIDED otherwise.
 
     Args:
         config (ConfigParser, optional): The AWS Deadline Cloud configuration
@@ -127,7 +127,7 @@ def get_credentials_source(config: Optional[ConfigParser] = None) -> AwsCredenti
     except ProfileNotFound:
         return AwsCredentialsSource.NOT_VALID
     if "monitor_id" in profile_config:
-        # Deadline Cloud Monitor Desktop adds the "monitor_id" key
+        # Deadline Cloud monitor Desktop adds the "monitor_id" key
         return AwsCredentialsSource.DEADLINE_CLOUD_MONITOR_LOGIN
     else:
         return AwsCredentialsSource.HOST_PROVIDED
@@ -137,7 +137,7 @@ def get_user_and_identity_store_id(
     config: Optional[ConfigParser] = None,
 ) -> tuple[Optional[str], Optional[str]]:
     """
-    If logged in with Deadline Cloud Monitor Desktop, returns a tuple
+    If logged in with Deadline Cloud monitor Desktop, returns a tuple
     (user_id, identity_store_id), otherwise returns None.
     """
     session = get_boto3_session(config=config)
@@ -265,7 +265,7 @@ def check_authentication_status(config: Optional[ConfigParser] = None) -> AwsAut
     Returns AwsAuthenticationStatus enum value:
       - CONFIGURATION_ERROR if there is an unexpected error accessing credentials
       - AUTHENTICATED if they are fine
-      - NEEDS_LOGIN if a Deadline Cloud Monitor login is required.
+      - NEEDS_LOGIN if a Deadline Cloud monitor login is required.
     """
 
     with _modified_logging_level(logging.getLogger("botocore.credentials"), logging.ERROR):
@@ -273,7 +273,7 @@ def check_authentication_status(config: Optional[ConfigParser] = None) -> AwsAut
             get_boto3_session(config=config).client("sts").get_caller_identity()
             return AwsAuthenticationStatus.AUTHENTICATED
         except Exception:
-            # We assume that the presence of a Deadline Cloud Monitor profile
+            # We assume that the presence of a Deadline Cloud monitor profile
             # means we will know everything necessary to start it and login.
 
             if get_credentials_source(config) == AwsCredentialsSource.DEADLINE_CLOUD_MONITOR_LOGIN:

--- a/src/deadline/client/cli/_groups/auth_group.py
+++ b/src/deadline/client/cli/_groups/auth_group.py
@@ -27,7 +27,7 @@ def _cli_on_pending_authorization(**kwargs):
     """
 
     if kwargs["credentials_source"] == AwsCredentialsSource.DEADLINE_CLOUD_MONITOR_LOGIN:
-        click.echo("Opening Deadline Cloud Monitor. Please login and then return here.")
+        click.echo("Opening Deadline Cloud Monitor. Please log in and then return here.")
 
 
 @click.group(name="auth")

--- a/src/deadline/client/cli/_groups/auth_group.py
+++ b/src/deadline/client/cli/_groups/auth_group.py
@@ -23,11 +23,11 @@ JSON_FIELD_AUTH_API_AVAILABLE = "api_availability"
 
 def _cli_on_pending_authorization(**kwargs):
     """
-    Callback for `login`, to tell the user that Deadline Cloud Monitor is opening
+    Callback for `login`, to tell the user that Deadline Cloud monitor is opening
     """
 
     if kwargs["credentials_source"] == AwsCredentialsSource.DEADLINE_CLOUD_MONITOR_LOGIN:
-        click.echo("Opening Deadline Cloud Monitor. Please log in and then return here.")
+        click.echo("Opening Deadline Cloud monitor. Please log in and then return here.")
 
 
 @click.group(name="auth")
@@ -45,7 +45,7 @@ def auth_login():
     Logs in to the AWS Deadline Cloud configured AWS profile.
 
     This is for any profile type that AWS Deadline Cloud knows how to login to
-    Currently only supports Deadline Cloud Monitor
+    Currently only supports Deadline Cloud monitor
     """
     click.echo(
         f"Logging into AWS Profile {config_file.get_setting('defaults.aws_profile_name')!r} for AWS Deadline Cloud"
@@ -62,11 +62,11 @@ def auth_login():
 @_handle_error
 def auth_logout():
     """
-    Logs out of the Deadline Cloud Monitor configured AWS profile.
+    Logs out of the Deadline Cloud monitor configured AWS profile.
     """
     api.logout()
 
-    click.echo("Successfully logged out of all Deadline Cloud Monitor AWS profiles")
+    click.echo("Successfully logged out of all Deadline Cloud monitor AWS profiles")
 
 
 @cli_auth.command(name="status")

--- a/src/deadline/client/cli/_groups/handle_web_url_command.py
+++ b/src/deadline/client/cli/_groups/handle_web_url_command.py
@@ -113,7 +113,7 @@ def cli_handle_web_url(
             step_id = url_queries.pop("step_id", None)
             task_id = url_queries.pop("task_id", None)
 
-            # Add the standard option "profile", using the one provided by the url (set by Deadline Cloud Monitor)
+            # Add the standard option "profile", using the one provided by the url (set by Deadline Cloud monitor)
             # or choosing a best guess based on farm and queue IDs
             aws_profile_name = url_queries.pop(
                 "profile",

--- a/src/deadline/client/config/config_file.py
+++ b/src/deadline/client/config/config_file.py
@@ -59,7 +59,7 @@ __config_mtime = None
 SETTINGS: Dict[str, Dict[str, Any]] = {
     "deadline-cloud-monitor.path": {
         "default": "",
-        "description": "The filesystem path to Deadline Cloud Monitor, set during login process.",
+        "description": "The filesystem path to Deadline Cloud monitor, set during login process.",
     },
     "defaults.aws_profile_name": {
         "default": "(default)",

--- a/src/deadline/client/ui/deadline_authentication_status.py
+++ b/src/deadline/client/ui/deadline_authentication_status.py
@@ -16,7 +16,7 @@ The status includes three parts:
      This is checked with an sts:GetCallerIdentity AWS API call.
   2. Do the credentials grant access to AWS Deadline Cloud APIs?
      This is checked with a simplified deadline:ListFarms AWS API call.
-  3. Do the credentials use Deadline Cloud Monitor?
+  3. Do the credentials use Deadline Cloud monitor?
      This is checked by looking for the relevant properties
      in the AWS profile configuration.
 """

--- a/src/deadline/client/ui/dev_application.py
+++ b/src/deadline/client/ui/dev_application.py
@@ -79,7 +79,7 @@ class DevMainWindow(QMainWindow):
         if DeadlineLoginDialog.login(parent=self):
             logger.info("Logged in successfully")
         else:
-            logger.info("Failed to login")
+            logger.info("Failed to log in")
 
     def logout(self):
         api.logout()

--- a/src/deadline/client/ui/dialogs/deadline_login_dialog.py
+++ b/src/deadline/client/ui/dialogs/deadline_login_dialog.py
@@ -110,7 +110,7 @@ class DeadlineLoginDialog(QMessageBox):
                     == AwsCredentialsSource.DEADLINE_CLOUD_MONITOR_LOGIN
                 ):
                     self.login_thread_message.emit(
-                        "Opening Deadline Cloud Monitor. Please log in before returning here."
+                        "Opening Deadline Cloud monitor. Please log in before returning here."
                     )
 
             def on_cancellation_check():

--- a/src/deadline/client/ui/dialogs/deadline_login_dialog.py
+++ b/src/deadline/client/ui/dialogs/deadline_login_dialog.py
@@ -110,7 +110,7 @@ class DeadlineLoginDialog(QMessageBox):
                     == AwsCredentialsSource.DEADLINE_CLOUD_MONITOR_LOGIN
                 ):
                     self.login_thread_message.emit(
-                        "Opening Deadline Cloud Monitor. Please login before returning here."
+                        "Opening Deadline Cloud Monitor. Please log in before returning here."
                     )
 
             def on_cancellation_check():

--- a/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
@@ -204,7 +204,7 @@ class SubmitJobToDeadlineDialog(QDialog):
 
     def refresh_deadline_settings(self):
         # Enable/disable the Login and Logout buttons based on whether
-        # the configured profile is for Deadline Cloud Monitor
+        # the configured profile is for Deadline Cloud monitor
         self.login_button.setEnabled(
             self.deadline_authentication_status.creds_source
             == api.AwsCredentialsSource.DEADLINE_CLOUD_MONITOR_LOGIN

--- a/test/unit/deadline_client/cli/test_cli_auth.py
+++ b/test/unit/deadline_client/cli/test_cli_auth.py
@@ -18,7 +18,7 @@ from deadline.client.cli import main
 
 def test_cli_deadline_cloud_monitor_login_and_logout(fresh_deadline_config):
     """
-    Confirm that the CLI login/logout command invokes Deadline Cloud Monitor as expected
+    Confirm that the CLI login/logout command invokes Deadline Cloud monitor as expected
     """
     scoped_config = {
         "credential_process": "/bin/DeadlineCloudMonitor get-credentials --profile sandbox-us-west-2",
@@ -65,7 +65,7 @@ def test_cli_deadline_cloud_monitor_login_and_logout(fresh_deadline_config):
         assert result.exit_code == 0
 
         assert (
-            "Successfully logged in: Deadline Cloud Monitor Profile: sandbox-us-west-2"
+            "Successfully logged in: Deadline Cloud monitor Profile: sandbox-us-west-2"
             in result.output
         )
         assert result.exit_code == 0


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
- Need to improve error messages and fix Minor typos with setup/login/logout
- Deadline Cloud Monitor should be `Deadline Cloud monitor`


<img width="408" alt="image" src="https://github.com/aws-deadline/deadline-cloud/assets/162955484/e87ee2e6-f39d-4079-8388-112db2ece0aa">


<img width="377" alt="Opening Deadline Cloud Monitor  Please login before" src="https://github.com/aws-deadline/deadline-cloud/assets/162955484/09faa01f-1e42-472f-a25b-329038083c9f">



### What was the solution? (How)
- improved error messages and fixed Minor typos with setup/login/logout
- replaced `Monitor` with `monitor`

### What is the impact of this change?
There won't be impact, as it doesn't change any logic

### How was this change tested?
tested in my local

### Was this change documented?

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*