### PR TITLE
test: Change name of Mainline Integration Tests

### DIFF
--- a/.github/workflows/mainline_integration_test.yml
+++ b/.github/workflows/mainline_integration_test.yml
@@ -1,4 +1,4 @@
-name: Mainline Merge Integration Tests
+name: Mainline Integration Tests
 
 on:
   schedule:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We should change the name of the mainline integration testsworkflow since they're ran on both merge and also as canary. 
### What was the solution? (How)
Change the name of the integration test workflow
### What is the impact of this change?
Better naming for the test actions
### How was this change tested?
No testing required
### Was this change documented?
No
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*