### PR TITLE
feat: Squish Automated Tests - Dev Submit GUI Settings flow

### DIFF
--- a/.github/workflows/mainline_integration_test.yml
+++ b/.github/workflows/mainline_integration_test.yml
@@ -15,3 +15,4 @@ jobs:
       repository: ${{ github.event.repository.name }}
       branch: mainline
       environment: mainline
+      os: linux

--- a/.github/workflows/mainline_integration_test.yml
+++ b/.github/workflows/mainline_integration_test.yml
@@ -4,8 +4,8 @@ on:
   workflow_dispatch:
 
 jobs:  
-  MainlineIntegrationTest:
-    name: Integration Test
+  MainlineLinuxIntegrationTest:
+    name: Linux Integration Test
     permissions:
       id-token: write
       contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.48.5 (2024-06-24)
+
+
+### Features
+* support JSON output in bundle GUI submitter (#357) ([`aad9a49`](https://github.com/aws-deadline/deadline-cloud/commit/aad9a49c9085e67031abc3ce342ca8068a6508d1))
+
+### Bug Fixes
+* bundle gui-submit fails loading bundles with saved queue parameter values (#360) ([`a2c1f2d`](https://github.com/aws-deadline/deadline-cloud/commit/a2c1f2ddb697f3e6ac8f17d443ad5618674216a6))
+* use sids when granting permissions with icacls (#359) ([`133b059`](https://github.com/aws-deadline/deadline-cloud/commit/133b05938288afbdc11b3dbfe11c8c98349f81b3))
+* bundles are stored in job_history in their original format (#344) ([`b5de504`](https://github.com/aws-deadline/deadline-cloud/commit/b5de504918cc6420d80d5206f9332cb8880471a5))
+
 ## 0.48.4 (2024-06-03)
 
 

--- a/hatch.toml
+++ b/hatch.toml
@@ -47,7 +47,8 @@ make_exe = "python scripts/pyinstaller/make_exe.py --output {env:OUT_FILE}"
 
 [envs.integ]
 pre-install-commands = [
-  "pip install -r requirements-integ-testing.txt"
+  "pip install -r requirements-integ-testing.txt",
+  "pip install -r requirements-testing.txt"
 ]
 
 [envs.integ.scripts]

--- a/requirements-release.txt
+++ b/requirements-release.txt
@@ -1,1 +1,1 @@
-python-semantic-release == 9.5.*
+python-semantic-release == 9.8.*

--- a/src/deadline/client/cli/_groups/bundle_group.py
+++ b/src/deadline/client/cli/_groups/bundle_group.py
@@ -5,8 +5,10 @@ All the `deadline bundle` commands.
 """
 from __future__ import annotations
 
+import json
 import logging
 import re
+from typing import Any, Dict, Optional
 
 import click
 from contextlib import ExitStack
@@ -249,8 +251,25 @@ def bundle_submit(
     is_flag=True,
     help="Allows user to choose Bundle and adds a 'Load a different job bundle' option to the Job-Specific Settings UI",
 )
+@click.option(
+    "--output",
+    type=click.Choice(
+        ["verbose", "json"],
+        case_sensitive=False,
+    ),
+    default="verbose",
+    help="Specifies the output format of the messages printed to stdout.\n"
+    "VERBOSE: Displays messages in a human-readable text format.\n"
+    "JSON: Displays messages in JSON line format, so that the info can be easily "
+    "parsed/consumed by custom scripts.",
+)
+@click.option(
+    "--extra-info",
+    is_flag=True,
+    help="Returns additional information about the submitted job. Only valid with JSON output.",
+)
 @_handle_error
-def bundle_gui_submit(job_bundle_dir, browse, **args):
+def bundle_gui_submit(job_bundle_dir, browse, output, extra_info, **args):
     """
     Opens GUI to submit an Open Job Description job bundle to AWS Deadline Cloud.
     """
@@ -262,6 +281,11 @@ def bundle_gui_submit(job_bundle_dir, browse, **args):
         if not job_bundle_dir and not browse:
             raise DeadlineOperationError(
                 "Specify a job bundle directory or run the bundle command with the --browse flag"
+            )
+        output = output.lower()
+        if output != "json" and extra_info:
+            raise DeadlineOperationError(
+                "--extra-info is only availalbe with JSON output. Add the --output JSON option."
             )
 
         submitter = show_job_bundle_submitter(input_job_bundle_dir=job_bundle_dir, browse=browse)
@@ -276,10 +300,51 @@ def bundle_gui_submit(job_bundle_dir, browse, **args):
         response = None
         if submitter:
             response = submitter.create_job_response
-        if response:
+
+        _print_response(
+            output=output,
+            extra_info=extra_info,
+            submitted=True if response else False,
+            job_bundle_dir=job_bundle_dir,
+            job_id=response["jobId"] if response else None,
+            parameter_values=submitter.parameter_values,
+            asset_references=submitter.job_attachments.get_asset_references().to_dict()[
+                "assetReferences"
+            ],
+        )
+
+
+def _print_response(
+    output: str,
+    extra_info: bool,
+    submitted: bool,
+    job_bundle_dir: str,
+    job_id: Optional[str],
+    parameter_values: Optional[list[Dict[str, Any]]],
+    asset_references: Dict[str, Any],
+):
+    if output == "json":
+        if submitted:
+            response: dict[str, Any] = {
+                "status": "SUBMITTED",
+                "jobId": job_id,
+                "jobBundleDirectory": job_bundle_dir,
+            }
+            if extra_info:
+                response.update(
+                    {
+                        "parameterValues": parameter_values,
+                        "assetReferences": asset_references,
+                    }
+                )
+            click.echo(json.dumps(response))
+        else:
+            click.echo(json.dumps({"status": "CANCELED"}))
+    else:
+        if submitted:
             click.echo("Submitted job bundle:")
             click.echo(f"   {job_bundle_dir}")
-            click.echo(f"Job ID: {response['jobId']}")
+            click.echo(f"Job ID: {job_id}")
         else:
             click.echo("Job submission canceled.")
 

--- a/src/deadline/client/config/config_file.py
+++ b/src/deadline/client/config/config_file.py
@@ -247,8 +247,11 @@ def _reset_directory_permissions_windows(directory: Path, username: str, permiss
             *_get_grant_args(username, permissions),
             # On Windows, both SYSTEM and the Administrators group normally
             # have Full Access to files in the user's home directory.
-            *_get_grant_args("Administrators", permissions),
-            *_get_grant_args("SYSTEM", permissions),
+            # Use SIDs to represent the Administrators and SYSTEM to
+            # support multi-language operating systems
+            # Administrator(S-1-5-32-544), SYSTEM(S-1-5-18)
+            *_get_grant_args("*S-1-5-32-544", permissions),
+            *_get_grant_args("*S-1-5-18", permissions),
         ],
         check=True,
         capture_output=True,

--- a/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
@@ -94,6 +94,7 @@ class SubmitJobToDeadlineDialog(QDialog):
         self.job_settings_type = type(initial_job_settings)
         self.on_create_job_bundle_callback = on_create_job_bundle_callback
         self.create_job_response: Optional[Dict[str, Any]] = None
+        self.parameter_values: Optional[list[Dict[str, Any]]] = None
         self.deadline_authentication_status = DeadlineAuthenticationStatus.getInstance()
         self.show_host_requirements_tab = show_host_requirements_tab
 
@@ -408,6 +409,19 @@ class SubmitJobToDeadlineDialog(QDialog):
             job_history_bundle_dir = create_job_history_bundle_dir(
                 settings.submitter_name, settings.name
             )
+
+            # First filter the queue parameters to exclude any from the job template,
+            # then extend it with the job template parameters.
+            job_parameter_names = {param["name"] for param in settings.parameters}
+            parameter_values: list[dict[str, Any]] = [
+                {"name": param["name"], "value": param["value"]}
+                for param in queue_parameters
+                if param["name"] not in job_parameter_names
+            ]
+            parameter_values.extend(
+                {"name": param["name"], "value": param["value"]} for param in settings.parameters
+            )
+            self.parameter_values = parameter_values
 
             if self.show_host_requirements_tab:
                 requirements = self.host_requirements.get_requirements()

--- a/src/deadline/client/ui/widgets/openjd_parameters_widget.py
+++ b/src/deadline/client/ui/widgets/openjd_parameters_widget.py
@@ -130,6 +130,13 @@ class OpenJDParametersWidget(QWidget):
             if ":" in parameter["name"]:
                 continue
 
+            # Skip any parameters that do not have a type defined.
+            # This can happen when a queue environment parameter was
+            # saved to the bundle, but the template itself does not contain
+            # that parameter.
+            if "type" not in parameter:
+                continue
+
             control_type_name = get_ui_control_for_parameter_definition(parameter)
 
             if parameter["type"] == "INT" and control_type_name == "SPIN_BOX":

--- a/test/squish/suite_VerifySettingsDialog/config.xml
+++ b/test/squish/suite_VerifySettingsDialog/config.xml
@@ -1,0 +1,8 @@
+<testconfig version="1.0">
+    <information>
+        <summary/>
+        <description/>
+    </information>
+    <testsettings/>
+    <passwords/>
+</testconfig>

--- a/test/squish/suite_VerifySettingsDialog/envvars
+++ b/test/squish/suite_VerifySettingsDialog/envvars
@@ -1,1 +1,1 @@
-LD_LIBRARY_PATH=./DeadlineCloudSubmitter/DeadlineClient/cli/PySide6/Qt/lib
+LD_LIBRARY_PATH=/home/rocky/DeadlineCloudSubmitter/DeadlineClient/cli/PySide6/Qt/lib

--- a/test/squish/suite_VerifySettingsDialog/envvars
+++ b/test/squish/suite_VerifySettingsDialog/envvars
@@ -1,1 +1,1 @@
-LD_LIBRARY_PATH=/home/rocky/DeadlineCloudSubmitter/DeadlineClient/cli/PySide6/Qt/lib
+LD_LIBRARY_PATH=./DeadlineCloudSubmitter/DeadlineClient/cli/PySide6/Qt/lib

--- a/test/squish/suite_VerifySettingsDialog/envvars
+++ b/test/squish/suite_VerifySettingsDialog/envvars
@@ -1,0 +1,1 @@
+LD_LIBRARY_PATH=./DeadlineCloudSubmitter/DeadlineClient/cli/PySide6/Qt/lib

--- a/test/squish/suite_VerifySettingsDialog/shared/scripts/gui_helpers.py
+++ b/test/squish/suite_VerifySettingsDialog/shared/scripts/gui_helpers.py
@@ -1,3 +1,4 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # -*- coding: utf-8 -*
 # mypy: disable-error-code="attr-defined"
 

--- a/test/squish/suite_VerifySettingsDialog/shared/scripts/gui_helpers.py
+++ b/test/squish/suite_VerifySettingsDialog/shared/scripts/gui_helpers.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*
+# mypy: disable-error-code="attr-defined"
 
-import test
 import gui_locators
 import squish
+import test
 
 snoozeTimeout = 3  # seconds
 

--- a/test/squish/suite_VerifySettingsDialog/shared/scripts/gui_helpers.py
+++ b/test/squish/suite_VerifySettingsDialog/shared/scripts/gui_helpers.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*
+import gui_locators
+import squish
+import test
+
+snoozeTimeout = 3 # seconds
+
+def launchDeadlineConfigGUI():
+    squish.startApplication("deadline config gui")
+    test.log("Launching Deadline Config GUI")
+    test.log("Sleep for " + str(snoozeTimeout) + " seconds to allow GUI authentication to fully load.")
+    squish.snooze(snoozeTimeout)
+    test.compare(squish.waitForObjectExists(gui_locators.aWS_Deadline_Cloud_workstation_configuration_DeadlineConfigDialog).visible, True, "Expect the Deadline Config GUI to be open.")
+    
+def setGlobalSettings(profileName: str, jobHistDir: str):
+    test.compare(str(squish.waitForObjectExists(gui_locators.profile_settings_QLineEdit).displayText), jobHistDir, "Expect job history directory default path to be equal.")
+    squish.mouseClick(squish.waitForObjectItem(gui_locators.global_settings_AWS_profile_QComboBox, profileName), 484, 9, squish.Qt.NoModifier, squish.Qt.LeftButton)
+    squish.mouseClick(squish.waitForObjectItem(gui_locators.global_settings_AWS_profile_QComboBox, profileName), 225, 6, squish.Qt.NoModifier, squish.Qt.LeftButton)
+    test.log("Set Global settings")
+    
+def setProfileSettings(farmName: str):
+    squish.mouseClick(squish.waitForObject(gui_locators.profile_settings_QComboBox), 407, 13, squish.Qt.NoModifier, squish.Qt.LeftButton)
+    squish.mouseClick(squish.waitForObjectItem(gui_locators.profile_settings_QComboBox, farmName), 189, 10, squish.Qt.NoModifier, squish.Qt.LeftButton)
+    test.log("Set Profile settings")
+ 
+def setFarmSettings(queueName: str, storageProfile: str, jobAttachments:str):   
+    squish.mouseClick(squish.waitForObject(gui_locators.farm_settings_QComboBox), 392, 10, squish.Qt.NoModifier, squish.Qt.LeftButton)
+    squish.mouseClick(squish.waitForObjectItem(gui_locators.farm_settings_QComboBox, queueName), 200, 9, squish.Qt.NoModifier, squish.Qt.LeftButton)
+    squish.mouseClick(squish.waitForObject(gui_locators.farm_settings_QComboBox_2), 389, 12, squish.Qt.NoModifier, squish.Qt.LeftButton)
+    squish.mouseClick(squish.waitForObjectItem(gui_locators.farm_settings_QComboBox_2, storageProfile), 185, 11, squish.Qt.NoModifier, squish.Qt.LeftButton)
+    squish.mouseClick(squish.waitForObject(gui_locators.farm_settings_QComboBox_3), 323, 8, squish.Qt.NoModifier, squish.Qt.LeftButton)
+    squish.mouseClick(squish.waitForObjectItem(gui_locators.farm_settings_QComboBox_3, jobAttachments), 183, 12, squish.Qt.NoModifier, squish.Qt.LeftButton)
+    test.log("Set Farm settings")
+    
+def setGeneralSettings(conflictResOption: str, loggingLevel:str):
+    squish.mouseClick(squish.waitForObject(gui_locators.general_settings_Conflict_resolution_option_QComboBox), 382, 10, squish.Qt.NoModifier, squish.Qt.LeftButton)
+    squish.mouseClick(squish.waitForObjectItem(gui_locators.general_settings_Conflict_resolution_option_QComboBox, conflictResOption), 202, 6, squish.Qt.NoModifier, squish.Qt.LeftButton)
+    squish.mouseClick(squish.waitForObject(gui_locators.general_settings_Current_logging_level_QComboBox), 382, 14, squish.Qt.NoModifier, squish.Qt.LeftButton)
+    squish.mouseClick(squish.waitForObjectItem(gui_locators.general_settings_Current_logging_level_QComboBox, loggingLevel), 204, 10, squish.Qt.NoModifier, squish.Qt.LeftButton)
+    squish.mouseClick(squish.waitForObject(gui_locators.aWS_Deadline_Cloud_workstation_configuration_Apply_QPushButton), 30, 8, squish.Qt.NoModifier, squish.Qt.LeftButton)
+    test.log("Set General settings")
+    
+def closeDeadlineConfigGUI():
+    test.log("Hit `OK` button to close GUI")
+    squish.clickButton(squish.waitForObject(gui_locators.aWS_Deadline_Cloud_workstation_configuration_OK_QPushButton))

--- a/test/squish/suite_VerifySettingsDialog/shared/scripts/gui_helpers.py
+++ b/test/squish/suite_VerifySettingsDialog/shared/scripts/gui_helpers.py
@@ -3,43 +3,161 @@ import gui_locators
 import squish
 import test
 
-snoozeTimeout = 3 # seconds
+snoozeTimeout = 3  # seconds
+
 
 def launchDeadlineConfigGUI():
     squish.startApplication("deadline config gui")
     test.log("Launching Deadline Config GUI")
-    test.log("Sleep for " + str(snoozeTimeout) + " seconds to allow GUI authentication to fully load.")
+    test.log(
+        "Sleep for " + str(snoozeTimeout) + " seconds to allow GUI authentication to fully load."
+    )
     squish.snooze(snoozeTimeout)
-    test.compare(squish.waitForObjectExists(gui_locators.aWS_Deadline_Cloud_workstation_configuration_DeadlineConfigDialog).visible, True, "Expect the Deadline Config GUI to be open.")
-    
+    test.compare(
+        squish.waitForObjectExists(
+            gui_locators.aWS_Deadline_Cloud_workstation_configuration_DeadlineConfigDialog
+        ).visible,
+        True,
+        "Expect the Deadline Config GUI to be open.",
+    )
+
+
 def setGlobalSettings(profileName: str, jobHistDir: str):
-    test.compare(str(squish.waitForObjectExists(gui_locators.profile_settings_QLineEdit).displayText), jobHistDir, "Expect job history directory default path to be equal.")
-    squish.mouseClick(squish.waitForObjectItem(gui_locators.global_settings_AWS_profile_QComboBox, profileName), 484, 9, squish.Qt.NoModifier, squish.Qt.LeftButton)
-    squish.mouseClick(squish.waitForObjectItem(gui_locators.global_settings_AWS_profile_QComboBox, profileName), 225, 6, squish.Qt.NoModifier, squish.Qt.LeftButton)
+    test.compare(
+        str(squish.waitForObjectExists(gui_locators.profile_settings_QLineEdit).displayText),
+        jobHistDir,
+        "Expect job history directory default path to be equal.",
+    )
+    squish.mouseClick(
+        squish.waitForObjectItem(gui_locators.global_settings_AWS_profile_QComboBox, profileName),
+        484,
+        9,
+        squish.Qt.NoModifier,
+        squish.Qt.LeftButton,
+    )
+    squish.mouseClick(
+        squish.waitForObjectItem(gui_locators.global_settings_AWS_profile_QComboBox, profileName),
+        225,
+        6,
+        squish.Qt.NoModifier,
+        squish.Qt.LeftButton,
+    )
     test.log("Set Global settings")
-    
+
+
 def setProfileSettings(farmName: str):
-    squish.mouseClick(squish.waitForObject(gui_locators.profile_settings_QComboBox), 407, 13, squish.Qt.NoModifier, squish.Qt.LeftButton)
-    squish.mouseClick(squish.waitForObjectItem(gui_locators.profile_settings_QComboBox, farmName), 189, 10, squish.Qt.NoModifier, squish.Qt.LeftButton)
+    squish.mouseClick(
+        squish.waitForObject(gui_locators.profile_settings_QComboBox),
+        407,
+        13,
+        squish.Qt.NoModifier,
+        squish.Qt.LeftButton,
+    )
+    squish.mouseClick(
+        squish.waitForObjectItem(gui_locators.profile_settings_QComboBox, farmName),
+        189,
+        10,
+        squish.Qt.NoModifier,
+        squish.Qt.LeftButton,
+    )
     test.log("Set Profile settings")
- 
-def setFarmSettings(queueName: str, storageProfile: str, jobAttachments:str):   
-    squish.mouseClick(squish.waitForObject(gui_locators.farm_settings_QComboBox), 392, 10, squish.Qt.NoModifier, squish.Qt.LeftButton)
-    squish.mouseClick(squish.waitForObjectItem(gui_locators.farm_settings_QComboBox, queueName), 200, 9, squish.Qt.NoModifier, squish.Qt.LeftButton)
-    squish.mouseClick(squish.waitForObject(gui_locators.farm_settings_QComboBox_2), 389, 12, squish.Qt.NoModifier, squish.Qt.LeftButton)
-    squish.mouseClick(squish.waitForObjectItem(gui_locators.farm_settings_QComboBox_2, storageProfile), 185, 11, squish.Qt.NoModifier, squish.Qt.LeftButton)
-    squish.mouseClick(squish.waitForObject(gui_locators.farm_settings_QComboBox_3), 323, 8, squish.Qt.NoModifier, squish.Qt.LeftButton)
-    squish.mouseClick(squish.waitForObjectItem(gui_locators.farm_settings_QComboBox_3, jobAttachments), 183, 12, squish.Qt.NoModifier, squish.Qt.LeftButton)
+
+
+def setFarmSettings(queueName: str, storageProfile: str, jobAttachments: str):
+    squish.mouseClick(
+        squish.waitForObject(gui_locators.farm_settings_QComboBox),
+        392,
+        10,
+        squish.Qt.NoModifier,
+        squish.Qt.LeftButton,
+    )
+    squish.mouseClick(
+        squish.waitForObjectItem(gui_locators.farm_settings_QComboBox, queueName),
+        200,
+        9,
+        squish.Qt.NoModifier,
+        squish.Qt.LeftButton,
+    )
+    squish.mouseClick(
+        squish.waitForObject(gui_locators.farm_settings_QComboBox_2),
+        389,
+        12,
+        squish.Qt.NoModifier,
+        squish.Qt.LeftButton,
+    )
+    squish.mouseClick(
+        squish.waitForObjectItem(gui_locators.farm_settings_QComboBox_2, storageProfile),
+        185,
+        11,
+        squish.Qt.NoModifier,
+        squish.Qt.LeftButton,
+    )
+    squish.mouseClick(
+        squish.waitForObject(gui_locators.farm_settings_QComboBox_3),
+        323,
+        8,
+        squish.Qt.NoModifier,
+        squish.Qt.LeftButton,
+    )
+    squish.mouseClick(
+        squish.waitForObjectItem(gui_locators.farm_settings_QComboBox_3, jobAttachments),
+        183,
+        12,
+        squish.Qt.NoModifier,
+        squish.Qt.LeftButton,
+    )
     test.log("Set Farm settings")
-    
-def setGeneralSettings(conflictResOption: str, loggingLevel:str):
-    squish.mouseClick(squish.waitForObject(gui_locators.general_settings_Conflict_resolution_option_QComboBox), 382, 10, squish.Qt.NoModifier, squish.Qt.LeftButton)
-    squish.mouseClick(squish.waitForObjectItem(gui_locators.general_settings_Conflict_resolution_option_QComboBox, conflictResOption), 202, 6, squish.Qt.NoModifier, squish.Qt.LeftButton)
-    squish.mouseClick(squish.waitForObject(gui_locators.general_settings_Current_logging_level_QComboBox), 382, 14, squish.Qt.NoModifier, squish.Qt.LeftButton)
-    squish.mouseClick(squish.waitForObjectItem(gui_locators.general_settings_Current_logging_level_QComboBox, loggingLevel), 204, 10, squish.Qt.NoModifier, squish.Qt.LeftButton)
-    squish.mouseClick(squish.waitForObject(gui_locators.aWS_Deadline_Cloud_workstation_configuration_Apply_QPushButton), 30, 8, squish.Qt.NoModifier, squish.Qt.LeftButton)
+
+
+def setGeneralSettings(conflictResOption: str, loggingLevel: str):
+    squish.mouseClick(
+        squish.waitForObject(gui_locators.general_settings_Conflict_resolution_option_QComboBox),
+        382,
+        10,
+        squish.Qt.NoModifier,
+        squish.Qt.LeftButton,
+    )
+    squish.mouseClick(
+        squish.waitForObjectItem(
+            gui_locators.general_settings_Conflict_resolution_option_QComboBox, conflictResOption
+        ),
+        202,
+        6,
+        squish.Qt.NoModifier,
+        squish.Qt.LeftButton,
+    )
+    squish.mouseClick(
+        squish.waitForObject(gui_locators.general_settings_Current_logging_level_QComboBox),
+        382,
+        14,
+        squish.Qt.NoModifier,
+        squish.Qt.LeftButton,
+    )
+    squish.mouseClick(
+        squish.waitForObjectItem(
+            gui_locators.general_settings_Current_logging_level_QComboBox, loggingLevel
+        ),
+        204,
+        10,
+        squish.Qt.NoModifier,
+        squish.Qt.LeftButton,
+    )
+    squish.mouseClick(
+        squish.waitForObject(
+            gui_locators.aWS_Deadline_Cloud_workstation_configuration_Apply_QPushButton
+        ),
+        30,
+        8,
+        squish.Qt.NoModifier,
+        squish.Qt.LeftButton,
+    )
     test.log("Set General settings")
-    
+
+
 def closeDeadlineConfigGUI():
     test.log("Hit `OK` button to close GUI")
-    squish.clickButton(squish.waitForObject(gui_locators.aWS_Deadline_Cloud_workstation_configuration_OK_QPushButton))
+    squish.clickButton(
+        squish.waitForObject(
+            gui_locators.aWS_Deadline_Cloud_workstation_configuration_OK_QPushButton
+        )
+    )

--- a/test/squish/suite_VerifySettingsDialog/shared/scripts/gui_helpers.py
+++ b/test/squish/suite_VerifySettingsDialog/shared/scripts/gui_helpers.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*
+
+import test
 import gui_locators
 import squish
-import test
 
 snoozeTimeout = 3  # seconds
 

--- a/test/squish/suite_VerifySettingsDialog/shared/scripts/gui_locators.py
+++ b/test/squish/suite_VerifySettingsDialog/shared/scripts/gui_locators.py
@@ -1,0 +1,22 @@
+# encoding: UTF-8
+
+from objectmaphelper import *
+
+aWS_Deadline_Cloud_workstation_configuration_DeadlineConfigDialog = {"type": "DeadlineConfigDialog", "unnamed": 1, "visible": 1, "windowTitle": "AWS Deadline Cloud workstation configuration"}
+aWS_Deadline_Cloud_workstation_configuration_Global_settings_QGroupBox = {"title": "Global settings", "type": "QGroupBox", "unnamed": 1, "visible": 1, "window": aWS_Deadline_Cloud_workstation_configuration_DeadlineConfigDialog}
+global_settings_AWS_profile_QLabel = {"container": aWS_Deadline_Cloud_workstation_configuration_Global_settings_QGroupBox, "text": "AWS profile", "type": "QLabel", "unnamed": 1, "visible": 1}
+global_settings_AWS_profile_QComboBox = {"container": aWS_Deadline_Cloud_workstation_configuration_Global_settings_QGroupBox, "leftWidget": global_settings_AWS_profile_QLabel, "type": "QComboBox", "unnamed": 1, "visible": 1}
+aWS_Deadline_Cloud_workstation_configuration_Profile_settings_QGroupBox = {"title": "Profile settings", "type": "QGroupBox", "unnamed": 1, "visible": 1, "window": aWS_Deadline_Cloud_workstation_configuration_DeadlineConfigDialog}
+profile_settings_QComboBox = {"container": aWS_Deadline_Cloud_workstation_configuration_Profile_settings_QGroupBox, "type": "QComboBox", "unnamed": 1, "visible": 1}
+profile_settings_QLineEdit = {"container": aWS_Deadline_Cloud_workstation_configuration_Profile_settings_QGroupBox, "type": "QLineEdit", "unnamed": 1, "visible": 1}
+aWS_Deadline_Cloud_workstation_configuration_Farm_settings_QGroupBox = {"title": "Farm settings", "type": "QGroupBox", "unnamed": 1, "visible": 1, "window": aWS_Deadline_Cloud_workstation_configuration_DeadlineConfigDialog}
+farm_settings_QComboBox = {"container": aWS_Deadline_Cloud_workstation_configuration_Farm_settings_QGroupBox, "type": "QComboBox", "unnamed": 1, "visible": 1}
+farm_settings_QComboBox_2 = {"container": aWS_Deadline_Cloud_workstation_configuration_Farm_settings_QGroupBox, "occurrence": 2, "type": "QComboBox", "unnamed": 1, "visible": 1}
+farm_settings_QComboBox_3 = {"container": aWS_Deadline_Cloud_workstation_configuration_Farm_settings_QGroupBox, "occurrence": 3, "type": "QComboBox", "unnamed": 1, "visible": 1}
+aWS_Deadline_Cloud_workstation_configuration_General_settings_QGroupBox = {"title": "General settings", "type": "QGroupBox", "unnamed": 1, "visible": 1, "window": aWS_Deadline_Cloud_workstation_configuration_DeadlineConfigDialog}
+general_settings_Conflict_resolution_option_QLabel = {"container": aWS_Deadline_Cloud_workstation_configuration_General_settings_QGroupBox, "text": "Conflict resolution option", "type": "QLabel", "unnamed": 1, "visible": 1}
+general_settings_Conflict_resolution_option_QComboBox = {"container": aWS_Deadline_Cloud_workstation_configuration_General_settings_QGroupBox, "leftWidget": general_settings_Conflict_resolution_option_QLabel, "type": "QComboBox", "unnamed": 1, "visible": 1}
+general_settings_Current_logging_level_QLabel = {"container": aWS_Deadline_Cloud_workstation_configuration_General_settings_QGroupBox, "text": "Current logging level", "type": "QLabel", "unnamed": 1, "visible": 1}
+general_settings_Current_logging_level_QComboBox = {"container": aWS_Deadline_Cloud_workstation_configuration_General_settings_QGroupBox, "leftWidget": general_settings_Current_logging_level_QLabel, "type": "QComboBox", "unnamed": 1, "visible": 1}
+aWS_Deadline_Cloud_workstation_configuration_Apply_QPushButton = {"text": "Apply", "type": "QPushButton", "unnamed": 1, "visible": 1, "window": aWS_Deadline_Cloud_workstation_configuration_DeadlineConfigDialog}
+aWS_Deadline_Cloud_workstation_configuration_OK_QPushButton = {"text": "OK", "type": "QPushButton", "unnamed": 1, "visible": 1, "window": aWS_Deadline_Cloud_workstation_configuration_DeadlineConfigDialog}

--- a/test/squish/suite_VerifySettingsDialog/shared/scripts/gui_locators.py
+++ b/test/squish/suite_VerifySettingsDialog/shared/scripts/gui_locators.py
@@ -1,22 +1,124 @@
 # encoding: UTF-8
 
-from objectmaphelper import *
-
-aWS_Deadline_Cloud_workstation_configuration_DeadlineConfigDialog = {"type": "DeadlineConfigDialog", "unnamed": 1, "visible": 1, "windowTitle": "AWS Deadline Cloud workstation configuration"}
-aWS_Deadline_Cloud_workstation_configuration_Global_settings_QGroupBox = {"title": "Global settings", "type": "QGroupBox", "unnamed": 1, "visible": 1, "window": aWS_Deadline_Cloud_workstation_configuration_DeadlineConfigDialog}
-global_settings_AWS_profile_QLabel = {"container": aWS_Deadline_Cloud_workstation_configuration_Global_settings_QGroupBox, "text": "AWS profile", "type": "QLabel", "unnamed": 1, "visible": 1}
-global_settings_AWS_profile_QComboBox = {"container": aWS_Deadline_Cloud_workstation_configuration_Global_settings_QGroupBox, "leftWidget": global_settings_AWS_profile_QLabel, "type": "QComboBox", "unnamed": 1, "visible": 1}
-aWS_Deadline_Cloud_workstation_configuration_Profile_settings_QGroupBox = {"title": "Profile settings", "type": "QGroupBox", "unnamed": 1, "visible": 1, "window": aWS_Deadline_Cloud_workstation_configuration_DeadlineConfigDialog}
-profile_settings_QComboBox = {"container": aWS_Deadline_Cloud_workstation_configuration_Profile_settings_QGroupBox, "type": "QComboBox", "unnamed": 1, "visible": 1}
-profile_settings_QLineEdit = {"container": aWS_Deadline_Cloud_workstation_configuration_Profile_settings_QGroupBox, "type": "QLineEdit", "unnamed": 1, "visible": 1}
-aWS_Deadline_Cloud_workstation_configuration_Farm_settings_QGroupBox = {"title": "Farm settings", "type": "QGroupBox", "unnamed": 1, "visible": 1, "window": aWS_Deadline_Cloud_workstation_configuration_DeadlineConfigDialog}
-farm_settings_QComboBox = {"container": aWS_Deadline_Cloud_workstation_configuration_Farm_settings_QGroupBox, "type": "QComboBox", "unnamed": 1, "visible": 1}
-farm_settings_QComboBox_2 = {"container": aWS_Deadline_Cloud_workstation_configuration_Farm_settings_QGroupBox, "occurrence": 2, "type": "QComboBox", "unnamed": 1, "visible": 1}
-farm_settings_QComboBox_3 = {"container": aWS_Deadline_Cloud_workstation_configuration_Farm_settings_QGroupBox, "occurrence": 3, "type": "QComboBox", "unnamed": 1, "visible": 1}
-aWS_Deadline_Cloud_workstation_configuration_General_settings_QGroupBox = {"title": "General settings", "type": "QGroupBox", "unnamed": 1, "visible": 1, "window": aWS_Deadline_Cloud_workstation_configuration_DeadlineConfigDialog}
-general_settings_Conflict_resolution_option_QLabel = {"container": aWS_Deadline_Cloud_workstation_configuration_General_settings_QGroupBox, "text": "Conflict resolution option", "type": "QLabel", "unnamed": 1, "visible": 1}
-general_settings_Conflict_resolution_option_QComboBox = {"container": aWS_Deadline_Cloud_workstation_configuration_General_settings_QGroupBox, "leftWidget": general_settings_Conflict_resolution_option_QLabel, "type": "QComboBox", "unnamed": 1, "visible": 1}
-general_settings_Current_logging_level_QLabel = {"container": aWS_Deadline_Cloud_workstation_configuration_General_settings_QGroupBox, "text": "Current logging level", "type": "QLabel", "unnamed": 1, "visible": 1}
-general_settings_Current_logging_level_QComboBox = {"container": aWS_Deadline_Cloud_workstation_configuration_General_settings_QGroupBox, "leftWidget": general_settings_Current_logging_level_QLabel, "type": "QComboBox", "unnamed": 1, "visible": 1}
-aWS_Deadline_Cloud_workstation_configuration_Apply_QPushButton = {"text": "Apply", "type": "QPushButton", "unnamed": 1, "visible": 1, "window": aWS_Deadline_Cloud_workstation_configuration_DeadlineConfigDialog}
-aWS_Deadline_Cloud_workstation_configuration_OK_QPushButton = {"text": "OK", "type": "QPushButton", "unnamed": 1, "visible": 1, "window": aWS_Deadline_Cloud_workstation_configuration_DeadlineConfigDialog}
+aWS_Deadline_Cloud_workstation_configuration_DeadlineConfigDialog = {
+    "type": "DeadlineConfigDialog",
+    "unnamed": 1,
+    "visible": 1,
+    "windowTitle": "AWS Deadline Cloud workstation configuration",
+}
+aWS_Deadline_Cloud_workstation_configuration_Global_settings_QGroupBox = {
+    "title": "Global settings",
+    "type": "QGroupBox",
+    "unnamed": 1,
+    "visible": 1,
+    "window": aWS_Deadline_Cloud_workstation_configuration_DeadlineConfigDialog,
+}
+global_settings_AWS_profile_QLabel = {
+    "container": aWS_Deadline_Cloud_workstation_configuration_Global_settings_QGroupBox,
+    "text": "AWS profile",
+    "type": "QLabel",
+    "unnamed": 1,
+    "visible": 1,
+}
+global_settings_AWS_profile_QComboBox = {
+    "container": aWS_Deadline_Cloud_workstation_configuration_Global_settings_QGroupBox,
+    "leftWidget": global_settings_AWS_profile_QLabel,
+    "type": "QComboBox",
+    "unnamed": 1,
+    "visible": 1,
+}
+aWS_Deadline_Cloud_workstation_configuration_Profile_settings_QGroupBox = {
+    "title": "Profile settings",
+    "type": "QGroupBox",
+    "unnamed": 1,
+    "visible": 1,
+    "window": aWS_Deadline_Cloud_workstation_configuration_DeadlineConfigDialog,
+}
+profile_settings_QComboBox = {
+    "container": aWS_Deadline_Cloud_workstation_configuration_Profile_settings_QGroupBox,
+    "type": "QComboBox",
+    "unnamed": 1,
+    "visible": 1,
+}
+profile_settings_QLineEdit = {
+    "container": aWS_Deadline_Cloud_workstation_configuration_Profile_settings_QGroupBox,
+    "type": "QLineEdit",
+    "unnamed": 1,
+    "visible": 1,
+}
+aWS_Deadline_Cloud_workstation_configuration_Farm_settings_QGroupBox = {
+    "title": "Farm settings",
+    "type": "QGroupBox",
+    "unnamed": 1,
+    "visible": 1,
+    "window": aWS_Deadline_Cloud_workstation_configuration_DeadlineConfigDialog,
+}
+farm_settings_QComboBox = {
+    "container": aWS_Deadline_Cloud_workstation_configuration_Farm_settings_QGroupBox,
+    "type": "QComboBox",
+    "unnamed": 1,
+    "visible": 1,
+}
+farm_settings_QComboBox_2 = {
+    "container": aWS_Deadline_Cloud_workstation_configuration_Farm_settings_QGroupBox,
+    "occurrence": 2,
+    "type": "QComboBox",
+    "unnamed": 1,
+    "visible": 1,
+}
+farm_settings_QComboBox_3 = {
+    "container": aWS_Deadline_Cloud_workstation_configuration_Farm_settings_QGroupBox,
+    "occurrence": 3,
+    "type": "QComboBox",
+    "unnamed": 1,
+    "visible": 1,
+}
+aWS_Deadline_Cloud_workstation_configuration_General_settings_QGroupBox = {
+    "title": "General settings",
+    "type": "QGroupBox",
+    "unnamed": 1,
+    "visible": 1,
+    "window": aWS_Deadline_Cloud_workstation_configuration_DeadlineConfigDialog,
+}
+general_settings_Conflict_resolution_option_QLabel = {
+    "container": aWS_Deadline_Cloud_workstation_configuration_General_settings_QGroupBox,
+    "text": "Conflict resolution option",
+    "type": "QLabel",
+    "unnamed": 1,
+    "visible": 1,
+}
+general_settings_Conflict_resolution_option_QComboBox = {
+    "container": aWS_Deadline_Cloud_workstation_configuration_General_settings_QGroupBox,
+    "leftWidget": general_settings_Conflict_resolution_option_QLabel,
+    "type": "QComboBox",
+    "unnamed": 1,
+    "visible": 1,
+}
+general_settings_Current_logging_level_QLabel = {
+    "container": aWS_Deadline_Cloud_workstation_configuration_General_settings_QGroupBox,
+    "text": "Current logging level",
+    "type": "QLabel",
+    "unnamed": 1,
+    "visible": 1,
+}
+general_settings_Current_logging_level_QComboBox = {
+    "container": aWS_Deadline_Cloud_workstation_configuration_General_settings_QGroupBox,
+    "leftWidget": general_settings_Current_logging_level_QLabel,
+    "type": "QComboBox",
+    "unnamed": 1,
+    "visible": 1,
+}
+aWS_Deadline_Cloud_workstation_configuration_Apply_QPushButton = {
+    "text": "Apply",
+    "type": "QPushButton",
+    "unnamed": 1,
+    "visible": 1,
+    "window": aWS_Deadline_Cloud_workstation_configuration_DeadlineConfigDialog,
+}
+aWS_Deadline_Cloud_workstation_configuration_OK_QPushButton = {
+    "text": "OK",
+    "type": "QPushButton",
+    "unnamed": 1,
+    "visible": 1,
+    "window": aWS_Deadline_Cloud_workstation_configuration_DeadlineConfigDialog,
+}

--- a/test/squish/suite_VerifySettingsDialog/shared/scripts/gui_locators.py
+++ b/test/squish/suite_VerifySettingsDialog/shared/scripts/gui_locators.py
@@ -1,3 +1,4 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # encoding: UTF-8
 
 aWS_Deadline_Cloud_workstation_configuration_DeadlineConfigDialog = {

--- a/test/squish/suite_VerifySettingsDialog/suite.conf
+++ b/test/squish/suite_VerifySettingsDialog/suite.conf
@@ -1,0 +1,9 @@
+AUT=deadline config gui
+ENVVARS=envvars
+HOOK_SUB_PROCESSES=true
+IMPLICITAUTSTART=0
+LANGUAGE=Python
+OBJECTMAPSTYLE=script
+TEST_CASES=tst_VerifySettingsDialog
+VERSION=3
+WRAPPERS=Qt

--- a/test/squish/suite_VerifySettingsDialog/tst_VerifySettingsDialog/test.py
+++ b/test/squish/suite_VerifySettingsDialog/tst_VerifySettingsDialog/test.py
@@ -1,3 +1,4 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # -*- coding: utf-8 -*-
 # mypy: disable-error-code="attr-defined"
 

--- a/test/squish/suite_VerifySettingsDialog/tst_VerifySettingsDialog/test.py
+++ b/test/squish/suite_VerifySettingsDialog/tst_VerifySettingsDialog/test.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import gui_helpers
-import squish
+import test
 
 profileName = "deadlinecloud\\_squish"
 jobHistDir = "~/.deadline/job_history/deadlinecloud_squish"
@@ -11,6 +11,7 @@ jobAttachments = "COPIED"
 storageProfile = "Squish Storage Profile"
 conflictResOption = "NOT\\_SELECTED"
 loggingLevel = "WARNING"
+
 
 def main():
     gui_helpers.launchDeadlineConfigGUI()

--- a/test/squish/suite_VerifySettingsDialog/tst_VerifySettingsDialog/test.py
+++ b/test/squish/suite_VerifySettingsDialog/tst_VerifySettingsDialog/test.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+
+import gui_helpers
+import squish
+
+profileName = "deadlinecloud\\_squish"
+jobHistDir = "~/.deadline/job_history/deadlinecloud_squish"
+farmName = "Deadline Cloud Squish Farm"
+queueName = "Squish Automation Queue"
+jobAttachments = "COPIED"
+storageProfile = "Squish Storage Profile"
+conflictResOption = "NOT\\_SELECTED"
+loggingLevel = "WARNING"
+
+def main():
+    gui_helpers.launchDeadlineConfigGUI()
+    gui_helpers.setGlobalSettings(profileName, jobHistDir)
+    gui_helpers.setProfileSettings(farmName)
+    gui_helpers.setFarmSettings(queueName, storageProfile, jobAttachments)
+    gui_helpers.setGeneralSettings(conflictResOption, loggingLevel)
+    test.log("All settings config have been applied.")
+    gui_helpers.closeDeadlineConfigGUI()

--- a/test/squish/suite_VerifySettingsDialog/tst_VerifySettingsDialog/test.py
+++ b/test/squish/suite_VerifySettingsDialog/tst_VerifySettingsDialog/test.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import gui_helpers
-import test
 
 profileName = "deadlinecloud\\_squish"
 jobHistDir = "~/.deadline/job_history/deadlinecloud_squish"
@@ -14,6 +13,7 @@ loggingLevel = "WARNING"
 
 
 def main():
+    import test
     gui_helpers.launchDeadlineConfigGUI()
     gui_helpers.setGlobalSettings(profileName, jobHistDir)
     gui_helpers.setProfileSettings(farmName)

--- a/test/squish/suite_VerifySettingsDialog/tst_VerifySettingsDialog/test.py
+++ b/test/squish/suite_VerifySettingsDialog/tst_VerifySettingsDialog/test.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
+# mypy: disable-error-code="attr-defined"
 
 import gui_helpers
+import test
 
 profileName = "deadlinecloud\\_squish"
 jobHistDir = "~/.deadline/job_history/deadlinecloud_squish"
@@ -13,8 +15,6 @@ loggingLevel = "WARNING"
 
 
 def main():
-    import test
-
     gui_helpers.launchDeadlineConfigGUI()
     gui_helpers.setGlobalSettings(profileName, jobHistDir)
     gui_helpers.setProfileSettings(farmName)

--- a/test/squish/suite_VerifySettingsDialog/tst_VerifySettingsDialog/test.py
+++ b/test/squish/suite_VerifySettingsDialog/tst_VerifySettingsDialog/test.py
@@ -13,7 +13,6 @@ loggingLevel = "WARNING"
 
 
 def main():
-    import test
     gui_helpers.launchDeadlineConfigGUI()
     gui_helpers.setGlobalSettings(profileName, jobHistDir)
     gui_helpers.setProfileSettings(farmName)

--- a/test/squish/suite_VerifySettingsDialog/tst_VerifySettingsDialog/test.py
+++ b/test/squish/suite_VerifySettingsDialog/tst_VerifySettingsDialog/test.py
@@ -13,6 +13,8 @@ loggingLevel = "WARNING"
 
 
 def main():
+    import test
+
     gui_helpers.launchDeadlineConfigGUI()
     gui_helpers.setGlobalSettings(profileName, jobHistDir)
     gui_helpers.setProfileSettings(farmName)

--- a/test/unit/deadline_client/cli/test_cli_bundle.py
+++ b/test/unit/deadline_client/cli/test_cli_bundle.py
@@ -6,6 +6,7 @@ Tests for the CLI job bundle commands.
 import os
 import tempfile
 import json
+from unittest import mock
 from unittest.mock import ANY, patch, Mock
 
 import boto3  # type: ignore[import]
@@ -21,6 +22,7 @@ from deadline.client.config.config_file import set_setting
 from deadline.job_attachments.upload import S3AssetManager
 from deadline.job_attachments.models import JobAttachmentsFileSystem
 from deadline.job_attachments.progress_tracker import SummaryStatistics
+from deadline.client.cli._groups.bundle_group import _print_response
 
 from ..api.test_job_bundle_submission import (
     MOCK_CREATE_JOB_RESPONSE,
@@ -750,3 +752,68 @@ def test_cli_bundle_reject_upload_confirmation(fresh_deadline_config, temp_job_b
 
         upload_attachments_mock.assert_not_called()
         assert result.exit_code == 0
+
+
+def test_cli_bundle_gui_submit_format_output():
+    """
+    Verify that the GUI submitter returns responses correctly.
+    """
+    with mock.patch("deadline.client.cli._groups.bundle_group.click") as mock_click:
+        _print_response(
+            output="json",
+            extra_info=True,
+            submitted=False,
+            job_bundle_dir="./test",
+            job_id="job-1234",
+            parameter_values=[],
+            asset_references={},
+        )
+        mock_click.echo.assert_called_with('{"status": "CANCELED"}')
+
+        _print_response(
+            output="json",
+            extra_info=False,
+            submitted=True,
+            job_bundle_dir="./test",
+            job_id="job-1234",
+            parameter_values=[{"name": "Frames", "value": "1-4"}],
+            asset_references={"inputs": {"filenames:": ["test.file"]}},
+        )
+        mock_click.echo.assert_called_with(
+            '{"status": "SUBMITTED", "jobId": "job-1234", "jobBundleDirectory": "./test"}'
+        )
+
+        _print_response(
+            output="json",
+            extra_info=True,
+            submitted=True,
+            job_bundle_dir="./test",
+            job_id="job-1234",
+            parameter_values=[{"name": "Frames", "value": "1-4"}],
+            asset_references={"inputs": {"filenames:": ["test.file"]}},
+        )
+        mock_click.echo.assert_called_with(
+            '{"status": "SUBMITTED", "jobId": "job-1234", "jobBundleDirectory": "./test", "parameterValues": [{"name": "Frames", "value": "1-4"}], "assetReferences": {"inputs": {"filenames:": ["test.file"]}}}'
+        )
+
+        _print_response(
+            output="verbose",
+            extra_info=False,
+            submitted=False,
+            job_bundle_dir="./test",
+            job_id="job-1234",
+            parameter_values=[],
+            asset_references={},
+        )
+        mock_click.echo.assert_called_with("Job submission canceled.")
+
+        _print_response(
+            output="verbose",
+            extra_info=False,
+            submitted=True,
+            job_bundle_dir="./test",
+            job_id="job-1234",
+            parameter_values=[],
+            asset_references={},
+        )
+        mock_click.echo.assert_any_call("Submitted job bundle:")


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We currently do not have automated user-facing tests for the Submitters dialogue which would catch regressions/bugs from being released to customers. 

### What was the solution? (How)
Implement/add tests for the Submitters dialogue using Squish Automated Test Framework. This is a first set of automated tests for the Submitters dialogue, and this is PR focuses on the Dev Submit GUI - Settings flow/config.

### What is the impact of this change?
Currently none as we don't have a CI/CD pipeline set up (yet). As this repo is open-source, users will have access to these tests (but probably won't be able to run it, yet, as they would need Squish licenses, and probably a ReadMe on how to run these tests).  

### How was this change tested?
I ran my tests locally and ensured that the tests passed with no issues.  

### Was this change documented?
I will have a quip doc/draft of Squish Automated framework, how to get set up with it, debug, etc. 

### Is this a breaking change?
No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*