### PR TITLE
fix: bundle submit parameter processing splits name/value at right-most =

### DIFF
--- a/src/deadline/client/cli/_groups/bundle_group.py
+++ b/src/deadline/client/cli/_groups/bundle_group.py
@@ -41,18 +41,27 @@ def cli_bundle():
     """
 
 
+# Latin alphanumeric, starting with a letter
+_openjd_identifier_regex = r"(?-m:^[A-Za-z_][A-Za-z0-9_]*\Z)"
+
+
 def validate_parameters(ctx, param, value):
     """
-    Validate provided --parameter values, ensuring that they are in the format "Key=Value", and convert them to a dict with the
+    Validate provided --parameter values, ensuring that they are in the format "ParamName=Value", and convert them to a dict with the
     following format:
         [{"name": "<name>", "value": "<value>"}, ...]
     """
     parameters_split = []
     for parameter in value:
-        regex_match = re.match("(.+)=(.*)", parameter)
+        regex_match = re.match("([^=]+)=(.*)", parameter)
         if not regex_match:
             raise click.BadParameter(
-                f'Parameters must be provided in the format "Key=Value". Invalid Parameter: {parameter}'
+                f'Parameters must be provided in the format "ParamName=Value". Invalid parameter: {parameter}'
+            )
+
+        if not re.match(_openjd_identifier_regex, regex_match[1]):
+            raise click.BadParameter(
+                f"Parameter names must be alphanumeric Open Job Description identifiers. Invalid parameter name: {regex_match[1]}"
             )
 
         parameters_split.append({"name": regex_match[1], "value": regex_match[2]})


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

When providing parameter values for a parameter like `CondaPackages`, it often has an `=` in it like
`-p CondaPackages=blender=3.6`. The regex validating these parameters allows the `=` to get in the parameter name
instead of the parameter value. The parameter name further needs to conform to the Open Job Description
<Identifier> syntax, so it would be helpful to validate it against that.

### What was the solution? (How)

* Fix the '-p' parameter regex to exclude '=' from the parameter name match.
* Incorporated a regex for the Open Job Description identifier constraints, to fail parameter validation when parameter names do not conform.
* Added two tests, one for the '=' splitting and one for the parameter name validation.

### What is the impact of this change?
Submitting jobs from the CLI for the buggy case will work. Other cases where the parameter name
doesn't conform will produce a quicker and more clear error message.

### How was this change tested?
Added unit tests, submitted a job and confirmed the parameter value was set correctly.

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*