### PR TITLE
 revert: "feat: use AWS CRT for faster transfers (#319)"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
 # Applications that consume this library should be the ones that are more strictly
 # limiting dependencies if they want/need to.
 dependencies = [
-    "boto3[crt] >= 1.34.75",
+    "boto3 >= 1.34.75",
     "click >= 8.1.7",
     "pyyaml >= 6.0",
     # Job Attachments

--- a/src/deadline/job_attachments/_aws/aws_clients.py
+++ b/src/deadline/job_attachments/_aws/aws_clients.py
@@ -7,9 +7,8 @@ from functools import lru_cache
 from typing import Optional
 
 import boto3
-from boto3.s3.transfer import create_crt_transfer_manager, create_transfer_manager
-
 import botocore
+from boto3.s3.transfer import create_transfer_manager
 from botocore.client import BaseClient, Config
 
 from deadline.client.config import config_file
@@ -105,13 +104,6 @@ def get_s3_max_pool_connections() -> int:
 @lru_cache(maxsize=MAX_SIZE_CACHE)
 def get_s3_transfer_manager(s3_client: BaseClient):
     transfer_config = boto3.s3.transfer.TransferConfig()
-
-    crt_transfer_manager = create_crt_transfer_manager(client=s3_client, config=transfer_config)
-    if crt_transfer_manager:
-        return crt_transfer_manager
-
-    # Fallback to regular transfer manager if CRT transfer manager does not support the configuration, which can happen if the client
-    # and bucket are in different regions.
     return create_transfer_manager(client=s3_client, config=transfer_config)
 
 

--- a/test/unit/deadline_job_attachments/test_asset_sync.py
+++ b/test/unit/deadline_job_attachments/test_asset_sync.py
@@ -44,10 +44,6 @@ from deadline.job_attachments._utils import _human_readable_file_size
 from ..conftest import is_windows_non_admin
 
 
-@patch(
-    f"{deadline.__package__}.job_attachments._aws.aws_clients.create_crt_transfer_manager",
-    MagicMock(return_value=None),
-)
 class TestAssetSync:
     @pytest.fixture(autouse=True)
     def before_test(

--- a/test/unit/deadline_job_attachments/test_download.py
+++ b/test/unit/deadline_job_attachments/test_download.py
@@ -566,10 +566,6 @@ def assert_get_job_input_output_paths_by_asset_root(
 
 @pytest.mark.docker
 @pytest.mark.parametrize("manifest_version", [ManifestVersion.v2023_03_03])
-@patch(
-    f"{deadline.__package__}.job_attachments._aws.aws_clients.create_crt_transfer_manager",
-    MagicMock(return_value=None),
-)
 class TestFullDownload:
     """
     Tests for downloads from cas.
@@ -1969,10 +1965,6 @@ class TestFullDownload:
 
 
 @pytest.mark.parametrize("manifest_version", [ManifestVersion.v2023_03_03])
-@patch(
-    f"{deadline.__package__}.job_attachments._aws.aws_clients.create_crt_transfer_manager",
-    MagicMock(return_value=None),
-)
 class TestFullDownloadPrefixesWithSlashes:
     """
     Tests for downloads from cas when the queue prefixes are created.

--- a/test/unit/deadline_job_attachments/test_upload.py
+++ b/test/unit/deadline_job_attachments/test_upload.py
@@ -57,10 +57,6 @@ from deadline.job_attachments._utils import _human_readable_file_size
 from ..conftest import is_windows_non_admin
 
 
-@patch(
-    f"{deadline.__package__}.job_attachments._aws.aws_clients.create_crt_transfer_manager",
-    MagicMock(return_value=None),
-)
 class TestUpload:
     """
     Tests for handling uploading assets.


### PR DESCRIPTION
This reverts commit dffc71e0c113437cfe3da5c934360db3573ad77c and 52da0ea8816df2f39ec24fd35646b27f978a0891

### What was the problem/requirement? (What/Why)
- From testing, we encountered the following errors:
```
FileNotFoundError: [Errno 2] No such file or directory
```

- From conversations, it seems the stack trace was:
```
[Errno 2] No such file or directory
Traceback (most recent call last):
  File "/opt/deadline/worker/lib64/python3.11/site-packages/deadline_worker_agent/sessions/actions/sync_input_job_attachments.py", line 141, in _on_done
    future.result()
  File "/usr/lib64/python3.11/concurrent/futures/_base.py", line 449, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
  File "/usr/lib64/python3.11/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/deadline/worker/lib64/python3.11/site-packages/deadline_worker_agent/sessions/session.py", line 942, in sync_asset_inputs
    (download_summary_statistics, path_mapping_rules) = self._asset_sync.sync_inputs(
                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/deadline/worker/lib64/python3.11/site-packages/deadline/job_attachments/asset_sync.py", line 504, in sync_inputs
    download_summary_statistics = download_files_from_manifests(
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/deadline/worker/lib64/python3.11/site-packages/deadline/job_attachments/download.py", line 769, in download_files_from_manifests
    downloaded_files_paths = _download_files_parallel(
                             ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/deadline/worker/lib64/python3.11/site-packages/deadline/job_attachments/download.py", line 565, in _download_files_parallel
    (file_bytes, local_file_name) = future.result()
                                    ^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/concurrent/futures/_base.py", line 449, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
  File "/usr/lib64/python3.11/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/deadline/worker/lib64/python3.11/site-packages/deadline/job_attachments/download.py", line 522, in download_file
    os.utime(local_file_name, (modified_time_override, modified_time_override))  # type: ignore[arg-type]
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory

```
### What was the solution? (How)
- Revert the CRT solution, we will investigate and push this solution again once it is fully tested.

### What is the impact of this change?
- This is a regression to the Job Attachments feature and was discovered by multiple developers.

### How was this change tested?
hatch build

### Was this change documented?
NA - revert only

### Is this a breaking change?
NA - revert only.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*