### PR TITLE
feat: support JSON output in bundle GUI submitter

### DIFF
--- a/src/deadline/client/cli/_groups/bundle_group.py
+++ b/src/deadline/client/cli/_groups/bundle_group.py
@@ -325,7 +325,7 @@ def _print_response(
 ):
     if output == "json":
         if submitted:
-            response = {
+            response: dict[str, Any] = {
                 "status": "SUBMITTED",
                 "jobId": job_id,
             }

--- a/src/deadline/client/cli/_groups/bundle_group.py
+++ b/src/deadline/client/cli/_groups/bundle_group.py
@@ -328,11 +328,13 @@ def _print_response(
                 "jobId": job_id,
             }
             if extra_info:
-                response.update({
-                    "jobBundleDirectory": job_bundle_dir,
-                    "parameterValues": parameter_values,
-                    "assetReferences": asset_references,
-                })
+                response.update(
+                    {
+                        "jobBundleDirectory": job_bundle_dir,
+                        "parameterValues": parameter_values,
+                        "assetReferences": asset_references,
+                    }
+                )
             click.echo(json.dumps(response))
         else:
             click.echo(json.dumps({"status": "CANCELED"}))

--- a/src/deadline/client/cli/_groups/bundle_group.py
+++ b/src/deadline/client/cli/_groups/bundle_group.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import json
 import logging
 import re
-from typing import Optional
+from typing import Any, Dict, Optional
 
 import click
 from contextlib import ExitStack
@@ -296,21 +296,29 @@ def bundle_gui_submit(job_bundle_dir, browse, output, **args):
             submitted=True if response else False,
             job_bundle_dir=job_bundle_dir,
             job_id=response["jobId"] if response else None,
+            parameter_values=submitter.parameter_values,
+            asset_references=submitter.job_attachments.get_asset_references().to_dict(),
         )
 
 
-def _print_response(output: str, submitted: bool, job_bundle_dir: str, job_id: Optional[str]):
+def _print_response(
+    output: str,
+    submitted: bool,
+    job_bundle_dir: str,
+    job_id: Optional[str],
+    parameter_values: Optional[list[Dict[str, Any]]],
+    asset_references: Dict[str, Any],
+):
     if output == "json":
         if submitted:
-            click.echo(
-                json.dumps(
-                    {
-                        "status": "SUBMITTED",
-                        "jobId": job_id,
-                        "jobBundleDirectory": job_bundle_dir,
-                    }
-                )
-            )
+            response = {
+                "status": "SUBMITTED",
+                "jobId": job_id,
+                "jobBundleDirectory": job_bundle_dir,
+                "parameterValues": parameter_values,
+                "assetReferences": asset_references,
+            }
+            click.echo(json.dumps(response))
         else:
             click.echo(json.dumps({"status": "CANCELED"}))
     else:

--- a/src/deadline/client/cli/_groups/bundle_group.py
+++ b/src/deadline/client/cli/_groups/bundle_group.py
@@ -308,7 +308,9 @@ def bundle_gui_submit(job_bundle_dir, browse, output, extra_info, **args):
             job_bundle_dir=job_bundle_dir,
             job_id=response["jobId"] if response else None,
             parameter_values=submitter.parameter_values,
-            asset_references=submitter.job_attachments.get_asset_references().to_dict()["assetReferences"],
+            asset_references=submitter.job_attachments.get_asset_references().to_dict()[
+                "assetReferences"
+            ],
         )
 
 

