### PR TITLE
fix: Implement s3 cache integrity checking on submission time.

### DIFF
--- a/src/deadline/job_attachments/caches/cache_db.py
+++ b/src/deadline/job_attachments/caches/cache_db.py
@@ -94,3 +94,13 @@ class CacheDB(ABC):
         if default_path:
             default_path = os.path.join(default_path, CONFIG_ROOT, COMPONENT_NAME)
         return default_path
+
+    def remove_cache(self) -> None:
+        if self.enabled:
+            self.db_connection.close()
+
+        logger.debug(f"The cache {self.cache_dir} will be removed")
+        try:
+            os.remove(self.cache_dir)
+        except Exception as e:
+            logger.info(f"Error occurred while removing the cache file {self.cache_dir}: {e}")

--- a/src/deadline/job_attachments/caches/cache_db.py
+++ b/src/deadline/job_attachments/caches/cache_db.py
@@ -96,6 +96,9 @@ class CacheDB(ABC):
         return default_path
 
     def remove_cache(self) -> None:
+        """
+        Removes the underlying cache contents from the file system.
+        """
         if self.enabled:
             self.db_connection.close()
 
@@ -103,4 +106,5 @@ class CacheDB(ABC):
         try:
             os.remove(self.cache_dir)
         except Exception as e:
-            logger.info(f"Error occurred while removing the cache file {self.cache_dir}: {e}")
+            logger.error(f"Error occurred while removing the cache file {self.cache_dir}: {e}")
+            raise e

--- a/src/deadline/job_attachments/caches/s3_check_cache.py
+++ b/src/deadline/job_attachments/caches/s3_check_cache.py
@@ -5,9 +5,10 @@ Module for accessing the local 'last seen on S3' cache.
 """
 
 import logging
+import random
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from .cache_db import CacheDB
 
@@ -90,3 +91,25 @@ class S3CheckCache(CacheDB):
                     f"INSERT OR REPLACE INTO {self.table_name} VALUES(:s3_key, :last_seen_time)",
                     entry.to_dict(),
                 )
+
+    def get_sampled_hash_from_cache(self, limit: int = 30) -> Optional[List[S3CheckCacheEntry]]:
+        """Checks if hashes exist in s3 bucket and match the LastModified time of cached files."""
+        logger.debug(f"Get sampled hash from cache with limit {limit}")
+
+        if not self.enabled:
+            return None
+
+        with self.db_lock, self.db_connection:
+            # Retrieve all entries from cache
+            logger.debug("Retrieve all entries from cache")
+            cache_entries: List[S3CheckCacheEntry] = self.db_connection.execute(
+                f"SELECT * FROM {self.table_name}"
+            ).fetchall()
+
+            # Determine the number of entries to sample
+            sampled_count: int = min(len(cache_entries), limit)
+            logger.debug(f"Retrieved all entries from cache: {cache_entries}")
+
+            # Shuffle entries to randomize the checking order
+            random.shuffle(cache_entries)
+            return cache_entries[:sampled_count]

--- a/src/deadline/job_attachments/caches/s3_check_cache.py
+++ b/src/deadline/job_attachments/caches/s3_check_cache.py
@@ -5,10 +5,9 @@ Module for accessing the local 'last seen on S3' cache.
 """
 
 import logging
-import random
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 from .cache_db import CacheDB
 
@@ -91,25 +90,3 @@ class S3CheckCache(CacheDB):
                     f"INSERT OR REPLACE INTO {self.table_name} VALUES(:s3_key, :last_seen_time)",
                     entry.to_dict(),
                 )
