### PR TITLE
Install boto3 CRT extra feature always

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,9 +35,7 @@ classifiers = [
 # Applications that consume this library should be the ones that are more strictly
 # limiting dependencies if they want/need to.
 dependencies = [
-    # See CR platform and Python version support here: https://pypi.org/project/awscrt/#files
-    "boto3[crt] >= 1.34.75; python_version >= '3.7' and python_version <= '3.11'",
-    "boto3 >= 1.34.75; python_version < '3.7' or python_version > '3.11'",
+    "boto3[crt] >= 1.34.75",
     "click >= 8.1.7",
     "pyyaml >= 6.0",
     # Job Attachments


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
When I added boto3 CRT support, I installed different versions of boto3 depending on of the underlying CRT libraries were available for the current version of Python. This prevent some unit tests from running in non-CRT enabled Python versions (namely 3.12). Also boto3 already handles CRT-Python compatibility, so we don't need to and shouldn't try to manage it ourselves.

### What was the solution? (How)
Remove the Python version filters on the CRT extra feature. Let boto3 handle compatibility and fallbacks.

### What is the impact of this change?
Package builds in Python 3.12.

### How was this change tested?
Using Python 3.12, I ran the unit tests, installed the package, and uploaded some job attachments using the CLI. Tests pass and uploads work as expected (though slower because they aren't using CRT under the hood).

### Was this change documented?
No need.

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*