### PR TITLE
fix: remove deprecated .aws/sso/cache watcher

### DIFF
--- a/src/deadline/client/ui/deadline_authentication_status.py
+++ b/src/deadline/client/ui/deadline_authentication_status.py
@@ -79,13 +79,11 @@ class DeadlineAuthenticationStatus(QObject):
         self.config = ConfigParser()
         self.config.read_dict(config_file.read_config())
 
-        # Watch the ~/.aws path for any changes to config or credentials,
-        # the ~/.aws/sso/cache to capture "aws sso login/logout", and
+        # Watch the ~/.aws path for any changes to config or credentials, and
         # the ~/.deadline path for any changes to the AWS Deadline Cloud config.
         self.aws_creds_file_watcher = QFileSystemWatcher()
         self.aws_creds_paths = [
             os.path.expanduser(os.path.join("~", ".aws")),
-            os.path.expanduser(os.path.join("~", ".aws", "sso", "cache")),
         ]
         self.deadline_config_paths = [
             os.path.expanduser(os.path.join("~", ".deadline")),


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

closes https://github.com/aws-deadline/deadline-cloud/issues/316

We were watching a folder we no longer care about and due to this, we were emitting an message that made users believe there was something critically wrong with their setup.

### What was the solution? (How)

As suggested in the issue, remove the watcher line! There are no other references to this path elsewhere in the code base.

### What is the impact of this change?

No more misleading error messages around the sso/cache folder.

### How was this change tested?

```
hatch run fmt
hatch build
hatch run lint
hatch run test
```

### Was this change documented?

N/A

### Is this a breaking change?

Nope

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*