### PR TITLE
test: add integ tests to test download func

### DIFF
--- a/test/integ/deadline_job_attachments/test_job_attachments.py
+++ b/test/integ/deadline_job_attachments/test_job_attachments.py
@@ -8,6 +8,7 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 from unittest.mock import MagicMock
+import sys
 
 from deadline.job_attachments.models import JobAttachmentS3Settings
 
@@ -1533,3 +1534,90 @@ def test_download_outputs_windows_max_file_path_length_exception(
         ),
     ):
         job_output_downloader.download_job_output()
+
+
+@pytest.mark.integ
+def test_download_outputs_no_outputs_dir(
+    job_attachment_test: JobAttachmentTest,
+    sync_outputs: SyncOutputsOutput,
+):
+    """
+    Test that if trying to download outputs but not specify a file path
+    Download will be saved to the current directory.
+    """
+
+    download_path = Path(
+        os.path.normpath(Path("").absolute()) / sync_outputs.step0_task0_output_file
+    )
+
+    job_attachment_settings = get_queue(
+        farm_id=job_attachment_test.farm_id,
+        queue_id=job_attachment_test.queue_id,
+        deadline_endpoint_url=job_attachment_test.deadline_endpoint,
+    ).jobAttachmentSettings
+
+    if job_attachment_settings is None:
+        raise Exception("Job attachment settings must be set for this test.")
+
+    job_output_downloader = download.OutputDownloader(
+        s3_settings=job_attachment_settings,
+        farm_id=job_attachment_test.farm_id,
+        queue_id=job_attachment_test.queue_id,
+        job_id=sync_outputs.job_id,
+        step_id=sync_outputs.step0_id,
+        task_id=sync_outputs.step0_task0_id,
+    )
+    job_output_downloader.set_root_path(str(job_attachment_test.ASSET_ROOT), "")
+
+    # WHEN
+    try:
+        job_output_downloader.download_job_output()
+        # THEN
+        # The output file should be downloaded to the current directory
+        assert download_path.exists()
+    finally:
+        shutil.rmtree(download_path.parent)
+
+
+@pytest.mark.integ
+@pytest.mark.skipif(
+    sys.platform != "win32",
+    reason="This test is for Windows file path length UNC, skipping this if os not Windows",
+)
+def test_download_outputs_windows_file_path_UNC(
+    job_attachment_test: JobAttachmentTest,
+    sync_outputs: SyncOutputsOutput,
+):
+    """
+    Test that if trying to download outputs to a file path that
+    longer than 260 chars in Windows but have UNC, the download is success.
+    """
+    long_root_path = Path("\\\\?\\" + __file__).parent / str("A" * 135)
+
+    job_attachment_settings = get_queue(
+        farm_id=job_attachment_test.farm_id,
+        queue_id=job_attachment_test.queue_id,
+        deadline_endpoint_url=job_attachment_test.deadline_endpoint,
+    ).jobAttachmentSettings
+
+    if job_attachment_settings is None:
+        raise Exception("Job attachment settings must be set for this test.")
+
+    job_output_downloader = download.OutputDownloader(
+        s3_settings=job_attachment_settings,
+        farm_id=job_attachment_test.farm_id,
+        queue_id=job_attachment_test.queue_id,
+        job_id=sync_outputs.job_id,
+        step_id=sync_outputs.step0_id,
+        task_id=sync_outputs.step0_task0_id,
+    )
+    job_output_downloader.set_root_path(str(job_attachment_test.ASSET_ROOT), str(long_root_path))
+
+    # WHEN
+    try:
+        job_output_downloader.download_job_output()
+        # THEN
+        # The output file should be downloaded to the current directory
+        assert Path(long_root_path / sync_outputs.step0_task0_output_file).exists()
+    finally:
+        shutil.rmtree(long_root_path)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Integ test did not cover all test cases that we wanted

### What was the solution? (How)
Add more integ test to improve coverage.

### What is the impact of this change?
We can now test if download with no output dir have the correct behavior
We can now test if long file path on Windows with UNC notation will not raise exception

### How was this change tested?
- `hatch run test` 

- `hatch run integ:test`

### Was this change documented?
Yes

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*