### PR TITLE
test: run integration tests every four hours

### DIFF
--- a/.github/workflows/mainline_integration_test.yml
+++ b/.github/workflows/mainline_integration_test.yml
@@ -1,6 +1,8 @@
 name: Mainline Merge Integration Tests
 
 on:
+  schedule:
+    - cron: '0 */4 * * *'
   push:
     branches:
       - mainline


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
To better the repo's code quality, we should run the integration tests on a scheduled basis, to prevent flakiness, issues with dependencies, etc.
### What was the solution? (How)
Every 4 hours, the integration tests will be ran as an action workflow in mainline. 
### What is the impact of this change?
Better repo quality and guarantee that the main functionality is tested.
### How was this change tested?
`hatch build`. Verified that the syntax was correct.
### Was this change documented?
N/A
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*