### PR TITLE
chore: Add OS field support for integ test

### DIFF
--- a/.github/workflows/mainline_integration_test.yml
+++ b/.github/workflows/mainline_integration_test.yml
@@ -15,3 +15,4 @@ jobs:
       repository: ${{ github.event.repository.name }}
       branch: mainline
       environment: mainline
+      os: linux


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We need to have more test on the deadline cloud repo
### What was the solution? (How)
Add OS field to enable integ test currently exist on deadline cloud
### What is the impact of this change?
Integ tests will now run correctly
### How was this change tested?
`hatch build && hatch run integ:test`
### Was this change documented?
Yes
### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*