### PR TITLE
ci: update workflow job names for integ tests

### DIFF
--- a/.github/workflows/mainline_integration_test.yml
+++ b/.github/workflows/mainline_integration_test.yml
@@ -4,8 +4,8 @@ on:
   workflow_dispatch:
 
 jobs:  
-  MainlineIntegrationTest:
-    name: Integration Test
+  MainlineLinuxIntegrationTest:
+    name: Linux Integration Test
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
reusable integration tests now requires the OS to be passed in as a paramater

### What was the solution? (How)
Add the OS parameter and specify the job name for the test name as a Linux test job.

### What is the impact of this change?
Uses OS param to differentiate which code build project should be run.

### How was this change tested?

### Was this change documented?
no

### Is this a breaking change?
this change depends on https://github.com/aws-deadline/.github/pull/9

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*