### PR TITLE
feat(cli)!: bundle submit - remove "--yes" and add "--trust" and "--upload"

### DIFF
--- a/src/deadline/client/cli/_groups/bundle_group.py
+++ b/src/deadline/client/cli/_groups/bundle_group.py
@@ -98,9 +98,14 @@ def validate_parameters(ctx, param, value):
     type=click.Choice([e.value for e in JobAttachmentsFileSystem]),
 )
 @click.option(
-    "--yes",
+    "--upload",
     is_flag=True,
-    help="Skip any confirmation prompts",
+    help="Indicates that files will be uploaded to S3 if needed",
+)
+@click.option(
+    "--trust",
+    is_flag=True,
+    help="Indicates the job bundle is trusted to not perform malicious activities",
 )
 @click.option(
     "--require-paths-exist",
@@ -118,7 +123,8 @@ def bundle_submit(
     job_bundle_dir,
     job_attachments_file_system,
     parameter,
-    yes,
+    upload,
+    trust,
     name,
     priority,
     max_failed_tasks_count,
@@ -139,55 +145,64 @@ def bundle_submit(
     def _check_create_job_wait_canceled() -> bool:
         return sigint_handler.continue_operation
 
-    def _decide_cancel_submission(upload_group: AssetUploadGroup) -> bool:
-        """
-        Callback to decide if submission should be cancelled or not. Return 'True' to cancel.
-        Prints a warning that requires confirmation if paths are found outside of configured storage profile locations.
-        """
-        warning_message = ""
+    def _does_user_trust_bundle(upload_group: AssetUploadGroup) -> bool:
+        locations_outside_trust = set()
+        trust_default = False
+
+        # If the user has indicated they trust the bundle, return early
+        if trust:
+            return True
+
+        if config_file.str2bool(get_setting("settings.auto_accept", config=config)):
+            # default option is to not trust the bundle, so auto_accept respects that and does not trust the bundle
+            return trust_default
+
         for group in upload_group.asset_groups:
             if not group.file_system_location_name:
-                warning_message += f"\n\nUnder the directory '{group.root_path}':"
-                warning_message += (
-                    f"\n\t{len(group.inputs)} input file{'' if len(group.inputs) == 1 else 's'}"
-                    if len(group.inputs) > 0
-                    else ""
-                )
-                warning_message += (
-                    f"\n\t{len(group.outputs)} output director{'y' if len(group.outputs) == 1 else 'ies'}"
-                    if len(group.outputs) > 0
-                    else ""
-                )
-                warning_message += (
-                    f"\n\t{len(group.references)} referenced file{'' if len(group.references) == 1 else 's'} and/or director{'y' if len(group.outputs) == 1 else 'ies'}"
-                    if len(group.references) > 0
-                    else ""
-                )
+                locations_outside_trust.add(group.root_path)
 
-        # Exit early if there are no warnings and we've either set auto accept or there's no files to confirm
-        if not warning_message and (
-            yes
+        if not locations_outside_trust:
+            return True
+
+        locations = "\n\t".join(locations_outside_trust)
+        trust_prompt = (
+            f"This job bundle is attempting to upload files outside of the job bundle and storage profile locations from the following directories:"
+            f"\n\t{locations}"
+            f"\n\Do you trust this job bundle?"
+        )
+        return click.confirm(trust_prompt, default=trust_default)
+
+    def _does_user_want_to_upload(upload_group: AssetUploadGroup) -> bool:
+        upload_default = True
+
+        if (
+            upload
             or config_file.str2bool(get_setting("settings.auto_accept", config=config))
             or upload_group.total_input_files == 0
         ):
-            return False
+            return True
 
-        message_text = (
-            f"Job submission contains {upload_group.total_input_files} input files totaling {_human_readable_file_size(upload_group.total_input_bytes)}. "
-            " All input files will be uploaded to S3 if they are not already present in the job attachments bucket."
+        upload_prompt = (
+            f"Job submission contains {upload_group.total_input_files} input files totaling {_human_readable_file_size(upload_group.total_input_bytes)}."
+            f" All input files will be uploaded to S3 if they are not already present in the job attachments bucket."
+            f"\n\nDo you wish to proceed?"
         )
-        if warning_message:
-            message_text += (
-                f"\n\nFiles were specified outside of the configured storage profile location(s). "
-                " Please confirm that you intend to submit a job that uses files from the following directories:"
-                f"{warning_message}\n\n"
-                "To permanently remove this warning you must only use files located within a storage profile location."
-            )
-        message_text += "\n\nDo you wish to proceed?"
-        return not click.confirm(
-            message_text,
-            default=not warning_message,
-        )
+        return click.confirm(upload_prompt, default=upload_default)
+
+    def _decide_cancel_submission(upload_group: AssetUploadGroup) -> bool:
+        """Callback to decide if submission should be cancelled or not. Return 'True' to cancel.
+
+        Currently there are two prompts:
+            1. Prompt user if they trust the bundle if paths are found outside the bundle or configured storage profile locations.
+            2. Prompt user if they want to upload files to S3
+        """
+        if not _does_user_trust_bundle(upload_group):
+            return True
+
+        if not _does_user_want_to_upload(upload_group):
+            return True
+
+        return False
 
     try:
         job_id = api.create_job_from_job_bundle(


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Starting this PR for discussion around the concept of trusting a job bundle and the UX we present around it.

Right now the deadline client lib is only concerned with job bundles uploading files a user might NOT want uploaded. This currently means that a user will be prompted if files are outside of storage profile locations returned by `GetStorageProfileForQueue`.

Fixing #407 would allow the client library to not prompt the user if the only files being uploaded are from within the job bundle. However this is all just treating the symptom of submitting untrusted bundles, rather than getting a user to confirm and understand what it means to submit a job bundle written by someone else.

Due to all of this, we've effectively blocked users from running `deadline bundle submit` as a scriptable/non-interactive command without piping "yes" into it. This especially becomes problematic for workflows that embed the usage of the deadline cli to perform the submission after they've generated a bundle. If they've just generated a job bundle in their workflow, they _should not_ be prompted about the job. They've specifically set out to create this job, we're just getting in the way.

If the workflow that generated the job bundle is malicious, then it can also just move whatever it wants to upload into the job bundle directory/storage profile locations and bypass these filepath checks. So if you trust the workflow to generate the bundle, you inherently trust the job bundle.

### What was the solution? (How)

To start unpacking this, we really want the ability to signify that we trust a job bundle, as trusting a path to be uploaded is just 1 part of the greater problem of trusting bundles. Future changes will most likely involve configuring paths to not warn about.

So for `deadline bundle submit` we split out the existing confusing prompt into 2 smaller prompts :( so that users can answer them individually. The first one is about trusting the bundle, and the second one is about confirmation around uploading files. These two prompts have their own flags, `--trust` and `--upload` that allow users of the cli to answer both, some, or neither. 

This change intentionally does not add `--trust` to `deadline bundle gui-submit`, since that function needs quite a bit of refactoring to pass in all the options to make it have parity with `deadline bundle submit`.

I've removed the `--yes` command because `auto-accepting defaults` is useless for actually making it through these prompts. Maybe it should stay in for now, but I believe there's a bigger topic for discussion about indicating that you _cannot_ answer prompts, ie you want to use the cli non-interactively, and fail if you do not have an answer for everything.

### What is the impact of this change?

Users can now script their usage of `deadline bundle submit` (minus concurrency) to submit jobs.

### How was this change tested?
- Have you run `hatch run test` ?
 
Yes

- Have you run `hatch run integ:test` ? See `DEVELOPMENT.md` on "Run integration tests"

Yes

### Was this change documented?

Self-documenting

### Is this a breaking change?

You better believe it!

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*