-
-    def get_sampled_hash_from_cache(self, limit: int = 30) -> Optional[List[S3CheckCacheEntry]]:
-        """Checks if hashes exist in s3 bucket and match the LastModified time of cached files."""
-        logger.debug(f"Get sampled hash from cache with limit {limit}")
-
-        if not self.enabled:
-            return None
-
-        with self.db_lock, self.db_connection:
-            # Retrieve all entries from cache
-            logger.debug("Retrieve all entries from cache")
-            cache_entries: List[S3CheckCacheEntry] = self.db_connection.execute(
-                f"SELECT * FROM {self.table_name}"
-            ).fetchall()
-
-            # Determine the number of entries to sample
-            sampled_count: int = min(len(cache_entries), limit)
-            logger.debug(f"Retrieved all entries from cache: {cache_entries}")
-
-            # Shuffle entries to randomize the checking order
-            random.shuffle(cache_entries)
-            return cache_entries[:sampled_count]

--- a/src/deadline/job_attachments/upload.py
+++ b/src/deadline/job_attachments/upload.py
@@ -17,7 +17,7 @@ from datetime import datetime
 from io import BufferedReader, BytesIO
 from math import trunc
 from pathlib import Path, PurePath
-from typing import Any, Callable, Generator, Optional, Tuple, Type, Union
+from typing import Any, Callable, Generator, List, Optional, Tuple, Type, Union
 
 import boto3
 from boto3.s3.transfer import ProgressCallbackInvoker
@@ -174,6 +174,8 @@ class S3AssetUploader:
             A tuple of (the partial key for the manifest on S3, the hash of input manifest).
         """
 
+        logger.debug("S3AssetUploader.upload_assets")
+
         # Upload asset manifest
         (hash_alg, manifest_bytes, manifest_name) = S3AssetUploader._gather_upload_metadata(
             manifest=manifest,
@@ -207,6 +209,9 @@ class S3AssetUploader:
                 key=full_manifest_key,
                 extra_args=manifest_metadata,
             )
+
+        # Reset if there is mismatch between cache and actual in S3
+        self.reset_s3_check_cache(s3_check_cache_dir)
 
         # Upload assets
         self.upload_input_files(
@@ -381,6 +386,49 @@ class S3AssetUploader:
                 raise AssetSyncCancelledError(
                     "File upload cancelled.", progress_tracker.get_summary_statistics()
                 )
+
+    def reset_s3_check_cache(self, s3_check_cache_dir: str) -> None:
+        """
+        Resets the S3 check cache if there are any mismatches between the cache entries and the actual hashes in S3
+        """
+        logger.debug("Reset s3 check cache if mismatch found")
+        with S3CheckCache(s3_check_cache_dir) as s3_check_cache:
+            # Get the sampled hash from the cache
+            cached_hash_entries: Optional[List[S3CheckCacheEntry]] = s3_check_cache.get_sampled_hash_from_cache()
+            logger.debug(f"cached_hash_entries in {s3_check_cache_dir}: {cached_hash_entries}")
+
+            # remove the cache file if cache entries do not match hashes uploaded to S3
+            if cached_hash_entries and self._check_hash_exist_in_s3(cached_hash_entries) is False:
+                logger.debug(f"The s3_check_cache.db file in {s3_check_cache_dir} will be deleted, "
+                             f"as a mismatch between the cache and the actual hash in S3 was found")
+
+                # Remove the cache file
+                s3_check_cache.remove_cache()
+
+    def _check_hash_exist_in_s3(self, cache_entries: List[S3CheckCacheEntry]) -> bool:
+        """
+        checks if the hashes in the cache entries exist in S3
+        """
+        count: int = 0
+        for cache_entry in cache_entries:
+            try:
+                # Split the S3 key into bucket and key parts
+                bucket, key = cache_entry[0].split("/", 1)
+
+                # Check if the object is already uploaded and exist in S3 bucket
+                if self.file_already_uploaded(bucket=bucket, key=key):
+                    logger.debug(f"cache_entry: {cache_entry} exist in S3")
+                    count += 1
+                # If a mismatch found, return False to reset the cache immediately. There's no need to check the rest.
+                else:
+                    return False
+            except Exception as e:
+                # If error occurs, log warning and return False to indicate cache reset required
+                logger.warning(f"Error occurred while checking {cache_entry}. Exception: {e}")
+                return False
+
+        # If all sampled objects match, return True, otherwise False
+        return count == len(cache_entries)
 
     def _separate_files_by_size(
         self,
@@ -689,6 +737,7 @@ class S3AssetUploader:
             )
             return True
         except ClientError as exc:
+            logger.debug(f"file_already_uploaded - ClientError: {exc}")
             error_code = int(exc.response["ResponseMetadata"]["HTTPStatusCode"])
             if error_code == 403:
                 message = (
@@ -1267,6 +1316,8 @@ class S3AssetManager:
             a tuple with (1) the summary statistics of the upload operation, and
             (2) the S3 path to the asset manifest file.
         """
