### PR TITLE
chore: bumping deadline-cloud-test-fixtures to 0.7.*

### DIFF
--- a/requirements-integ-testing.txt
+++ b/requirements-integ-testing.txt
@@ -1,1 +1,1 @@
-deadline-cloud-test-fixtures ~= 0.6.2
+deadline-cloud-test-fixtures ~= 0.7.*

--- a/requirements-integ-testing.txt
+++ b/requirements-integ-testing.txt
@@ -1,1 +1,1 @@
-deadline-cloud-test-fixtures ~= 0.7.*
+deadline-cloud-test-fixtures == 0.7.*


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
deadline-cloud-test-fixtures 0.7.1 was released.

### What was the solution? (How)
Bump the deps version here.

### What is the impact of this change?
Well use the latest version of the test-fixtures.

### How was this change tested?
I manually verified the changes in the 0.7.0 and 0.7.1 releases.

### Was this change documented?
no.

### Is this a breaking change?
no.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*