### PR TITLE
feat: support --submitter-name option for bundle GUI submitter command

### DIFF
--- a/src/deadline/client/api/_submit_job_bundle.py
+++ b/src/deadline/client/api/_submit_job_bundle.py
@@ -65,6 +65,7 @@ def create_job_from_job_bundle(
     upload_progress_callback: Optional[Callable[[ProgressReportMetadata], bool]] = None,
     create_job_result_callback: Optional[Callable[[], bool]] = None,
     require_paths_exist: bool = False,
+    submitter_name: str = "CLI",
 ) -> Union[str, None]:
     """
     Creates a job in the AWS Deadline Cloud farm/queue configured as default for the
@@ -310,7 +311,7 @@ def create_job_from_job_bundle(
 
     api.get_deadline_cloud_library_telemetry_client().record_event(
         event_type="com.amazon.rum.deadline.submission",
-        event_details={},
+        event_details={"submitter_name": submitter_name},
     )
 
     create_job_response = deadline.create_job(**create_job_args)

--- a/src/deadline/client/cli/_groups/bundle_group.py
+++ b/src/deadline/client/cli/_groups/bundle_group.py
@@ -257,6 +257,11 @@ def bundle_submit(
     help="Installs GUI dependencies if they are not installed already",
 )
 @click.option(
+    "--submitter-name",
+    type=click.STRING,
+    help="Name of the application submitting the bundle. If a name is specified, the GUI will automatically close after submitting the job.",
+)
+@click.option(
     "--output",
     type=click.Choice(
         ["verbose", "json"],
@@ -269,7 +274,7 @@ def bundle_submit(
     "parsed/consumed by custom scripts.",
 )
 @_handle_error
-def bundle_gui_submit(job_bundle_dir, browse, output, install_gui, **args):
+def bundle_gui_submit(job_bundle_dir, browse, output, install_gui, submitter_name, **args):
     """
     Opens GUI to submit an Open Job Description job bundle to AWS Deadline Cloud.
     """
@@ -284,7 +289,9 @@ def bundle_gui_submit(job_bundle_dir, browse, output, install_gui, **args):
             )
         output = output.lower()
 
-        submitter = show_job_bundle_submitter(input_job_bundle_dir=job_bundle_dir, browse=browse)
+        submitter = show_job_bundle_submitter(
+            input_job_bundle_dir=job_bundle_dir, browse=browse, submitter_name=submitter_name
+        )
 
         if not submitter:
             return

--- a/src/deadline/client/cli/_groups/bundle_group.py
+++ b/src/deadline/client/cli/_groups/bundle_group.py
@@ -107,6 +107,11 @@ def validate_parameters(ctx, param, value):
     is_flag=True,
     help="Require all input paths to exist",
 )
+@click.option(
+    "--submitter-name",
+    type=click.STRING,
+    help="Name of the application submitting the bundle.",
+)
 @click.argument("job_bundle_dir")
 @_handle_error
 def bundle_submit(
@@ -119,6 +124,7 @@ def bundle_submit(
     max_failed_tasks_count,
     max_retries_per_task,
     require_paths_exist,
+    submitter_name,
     **args,
 ):
     """
@@ -199,6 +205,7 @@ def bundle_submit(
             print_function_callback=click.echo,
             decide_cancel_submission_callback=_decide_cancel_submission,
             require_paths_exist=require_paths_exist,
+            submitter_name=submitter_name,
         )
 
         # Check Whether the CLI options are modifying any of the default settings that affect

--- a/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
@@ -94,7 +94,7 @@ class SubmitJobToDeadlineDialog(QDialog):
         self.setMinimumSize(400, 400)
 
         self.job_settings_type = type(initial_job_settings)
-        self.submitter_name = submitter_name or self.job_settings_type.submitter_name
+        self.submitter_name = submitter_name or self.job_settings_type().submitter_name
         self.on_create_job_bundle_callback = on_create_job_bundle_callback
         self.create_job_response: Optional[Dict[str, Any]] = None
         self.job_history_bundle_dir: Optional[str] = None

--- a/src/deadline/client/ui/job_bundle_submitter.py
+++ b/src/deadline/client/ui/job_bundle_submitter.py
@@ -38,7 +38,12 @@ logger = getLogger(__name__)
 
 
 def show_job_bundle_submitter(
-    *, input_job_bundle_dir: str = "", browse: bool = False, parent=None, f=Qt.WindowFlags()
+    *,
+    input_job_bundle_dir: str = "",
+    browse: bool = False,
+    parent=None,
+    f=Qt.WindowFlags(),
+    submitter_name="JobBundle",
 ) -> Optional[SubmitJobToDeadlineDialog]:
     """
     Opens an AWS Deadline Cloud job submission dialog for the provided job bundle.
@@ -177,6 +182,7 @@ def show_job_bundle_submitter(
         on_create_job_bundle_callback=on_create_job_bundle_callback,
         parent=parent,
         f=f,
+        submitter_name=submitter_name,
     )
     submitter_dialog.show()
     return submitter_dialog

--- a/test/unit/deadline_client/cli/test_cli_bundle.py
+++ b/test/unit/deadline_client/cli/test_cli_bundle.py
@@ -4,6 +4,7 @@
 Tests for the CLI job bundle commands.
 """
 import os
+import sys
 import tempfile
 import json
 from unittest.mock import ANY, patch, Mock
@@ -750,3 +751,23 @@ def test_cli_bundle_reject_upload_confirmation(fresh_deadline_config, temp_job_b
 
         upload_attachments_mock.assert_not_called()
         assert result.exit_code == 0
+
+
+@patch("deadline.client.ui.gui_context_for_cli")
+def test_gui_submit_submitter_name(_mock_context):
+    """
+    Verify that the --submitter-name arg gets passed through correctly
+    """
+
+    # Unconventional mocking pattern because of how the function is imported in code
+    mock_job_bundle_submitter = Mock()
+    sys.modules["deadline.client.ui.job_bundle_submitter"] = mock_job_bundle_submitter
+    mock_job_bundle_submitter.show_job_bundle_submitter
+
+    runner = CliRunner()
+    runner.invoke(
+        main,
+        ["bundle", "gui-submit", "--browse", "--submitter-name", "MyDCC"],
+    )
+    _args, kwargs = mock_job_bundle_submitter.show_job_bundle_submitter.call_args
+    assert kwargs["submitter_name"] == "MyDCC"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
One great way of integrating Deadline Cloud into a DCC is adding a button that invokes the GUI bundle submitter. To improve the UX, we can allow the submitter name (currently always "JobBundle" for bundle GUI submissions) to be customized. The submitter name is used for some alerts (e.g. an alert title "JobBundle job submission") and for bundle directory names in the job history folder.  

### What was the solution? (How)
Add a new `--submitter-name` option.

### What is the impact of this change?
A process that submits a job using the GUI bundle submitter appears more like a "real submitter" in the UI and job history folder. 

### How was this change tested?
Unit tests. Also manual tests:
- export a bundle without a custom submitter name. Verified the job bundle directory included "JobBundle" (previous behavior)
- export a bundle with a custom submitter name. Verified the job bundle directory included the custom name
- submit a bundle without a custom submitter name
- submit a bundle with a custom submitter name

### Was this change documented?
Documented in the CLI help automatically.

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*