+        logger.debug("S3AssetManager.upload_assets")
+
         # This is a programming error if the user did not construct the object with Farm and Queue IDs.
         if not self.farm_id or not self.queue_id:
             logger.error("upload_assets: Farm or Fleet ID is missing.")

--- a/src/deadline/job_attachments/upload.py
+++ b/src/deadline/job_attachments/upload.py
@@ -7,6 +7,7 @@ Classes for handling uploading of assets.
 from __future__ import annotations
 
 import concurrent.futures
+import random
 from contextlib import contextmanager
 import errno
 import logging
@@ -174,8 +175,6 @@ class S3AssetUploader:
             A tuple of (the partial key for the manifest on S3, the hash of input manifest).
         """
 
-        logger.debug("S3AssetUploader.upload_assets")
-
         # Upload asset manifest
         (hash_alg, manifest_bytes, manifest_name) = S3AssetUploader._gather_upload_metadata(
             manifest=manifest,
@@ -210,8 +209,14 @@ class S3AssetUploader:
                 extra_args=manifest_metadata,
             )
 
-        # Reset if there is mismatch between cache and actual in S3
-        self.reset_s3_check_cache(s3_check_cache_dir)
+        # Verify S3 hash cache integrity, and reset cache if cached files are missing
+        if not self.verify_hash_cache_integrity(
+            s3_check_cache_dir,
+            manifest,
+            job_attachment_settings.full_cas_prefix(),
+            job_attachment_settings.s3BucketName,
+        ):
+            self.reset_s3_check_cache(s3_check_cache_dir)
 
         # Upload assets
         self.upload_input_files(
@@ -387,38 +392,31 @@ class S3AssetUploader:
                     "File upload cancelled.", progress_tracker.get_summary_statistics()
                 )
 
-    def reset_s3_check_cache(self, s3_check_cache_dir: str) -> None:
+    def reset_s3_check_cache(self, s3_check_cache_dir: Optional[str]) -> None:
         """
