### PR TITLE
feat: support skipping prompts for installing GUI dependencies

### DIFF
--- a/src/deadline/client/cli/_groups/bundle_group.py
+++ b/src/deadline/client/cli/_groups/bundle_group.py
@@ -252,6 +252,11 @@ def bundle_submit(
     help="Allows user to choose Bundle and adds a 'Load a different job bundle' option to the Job-Specific Settings UI",
 )
 @click.option(
+    "-y",
+    is_flag=True,
+    help="Accept prompts about installing GUI dependencies",
+)
+@click.option(
     "--output",
     type=click.Choice(
         ["verbose", "json"],
@@ -264,13 +269,13 @@ def bundle_submit(
     "parsed/consumed by custom scripts.",
 )
 @_handle_error
-def bundle_gui_submit(job_bundle_dir, browse, output, **args):
+def bundle_gui_submit(job_bundle_dir, browse, output, y, **args):
     """
     Opens GUI to submit an Open Job Description job bundle to AWS Deadline Cloud.
     """
     from ...ui import gui_context_for_cli
 
-    with gui_context_for_cli() as app:
+    with gui_context_for_cli(automatically_install_dependencies=y) as app:
         from ...ui.job_bundle_submitter import show_job_bundle_submitter
 
         if not job_bundle_dir and not browse:

--- a/src/deadline/client/cli/_groups/bundle_group.py
+++ b/src/deadline/client/cli/_groups/bundle_group.py
@@ -252,9 +252,9 @@ def bundle_submit(
     help="Allows user to choose Bundle and adds a 'Load a different job bundle' option to the Job-Specific Settings UI",
 )
 @click.option(
-    "-y",
+    "--install-gui",
     is_flag=True,
-    help="Accept prompts about installing GUI dependencies",
+    help="Installs GUI dependencies if they are not installed already",
 )
 @click.option(
     "--output",
@@ -269,13 +269,13 @@ def bundle_submit(
     "parsed/consumed by custom scripts.",
 )
 @_handle_error
-def bundle_gui_submit(job_bundle_dir, browse, output, y, **args):
+def bundle_gui_submit(job_bundle_dir, browse, output, install_gui, **args):
     """
     Opens GUI to submit an Open Job Description job bundle to AWS Deadline Cloud.
     """
     from ...ui import gui_context_for_cli
 
-    with gui_context_for_cli(automatically_install_dependencies=y) as app:
+    with gui_context_for_cli(automatically_install_dependencies=install_gui) as app:
         from ...ui.job_bundle_submitter import show_job_bundle_submitter
 
         if not job_bundle_dir and not browse:

--- a/src/deadline/client/cli/_groups/config_group.py
+++ b/src/deadline/client/cli/_groups/config_group.py
@@ -83,14 +83,19 @@ def config_show():
 
 
 @cli_config.command(name="gui")
+@click.option(
+    "-y",
+    is_flag=True,
+    help="Accept prompts about installing GUI dependencies",
+)
 @_handle_error
-def config_gui():
+def config_gui(y: bool):
     """
     Open the workstation configuration settings GUI.
     """
     from ...ui import gui_context_for_cli
 
-    with gui_context_for_cli():
+    with gui_context_for_cli(automatically_install_dependencies=y):
         from ...ui.dialogs.deadline_config_dialog import DeadlineConfigDialog
 
         DeadlineConfigDialog.configure_settings()

--- a/src/deadline/client/cli/_groups/config_group.py
+++ b/src/deadline/client/cli/_groups/config_group.py
@@ -84,18 +84,18 @@ def config_show():
 
 @cli_config.command(name="gui")
 @click.option(
-    "-y",
+    "--install-gui",
     is_flag=True,
-    help="Accept prompts about installing GUI dependencies",
+    help="Installs GUI dependencies if they are not installed already",
 )
 @_handle_error
-def config_gui(y: bool):
+def config_gui(install_gui: bool):
     """
     Open the workstation configuration settings GUI.
     """
     from ...ui import gui_context_for_cli
 
-    with gui_context_for_cli(automatically_install_dependencies=y):
+    with gui_context_for_cli(automatically_install_dependencies=install_gui):
         from ...ui.dialogs.deadline_config_dialog import DeadlineConfigDialog
 
         DeadlineConfigDialog.configure_settings()

--- a/src/deadline/client/ui/__init__.py
+++ b/src/deadline/client/ui/__init__.py
@@ -45,19 +45,22 @@ def gui_error_handler(message_title: str, parent: Any = None):
 
 
 @contextmanager
-def gui_context_for_cli():
+def gui_context_for_cli(automatically_install_dependencies: bool):
     """
     A context manager that initializes a Qt GUI context for
     the CLI handler to use.
 
     For example:
 
-    with gui_context_for_cli() as app:
+    with gui_context_for_cli(automatically_install_dependencies) as app:
         from deadline.client.ui.cli_job_submitter import show_cli_job_submitter
 
         show_cli_job_submitter()
 
         app.exec()
+
+    If automatically_install_dependencies is true, dependencies will be installed without prompting the user. Useful
+    if the command is triggered not from a command line.
     """
     import importlib
     import os
@@ -73,11 +76,12 @@ def gui_context_for_cli():
     has_pyside6 = importlib.util.find_spec("PySide6")
     has_pyside2 = importlib.util.find_spec("PySide2")
     if not (has_pyside6 or has_pyside2):
-        message = "Optional GUI components for deadline are unavailable. Would you like to install PySide?"
-        will_install_gui = click.confirm(message, default=False)
-        if not will_install_gui:
-            click.echo("Unable to continue without GUI, exiting")
-            sys.exit(1)
+        if not automatically_install_dependencies:
+            message = "Optional GUI components for deadline are unavailable. Would you like to install PySide?"
+            will_install_gui = click.confirm(message, default=False)
+            if not will_install_gui:
+                click.echo("Unable to continue without GUI, exiting")
+                sys.exit(1)
 
         # this should match what's in the pyproject.toml
         pyside6_pypi = "PySide6-essentials==6.6.*"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
DCM should be able to invoke `deadline bundle gui-submit` non-CLI users can still submit bundles. But if the GUI dependencies aren't already installed, the command will hang until the prompt about installing GUI dependencies is answered.

### What was the solution? (How)
Support a `--install-gui` flag that skips the prompt.

### What is the impact of this change?
DCM can invoke the bundle submitter more reliably.

### How was this change tested?
By uninstalling PySide and then calling `deadline bundle gui-submit` and `deadline config gui` with and without the `--install-gui` flag.

### Was this change documented?
Yes - in the CLI help.

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*