### PR TITLE
fix: Add better log when JA hit Windows path length limit

### DIFF
--- a/test/integ/deadline_job_attachments/conftest.py
+++ b/test/integ/deadline_job_attachments/conftest.py
@@ -4,6 +4,7 @@ import getpass
 import json
 import sys
 import pytest
+import ctypes
 
 
 @pytest.fixture(scope="session")
@@ -103,3 +104,13 @@ def external_bucket() -> str:
 
 def is_windows_non_admin():
     return sys.platform == "win32" and getpass.getuser() != "Administrator"
+
+
+def is_Windows_file_path_limit():
+    if sys.platform == "win32":
+        ntdll = ctypes.WinDLL("ntdll")
+        ntdll.RtlAreLongPathsEnabled.restype = ctypes.c_ubyte
+        ntdll.RtlAreLongPathsEnabled.argtypes = ()
+
+        return bool(ntdll.RtlAreLongPathsEnabled())
+    return True

--- a/test/integ/deadline_job_attachments/test_job_attachments.py
+++ b/test/integ/deadline_job_attachments/test_job_attachments.py
@@ -34,7 +34,7 @@ from deadline.job_attachments.progress_tracker import SummaryStatistics
 from deadline.job_attachments._utils import (
     _get_unique_dest_dir_name,
 )
-from .conftest import is_windows_non_admin
+from .conftest import is_Windows_file_path_limit, is_windows_non_admin
 
 
 def notifier_callback(progress: float, message: str) -> None:
@@ -1485,5 +1485,57 @@ def test_download_outputs_bucket_wrong_account(
             job_id=sync_outputs.job_id,
             step_id=sync_outputs.step0_id,
             task_id=sync_outputs.step0_task0_id,
+        )
+        job_output_downloader.download_job_output()
+
+
+@pytest.mark.integ
+@pytest.mark.skipif(
+    not is_windows_non_admin(),
+    reason="This test is for Windows max file path length error, skipping this if OS is not Windows",
+)
+@pytest.mark.skipif(
+    is_Windows_file_path_limit(),
+    reason="This test is for Windows max file path length error, skipping this if Windows path limit is extended",
+)
+def test_download_outputs_windows_max_file_path_length_exception(
+    job_attachment_test: JobAttachmentTest,
+    tmp_path: Path,
+    sync_outputs: SyncOutputsOutput,
+    external_bucket: str,
+):
+    """
+    Test that if trying to download outputs to a file path that
+    longer than 260 chars in Windows, the correct error is thrown.
+    """
+    long_root_path = Path(__file__).parent / str("A" * 135)
+
+    job_attachment_settings = get_queue(
+        farm_id=job_attachment_test.farm_id,
+        queue_id=job_attachment_test.queue_id,
+        deadline_endpoint_url=job_attachment_test.deadline_endpoint,
+    ).jobAttachmentSettings
+
+    if job_attachment_settings is None:
+        raise Exception("Job attachment settings must be set for this test.")
+
+    # WHEN
+    with pytest.raises(
+        AssetSyncError,
+        match=(
+            "Your file path is longer than what Windows allow.\n"
+            + "This could be the error if you do not enable longer file path in Windows"
+        ),
+    ):
+        job_output_downloader = download.OutputDownloader(
+            s3_settings=job_attachment_settings,
+            farm_id=job_attachment_test.farm_id,
+            queue_id=job_attachment_test.queue_id,
+            job_id=sync_outputs.job_id,
+            step_id=sync_outputs.step0_id,
+            task_id=sync_outputs.step0_task0_id,
+        )
+        job_output_downloader.set_root_path(
+            str(job_attachment_test.ASSET_ROOT), str(long_root_path)
         )
         job_output_downloader.download_job_output()

--- a/test/integ/deadline_job_attachments/test_job_attachments.py
+++ b/test/integ/deadline_job_attachments/test_job_attachments.py
@@ -34,7 +34,7 @@ from deadline.job_attachments.progress_tracker import SummaryStatistics
 from deadline.job_attachments._utils import (
     _get_unique_dest_dir_name,
 )
-from .conftest import is_windows_non_admin
+from .conftest import is_Windows_file_path_limit, is_windows_non_admin
 
 
 def notifier_callback(progress: float, message: str) -> None:
@@ -1486,4 +1486,54 @@ def test_download_outputs_bucket_wrong_account(
             step_id=sync_outputs.step0_id,
             task_id=sync_outputs.step0_task0_id,
         )