-        Resets the S3 check cache if there are any mismatches between the cache entries and the actual hashes in S3
+        Resets the S3 check cache by removing the cache altogether.
         """
-        logger.debug("Reset s3 check cache if mismatch found")
         with S3CheckCache(s3_check_cache_dir) as s3_check_cache:
-            # Get the sampled hash from the cache
-            cached_hash_entries: Optional[List[S3CheckCacheEntry]] = s3_check_cache.get_sampled_hash_from_cache()
-            logger.debug(f"cached_hash_entries in {s3_check_cache_dir}: {cached_hash_entries}")
+            logger.debug(
+                f"The s3_check_cache.db file in {s3_check_cache_dir} will be deleted, "
+                f"as a mismatch between the cache and the actual hash in S3 was found"
+            )
+            # Remove the cache file
+            s3_check_cache.remove_cache()
 
-            # remove the cache file if cache entries do not match hashes uploaded to S3
-            if cached_hash_entries and self._check_hash_exist_in_s3(cached_hash_entries) is False:
-                logger.debug(f"The s3_check_cache.db file in {s3_check_cache_dir} will be deleted, "
-                             f"as a mismatch between the cache and the actual hash in S3 was found")
-
-                # Remove the cache file
-                s3_check_cache.remove_cache()
-
-    def _check_hash_exist_in_s3(self, cache_entries: List[S3CheckCacheEntry]) -> bool:
+    def _check_hashes_exist_in_s3(self, cache_entries: List[S3CheckCacheEntry]) -> bool:
         """
         checks if the hashes in the cache entries exist in S3
         """
-        count: int = 0
         for cache_entry in cache_entries:
             try:
                 # Split the S3 key into bucket and key parts
-                bucket, key = cache_entry[0].split("/", 1)
+                bucket, key = cache_entry.s3_key.split("/", 1)
 
                 # Check if the object is already uploaded and exist in S3 bucket
                 if self.file_already_uploaded(bucket=bucket, key=key):
                     logger.debug(f"cache_entry: {cache_entry} exist in S3")
-                    count += 1
+
                 # If a mismatch found, return False to reset the cache immediately. There's no need to check the rest.
                 else:
                     return False
@@ -427,8 +425,44 @@ class S3AssetUploader:
                 logger.warning(f"Error occurred while checking {cache_entry}. Exception: {e}")
                 return False
 
-        # If all sampled objects match, return True, otherwise False
-        return count == len(cache_entries)
+        # Otherwise all hashes exist in S3
+        return True
+
+    def _sample_cache_entries_with_limit(
+        self, cache_entries: List[S3CheckCacheEntry], limit: int = 30
+    ):
+        sampled_count: int = min(len(cache_entries), limit)
+        random.shuffle(cache_entries)
+        return cache_entries[:sampled_count]
+
+    def verify_hash_cache_integrity(
+        self,
+        s3_check_cache_dir: Optional[str],
+        manifest: BaseAssetManifest,
+        s3_cas_prefix: str,
+        s3_bucket: str,
+    ) -> bool:
+        """
+        Inspects a sampling of the assets provided in manifest that are present in the S3 check cache and
+        verifies if the cached assets exist in S3. Returns True if all sampled cached assets exist in S3, False
+        otherwise.
+        """
+
+        # Find the list of s3 upload keys that have been cached
+        s3_upload_keys: List[str] = [
+            self._generate_s3_upload_key(file, manifest.hashAlg, s3_cas_prefix)
+            for file in manifest.paths
+        ]
+        with S3CheckCache(s3_check_cache_dir) as s3_cache:
+            cache_entries = [
+                s3_cache.get_entry(s3_key=f"{s3_bucket}/{upload_key}")
+                for upload_key in s3_upload_keys
+                if s3_cache.get_entry(s3_key=f"{s3_bucket}/{upload_key}") is not None
+            ]
+
+            # verify that a sample of the cached entries still exist in S3
+            sampled_cache_entries = self._sample_cache_entries_with_limit(cache_entries)
+            return self._check_hashes_exist_in_s3(sampled_cache_entries)
 
     def _separate_files_by_size(
         self,
@@ -450,6 +484,17 @@ class S3AssetUploader:
     def _get_current_timestamp(self) -> str:
         return str(datetime.now().timestamp())
 
+    def _generate_s3_upload_key(
+        self,
+        file: base_manifest.BaseManifestPath,
+        hash_algorithm: HashAlgorithm,
+        s3_cas_prefix: str,
+    ) -> str:
+        s3_upload_key = f"{file.hash}.{hash_algorithm.value}"
+        if s3_cas_prefix:
+            s3_upload_key = _join_s3_paths(s3_cas_prefix, s3_upload_key)
+        return s3_upload_key
+
     def upload_object_to_cas(
         self,
         file: base_manifest.BaseManifestPath,
@@ -466,9 +511,7 @@ class S3AssetUploader:
         Returns a tuple (whether it has been uploaded, the file size).
         """
         local_path = source_root.joinpath(file.path)
-        s3_upload_key = f"{file.hash}.{hash_algorithm.value}"
-        if s3_cas_prefix:
-            s3_upload_key = _join_s3_paths(s3_cas_prefix, s3_upload_key)
+        s3_upload_key = self._generate_s3_upload_key(file, hash_algorithm, s3_cas_prefix)
         is_uploaded = False
         file_size = local_path.resolve().stat().st_size
 
