### PR TITLE
chore(deps): update ruff to 0.5.* and moto to 5.*

### DIFF
--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -12,6 +12,6 @@ twine == 5.*; python_version > '3.7'
 black == 24.4.*; python_version > '3.7'
 mypy == 1.10.*; python_version == '3.7'
 mypy == 1.*; python_version > '3.7'
-ruff == 0.3.*
-moto == 4.*
+ruff == 0.5.*
+moto == 5.*
 jsondiff == 2.*

--- a/test/unit/deadline_job_attachments/conftest.py
+++ b/test/unit/deadline_job_attachments/conftest.py
@@ -14,13 +14,7 @@ from typing import Any, Callable, Generator
 from unittest.mock import patch
 
 import pytest
-from moto import mock_iotdata, mock_s3
-
-# A recent change to moto means that we _must_ start moto at least once before the first initialization of boto3
-# Else our mocks don't take effect
-# Our static initialization ends up initialization the iot data client. we don't interact with this service
-# or otherwise use moto with it in our tests, so let's just start it here so the rest of our mocking works as expected
-mock_iotdata().start()
+from moto import mock_aws
 
 from botocore.client import BaseClient  # noqa: E402 isort:skip
 
@@ -54,7 +48,7 @@ def s3_fixture(boto_config) -> Generator[BaseClient, None, None]:
     Fixture to get a mock S3 client.
     """
 
-    with mock_s3():
+    with mock_aws():
         yield aws_clients.get_s3_client()
 
 

--- a/test/unit/deadline_job_attachments/test_asset_sync.py
+++ b/test/unit/deadline_job_attachments/test_asset_sync.py
@@ -13,7 +13,7 @@ from unittest.mock import ANY, MagicMock, patch
 
 import boto3
 import pytest
-from moto import mock_sts
+from moto import mock_aws
 
 import deadline
 from deadline.job_attachments.asset_manifests.decode import decode_manifest
@@ -558,7 +558,7 @@ class TestAssetSync:
                 in str(ase)
             )
 
-    @mock_sts
+    @mock_aws
     @pytest.mark.parametrize(
         (
             "s3_settings_fixture_name",

--- a/test/unit/deadline_job_attachments/test_download.py
+++ b/test/unit/deadline_job_attachments/test_download.py
@@ -21,7 +21,7 @@ from botocore.exceptions import BotoCoreError, ClientError, ReadTimeoutError
 from botocore.stub import Stubber
 
 import pytest
-from moto import mock_sts
+from moto import mock_aws
 
 import deadline
 from deadline.job_attachments.asset_manifests import HashAlgorithm
@@ -663,7 +663,7 @@ class TestFullDownload:
         ManifestVersion.v2023_03_03: INPUT_MANIFEST_PATHS_BY_ASSET_ROOT_v2023_03_03,
     }
 
-    @mock_sts
+    @mock_aws
     def test_get_job_input_paths_by_asset_root(self, manifest_version: ManifestVersion):
         assert self.job.attachments is not None
         assert_get_job_input_paths_by_asset_root(
@@ -695,7 +695,7 @@ class TestFullDownload:
         ManifestVersion.v2023_03_03: MANIFEST_PATHS_BY_ASSET_ROOT_v2023_03_03,
     }
 
-    @mock_sts
+    @mock_aws
     def test_get_job_output_paths_by_asset_root(
         self, farm_id, queue_id, manifest_version: ManifestVersion
     ):
@@ -708,13 +708,13 @@ class TestFullDownload:
             manifest_version,
         )
 
-    @mock_sts
+    @mock_aws
     def test_get_job_outputs_paths_by_asset_root_when_no_asset_root(self, farm_id, queue_id):
         assert_get_job_output_paths_by_asset_root_when_no_asset_root_throws_error(
             farm_id, queue_id, self.job_attachment_settings
         )
 
-    @mock_sts
+    @mock_aws
     def test_get_job_input_output_paths_by_asset_root(
         self, farm_id, queue_id, manifest_version: ManifestVersion
     ):
@@ -752,7 +752,7 @@ class TestFullDownload:
         "inputs/input5.txt",
     ]
 
-    @mock_sts
+    @mock_aws
     @pytest.mark.skipif(
         sys.platform == "win32",
         reason="This test is for testing file permission changes in Posix-based OS.",
@@ -819,7 +819,7 @@ class TestFullDownload:
             [path for path in tmp_path.glob("**/*") if path.is_file()]
         )
 
-    @mock_sts
+    @mock_aws
     @pytest.mark.skipif(
         sys.platform != "win32",
         reason="This test is for testing file permission changes in Windows.",
@@ -892,7 +892,7 @@ class TestFullDownload:
             [path for path in tmp_path.glob("**/*") if path.is_file()]
         )
 
-    @mock_sts
+    @mock_aws
     @pytest.mark.skipif(
         sys.platform == "win32",
         reason="This test is for testing file permission changes in Posix-based OS.",
@@ -976,7 +976,7 @@ class TestFullDownload:
             group_name = grp.getgrgid(os.stat(str(path)).st_gid).gr_name  # type: ignore
             assert group_name != posix_target_group
 
-    @mock_sts
+    @mock_aws
     @pytest.mark.skipif(
         sys.platform != "win32",
         reason="This test is for testing file permission changes in Windows.",
@@ -1057,7 +1057,7 @@ class TestFullDownload:
             assert "Guest" in permission_mapping
             assert permission_mapping["Guest"] == ntsecuritycon.FILE_ALL_ACCESS
 
-    @mock_sts
+    @mock_aws
     def test_download_task_output(
         self, farm_id, queue_id, tmp_path: Path, manifest_version: ManifestVersion
     ):
@@ -1078,7 +1078,7 @@ class TestFullDownload:
             manifest_version=manifest_version,
         )
 
-    @mock_sts
+    @mock_aws
     def test_download_step_output(
         self, farm_id, queue_id, tmp_path: Path, manifest_version: ManifestVersion
     ):
@@ -1103,7 +1103,7 @@ class TestFullDownload:
             manifest_version=manifest_version,
         )
 
-    @mock_sts
+    @mock_aws
     def test_download_job_output(
         self, farm_id, queue_id, tmp_path: Path, manifest_version: ManifestVersion
     ):
@@ -1134,7 +1134,7 @@ class TestFullDownload:
             manifest_version=manifest_version,
         )
 
-    @mock_sts
+    @mock_aws
     def test_download_files_in_directory(
         self, farm_id, queue_id, tmp_path: Path, manifest_version: ManifestVersion
     ):
@@ -1161,7 +1161,7 @@ class TestFullDownload:
             manifest_version=manifest_version,
         )
 
-    @mock_sts
+    @mock_aws
     def test_OutputDownloader_get_output_paths_by_root(
         self,
         farm_id,
@@ -1200,7 +1200,7 @@ class TestFullDownload:
             ]
         }
 
-    @mock_sts
+    @mock_aws
     def test_OutputDownloader_set_root_path(self, farm_id, queue_id, tmp_path: Path):
         with patch(
             f"{deadline.__package__}.job_attachments.download._get_asset_root_from_s3",
@@ -1244,7 +1244,7 @@ class TestFullDownload:
         is_windows_non_admin(),
         reason="Windows requires Admin to create symlinks, skipping this test.",
     )
-    @mock_sts
+    @mock_aws
     def test_OutputDownloader_set_root_path_with_symlinks(self, farm_id, queue_id, tmp_path: Path):
         """
         Test that when a symlink path containing '..' is used as a new root. Without
