### PR TITLE
fix: Prevent submission dialog sometimes closing on exceptions

### DIFF
--- a/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
@@ -385,6 +385,9 @@ class SubmitJobToDeadlineDialog(QDialog):
         """
         Perform a submission when the submit button is pressed
         """
+        # Unset any cached response
+        self.create_job_response = None
+
         # Retrieve all the settings into the dataclass
         settings = self.job_settings_type()
         self.shared_job_settings.update_settings(settings)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We have logic to only close the submitter if the `create_job_response` is set [here](https://github.com/aws-deadline/deadline-cloud/blob/mainline/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py#L494-L498). (Initialized to `none` when the submitter UI is created).

The problem is that the submitter UI object can be persisted in an integration, and just shown and closed when the submit button is pressed. Since we never unset `create_job_response`, then after the first submission, the submitter is closed every time, even when it hasn't successfully submitted a job.

### What was the solution? (How)
Unset the `create_job_response` when entering the `on_submit` function

### What is the impact of this change?
The submitter does not close on exceptions as intended, even if previous job submissions have succeeded.

### How was this change tested?
Tested with a local build within the Nuke Integration, that exceptions raised in the `on_create_job_bundle_callback` did not close the submitter after this change.

### Was this change documented?

It will be automatically during release

### Is this a breaking change?

No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*