### PR TITLE
chore: fix typo in CLI error message

### DIFF
--- a/src/deadline/client/cli/_groups/bundle_group.py
+++ b/src/deadline/client/cli/_groups/bundle_group.py
@@ -285,7 +285,7 @@ def bundle_gui_submit(job_bundle_dir, browse, output, extra_info, **args):
         output = output.lower()
         if output != "json" and extra_info:
             raise DeadlineOperationError(
-                "--extra-info is only availalbe with JSON output. Add the --output JSON option."
+                "--extra-info is only available with JSON output. Add the --output JSON option."
             )
 
         submitter = show_job_bundle_submitter(input_job_bundle_dir=job_bundle_dir, browse=browse)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Spotted a typo in an error message.

### What was the solution? (How)
Fixed it :)

### What is the impact of this change?
Makes the error message easier to understand

### How was this change tested?
`hatch build && hatch run test` passes

### Was this change documented?
No, not required

### Is this a breaking change?
Because this field was [just merged](https://github.com/aws-deadline/deadline-cloud/commit/aad9a49c9085e67031abc3ce342ca8068a6508d1), we know it is not yet in use and can safely update it.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*