### PR TITLE
ci: Add requirement file when run integ test

### DIFF
--- a/.github/workflows/mainline_integration_test.yml
+++ b/.github/workflows/mainline_integration_test.yml
@@ -15,3 +15,4 @@ jobs:
       repository: ${{ github.event.repository.name }}
       branch: mainline
       environment: mainline
+      os: linux

--- a/hatch.toml
+++ b/hatch.toml
@@ -47,7 +47,8 @@ make_exe = "python scripts/pyinstaller/make_exe.py --output {env:OUT_FILE}"
 
 [envs.integ]
 pre-install-commands = [
-  "pip install -r requirements-integ-testing.txt"
+  "pip install -r requirements-integ-testing.txt",
+  "pip install -r requirements-testing.txt"
 ]
 
 [envs.integ.scripts]


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Integ test missing dependency
### What was the solution? (How)
Add dependency so Integ could run successfully
### What is the impact of this change?
Integ workflow could now run
### How was this change tested?
`./pipeline/integ.sh`
### Was this change documented?
Yes
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*