### PR TITLE
chore(deps): Update deadline-cloud-test-fixtures requirement from ==0.8.* to ==0.9.*

### DIFF
--- a/requirements-integ-testing.txt
+++ b/requirements-integ-testing.txt
@@ -1,1 +1,1 @@
-deadline-cloud-test-fixtures == 0.8.*
+deadline-cloud-test-fixtures == 0.9.*


### PR DESCRIPTION


### What was the problem/requirement? (What/Why)
Depedency upgrade as new deadline-cloud-test-fixtures version is available. Code has already been updated to make 0.9.* work.