### PR TITLE
fix(cli): correct download-output command displaying resolved UNC path

### DIFF
--- a/src/deadline/client/cli/_groups/job_group.py
+++ b/src/deadline/client/cli/_groups/job_group.py
@@ -365,9 +365,7 @@ def _download_job_output(
             )
             for index, confirmed_root in enumerate(confirmed_asset_roots):
                 _assert_valid_path(confirmed_root)
-                job_output_downloader.set_root_path(
-                    asset_roots[index], str(Path(confirmed_root))
-                )
+                job_output_downloader.set_root_path(asset_roots[index], str(Path(confirmed_root)))
             output_paths_by_root = job_output_downloader.get_output_paths_by_root()
 
     # If the conflict resolution option was not specified, auto-accept is false, and
@@ -951,4 +949,3 @@ def job_trace_schedule(verbose, trace_format, trace_file, **args):
     if trace_file:
         with open(trace_file, "w", encoding="utf8") as f:
             json.dump(tracing_data, f, indent=1)
-

--- a/src/deadline/client/cli/_groups/job_group.py
+++ b/src/deadline/client/cli/_groups/job_group.py
@@ -330,8 +330,7 @@ def _download_job_output(
                     _get_summary_of_files_to_download_message(output_paths_by_root, is_json_format)
                 )
                 asset_roots = list(output_paths_by_root.keys())
-                asset_roots_resolved = [f"{str(Path(root).resolve())}" for root in asset_roots]
-                click.echo(_get_roots_list_message(asset_roots_resolved, is_json_format))
+                click.echo(_get_roots_list_message(asset_roots, is_json_format))
                 user_choice = click.prompt(
                     "> Please enter the index of root directory to edit, y to proceed without changes, or n to cancel the download",
                     type=click.Choice(
@@ -348,10 +347,10 @@ def _download_job_output(
                     new_root = click.prompt(
                         "> Please enter the new root directory path, or press Enter to keep it unchanged",
                         type=click.Path(exists=False),
-                        default=asset_roots_resolved[index_to_change],
+                        default=asset_roots[index_to_change],
                     )
                     job_output_downloader.set_root_path(
-                        asset_roots[index_to_change], str(Path(new_root).resolve())
+                        asset_roots[index_to_change], str(Path(new_root))
                     )
                     output_paths_by_root = job_output_downloader.get_output_paths_by_root()
         else:
@@ -359,8 +358,7 @@ def _download_job_output(
                 _get_summary_of_files_to_download_message(output_paths_by_root, is_json_format)
             )
             asset_roots = list(output_paths_by_root.keys())
-            asset_roots_resolved = [f"{str(Path(root).resolve())}" for root in asset_roots]
-            click.echo(_get_roots_list_message(asset_roots_resolved, is_json_format))
+            click.echo(_get_roots_list_message(asset_roots, is_json_format))
             json_string = click.prompt("", prompt_suffix="", type=str)
             confirmed_asset_roots = _get_value_from_json_line(
                 json_string, JSON_MSG_TYPE_PATHCONFIRM, expected_size=len(asset_roots)
@@ -368,7 +366,7 @@ def _download_job_output(
             for index, confirmed_root in enumerate(confirmed_asset_roots):
                 _assert_valid_path(confirmed_root)
                 job_output_downloader.set_root_path(
-                    asset_roots[index], str(Path(confirmed_root).resolve())
+                    asset_roots[index], str(Path(confirmed_root))
                 )
             output_paths_by_root = job_output_downloader.get_output_paths_by_root()
 
@@ -645,7 +643,7 @@ def job_download_output(step_id, task_id, output, **args):
     except Exception as e:
         if is_json_format:
             error_one_liner = str(e).replace("\n", ". ")
-            click.echo(_get_json_line("error", error_one_liner))
+            click.echo(_get_json_line(JSON_MSG_TYPE_ERROR, error_one_liner))
             sys.exit(1)
         else:
             raise DeadlineOperationError(f"Failed to download output:\n{e}") from e
@@ -953,3 +951,4 @@ def job_trace_schedule(verbose, trace_format, trace_file, **args):
     if trace_file:
         with open(trace_file, "w", encoding="utf8") as f:
             json.dump(tracing_data, f, indent=1)
+


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The `download-output` CLI command can output resolved UNC root paths for mapped drive, leading to confusing logs like below
```
PS C:\Users\yuanbian\Git\deadline\deadline-cloud> deadline job download-output --job-id job-f5c23912e3b946799f9f18d30765847c
Downloading output from Job 'blender-3.5-splash'

Summary of files to download:
    S:\Blender\Output (2 files)

You are about to download files which may come from multiple root directories. Here are a list of the current root directories:
[0] \\DESKTOP-XXXXX\SD\Blender
> Please enter the index of root directory to edit, y to proceed without changes, or n to cancel the download (0, y, n) [y]: 0
> Please enter the new root directory path, or press Enter to keep it unchanged [\\DESKTOP-4LN5768\SD\Blender]: S:\Blender\Output

Summary of files to download:
    \\DESKTOP-XXXXX\SD\Blender\Output\Output (2 files)

You are about to download files which may come from multiple root directories. Here are a list of the current root directories:
[0] \\DESKTOP-XXXXX\SD\Blender\Output
> Please enter the index of root directory to edit, y to proceed without changes, or n to cancel the download (0, y, n) [y]: 0
```

### What was the solution? (How)
Remove path resolve that output UNC path for mapped network drive.

### What is the impact of this change?
The download-output command shows unresolved path for mapped drive.

```
PS C:\Users\yuanbian\Git\deadline\deadline-cloud> hatch run default:deadline job download-output --job-id job-f5c23912e3b946799f9f18d30765847c
Downloading output from Job 'blender-3.5-splash'

Summary of files to download:
    S:\Blender\Output (2 files)

You are about to download files which may come from multiple root directories. Here are a list of the current root directories:
[0] S:\Blender
> Please enter the index of root directory to edit, y to proceed without changes, or n to cancel the download (0, y, n) [y]: 0
> Please enter the new root directory path, or press Enter to keep it unchanged [S:\Blender]: S:\Blender\Out

Summary of files to download:
    S:\Blender\Out\Output (2 files)

You are about to download files which may come from multiple root directories. Here are a list of the current root directories:
[0] S:\Blender\Out
> Please enter the index of root directory to edit, y to proceed without changes, or n to cancel the download (0, y, n) [y]: y
```

### How was this change tested?
- All unit tests passed successfully.
- Done some manual end-to-end tests including cross-platform scenarios, confirming that it worked as expected. 
  - Fix Test
    - Downloading outputs from job with mapped drive on Windows: shows mapped drive letter (used to be UNC format path)
  - Regression Test
    - Downloading outputs from job with UNC format root paths on Windows: shows UNC format root paths
    - Downloading outputs from job with C drive root paths on windows: shows C drive root paths
    - Downloading outputs from job with UNC format root paths on Linux: prompt OS mismatch and ask user to select local path
    - Downloading outputs from job with C drive root paths on Linux: prompt OS mismatch and ask user to select local path
    - Downloading outputs from job with Linux root paths on Linux: download as expected

### Was this change documented?
No.

### Is this a breaking change?
No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*