### PR TITLE
ci: Add req to toml file 

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -47,7 +47,8 @@ make_exe = "python scripts/pyinstaller/make_exe.py --output {env:OUT_FILE}"
 
 [envs.integ]
 pre-install-commands = [
-  "pip install -r requirements-integ-testing.txt"
+  "pip install -r requirements-integ-testing.txt",
+  "pip install -r requirements-testing.txt"
 ]
 
 [envs.integ.scripts]


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

- Integ workflow of this package could not be run successful due to missing dependency

- Error message:

<img width="496" alt="image" src="https://github.com/aws-deadline/deadline-cloud/assets/167144297/faf2857b-81f2-4af6-8f65-740735df214d">

- After deep dive into the problem, it turn out that Pytest was missing:

```
Checking dependencies
/bin/sh: pytest: command not found
```

This is due to the pre install file do not contain enough dependencies.


### What was the solution? (How)
We add the pre install file that needed for unittest to the list of requirement before running Integ test. This will ensure the tests have all dependencies needed to work correctly.
### What is the impact of this change?
The Integ workflow will now run successfully.
### How was this change tested?
`./pipeline/integ.sh`
### Was this change documented?
NA
### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*