### PR TITLE
fix: Fix JA wrong account bucket integration test temp path name

### DIFF
--- a/test/integ/deadline_job_attachments/test_job_attachments.py
+++ b/test/integ/deadline_job_attachments/test_job_attachments.py
@@ -1355,7 +1355,7 @@ def test_sync_inputs_bucket_wrong_account(
     )
 
     syncer = asset_sync.AssetSync(job_attachment_test.farm_id)
-    session_dir = tmp_path_factory.mktemp(r"An error occurred \(403\)")
+    session_dir = tmp_path_factory.mktemp("session_dir")
 
     def on_downloading_files(*args, **kwargs):
         return True


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The windows integration tests were failing due to `FAILED test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_inputs_bucket_wrong_account[2023-03-03] - ValueError: An error occurred \(403\) is not a normalized and relative path`
### What was the solution? (How)
Fix the test which is creating a temp path with a weird path to just use a normal path
### What is the impact of this change?
The tests should pass on windows.

### How was this change tested?
No windows environment, but confirmed that mac tests still work properly by `hatch run integ:test`
### Was this change documented?
No
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*