### PR TITLE
chore: add pyinstaller hidden import

### DIFF
--- a/scripts/pyinstaller/deadline_cli.spec
+++ b/scripts/pyinstaller/deadline_cli.spec
@@ -24,6 +24,11 @@ datas += [
     (b_module_path + '/../../THIRD_PARTY_LICENSES',
      '.')
 ]
+
+# https://github.com/pyinstaller/pyinstaller/issues/8554
+# Can be removed once pyinstaller is upgraded to >= 6.7.0
+hiddenimports += ['pkg_resources.extern']
+
 cli_a = Analysis(
     ['../../src/deadline/client/cli/deadline_cli_main.py'],
     binaries=binaries,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Pyinstaller versions < 6.7.0 aren't detecting a required import when bundling everything together and using versions of setuptools > 70. 
### What was the solution? (How)
Folowing the instructions from the initial Pyinstaller bug report I've added the missing import as a hidden import
https://github.com/pyinstaller/pyinstaller/issues/8554
### What is the impact of this change?
Fixed installer build process
### How was this change tested?
Built an installer myself and verified the changes
### Was this change documented?
No
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*