@@ -737,7 +780,6 @@ class S3AssetUploader:
             )
             return True
         except ClientError as exc:
-            logger.debug(f"file_already_uploaded - ClientError: {exc}")
             error_code = int(exc.response["ResponseMetadata"]["HTTPStatusCode"])
             if error_code == 403:
                 message = (
@@ -1316,8 +1358,6 @@ class S3AssetManager:
             a tuple with (1) the summary statistics of the upload operation, and
             (2) the S3 path to the asset manifest file.
         """
-        logger.debug("S3AssetManager.upload_assets")
-
         # This is a programming error if the user did not construct the object with Farm and Queue IDs.
         if not self.farm_id or not self.queue_id:
             logger.error("upload_assets: Farm or Fleet ID is missing.")

--- a/test/unit/deadline_job_attachments/caches/test_caches.py
+++ b/test/unit/deadline_job_attachments/caches/test_caches.py
@@ -69,6 +69,7 @@ class TestCacheDB:
         with pytest.raises(JobAttachmentsError):
             CacheDB(cache_name, table_name, create_query)
 
+
 class TestHashCache:
     """
     Tests for the local Hash Cache

--- a/test/unit/deadline_job_attachments/caches/test_caches.py
+++ b/test/unit/deadline_job_attachments/caches/test_caches.py
@@ -69,7 +69,6 @@ class TestCacheDB:
         with pytest.raises(JobAttachmentsError):
             CacheDB(cache_name, table_name, create_query)
 
-
 class TestHashCache:
     """
     Tests for the local Hash Cache
@@ -210,3 +209,16 @@ class TestS3CheckCache:
                     )
                 )
                 assert s3c.get_entry("bucket/Data/somehash") is None
+
+    def test_delete_cache(self, tmpdir):
+        """
+        Tests if the cache file can be deleted when calling remove_cache
+        """
+        cache_dir = tmpdir.mkdir("cache")
+        with S3CheckCache(cache_dir) as s3c:
+            file_name: str = os.path.join(cache_dir, "s3_check_cache.db")
+            assert os.path.exists(file_name)
+            s3c.remove_cache()
+
+            # Test if the cache file was deleted
+            assert not os.path.exists(file_name)

--- a/test/unit/deadline_job_attachments/test_upload.py
+++ b/test/unit/deadline_job_attachments/test_upload.py
@@ -29,7 +29,7 @@ from deadline.job_attachments.asset_manifests import (
     HashAlgorithm,
     ManifestVersion,
 )
-from deadline.job_attachments.caches import HashCacheEntry, S3CheckCacheEntry
+from deadline.job_attachments.caches import HashCacheEntry, S3CheckCache, S3CheckCacheEntry
 from deadline.job_attachments.exceptions import (
     AssetSyncError,
     JobAttachmentsS3ClientError,
@@ -2477,6 +2477,26 @@ class TestUpload:
             size_threshold=size_threshold,
         )
         assert actual_queues == expected_queues
+
+    def test_reset_s3_check_cache(self, tmpdir):
+        # Create a test cache file in mock_dir
+        cache_dir: str = "mock_dir"
+        tmpdir.mkdir(cache_dir)
+        entry: S3CheckCacheEntry = S3CheckCacheEntry(
+            s3_key="bucket/Data/somehash",
+            last_seen_time=str(datetime.now().timestamp()),
+        )
+        with S3CheckCache(cache_dir) as s3c:
+            s3c.put_entry(entry)
+
+        # Execute reset_s3_check_cache where the cached hash does not exist in S3
+        s3_asset_uploader = S3AssetUploader()
+        s3_asset_uploader._check_hash_exist_in_s3 = MagicMock(return_value=False)
+        s3_asset_uploader.reset_s3_check_cache(cache_dir)
+
+        # Verify that the cache file is deleted
+        s3_asset_uploader._check_hash_exist_in_s3.assert_called_once()
+        assert not os.path.exists(os.path.join(cache_dir, "s3_check_cache.db"))
 
     @mock_aws
     @pytest.mark.parametrize(

--- a/test/unit/deadline_job_attachments/test_upload.py
+++ b/test/unit/deadline_job_attachments/test_upload.py
@@ -29,7 +29,7 @@ from deadline.job_attachments.asset_manifests import (
     HashAlgorithm,
     ManifestVersion,
 )
-from deadline.job_attachments.caches import HashCacheEntry, S3CheckCache, S3CheckCacheEntry
+from deadline.job_attachments.caches import HashCacheEntry, S3CheckCacheEntry
 from deadline.job_attachments.exceptions import (
     AssetSyncError,
     JobAttachmentsS3ClientError,
@@ -2478,25 +2478,130 @@ class TestUpload:
         )
         assert actual_queues == expected_queues
 
-    def test_reset_s3_check_cache(self, tmpdir):
-        # Create a test cache file in mock_dir
-        cache_dir: str = "mock_dir"
-        tmpdir.mkdir(cache_dir)
-        entry: S3CheckCacheEntry = S3CheckCacheEntry(
-            s3_key="bucket/Data/somehash",
+    @pytest.mark.parametrize(
+        "cache_entry",
+        [
+            S3CheckCacheEntry(
+                s3_key="bucket/Data/test-hash",
+                last_seen_time=str(datetime.now().timestamp()),
+            ),
+            None,
+        ],
+    )
+    def test_verify_hash_cache_integrity_returns_true_when_cache_and_s3_match(self, cache_entry):
+        # Given
+        mock_s3_check_cache_impl = MagicMock()
+        mock_s3_check_cache_impl.get_entry.return_value = cache_entry
+        mock_s3_check_cache = MagicMock()
+        mock_s3_check_cache.__enter__.return_value = mock_s3_check_cache_impl
+
+        mock_s3_client = MagicMock()
+        mock_s3_client.head_object.return_value = {}
+
+        s3_asset_uploader = S3AssetUploader()
+        s3_asset_uploader._s3 = mock_s3_client
+
+        # When
+        with patch(
+            f"{deadline.__package__}.job_attachments.upload.S3CheckCache",
+            return_value=mock_s3_check_cache,
+        ):
+            with patch.object(
+                s3_asset_uploader,
+                "file_already_uploaded",
+                wraps=s3_asset_uploader.file_already_uploaded,
+            ) as file_already_uploaded_spy:
+                # Then
+                # Execute verify_hash_cache_integrity where hash exists in S3
+                assert s3_asset_uploader.verify_hash_cache_integrity(
+                    s3_check_cache_dir="cache-dir",
+                    manifest=AssetManifest(
+                        hash_alg=HashAlgorithm.XXH128,
+                        paths=[
+                            BaseManifestPath(
+                                path="test-file.txt", hash="test-hash", size=5, mtime=1
+                            )
+                        ],
+                        total_size=1,
+                    ),
+                    s3_cas_prefix="Data",
+                    s3_bucket="bucket",
+                )
+                if cache_entry:
+                    file_already_uploaded_spy.assert_called_once_with(
+                        bucket="bucket", key="Data/test-hash"
+                    )
+                else:
+                    file_already_uploaded_spy.assert_not_called()
+
+    def test_verify_hash_cache_integrity_returns_false_when_cache_and_s3_mismatch(self):
+        # Given
+        mock_s3_check_cache_impl = MagicMock()
+        mock_s3_check_cache_impl.get_entry.return_value = S3CheckCacheEntry(
+            s3_key="bucket/Data/test-hash",
             last_seen_time=str(datetime.now().timestamp()),
         )
-        with S3CheckCache(cache_dir) as s3c:
-            s3c.put_entry(entry)
+        mock_s3_check_cache = MagicMock()
+        mock_s3_check_cache.__enter__.return_value = mock_s3_check_cache_impl
 
-        # Execute reset_s3_check_cache where the cached hash does not exist in S3
+        mock_s3_client = MagicMock()
+        mock_s3_client.head_object.side_effect = ClientError(
+            {"ResponseMetadata": {"HTTPStatusCode": 404}}, "HeadObject"
+        )
+
         s3_asset_uploader = S3AssetUploader()
-        s3_asset_uploader._check_hash_exist_in_s3 = MagicMock(return_value=False)
-        s3_asset_uploader.reset_s3_check_cache(cache_dir)
+        s3_asset_uploader._s3 = mock_s3_client
 
-        # Verify that the cache file is deleted
-        s3_asset_uploader._check_hash_exist_in_s3.assert_called_once()
-        assert not os.path.exists(os.path.join(cache_dir, "s3_check_cache.db"))
+        # When
+        with patch(
+            f"{deadline.__package__}.job_attachments.upload.S3CheckCache",
+            return_value=mock_s3_check_cache,
+        ):
+            with patch.object(
+                s3_asset_uploader,
+                "file_already_uploaded",
+                wraps=s3_asset_uploader.file_already_uploaded,
+            ) as file_already_uploaded_spy:
+                # Execute verify_hash_cache_integrity where hash does not exist in S3
+                # Then
+                assert not s3_asset_uploader.verify_hash_cache_integrity(
+                    s3_check_cache_dir="cache-dir",
+                    manifest=AssetManifest(
+                        hash_alg=HashAlgorithm.XXH128,
+                        paths=[
+                            BaseManifestPath(
+                                path="test-file.txt", hash="test-hash", size=5, mtime=1
+                            )
+                        ],
+                        total_size=1,
+                    ),
+                    s3_cas_prefix="Data",
+                    s3_bucket="bucket",
+                )
+
+                file_already_uploaded_spy.assert_called_once_with(
+                    bucket="bucket", key="Data/test-hash"
+                )
+
+    def test_reset_s3_check_cache_removes_cache(self, tmpdir):
+        # Given
+        cache_dir: str = "mock_dir"
+        mock_s3_check_cache_impl = MagicMock()
+
+        mock_s3_check_cache = MagicMock()
+        mock_s3_check_cache.__enter__.return_value = mock_s3_check_cache_impl
+
+        # When
+        with patch(
+            f"{deadline.__package__}.job_attachments.upload.S3CheckCache",
+            return_value=mock_s3_check_cache,
+        ):
+            # Execute reset_s3_check_cache where the cached hash does not exist in S3
+            s3_asset_uploader = S3AssetUploader()
+            s3_asset_uploader.reset_s3_check_cache(cache_dir)
+
+            # Then
+            mock_s3_check_cache_impl.remove_cache.assert_called_once()
 
     @mock_aws
     @pytest.mark.parametrize(


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
* When assets in S3 get deleted, it can result in the local S3 cache becoming invalid. That is, assets may fail to be uploaded if the client believes an asset is already uploaded, when in reality it is no longer present in S3.
* This results in failed jobs, as workers will not be able to find these assets in S3.

### What was the solution? (How)
* The solution is to implement sampled cached asset inspections to verify that the contents in the scope of a submission that are cached, are also present in S3.
  * When assets are cached but not present in S3, the client resets its cache. 
* When the cache is reset, all assets will be re-checked for upload.

### What is the impact of this change?
* Reduces the likelihood of jobs failing due to missing assets in S3.

### How was this change tested?

**The following setup was done:**
* The local submission host was cleared of its caches.
* The S3 job attachments bucket was cleared of all objects.
* A job with 5 attachments was submitted to a test queue. 
  * One of the 5 attachments was deleted from the Job Attachments bucket
  * The job was re-submitted, and it was validated that the deleted attachment again re-appeared in the Job Attachments bucket.

### Was this change documented?
No. This is a bug fix / improvement.

### Is this a breaking change?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*