### PR TITLE
feat: support JSON output from bundle gui-submit

### DIFF
--- a/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
@@ -94,6 +94,7 @@ class SubmitJobToDeadlineDialog(QDialog):
         self.job_settings_type = type(initial_job_settings)
         self.on_create_job_bundle_callback = on_create_job_bundle_callback
         self.create_job_response: Optional[Dict[str, Any]] = None
+        self.job_history_bundle_dir: Optional[str] = None
         self.deadline_authentication_status = DeadlineAuthenticationStatus.getInstance()
         self.show_host_requirements_tab = show_host_requirements_tab
 
@@ -339,7 +340,7 @@ class SubmitJobToDeadlineDialog(QDialog):
 
         # Save the bundle
         try:
-            job_history_bundle_dir = create_job_history_bundle_dir(
+            self.job_history_bundle_dir = create_job_history_bundle_dir(
                 settings.submitter_name, settings.name
             )
 
@@ -347,7 +348,7 @@ class SubmitJobToDeadlineDialog(QDialog):
                 requirements = self.host_requirements.get_requirements()
                 self.on_create_job_bundle_callback(
                     self,
-                    job_history_bundle_dir,
+                    self.job_history_bundle_dir,
                     settings,
                     queue_parameters,
                     asset_references,
@@ -358,21 +359,21 @@ class SubmitJobToDeadlineDialog(QDialog):
                 # Maintaining backward compatibility for submitters that do not support host_requirements yet
                 self.on_create_job_bundle_callback(
                     self,
-                    job_history_bundle_dir,
+                    self.job_history_bundle_dir,
                     settings,
                     queue_parameters,
                     asset_references,
                     purpose=JobBundlePurpose.EXPORT,
                 )
 
-            logger.info(f"Saved the submission as a job bundle: {job_history_bundle_dir}")
+            logger.info(f"Saved the submission as a job bundle: {self.job_history_bundle_dir}")
             if sys.platform == "win32":
                 # Open the directory in the OS's file explorer
-                os.startfile(job_history_bundle_dir)
+                os.startfile(self.job_history_bundle_dir)
             QMessageBox.information(
                 self,
                 f"{settings.submitter_name} job submission",
-                f"Saved the submission as a job bundle:\n{job_history_bundle_dir}",
+                f"Saved the submission as a job bundle:\n{self.job_history_bundle_dir}",
             )
             # Close the submitter window to signal the submission is done
             self.close()
@@ -405,7 +406,7 @@ class SubmitJobToDeadlineDialog(QDialog):
         try:
             deadline = api.get_boto3_client("deadline")
 
-            job_history_bundle_dir = create_job_history_bundle_dir(
+            self.job_history_bundle_dir = create_job_history_bundle_dir(
                 settings.submitter_name, settings.name
             )
 
@@ -413,7 +414,7 @@ class SubmitJobToDeadlineDialog(QDialog):
                 requirements = self.host_requirements.get_requirements()
                 self.on_create_job_bundle_callback(
                     self,
-                    job_history_bundle_dir,
+                    self.job_history_bundle_dir,
                     settings,
                     queue_parameters,
                     asset_references,
@@ -424,7 +425,7 @@ class SubmitJobToDeadlineDialog(QDialog):
                 # Maintaining backward compatibility for submitters that do not support host_requirements yet
                 self.on_create_job_bundle_callback(
                     self,
-                    job_history_bundle_dir,
+                    self.job_history_bundle_dir,
                     settings,
                     queue_parameters,
                     asset_references,
@@ -473,7 +474,7 @@ class SubmitJobToDeadlineDialog(QDialog):
                 farm_id,
                 queue_id,
                 storage_profile,
-                job_history_bundle_dir,
+                self.job_history_bundle_dir,
                 queue_parameters,
                 asset_manager,
                 deadline,


### PR DESCRIPTION
Copied from https://github.com/aws-deadline/deadline-cloud/pull/357
This is a simplified version of that PR.

### What was the problem/requirement? (What/Why)
In a DCC integration, I was trying to read out the most recently submitted job settings. The bundle GUI submitter prints a human readable output with the bundle directory path where the settings can be found. but the response is not machine readable. 

### What was the solution? (How)
Add a JSON output option.

### What is the impact of this change?
Scripts calling the GUI submitter can easily read back where the job bundle is saved and what the submitted job ID is.

### How was this change tested?
Unit tests and manually running the CLI commands.

### Was this change documented?
Auto-documented in the CLI help.

### Is this a breaking change?
No - new minor feature.
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*