@@ -1281,7 +1281,7 @@ class TestFullDownload:
             ]
         }
 
-    @mock_sts
+    @mock_aws
     def test_OutputDownloader_set_root_path_wrong_root_throws_exception(
         self, farm_id, queue_id, tmp_path: Path
     ):
@@ -1304,7 +1304,7 @@ class TestFullDownload:
         with pytest.raises(ValueError):
             output_downloader.set_root_path(original_root="/wrong_root", new_root="/new_root_path")
 
-    @mock_sts
+    @mock_aws
     def test_OutputDownloader_download_job_output_when_skip(
         self, farm_id, queue_id, tmp_path: Path
     ):
@@ -1367,7 +1367,7 @@ class TestFullDownload:
             modified_time_after_second_trial = [path.stat().st_ctime for path in expected_files]
             assert modified_time_before_second_trial == modified_time_after_second_trial
 
-    @mock_sts
+    @mock_aws
     def test_OutputDownloader_download_job_output_when_overwrite(
         self, farm_id, queue_id, tmp_path: Path
     ):
@@ -1434,7 +1434,7 @@ class TestFullDownload:
             ):
                 assert time_before < time_after
 
-    @mock_sts
+    @mock_aws
     def test_OutputDownloader_download_job_output_when_create_copy(
         self, farm_id, queue_id, tmp_path: Path
     ):
