### PR TITLE
feat(asset-cli): asset diff subcommand to diff directory changes with manfiest

### DIFF
--- a/src/deadline/client/cli/_groups/asset_group.py
+++ b/src/deadline/client/cli/_groups/asset_group.py
@@ -237,7 +237,9 @@ def asset_upload(root_dir: str, manifest_dir: str, update: bool, **args):
 @cli_asset.command(name="diff")
 @click.option("--root-dir", help="The root directory to compare changes to. ")
 @click.option(
-    "--manifest", help="The path to manifest folder of the directory to show changes of. "
+    "--manifest",
+    required=True,
+    help="The path to manifest folder of the directory to show changes of. ",
 )
 @click.option(
     "--format",
@@ -247,13 +249,58 @@ def asset_upload(root_dir: str, manifest_dir: str, update: bool, **args):
     default=False,
 )
 @_handle_error
-def asset_diff(**args):
+def asset_diff(root_dir: str, manifest: str, format: bool, **args):
     """
-    Check file differences of a directory since last snapshot.
+    Check file differences of a directory since last snapshot, specified by manifest.
+    """
+    print("root_dir: ", root_dir)
 
-    TODO: show example of diff output
-    """
-    click.echo("diff shown")
+    if not os.path.isdir(manifest):
+        raise NonValidInputError(f"Specified manifest directory {manifest} does not exist. ")
+
+    if root_dir is None:
+        asset_root_dir = os.path.dirname(manifest)
+    else:
+        if not os.path.isdir(root_dir):
+            raise NonValidInputError(f"Specified root directory {root_dir} does not exist. ")
+        asset_root_dir = root_dir
+
+    # Placeholder Asset Manager
+    asset_manager = S3AssetManager(
+        farm_id=" ", queue_id=" ", job_attachment_settings=JobAttachmentS3Settings(" ", " ")
+    )
+
+    # get inputs of directory
+    input_paths = []
+    for root, dirs, files in os.walk(asset_root_dir):
+        # ignore manifest folder
+        # if os.path.samefile(root, manifest):
+        #     dirs[:] = []
+        #     continue
+        for filename in files:
+            file_path = os.path.join(root, filename)
+            input_paths.append(Path(file_path))
+
+    # hash and create manifest of local directory
+    cache_config = config_file.get_cache_directory()
+    with HashCache(cache_config) as hash_cache:
+        directory_manifest_object = asset_manager._create_manifest_file(
+            input_paths=input_paths, root_path=asset_root_dir, hash_cache=hash_cache
+        )
+
+    # parse local manifest
+    local_manifest_object = read_local_manifest(manifest=manifest)
+
+    # compare manifests
+    differences = compare_manifest(
+        reference_manifest=local_manifest_object, compare_manifest=directory_manifest_object
+    )
+
+    if format:
+        click.echo(f"\n{asset_root_dir}")
+        pretty_print(file_status_list=differences)
+    else:
+        click.echo(f"\nFile Diffs: {differences}")
 
 
 @cli_asset.command(name="download")
@@ -408,3 +455,112 @@ def update_manifest(manifest: str, new_or_modified_paths: List[tuple]) -> BaseAs
         manifest_file.write(local_base_asset_manifest.encode())
 
     return local_base_asset_manifest
+
+
+def compare_manifest(
+    reference_manifest: BaseAssetManifest, compare_manifest: BaseAssetManifest
+) -> List[(tuple)]:
+    """
+    Compares two manifests, reference_manifest acting as the base, and compare_manifest acting as manifest with changes.
+    Returns a list of FileStatus and BaseManifestPath
+
+    """
+    reference_dict = {
+        manifest_path.path: manifest_path for manifest_path in reference_manifest.paths
+    }
+    compare_dict = {manifest_path.path: manifest_path for manifest_path in compare_manifest.paths}
+
+    differences = []
+
+    # Find new files
+    for file_path, manifest_path in compare_dict.items():
+        if file_path not in reference_dict:
+            differences.append((FileStatus.NEW, manifest_path))
+            continue
+        if file_path in reference_dict:
+            if reference_dict[file_path].hash != manifest_path.hash:
+                differences.append((FileStatus.MODIFIED, manifest_path))
+            else:
+                differences.append((FileStatus.UNCHANGED, manifest_path))
+            continue
+
+    # Find deleted files
+    for file_path, manifest_path in reference_dict.items():
+        if file_path not in compare_dict:
+            differences.append((FileStatus.DELETED, manifest_path))
+
+    return differences
+
+
+def pretty_print(file_status_list: List[(tuple)]):
+    """
+    Prints to command line a well formatted version of
+    """
+
+    # ASCII characters for the tree structure
+    PIPE = "│"
+    HORIZONTAL = "──"
+    ELBOW = "└"
+    TEE = "├"
+    SPACE = "    "
+
+    # ANSI escape sequences for colors
+    COLORS = {
+        "MODIFIED": "\033[93m",  # yellow
+        "NEW": "\033[92m",  # green
+        "DELETED": "\033[91m",  # red
+        "UNCHANGED": "\033[90m",  # grey
+        "reset": "\033[0m",  # base color
+        "directory": "\033[90m",  # grey
+    }
+
+    # Tooltips:
+    TOOLTIPS = {
+        "NEW": " +",  # added files
+        "DELETED": " -",  # deleted files
+        "MODIFIED": " M",  # modified files
+        "UNCHANGED": "",  # unchanged files
+    }
+
+    def print_tree(directory_tree, prefix=""):
+        sorted_entries = sorted(directory_tree.items())
+
+        for i, (entry, subtree) in enumerate(sorted_entries, start=1):
+            # print("SUBTREE", subtree)
+            is_last_entry = i == len(sorted_entries)
+            symbol = ELBOW + HORIZONTAL if is_last_entry else TEE + HORIZONTAL
+            is_dir = isinstance(subtree, dict)
+            color = COLORS["directory"] if is_dir else COLORS[subtree.name]
+            tooltip = TOOLTIPS["UNCHANGED"] if is_dir else TOOLTIPS[subtree.name]
+
+            print(
+                f"{prefix}{symbol}{color}{entry}{tooltip}{COLORS['reset']}{os.path.sep if is_dir else ''}"
+            )
+
+            if is_dir:
+                new_prefix = prefix + (SPACE if is_last_entry else PIPE + SPACE)
+                print_tree(subtree, new_prefix)
+
+        if not directory_tree:
+            symbol = ELBOW + HORIZONTAL
+            print(f"{prefix}{symbol}{COLORS['unchanged']}. {COLORS['reset']}")
+
+    def build_directory_tree(file_status_list: List[(tuple)]) -> dict[str, dict]:
+        directory_tree: dict = {}
+
+        def add_to_tree(path, status):
+            parts = path.split(os.path.sep)
+            current_level = directory_tree
+            for i, part in enumerate(parts):
+                if i == len(parts) - 1:
+                    current_level[part] = status
+                else:
+                    current_level = current_level.setdefault(part, {})
+
+        for status, manifest_path in file_status_list:
+            add_to_tree(manifest_path.path, status)
+        return directory_tree
+
+    directory_tree = build_directory_tree(file_status_list)
+    print_tree(directory_tree)
+    print()

--- a/src/deadline/job_attachments/upload.py
+++ b/src/deadline/job_attachments/upload.py
@@ -91,6 +91,7 @@ class FileStatus(Enum):
     UNCHANGED = 0
     NEW = 1
     MODIFIED = 2
+    DELETED = 3
 
 
 class S3AssetUploader:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Users want to be able to view directory changes since the previous capture of manifest, showing what files have been modified, added, or deleted.

### What was the solution? (How)
Created an asset CLI subcommand diff to diff directories with their corresponding manifests

### What is the impact of this change?
Users are now able to compare their local changes with their local manifests using a CLI command

### How was this change tested?
- Added unit tests mocking snapshot functionality at test/unit/deadline_client/cli/test_cli_asset.py, passing successfully
- manual end to end testing with local directories and local manifests

Sample Output Default:
![image](https://github.com/user-attachments/assets/f9b5eacd-c94e-4254-b189-56c2dea8327d)

Sample Output Raw:
![image](https://github.com/user-attachments/assets/5a035ee4-d68e-45e7-84ac-be9cc2246357)

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*