### PR TITLE
feat(asset-cli): asset download subcommand

### DIFF
--- a/src/deadline/job_attachments/download.py
+++ b/src/deadline/job_attachments/download.py
@@ -372,6 +372,68 @@ def download_files_in_directory(
     )
 
 
+def download_file_with_s3_key(
+    s3_bucket: str,
+    s3_key: str,
+    transfer_manager,
+    local_file_name: Path,
+    file_bytes: Optional[int] = 0,
+    session: Optional[boto3.Session] = None,
+    progress_tracker: Optional[ProgressTracker] = None,
+    file_conflict_resolution: Optional[FileConflictResolution] = FileConflictResolution.CREATE_COPY,
+) -> Optional[concurrent.futures.Future]:
+    """
+    Helper to download a file from the S3 bucket with a specified S3 key to the local directory.
+    Returns the asynchronous result of the downloaded file, and None if otherwise
+    """
+
+    # If the file name already exists, resolve the conflict based on the file_conflict_resolution
+    if local_file_name.is_file():
+        if file_conflict_resolution == FileConflictResolution.SKIP:
+            # if file is said to be skipped, no dowload will occur, and None will be returned.
+            # This allows `download_file` to return (file_bytes, None) when this function is called.
+            return None
+        elif file_conflict_resolution == FileConflictResolution.OVERWRITE:
+            pass
+        elif file_conflict_resolution == FileConflictResolution.CREATE_COPY:
+            # This loop resolves filename conflicts by appending " (1)"
+            # to the stem of the filename until a unique name is found.
+            while local_file_name.is_file():
+                local_file_name = local_file_name.parent.joinpath(
+                    local_file_name.stem + " (1)" + local_file_name.suffix
+                )
+        else:
+            raise ValueError(
+                f"Unknown choice for file conflict resolution: {file_conflict_resolution}"
+            )
+
+    local_file_name.parent.mkdir(parents=True, exist_ok=True)
+
+    future: concurrent.futures.Future
+
+    # provides progress callback for asynchronous download from S3
+    def handler(bytes_downloaded):
+        nonlocal progress_tracker
+        nonlocal future
+
+        if progress_tracker:
+            should_continue = progress_tracker.track_progress_callback(bytes_downloaded)
+            if not should_continue:
+                future.cancel()
+
+    subscribers = [ProgressCallbackInvoker(handler)]
+
+    future = transfer_manager.download(
+        bucket=s3_bucket,
+        key=s3_key,
+        fileobj=str(local_file_name),
+        extra_args={"ExpectedBucketOwner": get_account_id(session=session)},
+        subscribers=subscribers,
+    )
+    future.result()
+    return future
+
+
 def download_file(
     file: RelativeFilePath,
     hash_algorithm: HashAlgorithm,
@@ -396,10 +458,10 @@ def download_file(
 
     transfer_manager = get_s3_transfer_manager(s3_client=s3_client)
 
+    file_bytes = file.size
+
     # The modified time in the manifest is in microseconds, but utime requires the time be expressed in seconds.
     modified_time_override = file.mtime / 1000000  # type: ignore[attr-defined]
-
-    file_bytes = file.size
 
     # Python will handle the path separator '/' correctly on every platform.
     local_file_name = Path(local_download_dir).joinpath(file.path)
@@ -410,49 +472,21 @@ def download_file(
         else f"{file.hash}.{hash_algorithm.value}"
     )
 
-    # If the file name already exists, resolve the conflict based on the file_conflict_resolution
-    if local_file_name.is_file():
-        if file_conflict_resolution == FileConflictResolution.SKIP:
-            return (file_bytes, None)
-        elif file_conflict_resolution == FileConflictResolution.OVERWRITE:
-            pass
-        elif file_conflict_resolution == FileConflictResolution.CREATE_COPY:
-            # This loop resolves filename conflicts by appending " (1)"
-            # to the stem of the filename until a unique name is found.
-            while local_file_name.is_file():
-                local_file_name = local_file_name.parent.joinpath(
-                    local_file_name.stem + " (1)" + local_file_name.suffix
-                )
-        else:
-            raise ValueError(
-                f"Unknown choice for file conflict resolution: {file_conflict_resolution}"
-            )
-
-    local_file_name.parent.mkdir(parents=True, exist_ok=True)
-
-    future: concurrent.futures.Future
-
-    def handler(bytes_downloaded):
-        nonlocal progress_tracker
-        nonlocal future
-
-        if progress_tracker:
-            should_continue = progress_tracker.track_progress_callback(bytes_downloaded)
-            if not should_continue:
-                future.cancel()
-
-    subscribers = [ProgressCallbackInvoker(handler)]
-
-    future = transfer_manager.download(
-        bucket=s3_bucket,
-        key=s3_key,
-        fileobj=str(local_file_name),
-        extra_args={"ExpectedBucketOwner": get_account_id(session=session)},
-        subscribers=subscribers,
-    )
-
     try:
-        future.result()
+        future = download_file_with_s3_key(
+            s3_bucket=s3_bucket,
+            s3_key=s3_key,
+            file_bytes=file_bytes,
+            transfer_manager=transfer_manager,
+            local_file_name=local_file_name,
+            session=session,
+            progress_tracker=progress_tracker,
+            file_conflict_resolution=file_conflict_resolution,
+        )
+
+        if future is None:
+            return (file_bytes, None)
+
     except concurrent.futures.CancelledError as ce:
         if progress_tracker and progress_tracker.continue_reporting is False:
             raise AssetSyncCancelledError("File download cancelled.")
@@ -490,6 +524,18 @@ def download_file(
         # TODO: Temporary to prevent breaking backwards-compatibility; if file not found, try again without hash alg postfix
         status_code = int(exc.response["ResponseMetadata"]["HTTPStatusCode"])
         if status_code == 404:
+
+            def handler(bytes_downloaded):
+                nonlocal progress_tracker
+                nonlocal future
+
+                if progress_tracker:
+                    should_continue = progress_tracker.track_progress_callback(bytes_downloaded)
+                    if not should_continue and future is not None:
+                        future.cancel()
+
+            subscribers = [ProgressCallbackInvoker(handler)]
+
             s3_key = s3_key.rsplit(".", 1)[0]
             future = transfer_manager.download(
                 bucket=s3_bucket,
@@ -499,7 +545,8 @@ def download_file(
                 subscribers=subscribers,
             )
             try:
-                future.result()
+                if future is not None:
+                    future.result()
             except concurrent.futures.CancelledError as ce:
                 if progress_tracker and progress_tracker.continue_reporting is False:
                     raise AssetSyncCancelledError("File download cancelled.")

--- a/src/deadline/job_attachments/upload.py
+++ b/src/deadline/job_attachments/upload.py
@@ -191,7 +191,10 @@ class S3AssetUploader:
 
         if manifest_write_dir:
             self._write_local_manifest(
-                manifest_write_dir, manifest_name, full_manifest_key, manifest
+                manifest_write_dir,
+                manifest_name,
+                full_manifest_key,
+                manifest,
             )
 
         self.upload_bytes_to_s3(

--- a/test/integ/cli/test_cli_asset.py
+++ b/test/integ/cli/test_cli_asset.py
@@ -60,7 +60,7 @@ class TestSnapshot:
         with open(manifest_file_path, "r") as f:
             manifest_data = json.load(f)
 
-        expected_hash = hash_file(file_path, HashAlgorithm())  # hashed with xxh128
+        expected_hash = hash_file(file_path, HashAlgorithm("xxh128"))  # hashed with xxh128
         manifest_data_paths = manifest_data["paths"]
         assert (
             len(manifest_data_paths) == 1
@@ -103,7 +103,7 @@ class TestSnapshot:
             manifest_data = json.load(f)
 
         # should ignore subdirectories
-        expected_hash = hash_file(root_file_path, HashAlgorithm())  # hashed with xxh128
+        expected_hash = hash_file(root_file_path, HashAlgorithm("xxh128"))  # hashed with xxh128
         manifest_data_paths = manifest_data["paths"]
         assert (
             len(manifest_data_paths) == 1
@@ -118,7 +118,8 @@ class TestSnapshot:
         root_dir = os.path.join(temp_dir, TEST_ROOT_DIR)
 
         # Create a file in the root directory
-        root_file_path = os.path.join(root_dir, TEST_ROOT_DIR)
+        root_file_path = os.path.join(root_dir, TEST_ROOT_FILE)
+        os.makedirs(os.path.dirname(root_file_path), exist_ok=True)
         with open(root_file_path, "w") as f:
             f.write(TEST_ROOT_DIR_FILE_CONTENT)
 
@@ -145,8 +146,10 @@ class TestSnapshot:
         with open(root_manifest_file_path, "r") as f:
             manifest_data = json.load(f)
 
-        root_file_hash = hash_file(root_file_path, HashAlgorithm())  # hashed with xxh128
-        subdir_file_hash = hash_file(subdir_file_path, HashAlgorithm())  # hashed with xxh128
+        root_file_hash = hash_file(root_file_path, HashAlgorithm("xxh128"))  # hashed with xxh128
+        subdir_file_hash = hash_file(
+            subdir_file_path, HashAlgorithm("xxh128")
+        )  # hashed with xxh128
         manifest_data_paths = manifest_data["paths"]
         assert (
             len(manifest_data_paths) == 2
@@ -192,7 +195,7 @@ class TestSnapshot:
         with open(manifest_file_path, "r") as f:
             manifest_data = json.load(f)
 
-        expected_hash = hash_file(file_path, HashAlgorithm())  # hashed with xxh128
+        expected_hash = hash_file(file_path, HashAlgorithm("xxh128"))  # hashed with xxh128
         manifest_data_paths = manifest_data["paths"]
         assert (
             len(manifest_data_paths) == 1

--- a/test/unit/deadline_job_attachments/test_download.py
+++ b/test/unit/deadline_job_attachments/test_download.py
@@ -14,7 +14,7 @@ from pathlib import Path
 import sys
 import tempfile
 from typing import Any, Callable, List
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, call, patch, ANY
 
 import boto3
 from botocore.exceptions import BotoCoreError, ClientError, ReadTimeoutError
@@ -36,6 +36,7 @@ from deadline.job_attachments.asset_manifests.versions import ManifestVersion
 from deadline.job_attachments.download import (
     OutputDownloader,
     download_file,
+    download_file_with_s3_key,
     download_files_from_manifests,
     download_files_in_directory,
     get_job_input_output_paths_by_asset_root,
@@ -2402,3 +2403,58 @@ def test_mount_vfs_from_manifests(
         mock_vfs_start.assert_has_calls(
             [call(session_dir=temp_dir_path), call(session_dir=temp_dir_path)]
         )
+
+
+@pytest.mark.parametrize(
+    "file_conflict_resolution",
+    [
+        FileConflictResolution.OVERWRITE,
+        FileConflictResolution.CREATE_COPY,
+        FileConflictResolution.SKIP,
+    ],
+)
+def test_download_file_with_s3_key(tmp_path, file_conflict_resolution):
+    s3_bucket = "test-bucket"
+    s3_key = "test-key"
+    local_file_path = tmp_path / "test-file.txt"
+    file_bytes = 1024
+
+    mock_transfer_manager = MagicMock()
+
+    if file_conflict_resolution == FileConflictResolution.SKIP:
+        local_file_path.touch()
+        mock_transfer_manager.download.return_value = None
+    else:
+        mock_future = MagicMock()
+        mock_transfer_manager.download.return_value = mock_future
+
+    with patch(
+        "deadline.job_attachments.download.get_account_id", return_value="YOUR_AWS_ACCOUNT_ID"
+    ):
+        future = download_file_with_s3_key(
+            s3_bucket=s3_bucket,
+            s3_key=s3_key,
+            transfer_manager=mock_transfer_manager,
+            local_file_name=local_file_path,
+            file_bytes=file_bytes,
+            file_conflict_resolution=file_conflict_resolution,
+        )
+
+        # Make sure download funciton isn't called and returns None when SKIP
+        if file_conflict_resolution == FileConflictResolution.SKIP:
+            assert future is None
+            mock_transfer_manager.download.assert_not_called()
+        else:
+            assert future is mock_future
+            mock_transfer_manager.download.assert_called_once_with(
+                bucket=s3_bucket,
+                key=s3_key,
+                fileobj=str(local_file_path),
+                extra_args={"ExpectedBucketOwner": "YOUR_AWS_ACCOUNT_ID"},
+                subscribers=[ANY],
+            )
+
+            # Check if the file name is modified for CREATE_COPY resolution
+            if file_conflict_resolution == FileConflictResolution.CREATE_COPY:
+                assert local_file_path.name.startswith("test-file")
+                assert local_file_path.name.endswith(".txt")


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Users want to be able to easily find the input manifest files of a previously submitted job, not just a job's output files.

### What was the solution? (How)
Created a CLI command to allow users to download a job's corresponding input manifest, using job id's

### What is the impact of this change?
Users are able to download manifest files off of their S3 bucket, with the S3 key mapped form job information. Once downloaded, users can now view, and share these manifests files to show the inputs of a render job.

### How was this change tested?
- added unit tests mocking download functionality at test/unit/deadline_client/cli/test_cli_asset.py, passing successfully
- ran integ tests to check refactoring of existing code
- ran manual end to end test to test the refactoring of download functionalities
![image](https://github.com/user-attachments/assets/1907b6d0-c95e-4300-a0b3-f9fb00d06c18)

![image](https://github.com/user-attachments/assets/b3b3b3fc-b8bd-4228-b0b8-9011b9b7ea2b)


----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*