@@ -1500,7 +1500,7 @@ class TestFullDownload:
             [path for path in tmp_path.glob("**/*") if path.is_file()]
         )
 
-    @mock_sts
+    @mock_aws
     def test_OutputDownloader_download_job_output_unknown_resolution_throws_exception(
         self, farm_id, queue_id, tmp_path: Path
     ):
@@ -1523,7 +1523,7 @@ class TestFullDownload:
                 file_conflict_resolution=FileConflictResolution(99)
             )
 
-    @mock_sts
+    @mock_aws
     def test_OutputDownloader_download_job_output_to_new_asset_root(
         self, farm_id, queue_id, tmp_path: Path
     ):
@@ -1713,7 +1713,7 @@ class TestFullDownload:
         ), pytest.raises((PathOutsideDirectoryError, ValueError)):
             output_downloader.download_job_output()
 
-    @mock_sts
+    @mock_aws
     def test_get_asset_root_from_s3_error_message_on_not_found(self):
         """
         Test if the function raises the expected exception with a proper error message
@@ -1742,7 +1742,7 @@ class TestFullDownload:
                 "HTTP Status Code: 404, Not found. "
             ) in str(err.value)
 
-    @mock_sts
+    @mock_aws
     def test_get_asset_root_from_s3_error_message_on_timeout(self):
         """
         Test that the appropriate error is raised when a ReadTimeoutError occurs
@@ -1766,7 +1766,7 @@ class TestFullDownload:
                 " or contact support for further assistance."
             ) in str(exc.value)
 
-    @mock_sts
+    @mock_aws
     def test_get_manifest_from_s3_error_message_on_access_denied(self):
         """
         Test if the function raises the expected exception with a proper error message
@@ -1795,7 +1795,7 @@ class TestFullDownload:
                 "HTTP Status Code: 403, Forbidden or Access denied. "
             ) in str(exc.value)
 
-    @mock_sts
+    @mock_aws
     def test_get_manifest_from_s3_error_message_on_timeout(self):
         """
         Test that the appropriate error is raised when a ReadTimeoutError occurs
@@ -1819,7 +1819,7 @@ class TestFullDownload:
                 " or contact support for further assistance."
             ) in str(exc.value)
 
-    @mock_sts
+    @mock_aws
     def test_get_tasks_manifests_keys_from_s3_error_message_on_access_denied(self):
         """
         Test if the function raises the expected exception with a proper error message
@@ -1851,7 +1851,7 @@ class TestFullDownload:
                 "HTTP Status Code: 403, Forbidden or Access denied. "
             ) in str(exc.value)
 
-    @mock_sts
+    @mock_aws
     def test_get_tasks_manifests_keys_from_s3_error_message_on_timeout(self):
         """
         Test that the appropriate error is raised when S3 client's get_paginator call triggers
@@ -1878,7 +1878,7 @@ class TestFullDownload:
                 " or contact support for further assistance."
             ) in str(exc.value)
 
-    @mock_sts
+    @mock_aws
     def test_download_file_error_message_on_access_denied(self):
         """
         Test if the function raises the expected exception with a proper error message
@@ -1920,7 +1920,7 @@ class TestFullDownload:
             failed_file_path = Path("/home/username/assets/inputs/input1.txt")
             assert (f"(Failed to download the file to {str(failed_file_path)})") in str(exc.value)
 
-    @mock_sts
+    @mock_aws
     def test_download_file_error_message_on_timeout(self):
         """
         Test that the appropriate error is raised when a ReadTimeoutError occurs