--- a/src/deadline/client/cli/_groups/bundle_group.py
+++ b/src/deadline/client/cli/_groups/bundle_group.py
@@ -328,11 +328,11 @@ def _print_response(
             response: dict[str, Any] = {
                 "status": "SUBMITTED",
                 "jobId": job_id,
+                "jobBundleDirectory": job_bundle_dir,
             }
             if extra_info:
                 response.update(
                     {
-                        "jobBundleDirectory": job_bundle_dir,
                         "parameterValues": parameter_values,
                         "assetReferences": asset_references,
                     }

--- a/src/deadline/client/cli/_groups/bundle_group.py
+++ b/src/deadline/client/cli/_groups/bundle_group.py
@@ -5,8 +5,10 @@ All the `deadline bundle` commands.
 """
 from __future__ import annotations
 
+import json
 import logging
 import re
+from typing import Optional
 
 import click
 from contextlib import ExitStack
@@ -249,8 +251,20 @@ def bundle_submit(
     is_flag=True,
     help="Allows user to choose Bundle and adds a 'Load a different job bundle' option to the Job-Specific Settings UI",
 )
+@click.option(
+    "--output",
+    type=click.Choice(
+        ["verbose", "json"],
+        case_sensitive=False,
+    ),
+    default="verbose",
+    help="Specifies the output format of the messages printed to stdout.\n"
+    "VERBOSE: Displays messages in a human-readable text format.\n"
+    "JSON: Displays messages in JSON line format, so that the info can be easily "
+    "parsed/consumed by custom scripts.",
+)
 @_handle_error
-def bundle_gui_submit(job_bundle_dir, browse, **args):
+def bundle_gui_submit(job_bundle_dir, browse, output, **args):
     """
     Opens GUI to submit an Open Job Description job bundle to AWS Deadline Cloud.
     """
@@ -276,10 +290,34 @@ def bundle_gui_submit(job_bundle_dir, browse, **args):
         response = None
         if submitter:
             response = submitter.create_job_response
-        if response:
+
+        _print_response(
+            output=output,
+            submitted=True if response else False,
+            job_bundle_dir=job_bundle_dir,
+            job_id=response["jobId"] if response else None,
+        )
+
+
+def _print_response(output: str, submitted: bool, job_bundle_dir: str, job_id: Optional[str]):
+    if output == "json":
+        if submitted:
+            click.echo(
+                json.dumps(
+                    {
+                        "status": "SUBMITTED",
+                        "jobId": job_id,
+                        "jobBundleDirectory": job_bundle_dir,
+                    }
+                )
+            )
+        else:
+            click.echo(json.dumps({"status": "CANCELED"}))
+    else:
+        if submitted:
             click.echo("Submitted job bundle:")
             click.echo(f"   {job_bundle_dir}")
-            click.echo(f"Job ID: {response['jobId']}")
+            click.echo(f"Job ID: {job_id}")
         else:
             click.echo("Job submission canceled.")
 

--- a/src/deadline/client/cli/_groups/bundle_group.py
+++ b/src/deadline/client/cli/_groups/bundle_group.py
@@ -308,7 +308,7 @@ def bundle_gui_submit(job_bundle_dir, browse, output, extra_info, **args):
             job_bundle_dir=job_bundle_dir,
             job_id=response["jobId"] if response else None,
             parameter_values=submitter.parameter_values,
-            asset_references=submitter.job_attachments.get_asset_references().to_dict(),
+            asset_references=submitter.job_attachments.get_asset_references().to_dict()["assetReferences"],
         )
 
 

--- a/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
@@ -94,6 +94,7 @@ class SubmitJobToDeadlineDialog(QDialog):
         self.job_settings_type = type(initial_job_settings)
         self.on_create_job_bundle_callback = on_create_job_bundle_callback
         self.create_job_response: Optional[Dict[str, Any]] = None
+        self.parameter_values: Optional[list[Dict[str, Any]]] = None
         self.deadline_authentication_status = DeadlineAuthenticationStatus.getInstance()
         self.show_host_requirements_tab = show_host_requirements_tab
 
@@ -408,6 +409,19 @@ class SubmitJobToDeadlineDialog(QDialog):
             job_history_bundle_dir = create_job_history_bundle_dir(
                 settings.submitter_name, settings.name
             )
+
+            # First filter the queue parameters to exclude any from the job template,
+            # then extend it with the job template parameters.
+            job_parameter_names = {param["name"] for param in settings.parameters}
+            parameter_values: list[dict[str, Any]] = [
+                {"name": param["name"], "value": param["value"]}
+                for param in queue_parameters
+                if param["name"] not in job_parameter_names
+            ]
+            parameter_values.extend(
+                {"name": param["name"], "value": param["value"]} for param in settings.parameters
+            )
+            self.parameter_values = parameter_values
 
             if self.show_host_requirements_tab:
                 requirements = self.host_requirements.get_requirements()

--- a/test/unit/deadline_client/cli/test_cli_bundle.py
+++ b/test/unit/deadline_client/cli/test_cli_bundle.py
@@ -779,7 +779,9 @@ def test_cli_bundle_gui_submit_format_output():
             parameter_values=[{"name": "Frames", "value": "1-4"}],
             asset_references={"inputs": {"filenames:": ["test.file"]}},
         )
-        mock_click.echo.assert_called_with('{"status": "SUBMITTED", "jobId": "job-1234"}')
+        mock_click.echo.assert_called_with(
+            '{"status": "SUBMITTED", "jobId": "job-1234", "jobBundleDirectory": "./test"}'
+        )
 
         _print_response(
             output="json",

--- a/test/unit/deadline_client/cli/test_cli_bundle.py
+++ b/test/unit/deadline_client/cli/test_cli_bundle.py
@@ -779,9 +779,7 @@ def test_cli_bundle_gui_submit_format_output():
             parameter_values=[{"name": "Frames", "value": "1-4"}],
             asset_references={"inputs": {"filenames:": ["test.file"]}},
         )
-        mock_click.echo.assert_called_with(
-            '{"status": "SUBMITTED", "jobId": "job-1234"}'
-        )
+        mock_click.echo.assert_called_with('{"status": "SUBMITTED", "jobId": "job-1234"}')
 
         _print_response(
             output="json",

--- a/test/unit/deadline_client/cli/test_cli_bundle.py
+++ b/test/unit/deadline_client/cli/test_cli_bundle.py
@@ -761,6 +761,7 @@ def test_cli_bundle_gui_submit_format_output():
     with mock.patch("deadline.client.cli._groups.bundle_group.click") as mock_click:
         _print_response(
             output="json",
+            extra_info=True,
             submitted=False,
             job_bundle_dir="./test",
             job_id="job-1234",
@@ -771,6 +772,20 @@ def test_cli_bundle_gui_submit_format_output():
 
         _print_response(
             output="json",
+            extra_info=False,
+            submitted=True,
+            job_bundle_dir="./test",
+            job_id="job-1234",
+            parameter_values=[{"name": "Frames", "value": "1-4"}],
+            asset_references={"inputs": {"filenames:": ["test.file"]}},
+        )
+        mock_click.echo.assert_called_with(
+            '{"status": "SUBMITTED", "jobId": "job-1234"}'
+        )
+
+        _print_response(
+            output="json",
+            extra_info=True,
             submitted=True,
             job_bundle_dir="./test",
             job_id="job-1234",
@@ -783,6 +798,7 @@ def test_cli_bundle_gui_submit_format_output():
 
         _print_response(
             output="verbose",
+            extra_info=False,
             submitted=False,
             job_bundle_dir="./test",
             job_id="job-1234",
@@ -793,6 +809,7 @@ def test_cli_bundle_gui_submit_format_output():
 
         _print_response(
             output="verbose",
+            extra_info=False,
             submitted=True,
             job_bundle_dir="./test",
             job_id="job-1234",

--- a/test/unit/deadline_client/cli/test_cli_bundle.py
+++ b/test/unit/deadline_client/cli/test_cli_bundle.py
@@ -759,20 +759,44 @@ def test_cli_bundle_gui_submit_format_output():
     Verify that the GUI submitter returns responses correctly.
     """
     with mock.patch("deadline.client.cli._groups.bundle_group.click") as mock_click:
-        _print_response(output="json", submitted=False, job_bundle_dir="./test", job_id="job-1234")
+        _print_response(
+            output="json",
+            submitted=False,
+            job_bundle_dir="./test",
+            job_id="job-1234",
+            parameter_values=[],
+            asset_references={},
+        )
         mock_click.echo.assert_called_with('{"status": "CANCELED"}')
 
-        _print_response(output="json", submitted=True, job_bundle_dir="./test", job_id="job-1234")
+        _print_response(
+            output="json",
+            submitted=True,
+            job_bundle_dir="./test",
+            job_id="job-1234",
+            parameter_values=[{"name": "Frames", "value": "1-4"}],
+            asset_references={"inputs": {"filenames:": ["test.file"]}},
+        )
         mock_click.echo.assert_called_with(
-            '{"status": "SUBMITTED", "jobId": "job-1234", "jobBundleDirectory": "./test"}'
+            '{"status": "SUBMITTED", "jobId": "job-1234", "jobBundleDirectory": "./test", "parameterValues": [{"name": "Frames", "value": "1-4"}], "assetReferences": {"inputs": {"filenames:": ["test.file"]}}}'
         )
 
         _print_response(
-            output="verbose", submitted=False, job_bundle_dir="./test", job_id="job-1234"
+            output="verbose",
+            submitted=False,
+            job_bundle_dir="./test",
+            job_id="job-1234",
+            parameter_values=[],
+            asset_references={},
         )
         mock_click.echo.assert_called_with("Job submission canceled.")
 
         _print_response(
-            output="verbose", submitted=True, job_bundle_dir="./test", job_id="job-1234"
+            output="verbose",
+            submitted=True,
+            job_bundle_dir="./test",
+            job_id="job-1234",
+            parameter_values=[],
+            asset_references={},
         )
         mock_click.echo.assert_any_call("Submitted job bundle:")


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
In a DCC integration, I was trying to read out the most recently submitted job settings. The bundle GUI submitter prints a human readable output with the bundle directory path where the settings can be found. but the response is not machine readable. 

### What was the solution? (How)
Add a JSON output option.

### What is the impact of this change?
Scripts calling the GUI submitter can easily read back where the job bundle is saved and what the submitted job ID is.

### How was this change tested?
Unit tests and manually running the CLI commands.

### Was this change documented?
Auto-documented in the CLI help.

### Is this a breaking change?
No - new minor feature.
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*