### PR TITLE
fix: bundle gui-submit fails loading bundles with saved queue parameter values

### DIFF
--- a/src/deadline/client/ui/widgets/openjd_parameters_widget.py
+++ b/src/deadline/client/ui/widgets/openjd_parameters_widget.py
@@ -130,6 +130,13 @@ class OpenJDParametersWidget(QWidget):
             if ":" in parameter["name"]:
                 continue
 
+            # Skip any parameters that do not have a type defined.
+            # This can happen when a queue environment parameter was
+            # saved to the bundle, but the template itself does not contain
+            # that parameter.
+            if "type" not in parameter:
+                continue
+
             control_type_name = get_ui_control_for_parameter_definition(parameter)
 
             if parameter["type"] == "INT" and control_type_name == "SPIN_BOX":


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The bundle submitter GUI will fail to open a job bundle if a parameter has a value in `parameter_values` but the parameter does not exist in the template.

### What was the solution? (How)

The error was caused when trying to generate a GUI component for the parameter. `parameter_values` does not contain type information for the parameter, only the value. The code that generates a component for a parameter assumes there is type information for all parameters. If type information is not found, we simply skip generating a component for that parameter. Note that we still want to retain these parameter values as they can still be used to populate queue parameter values.

### What is the impact of this change?

Job bundles as described above can now be opened in the bundle submission GUI. In particular, job bundles generated by the integrated submitters when queue environment parameters were present will now work with the job bundle submission GUI.

### How was this change tested?

I opened a job bundle that was previously not opening.

### Was this change documented?

No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*