+        job_output_downloader.download_job_output()
+
+
+@pytest.mark.integ
+@pytest.mark.skipif(
+    not is_windows_non_admin(),
+    reason="This test is for Windows max file path length error, skipping this if OS is not Windows",
+)
+@pytest.mark.skipif(
+    is_Windows_file_path_limit(),
+    reason="This test is for Windows max file path length error, skipping this if Windows path limit is extended",
+)
+def test_download_outputs_windows_max_file_path_length_exception(
+    job_attachment_test: JobAttachmentTest,
+    tmp_path: Path,
+    sync_outputs: SyncOutputsOutput,
+    external_bucket: str,
+):
+    """
+    Test that if trying to download outputs to a file path that
+    longer than 260 chars in Windows, the correct error is thrown.
+    """
+    long_root_path = Path(__file__).parent / str("A" * 135)
+
+    job_attachment_settings = get_queue(
+        farm_id=job_attachment_test.farm_id,
+        queue_id=job_attachment_test.queue_id,
+        deadline_endpoint_url=job_attachment_test.deadline_endpoint,
+    ).jobAttachmentSettings
+
+    if job_attachment_settings is None:
+        raise Exception("Job attachment settings must be set for this test.")
+
+    # WHEN
+    with pytest.raises(
+        AssetSyncError,
+        match=(
+            "Your file path is longer than what Windows allow.\n"
+            + "This could be the error if you do not enable longer file path in Windows"
+        ),
+    ):
+        job_output_downloader = download.OutputDownloader(
+            s3_settings=job_attachment_settings,
+            farm_id=job_attachment_test.farm_id,
+            queue_id=job_attachment_test.queue_id,
+            job_id=sync_outputs.job_id,
+            step_id=sync_outputs.step0_id,
+            task_id=sync_outputs.step0_task0_id,
+        )
+        job_output_downloader.set_root_path(str(job_attachment_test.ASSET_ROOT), long_root_path)
         job_output_downloader.download_job_output()

--- a/test/unit/deadline_job_attachments/test_download.py
+++ b/test/unit/deadline_job_attachments/test_download.py
@@ -2004,7 +2004,7 @@ class TestFullDownload:
         assert str(exc.value) == expected_message
 
     @mock_aws
-    @patch("os.name", "NT")
+    @patch("os.name", "nt")
     def test_windows_long_path_exception_WindowsOS(self):
         mock_s3_client = MagicMock()
         mock_future = MagicMock()

--- a/test/unit/deadline_job_attachments/test_download.py
+++ b/test/unit/deadline_job_attachments/test_download.py
@@ -1963,6 +1963,86 @@ class TestFullDownload:
                 " or contact support for further assistance."
             ) in str(exc.value)
 
