### PR TITLE
chore(ci): Add windows powershell integ test script

### DIFF
--- a/pipeline/integ.ps1
+++ b/pipeline/integ.ps1
@@ -1,0 +1,5 @@
+$ErrorActionPreference = "Stop"
+
+pip install --upgrade pip
+pip install --upgrade hatch
+hatch run integ:test


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
To test the integration tests as an action in a windows environment, we need to have the corresponding powershell script similar to ./pipelines/integ.sh
### What was the solution? (How)
Add this powershell script
### What is the impact of this change?
The windows action tests should be able to run properly.
### How was this change tested?
Could not be tested locally as I work on a mac.
### Was this change documented?
No
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*