@@ -2029,7 +2029,7 @@ class TestFullDownloadPrefixesWithSlashes:
             f"Manifests/{farm_id}/{queue_id}/job-1/junk2.json",
         )
 
-    @mock_sts
+    @mock_aws
     def test_download_task_output_prefixes_with_slashes(
         self, farm_id, queue_id, tmp_path: Path, manifest_version: ManifestVersion
     ):
@@ -2051,7 +2051,7 @@ class TestFullDownloadPrefixesWithSlashes:
             manifest_version=manifest_version,
         )
 
-    @mock_sts
+    @mock_aws
     def test_download_step_prefixes_with_slashes(
         self, farm_id, queue_id, tmp_path: Path, manifest_version: ManifestVersion
     ):
@@ -2077,7 +2077,7 @@ class TestFullDownloadPrefixesWithSlashes:
             manifest_version=manifest_version,
         )
 
-    @mock_sts
+    @mock_aws
     def test_download_job_prefixes_with_slashes(
         self, farm_id, queue_id, tmp_path: Path, manifest_version: ManifestVersion
     ):

--- a/test/unit/deadline_job_attachments/test_upload.py
+++ b/test/unit/deadline_job_attachments/test_upload.py
@@ -19,7 +19,7 @@ import py.path
 import pytest
 from botocore.exceptions import BotoCoreError, ClientError, ReadTimeoutError
 from botocore.stub import Stubber
-from moto import mock_sts
+from moto import mock_aws
 
 import deadline
 from deadline.client import config
@@ -76,7 +76,7 @@ class TestUpload:
         self.job_attachment_s3_settings = default_job_attachment_s3_settings
         create_s3_bucket(bucket_name=default_job_attachment_s3_settings.s3BucketName)
 