+    @mock_aws
+    @patch("os.name", "posix")
+    def test_windows_long_path_exception_PosixOS(self):
+        mock_s3_client = MagicMock()
+        mock_future = MagicMock()
+        mock_transfer_manager = MagicMock()
+        mock_transfer_manager.download.return_value = mock_future
+        mock_future.result.side_effect = Exception("Test exception")
+
+        file_path = ManifestPathv2023_03_03(
+            path="very/long/input/to/test/windows/max/file/path/for/error/handling/when/downloading/assest/from/job/attachment.txt",
+            hash="path",
+            size=1,
+            mtime=1234000000,
+        )
+
+        local_path = "Users/path/to/a/very/long/file/path/that/exceeds/the/windows/max/path/length/for/testing/max/file/path/error/handling/when/download/or/syncing/assest/using/job/attachment"
+
+        with patch(
+            f"{deadline.__package__}.job_attachments.download.get_s3_client",
+            return_value=mock_s3_client,
+        ), patch(
+            f"{deadline.__package__}.job_attachments.download.get_s3_transfer_manager",
+            return_value=mock_transfer_manager,
+        ), patch(
+            f"{deadline.__package__}.job_attachments.download.Path.mkdir"
+        ):
+            with pytest.raises(AssetSyncError) as exc:
+                download_file(
+                    file_path,
+                    HashAlgorithm.XXH128,
+                    local_path,
+                    "test-bucket",
+                    "rootPrefix/Data",
+                    mock_s3_client,
+                )
+
+        expected_message = "Test exception"
+        assert str(exc.value) == expected_message
+
+    @mock_aws
+    @patch("os.name", "NT")
+    def test_windows_long_path_exception_WindowsOS(self):
+        mock_s3_client = MagicMock()
+        mock_future = MagicMock()
+        mock_transfer_manager = MagicMock()
+        mock_transfer_manager.download.return_value = mock_future
+        mock_future.result.side_effect = Exception("Test exception")
+
+        file_path = ManifestPathv2023_03_03(
+            path="very/long/input/to/test/windows/max/file/path/for/error/handling/when/downloading/assest/from/job/attachment.txt",
+            hash="path",
+            size=1,
+            mtime=1234000000,
+        )
+
+        local_path = "C:\\path\\to\\a\\very\\long\\file\\path\\that\\exceeds\\the\\windows\\max\\path\\length\\for\\testing\\max\\file\\path\\error\\handling\\when\\download\\or\\syncing\\assest\\using\\job\\attachment"
+
+        with patch(
+            f"{deadline.__package__}.job_attachments.download.get_s3_client",
+            return_value=mock_s3_client,
+        ), patch(
+            f"{deadline.__package__}.job_attachments.download.get_s3_transfer_manager",
+            return_value=mock_transfer_manager,
+        ), patch(
+            f"{deadline.__package__}.job_attachments.download.Path.mkdir"
+        ):
+            with pytest.raises(AssetSyncError) as exc:
+                download_file(
+                    file_path,
+                    HashAlgorithm.XXH128,
+                    local_path,
+                    "test-bucket",
+                    "rootPrefix/Data",
+                    mock_s3_client,
+                )
+
+        expected_message = "Your file path is longer than what Windows allow.\nThis could be the error if you do not enable longer file path in Windows"
+        assert str(exc.value) == expected_message
+
 
 @pytest.mark.parametrize("manifest_version", [ManifestVersion.v2023_03_03])
 class TestFullDownloadPrefixesWithSlashes:

--- a/test/unit/deadline_job_attachments/test_download.py
+++ b/test/unit/deadline_job_attachments/test_download.py
@@ -1964,7 +1964,10 @@ class TestFullDownload:
             ) in str(exc.value)
 
     @mock_aws
-    @patch("os.name", "posix")
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+            reason="This test is for Linux path only.",
+    )
     def test_windows_long_path_exception_PosixOS(self):
         mock_s3_client = MagicMock()
         mock_future = MagicMock()
@@ -2004,7 +2007,10 @@ class TestFullDownload:
         assert str(exc.value) == expected_message
 
     @mock_aws
-    @patch("os.name", "nt")
+    @pytest.mark.skipif(
+        sys.platform != "win32",
+            reason="This test is for Windows path only.",
+    )
     def test_windows_long_path_exception_WindowsOS(self):
         mock_s3_client = MagicMock()
         mock_future = MagicMock()

--- a/test/unit/deadline_job_attachments/test_download.py
+++ b/test/unit/deadline_job_attachments/test_download.py
@@ -1966,7 +1966,7 @@ class TestFullDownload:
     @mock_aws
     @pytest.mark.skipif(
         sys.platform == "win32",
-            reason="This test is for Linux path only.",
+        reason="This test is for Linux path only.",
     )
     def test_windows_long_path_exception_PosixOS(self):
         mock_s3_client = MagicMock()
@@ -2009,7 +2009,7 @@ class TestFullDownload:
     @mock_aws
     @pytest.mark.skipif(
         sys.platform != "win32",
-            reason="This test is for Windows path only.",
+        reason="This test is for Windows path only.",
     )
     def test_windows_long_path_exception_WindowsOS(self):
         mock_s3_client = MagicMock()


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
If we have file path that is longer than 260 chars on Windows, JA will throw an error of file not found which is not necessary correct and do not bring any value to track down the problem
### What was the solution? (How)
Add comparison of file path and if longer than 260 chars, we will throw a more meaningful error message
### What is the impact of this change?
We have more meaningful logs so it's easier to detect what when wrong
### How was this change tested?
Run all unit + integ tests
Manually run download job output test on Linux and Windows
Manually run Asset sync on Linux and Windows CMF
![image](https://github.com/aws-deadline/deadline-cloud/assets/167144297/6a196a7e-ee15-4140-b291-66e8fb81704a)

### Was this change documented?
Yes

### Is this a breaking change?
No


----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*