### PR TITLE
feat: record Success-Fail telemetry event on job attachments upload and download.

### DIFF
--- a/src/deadline/client/api/__init__.py
+++ b/src/deadline/client/api/__init__.py
@@ -23,6 +23,7 @@ __all__ = [
     "get_telemetry_client",
     "get_deadline_cloud_library_telemetry_client",
     "get_storage_profile_for_queue",
+    "record_success_fail_telemetry_event",
 ]
 
 # The following import is needed to prevent the following sporadic failure:
@@ -52,12 +53,15 @@ from ._list_apis import (
     list_storage_profiles_for_queue,
 )
 from ._queue_parameters import get_queue_parameter_definitions
-from ._submit_job_bundle import create_job_from_job_bundle, wait_for_create_job_to_complete
+
+# Telemetry must be imported before Submit Job Bundle to avoid circular dependencies.
 from ._telemetry import (
     get_telemetry_client,
     get_deadline_cloud_library_telemetry_client,
     TelemetryClient,
+    record_success_fail_telemetry_event,
 )
+from ._submit_job_bundle import create_job_from_job_bundle, wait_for_create_job_to_complete
 from ._get_storage_profile_for_queue import get_storage_profile_for_queue
 
 logger = getLogger(__name__)

--- a/src/deadline/client/api/_submit_job_bundle.py
+++ b/src/deadline/client/api/_submit_job_bundle.py
@@ -285,7 +285,7 @@ def create_job_from_job_bundle(
                 hashing_progress_callback=hashing_progress_callback,
             )
 
