### PR TITLE
fix: use sids when granting permissions with icacls

### DIFF
--- a/src/deadline/client/config/config_file.py
+++ b/src/deadline/client/config/config_file.py
@@ -247,8 +247,11 @@ def _reset_directory_permissions_windows(directory: Path, username: str, permiss
             *_get_grant_args(username, permissions),
             # On Windows, both SYSTEM and the Administrators group normally
             # have Full Access to files in the user's home directory.
-            *_get_grant_args("Administrators", permissions),
-            *_get_grant_args("SYSTEM", permissions),
+            # Use SIDs to represent the Administrators and SYSTEM to
+            # support multi-language operating systems
+            # Administrator(S-1-5-32-544), SYSTEM(S-1-5-18)
+            *_get_grant_args("*S-1-5-32-544", permissions),
+            *_get_grant_args("*S-1-5-18", permissions),
         ],
         check=True,
         capture_output=True,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
icacls will fail to set permissions on the config directory when using non-english operating systems.

### What was the solution? (How)
Use the [SID](https://learn.microsoft.com/en-us/windows-server/identity/ad-ds/manage/understand-security-identifiers) of Administrators and SYSTEM to set the permissions. with [icacls](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/icacls).

### What is the impact of this change?
Users using different OS languages can use the submitter. 

### How was this change tested?
Tested on a Windows OS with Spanish setup. Confirmed I was not able to submit a blender job to a farm. Once the change was implemented, job submission was successful.

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*