### PR TITLE
fix: Add file path limit log

### DIFF
--- a/test/integ/deadline_job_attachments/conftest.py
+++ b/test/integ/deadline_job_attachments/conftest.py
@@ -4,6 +4,7 @@ import getpass
 import json
 import sys
 import pytest
+import ctypes
 
 
 @pytest.fixture(scope="session")
@@ -103,3 +104,10 @@ def external_bucket() -> str:
 
 def is_windows_non_admin():
     return sys.platform == "win32" and getpass.getuser() != "Administrator"
+
+def is_Windows_file_path_limit():
+    ntdll = ctypes.WinDLL('ntdll')
+    ntdll.RtlAreLongPathsEnabled.restype = ctypes.c_ubyte
+    ntdll.RtlAreLongPathsEnabled.argtypes = ()
+
+    return bool(ntdll.RtlAreLongPathsEnabled())

--- a/test/integ/deadline_job_attachments/test_job_attachments.py
+++ b/test/integ/deadline_job_attachments/test_job_attachments.py
@@ -34,7 +34,7 @@ from deadline.job_attachments.progress_tracker import SummaryStatistics
 from deadline.job_attachments._utils import (
     _get_unique_dest_dir_name,
 )
-from .conftest import is_windows_non_admin
+from .conftest import is_Windows_file_path_limit, is_windows_non_admin
 
 
 def notifier_callback(progress: float, message: str) -> None:
@@ -1486,4 +1486,53 @@ def test_download_outputs_bucket_wrong_account(
             step_id=sync_outputs.step0_id,
             task_id=sync_outputs.step0_task0_id,
         )
+        job_output_downloader.download_job_output()
+
+@pytest.mark.integ
+@pytest.mark.skipif(
+    not is_windows_non_admin(),
+    reason="This test is for Windows max file path length error, skipping this if OS is not Windows",
+
+)
+@pytest.mark.skipif(
+    is_Windows_file_path_limit(),
+    reason="This test is for Windows max file path length error, skipping this if Windows path limit is extended",
+)
+def test_download_outputs_windows_max_file_path_length_exception(
+    job_attachment_test: JobAttachmentTest,
+    tmp_path: Path,
+    sync_outputs: SyncOutputsOutput,
+    external_bucket: str,
+):
+    """
+    Test that if trying to download outputs to a file path that
+    longer than 260 chars in Windows, the correct error is thrown.
+    """
+    long_root_path = Path(__file__).parent / str("A" * 135)
+
+    job_attachment_settings = get_queue(
+        farm_id=job_attachment_test.farm_id,
+        queue_id=job_attachment_test.queue_id,
+        deadline_endpoint_url=job_attachment_test.deadline_endpoint,
+    ).jobAttachmentSettings
+
+    if job_attachment_settings is None:
+        raise Exception("Job attachment settings must be set for this test.")
+
+    # WHEN
+    with pytest.raises(
+        AssetSyncError,
+        match=("Your file path is longer than what Windows allow.\n"
+            + "This could be the error if you do not enable longer file path in Windows"
+        ),
+    ):
+        job_output_downloader = download.OutputDownloader(
+            s3_settings=job_attachment_settings,
+            farm_id=job_attachment_test.farm_id,
+            queue_id=job_attachment_test.queue_id,
+            job_id=sync_outputs.job_id,
+            step_id=sync_outputs.step0_id,
+            task_id=sync_outputs.step0_task0_id,
+        )
+        job_output_downloader.set_root_path(str(job_attachment_test.ASSET_ROOT), long_root_path)
         job_output_downloader.download_job_output()


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
If we have file path that is longer than 260 chars on Windows, JA will throw an error of file not found which is not necessary correct and do not bring any value to track down the problem
### What was the solution? (How)
Add comparison of file path and if longer than 260 chars, we will throw a more meaningful error message
### What is the impact of this change?
We have more meaningful logs so it's easier to detect what when wrong
### How was this change tested?
Run all unit + integ tests
Manually run download job output test on Linux and Windows
Manually run Asset sync on Linux and Windows CMF
![image](https://github.com/aws-deadline/deadline-cloud/assets/167144297/6a196a7e-ee15-4140-b291-66e8fb81704a)

### Was this change documented?
Yes

### Is this a breaking change?
No


----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*