### PR TITLE
revert: revert json output and schema version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     # Pinning due to 3.4 not being available upstream
     "xxhash == 3.4.*",
     # Pinning due to new 4.18 dependencies breaking pyinstaller implementation
-    "jsonschema >= 4.17,< 4.23",
+    "jsonschema == 4.17.*",
     "pywin32 == 306; sys_platform == 'win32'",
     "QtPy == 2.4.*",
 ]

--- a/src/deadline/client/cli/_groups/bundle_group.py
+++ b/src/deadline/client/cli/_groups/bundle_group.py
@@ -5,10 +5,8 @@ All the `deadline bundle` commands.
 """
 from __future__ import annotations
 
-import json
 import logging
 import re
-from typing import Any, Dict, Optional
 
 import click
 from contextlib import ExitStack
@@ -251,25 +249,8 @@ def bundle_submit(
     is_flag=True,
     help="Allows user to choose Bundle and adds a 'Load a different job bundle' option to the Job-Specific Settings UI",
 )
-@click.option(
-    "--output",
-    type=click.Choice(
-        ["verbose", "json"],
-        case_sensitive=False,
-    ),
-    default="verbose",
-    help="Specifies the output format of the messages printed to stdout.\n"
-    "VERBOSE: Displays messages in a human-readable text format.\n"
-    "JSON: Displays messages in JSON line format, so that the info can be easily "
-    "parsed/consumed by custom scripts.",
-)
-@click.option(
-    "--extra-info",
-    is_flag=True,
-    help="Returns additional information about the submitted job. Only valid with JSON output.",
-)
 @_handle_error
-def bundle_gui_submit(job_bundle_dir, browse, output, extra_info, **args):
+def bundle_gui_submit(job_bundle_dir, browse, **args):
     """
     Opens GUI to submit an Open Job Description job bundle to AWS Deadline Cloud.
     """
@@ -281,11 +262,6 @@ def bundle_gui_submit(job_bundle_dir, browse, output, extra_info, **args):
         if not job_bundle_dir and not browse:
             raise DeadlineOperationError(
                 "Specify a job bundle directory or run the bundle command with the --browse flag"
-            )
-        output = output.lower()
-        if output != "json" and extra_info:
-            raise DeadlineOperationError(
-                "--extra-info is only availalbe with JSON output. Add the --output JSON option."
             )
 
         submitter = show_job_bundle_submitter(input_job_bundle_dir=job_bundle_dir, browse=browse)
@@ -300,51 +276,10 @@ def bundle_gui_submit(job_bundle_dir, browse, output, extra_info, **args):
         response = None
         if submitter:
             response = submitter.create_job_response
-
-        _print_response(
-            output=output,
-            extra_info=extra_info,
-            submitted=True if response else False,
-            job_bundle_dir=job_bundle_dir,
-            job_id=response["jobId"] if response else None,
-            parameter_values=submitter.parameter_values,
-            asset_references=submitter.job_attachments.get_asset_references().to_dict()[
-                "assetReferences"
-            ],
-        )
-
-
-def _print_response(
-    output: str,
-    extra_info: bool,
-    submitted: bool,
-    job_bundle_dir: str,
-    job_id: Optional[str],
-    parameter_values: Optional[list[Dict[str, Any]]],
-    asset_references: Dict[str, Any],
-):
-    if output == "json":
-        if submitted:
-            response: dict[str, Any] = {
-                "status": "SUBMITTED",
-                "jobId": job_id,
-                "jobBundleDirectory": job_bundle_dir,
-            }
-            if extra_info:
-                response.update(
-                    {
-                        "parameterValues": parameter_values,
-                        "assetReferences": asset_references,
-                    }
-                )
-            click.echo(json.dumps(response))
-        else:
-            click.echo(json.dumps({"status": "CANCELED"}))
-    else:
-        if submitted:
+        if response:
             click.echo("Submitted job bundle:")
             click.echo(f"   {job_bundle_dir}")
-            click.echo(f"Job ID: {job_id}")
+            click.echo(f"Job ID: {response['jobId']}")
         else:
             click.echo("Job submission canceled.")
 

--- a/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
@@ -94,7 +94,6 @@ class SubmitJobToDeadlineDialog(QDialog):
         self.job_settings_type = type(initial_job_settings)
         self.on_create_job_bundle_callback = on_create_job_bundle_callback
         self.create_job_response: Optional[Dict[str, Any]] = None
-        self.parameter_values: Optional[list[Dict[str, Any]]] = None
         self.deadline_authentication_status = DeadlineAuthenticationStatus.getInstance()
         self.show_host_requirements_tab = show_host_requirements_tab
 
@@ -409,19 +408,6 @@ class SubmitJobToDeadlineDialog(QDialog):
             job_history_bundle_dir = create_job_history_bundle_dir(
                 settings.submitter_name, settings.name
             )
-
-            # First filter the queue parameters to exclude any from the job template,
-            # then extend it with the job template parameters.
-            job_parameter_names = {param["name"] for param in settings.parameters}
-            parameter_values: list[dict[str, Any]] = [
-                {"name": param["name"], "value": param["value"]}
-                for param in queue_parameters
-                if param["name"] not in job_parameter_names
-            ]
-            parameter_values.extend(
-                {"name": param["name"], "value": param["value"]} for param in settings.parameters
-            )
-            self.parameter_values = parameter_values
 
             if self.show_host_requirements_tab:
                 requirements = self.host_requirements.get_requirements()

--- a/test/unit/deadline_client/cli/test_cli_bundle.py
+++ b/test/unit/deadline_client/cli/test_cli_bundle.py
@@ -6,7 +6,6 @@ Tests for the CLI job bundle commands.
 import os
 import tempfile
 import json
-from unittest import mock
 from unittest.mock import ANY, patch, Mock
 
 import boto3  # type: ignore[import]
@@ -22,7 +21,6 @@ from deadline.client.config.config_file import set_setting
 from deadline.job_attachments.upload import S3AssetManager
 from deadline.job_attachments.models import JobAttachmentsFileSystem
 from deadline.job_attachments.progress_tracker import SummaryStatistics
-from deadline.client.cli._groups.bundle_group import _print_response
 
 from ..api.test_job_bundle_submission import (
     MOCK_CREATE_JOB_RESPONSE,
@@ -752,68 +750,3 @@ def test_cli_bundle_reject_upload_confirmation(fresh_deadline_config, temp_job_b
 
         upload_attachments_mock.assert_not_called()
         assert result.exit_code == 0
-
-
-def test_cli_bundle_gui_submit_format_output():
-    """
-    Verify that the GUI submitter returns responses correctly.
-    """
-    with mock.patch("deadline.client.cli._groups.bundle_group.click") as mock_click:
-        _print_response(
-            output="json",
-            extra_info=True,
-            submitted=False,
-            job_bundle_dir="./test",
-            job_id="job-1234",
-            parameter_values=[],
-            asset_references={},
-        )
-        mock_click.echo.assert_called_with('{"status": "CANCELED"}')
-
-        _print_response(
-            output="json",
-            extra_info=False,
-            submitted=True,
-            job_bundle_dir="./test",
-            job_id="job-1234",
-            parameter_values=[{"name": "Frames", "value": "1-4"}],
-            asset_references={"inputs": {"filenames:": ["test.file"]}},
-        )
-        mock_click.echo.assert_called_with(
-            '{"status": "SUBMITTED", "jobId": "job-1234", "jobBundleDirectory": "./test"}'
-        )
-
-        _print_response(
-            output="json",
-            extra_info=True,
-            submitted=True,
-            job_bundle_dir="./test",
-            job_id="job-1234",
-            parameter_values=[{"name": "Frames", "value": "1-4"}],
-            asset_references={"inputs": {"filenames:": ["test.file"]}},
-        )
-        mock_click.echo.assert_called_with(
-            '{"status": "SUBMITTED", "jobId": "job-1234", "jobBundleDirectory": "./test", "parameterValues": [{"name": "Frames", "value": "1-4"}], "assetReferences": {"inputs": {"filenames:": ["test.file"]}}}'
-        )
-
-        _print_response(
-            output="verbose",
-            extra_info=False,
-            submitted=False,
-            job_bundle_dir="./test",
-            job_id="job-1234",
-            parameter_values=[],
-            asset_references={},
-        )
-        mock_click.echo.assert_called_with("Job submission canceled.")
-
-        _print_response(
-            output="verbose",
-            extra_info=False,
-            submitted=True,
-            job_bundle_dir="./test",
-            job_id="job-1234",
-            parameter_values=[],
-            asset_references={},
-        )
-        mock_click.echo.assert_any_call("Submitted job bundle:")


### PR DESCRIPTION
Resolves #376 

### What was the problem/requirement? (What/Why)

1. Integrated submitters failed on submit with:

```
'RenderSubmitterUISettings' object has no attribute 'parameters'
```

![image](https://github.com/aws-deadline/deadline-cloud/assets/60796713/ca8c1fa6-aeb1-43da-84cf-a11d7f4d02f9)

2. jsonschema was updated to a version that required additional code changes

### What was the solution? (How)

Revert the two commits that introduced issues

### What is the impact of this change?

integrated submitters work, and we can build submitter installers again

### How was this change tested?

Deployed the new version with Maya and confirmed that we no longer get this error

### Was this change documented?

N/A

### Is this a breaking change?

Yes - we're removing a CLI option that was added that may have worked for users until we get the proper fix in.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*