### PR TITLE
feat: update DEVELOPMENT.md on how to run integ tests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,9 @@
 ### What is the impact of this change?
 
 ### How was this change tested?
+- Have you run `hatch run test` ?
+
+- Have you run `hatch run integ:test` ? See `DEVELOPMENT.md` on "Run integration tests"
 
 ### Was this change documented?
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -54,10 +54,32 @@ hatch run test
 ```
 
 ## Run integration tests
+- Pre-requisites:
+  - Developer must have a valid AWS account.
+  - Developer must create a Farm and Queue. This can be done easily via Deadline Cloud's AWS Console quick Farm create workflow. Please copy the Farm resource ID for the next step. Please copy the Queue's Job Attachment S3 bucket name and Root Prefix for the next step.
+
+- Setup Environment Variables
+```bash
+export SERVICE_ACCOUNT_ID="your AWS Account Id"
+export JOB_ATTACHMENTS_BUCKET="your Queue configured Job Attachments bucket"
+export JA_TEST_ROOT_PREFIX="/your/path/root"
+export FARM_ID="farm-{uuid}"
+export AWS_DEFAULT_REGION="us-west-2"
+```
+
+- Optional Environment Variables
+```bash
+export AWS_ENDPOINT_URL_DEADLINE="https://deadline.$AWS_DEFAULT_REGION.amazonaws.com"
+export INTEG_TEST_JA_CROSS_ACCOUNT_BUCKET="Your regional S3 bucket in another account"
+```
+
+- Running the integration tests.
 ```
 hatch run integ:test
 ```
 
+- Notes:
+  - If the integration test is run in any region other than `us-west-2`, please set the environment variable `INTEG_TEST_JA_CROSS_ACCOUNT_BUCKET`. The bucket must be from another AWS account in the same region as the farm setup to run this test.
 ## Run linting
 ```
 hatch run lint

--- a/test/integ/deadline_job_attachments/conftest.py
+++ b/test/integ/deadline_job_attachments/conftest.py
@@ -1,6 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 import getpass
+import os
 import json
 import sys
 import pytest
@@ -98,7 +99,7 @@ def external_bucket() -> str:
     """
     Return a bucket that all developers and test accounts have access to, but isn't in the testers account.
     """
-    return "job-attachment-bucket-snipe-test"
+    return os.environ.get("INTEG_TEST_JA_CROSS_ACCOUNT_BUCKET", "job-attachment-bucket-snipe-test")
 
 
 def is_windows_non_admin():


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
- Developers and contributors did not have any setup instructions to run the integration tests.

### What was the solution? (How)
- Lets add some basic instructions to the readme.
- Developer pull request template is now updated to request running both unit test and integration test.

### What is the impact of this change?
- EVERYONE should be running integ tests on submission.

### How was this change tested?
- Exported the environment variables
- `hatch run integ:test`

```

================================================================================================ slowest 5 durations =================================================================================================
9.95s setup    test/integ/deadline_job_attachments/test_job_attachments.py::test_upload_input_files_all_assets_in_cas[2023-03-03]
8.73s call     test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_outputs_no_job_attachment_settings_in_job[2023-03-03]
7.20s setup    test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_inputs_with_step_dependencies[2023-03-03]
5.68s teardown test/integ/deadline_job_attachments/test_job_attachments.py::test_download_outputs_windows_max_file_path_length_exception[2023-03-03]
4.72s call     test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_inputs_with_step_dependencies[2023-03-03]
====================================================================================== 14 passed, 1 skipped in 66.24s (0:01:06) ======================================================================================

```

### Was this change documented?
- This changes is documentation in itself.

### Is this a breaking change?
- No.
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*