-            attachment_settings = _upload_attachments(
+            attachment_settings = _upload_attachments(  # type: ignore
                 asset_manager, asset_manifests, print_function_callback, upload_progress_callback
             )
             attachment_settings["fileSystem"] = JobAttachmentsFileSystem(
@@ -432,6 +432,7 @@ def _hash_attachments(
     return hashing_summary, manifests
 
 
+@api.record_success_fail_telemetry_event(metric_name="cli_asset_upload")  # type: ignore
 def _upload_attachments(
     asset_manager: S3AssetManager,
     manifests: List[AssetRootManifest],

--- a/src/deadline/client/ui/dialogs/submit_job_progress_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_progress_dialog.py
@@ -366,6 +366,7 @@ class SubmitJobProgressDialog(QDialog):
             # Send the exception to the dialog
             self.hashing_thread_exception.emit(e)
 
+    @api.record_success_fail_telemetry_event(metric_name="gui_asset_upload")  # type: ignore
     def _upload_background_thread(self, manifests: List[AssetRootManifest]) -> None:
         """
         This function gets started in a background thread to start the upload

--- a/test/unit/deadline_client/api/test_job_bundle_submission.py
+++ b/test/unit/deadline_client/api/test_job_bundle_submission.py
@@ -487,7 +487,7 @@ def test_create_job_from_job_bundle_job_attachments(
         S3AssetManager, "upload_assets"
     ) as mock_upload_assets, patch.object(
         _submit_job_bundle.api, "get_deadline_cloud_library_telemetry_client"
-    ), patch.object(
+    ) as mock_telemetry, patch.object(
         api._telemetry, "get_deadline_endpoint_url", side_effect=["https://fake-endpoint-url"]
     ):
         client_mock().get_queue.side_effect = [MOCK_GET_QUEUE_RESPONSE]
@@ -585,6 +585,7 @@ def test_create_job_from_job_bundle_job_attachments(
                 "fileSystem": JobAttachmentsFileSystem.COPIED,
             },
         )
+        assert mock_telemetry.call_count == 3
 
 
 def test_create_job_from_job_bundle_empty_job_attachments(


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
- deadline cloud had a regression when 0.48.2 release was pushed to Pypi. 
- The regression was root caused to Job Attachments download code paths after enabling boto3 with CRT.
- The client side lacked telemetry of different upload / download use cases that can be good signals of a regression.

### What was the solution? (How)
- Add a try-caught wrapper decorator that can be used to emit simple success or fail telemetries.
- Add the decorator to both Job Submission (CLI / GUI) code paths and to Job output download code paths.

### What is the impact of this change?
- Capture more data about how the component is behaving after release.

### How was this change tested?
- hatch run build
- hatch run fmt
- hatch run test
```
------------------------------------------------------------------------------------------------------------------------
TOTAL                                                                         4808    672   2110    204    84%
Coverage HTML written to dir build/coverage
Coverage XML written to file build/coverage/coverage.xml

Required test coverage of 80.0% reached. Total coverage: 84.42%
```
- hatch run integ:test
```
scheduling tests via LoadScheduling

test/integ/deadline_job_attachments/test_job_attachments.py::test_upload_input_files_all_assets_in_cas[2023-03-03] 
[gw0] [  7%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_upload_input_files_all_assets_in_cas[2023-03-03] 
test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_outputs_no_job_attachment_settings_in_job[2023-03-03] 
[gw0] [ 14%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_outputs_no_job_attachment_settings_in_job[2023-03-03] 
test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_outputs_no_job_attachment_s3_settings[2023-03-03] 
[gw0] [ 21%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_outputs_no_job_attachment_s3_settings[2023-03-03] 
test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_outputs_with_symlink[2023-03-03] 
[gw0] [ 28%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_outputs_with_symlink[2023-03-03] 
test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_inputs_with_step_dependencies[2023-03-03] 
[gw0] [ 35%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_inputs_with_step_dependencies[2023-03-03] 
test/integ/deadline_job_attachments/test_job_attachments.py::test_download_outputs_with_job_id_step_id_task_id_and_download_directory[2023-03-03] 
[gw0] [ 42%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_download_outputs_with_job_id_step_id_task_id_and_download_directory[2023-03-03] 
test/integ/deadline_job_attachments/test_job_attachments.py::test_download_outputs_with_job_id_step_id_and_download_directory[2023-03-03] 
[gw0] [ 50%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_download_outputs_with_job_id_step_id_and_download_directory[2023-03-03] 
test/integ/deadline_job_attachments/test_job_attachments.py::test_download_outputs_with_job_id_and_download_directory[2023-03-03] 
[gw0] [ 57%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_download_outputs_with_job_id_and_download_directory[2023-03-03] 
test/integ/deadline_job_attachments/test_job_attachments.py::test_upload_input_files_no_download_paths[2023-03-03] 
[gw0] [ 64%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_upload_input_files_no_download_paths[2023-03-03] 
test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_inputs_no_inputs[2023-03-03] 
[gw0] [ 71%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_inputs_no_inputs[2023-03-03] 
test/integ/deadline_job_attachments/test_job_attachments.py::test_upload_bucket_wrong_account[2023-03-03] 
[gw0] [ 78%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_upload_bucket_wrong_account[2023-03-03] 
test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_inputs_bucket_wrong_account[2023-03-03] 
[gw0] [ 85%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_inputs_bucket_wrong_account[2023-03-03] 
test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_outputs_bucket_wrong_account[2023-03-03] 
[gw0] [ 92%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_outputs_bucket_wrong_account[2023-03-03] 
test/integ/deadline_job_attachments/test_job_attachments.py::test_download_outputs_bucket_wrong_account[2023-03-03] 
[gw0] [100%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_download_outputs_bucket_wrong_account[2023-03-03] 

================================================================ slowest 5 durations =================================================================
3.04s setup    test/integ/deadline_job_attachments/test_job_attachments.py::test_upload_input_files_all_assets_in_cas[2023-03-03]
1.56s setup    test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_inputs_with_step_dependencies[2023-03-03]
1.36s teardown test/integ/deadline_job_attachments/test_job_attachments.py::test_download_outputs_bucket_wrong_account[2023-03-03]
1.25s setup    test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_outputs_no_job_attachment_settings_in_job[2023-03-03]
1.18s call     test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_outputs_no_job_attachment_settings_in_job[2023-03-03]
================================================================ 14 passed in 17.45s =================================================================

```
Manual testing:
- Performed a Job submission using a blender bundle I have. Assets were hashed and uploaded.
- Downloaded the output of the blender job I submitted. The job outputs were downloaded correctly.

### Was this change documented?
- Not applicable, this is not changing any contracts.

### Is this a breaking change?
- No, this is internal.
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*