### PR TITLE
feat: Run Integration tests on Windows as well

### DIFF
--- a/.github/workflows/mainline_integration_test.yml
+++ b/.github/workflows/mainline_integration_test.yml
@@ -1,4 +1,4 @@
-name: Mainline Integration Test
+name: Mainline Merge Integration Test
 
 on:
   workflow_dispatch:
@@ -16,3 +16,15 @@ jobs:
       branch: mainline
       environment: mainline
       os: linux
+  MainlineWindowsIntegrationTest:
+    name: Windows Integration Test
+    permissions:
+      id-token: write
+      contents: read
+    uses: aws-deadline/.github/.github/workflows/reusable_integration_test.yml@mainline
+    secrets: inherit
+    with:
+      repository: ${{ github.event.repository.name }}
+      branch: mainline
+      environment: mainline
+      os: windows


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We have successfully fixed the integration tests that are being ran for Job Attachments (which are currently the only integ tests in this repo) on Linux. We would like to add this workflow  to also run on Windows.
### What was the solution? (How)
Add it to the actions
### What is the impact of this change?
We can verify if the tests run properly on Windows
### How was this change tested?
The linux workflow was tested https://github.com/aws-deadline/deadline-cloud/actions/runs/9704180168 to verify that it works
### Was this change documented?
No
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*