-    @mock_sts
+    @mock_aws
     @pytest.mark.parametrize(
         "manifest_version,expected_manifest",
         [
@@ -299,7 +299,7 @@ class TestUpload:
                 expected_manifest=expected_manifest,
             )
 
-    @mock_sts
+    @mock_aws
     @pytest.mark.skipif(
         sys.platform != "win32",
         reason="Requires Windows to test resolving paths completely with multiple drives",
@@ -467,7 +467,7 @@ class TestUpload:
                 expected_manifest=expected_manifest,
             )
 
-    @mock_sts
+    @mock_aws
     @pytest.mark.parametrize(
         "num_input_files",
         [
@@ -627,7 +627,7 @@ class TestUpload:
             )
             assert_expected_files_on_s3(bucket, expected_files=expected_files)
 
-    @mock_sts
+    @mock_aws
     @pytest.mark.parametrize(
         "num_input_files",
         [
@@ -739,7 +739,7 @@ class TestUpload:
                 skipped_bytes=expected_total_input_bytes - expected_total_downloaded_bytes,
             )
 
-    @mock_sts
+    @mock_aws
     @pytest.mark.parametrize(
         "manifest_version",
         [
@@ -877,7 +877,7 @@ class TestUpload:
                 },
             )
 
-    @mock_sts
+    @mock_aws
     @pytest.mark.parametrize(
         "num_input_files",
         [
@@ -1021,7 +1021,7 @@ class TestUpload:
             )
             assert_expected_files_on_s3(bucket, expected_files=expected_files)
 
-    @mock_sts
+    @mock_aws
     @pytest.mark.parametrize(
         "manifest_version",
         [
@@ -1336,7 +1336,7 @@ class TestUpload:
             _ = S3AssetUploader()
         assert expected_error_msg in str(err.value)
 
-    @mock_sts
+    @mock_aws
     def test_file_already_uploaded_bucket_in_different_account(self):
         """
         Test that the appropriate error is raised when checking if a file has already been uploaded, but the bucket
@@ -1370,7 +1370,7 @@ class TestUpload:
                 "and your AWS IAM Role or User has the 's3:ListBucket' permission for this bucket."
             ) in str(err.value)
 
-    @mock_sts
+    @mock_aws
     def test_file_already_uploaded_timeout(self):
         """
         Test that the appropriate error is raised when a ReadTimeoutError occurs
@@ -1393,7 +1393,7 @@ class TestUpload:
             " or contact support for further assistance."
         ) in str(err.value)
 
-    @mock_sts
+    @mock_aws
     def test_upload_bytes_to_s3_bucket_in_different_account(self):
         """
         Test that the appropriate error is raised when uploading bytes, but the bucket
@@ -1428,7 +1428,7 @@ class TestUpload:
                 "HTTP Status Code: 403, Forbidden or Access denied. "
             ) in str(err.value)
 
-    @mock_sts
+    @mock_aws
     def test_upload_bytes_to_s3_timeout(self):
         """
         Test that the appropriate error is raised when a ReadTimeoutError occurs
@@ -1453,7 +1453,7 @@ class TestUpload:
             " or contact support for further assistance."
         ) in str(err.value)
 
-    @mock_sts
+    @mock_aws
     def test_upload_file_to_s3_bucket_in_different_account(self, tmp_path: Path):
         """
         Test that the appropriate error is raised when uploading files, but the bucket
@@ -1492,7 +1492,7 @@ class TestUpload:
             ) in str(err.value)
             assert (f"(Failed to upload {str(file)})") in str(err.value)
 
-    @mock_sts
+    @mock_aws
     def test_upload_file_to_s3_bucket_has_kms_permissions_error(self, tmp_path: Path):
         """
         Test that the appropriate error is raised when uploading files, but the bucket
@@ -1531,7 +1531,7 @@ class TestUpload:
             ) in str(err.value)
             assert (f"(Failed to upload {str(file)})") in str(err.value)
 
-    @mock_sts
+    @mock_aws
     def test_upload_file_to_s3_timeout(self, tmp_path: Path):
         """
         Test that the appropriate error is raised when a ReadTimeoutError occurs
@@ -1648,7 +1648,7 @@ class TestUpload:
             assert man_path.hash == "a"
             hash_cache.put_entry.assert_not_called()
 
-    @mock_sts
+    @mock_aws
     def test_asset_management_misconfigured_inputs(self, farm_id, queue_id, tmpdir):
         """
         Ensure that when directories are classified as files the submission is prevented with a MisconfiguredInputsError.
@@ -1685,7 +1685,7 @@ class TestUpload:
                     referenced_paths=[],
                 )
 
-    @mock_sts
+    @mock_aws
     def test_asset_management_input_not_exists(self, farm_id, queue_id, tmpdir, caplog):
         """Test that input paths that do not exist are added to referenced files."""
         asset_root = str(tmpdir)
@@ -1772,7 +1772,7 @@ class TestUpload:
                 skipped_bytes=0,
             )
 
-    @mock_sts
+    @mock_aws
     def test_asset_management_input_not_exists_require_fails(self, farm_id, queue_id, tmpdir):
         """Test that input paths that do not exist raise a MisconfiguredInputsError if the `require_paths_exist` flag is true."""
         asset_root = str(tmpdir)
@@ -1809,7 +1809,7 @@ class TestUpload:
 
             assert "notexist.anywhere" in str(execinfo)
 
-    @mock_sts
+    @mock_aws
     @pytest.mark.parametrize(
         "manifest_version,expected_manifest",
         [
@@ -2494,7 +2494,7 @@ class TestUpload:
         )
         assert actual_queues == expected_queues
 
-    @mock_sts
+    @mock_aws
     @pytest.mark.parametrize(
         "manifest_version",
         [
@@ -2576,7 +2576,7 @@ class TestUpload:
                 # Posix
                 assert "Too many levels of symbolic links:" in caplog.text
 
-    @mock_sts
+    @mock_aws
     @pytest.mark.parametrize(
         "manifest_version",
         [


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

dependabot was failing to update moto since it required code changes to our tests

### What was the solution? (How)

Everything was changed to a single decorator, mock_aws. And we can remove the iotdata init workaround

### What is the impact of this change?

updated deps!

### How was this change tested?

```
hatch run lint
hatch run test
```

### Was this change documented?

N/A

### Is this a breaking change?

Nope

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*