### PR TITLE
test: Add integration test runs as part of mainline merge and release bump workflows

### DIFF
--- a/.github/workflows/mainline_integration_test.yml
+++ b/.github/workflows/mainline_integration_test.yml
@@ -1,6 +1,9 @@
-name: Mainline Merge Integration Test
+name: Mainline Merge Integration Tests
 
 on:
+  push:
+    branches:
+      - mainline
   workflow_dispatch:
 
 jobs:  

--- a/.github/workflows/release_bump.yml
+++ b/.github/workflows/release_bump.yml
@@ -21,11 +21,36 @@ jobs:
     name: Unit Tests
     uses: ./.github/workflows/code_quality.yml
     with:
+      branch: mainline 
+  LinuxIntegrationTests:
+    name: Linux Integration Tests
+    needs: UnitTests
+    permissions:
+      id-token: write
+      contents: read
+    uses: aws-deadline/.github/.github/workflows/reusable_integration_test.yml@mainline
+    secrets: inherit
+    with:
+      repository: ${{ github.event.repository.name }}
       branch: mainline
-
+      environment: mainline
+      os: linux
+  WindowsIntegrationTests:
+    name: Windows Integration Tests
+    needs: UnitTests
+    permissions:
+      id-token: write
+      contents: read
+    uses: aws-deadline/.github/.github/workflows/reusable_integration_test.yml@mainline
+    secrets: inherit
+    with:
+      repository: ${{ github.event.repository.name }}
+      branch: mainline
+      environment: mainline
+      os: windows
   Bump:
     name: Version Bump
-    needs: UnitTests
+    needs: [UnitTests, WindowsIntegrationTests, LinuxIntegrationTests]
     uses: aws-deadline/.github/.github/workflows/reusable_bump.yml@mainline
     secrets: inherit
     with:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
For better code quality gates, we should run the integration tests that test the Job Attachments functionality on release, as well as on merges to mainline.
### What was the solution? (How)
On PR merge to mainline, or release of the package, automated integration test workflows will be triggered. If the test workflow fails on release of the package, it will block the release.
### What is the impact of this change?
Bad code changes that break the entire Job Attachments functionality should be observable after mainline is merged into, 

Furthermore, failing tests will stop the release workflow when release bump is ran.
### How was this change tested?
`hatch build` was still working.

The integration tests do work properly as tested in https://github.com/aws-deadline/deadline-cloud/actions/runs/9765921768
### Was this change documented?
No
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*