### PR TITLE
fix: use devnull for stderr pipe to dcm process handle

### DIFF
--- a/src/deadline/client/api/_loginout.py
+++ b/src/deadline/client/api/_loginout.py
@@ -46,16 +46,12 @@ def _login_deadline_cloud_monitor(
             # We don't hookup to stdin but do this to avoid issues on windows
             # See https://docs.python.org/3/library/subprocess.html#subprocess.STARTUPINFO.lpAttributeList
             p = subprocess.Popen(
-                args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, stdin=subprocess.PIPE
+                args, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, stdin=subprocess.PIPE
             )
         else:
             p = subprocess.Popen(
-                args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, stdin=subprocess.DEVNULL
+                args, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, stdin=subprocess.DEVNULL
             )
-        # Linux takes time to start DCM binary, which causes the TTY to suspend the process and send it to background job
-        # With wait here, the DCM binary starts and TTY does not suspend the deadline process.
-        if sys.platform == "linux":
-            time.sleep(0.5)
     except FileNotFoundError:
         raise DeadlineOperationError(
             f"Could not find Deadline Cloud monitor at {deadline_cloud_monitor_path}. "

--- a/test/unit/deadline_client/cli/test_cli_auth.py
+++ b/test/unit/deadline_client/cli/test_cli_auth.py
@@ -51,14 +51,14 @@ def test_cli_deadline_cloud_monitor_login_and_logout(fresh_deadline_config):
             popen_mock.assert_called_once_with(
                 ["/bin/DeadlineCloudMonitor", "login", "--profile", "sandbox-us-west-2"],
                 stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
+                stderr=subprocess.DEVNULL,
                 stdin=subprocess.PIPE,
             )
         else:
             popen_mock.assert_called_once_with(
                 ["/bin/DeadlineCloudMonitor", "login", "--profile", "sandbox-us-west-2"],
                 stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
+                stderr=subprocess.DEVNULL,
                 stdin=subprocess.DEVNULL,
             )
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
When using **deadline auth login** and **deadline gui** for login using Deadline Cloud monitor, there is race condition that Deadline Cloud monitor process handle closes early while the application is starting. This closes the stderr pipe opened with Deadline Cloud monitor process, and any messages sent to stderr results in panic, crashing the Deadline Cloud monitor. 

### What was the solution? (How)
The error messages in stderr are coming from crates used in DCM, which login flow does not need to know. DCM itself sends login failure message over stdout. This change is pointing process stderr pipe to devnull to prevent panic. 

### What is the impact of this change?
Fix the race condition which crashes the Deadline Cloud monitor application during login. 

### How was this change tested?
```
hatch build
hatch run fmt
hatch run lint
```
```
hatch run test
...
Required test coverage of 80.0% reached. Total coverage: 83.28%
=============================================================================================== slowest 5 durations ===============================================================================================
6.16s call     test/unit/deadline_job_attachments/test_upload.py::TestUpload::test_asset_management_no_outputs_large_number_of_inputs_already_uploaded[2023-03-03-200]
5.06s call     test/unit/deadline_job_attachments/test_progress_tracker.py::TestProgressTracker::test_increment_race_condition
4.96s call     test/unit/deadline_job_attachments/test_upload.py::TestUpload::test_asset_management_many_inputs[2023-03-03-200]
3.98s call     test/unit/deadline_job_attachments/test_upload.py::TestUpload::test_asset_management_no_outputs_large_number_of_inputs_already_uploaded[2023-03-03-100]
3.41s call     test/unit/deadline_job_attachments/test_upload.py::TestUpload::test_asset_management_many_inputs[2023-03-03-100]
============================================================================= 1326 passed, 46 skipped, 1 xfailed, 1 warning in 28.98s =============================================================================
```

### Was this change documented?
Not applicable, no APIs or customer behaviors are changed.

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*