### PR TITLE
fix: credential caching improvements

### DIFF
--- a/src/deadline/client/api/_loginout.py
+++ b/src/deadline/client/api/_loginout.py
@@ -13,12 +13,12 @@ import sys
 
 
 from ._session import (
-    invalidate_boto3_session_cache,
     get_credentials_source,
     check_authentication_status,
     AwsCredentialsSource,
     AwsAuthenticationStatus,
 )
+from . import _session
 from ..config import get_setting
 from ..exceptions import DeadlineOperationError
 import time
@@ -143,7 +143,7 @@ def logout(config: Optional[ConfigParser] = None) -> str:
             )
 
         # Force a refresh of the cached boto3 Session
-        invalidate_boto3_session_cache()
+        _session.invalidate_boto3_session_cache()
         return output.decode("utf8")
     raise UnsupportedProfileTypeForLoginLogout(
         "Logging out is only supported for AWS Profiles created by Deadline Cloud monitor."

--- a/src/deadline/client/api/_session.py
+++ b/src/deadline/client/api/_session.py
@@ -75,11 +75,19 @@ def _get_boto3_session_for_profile(profile_name: str):
     # Also DCM credentials currently take several seconds to refresh. Lower the refresh timeouts so creds
     # are reused between API calls to save time.
     # See https://github.com/boto/botocore/blob/develop/botocore/credentials.py#L342-L362
-    credentials = session.get_credentials()
-    if isinstance(credentials, RefreshableCredentials):
-        credentials._advisory_refresh_timeout = 5 * 60  # 5 minutes
-        credentials._mandatory_refresh_timeout = 2.5 * 60  # 2.5 minutes
 
+    try:
+        credentials = session.get_credentials()
+        if (
+            isinstance(credentials, RefreshableCredentials)
+            and credentials.method == "custom-process"
+        ):
+            credentials._advisory_refresh_timeout = 5 * 60  # 5 minutes
+            credentials._mandatory_refresh_timeout = 2.5 * 60  # 2.5 minutes
+    except:  # noqa: E722
+        # Attempt to patch the timeouts but ignore any errors. These patched proeprties are internal and could change
+        # without notice. Creds are functional without patching timeouts.
+        pass
     return session
 
 

--- a/src/deadline/client/api/_session.py
+++ b/src/deadline/client/api/_session.py
@@ -72,13 +72,13 @@ def _get_boto3_session_for_profile(profile_name: str):
 
     # By default, DCM returns creds that expire after 15 minutes, and boto3's RefreshableCredentials
     # class refreshes creds that are within 15 minutes of expiring, so credentials would never be reused.
-    # Also DCM credentials currently take several seconds to refresh. Set the refresh timeouts to 1 and
-    # 2 minutes so they are reused between API calls to save time.
+    # Also DCM credentials currently take several seconds to refresh. Lower the refresh timeouts so creds
+    # are reused between API calls to save time.
     # See https://github.com/boto/botocore/blob/develop/botocore/credentials.py#L342-L362
     credentials = session.get_credentials()
     if isinstance(credentials, RefreshableCredentials):
-        credentials._advisory_refresh_timeout = 2 * 60  # 2 minutes
-        credentials._mandatory_refresh_timeout = 60  # 1 minute
+        credentials._advisory_refresh_timeout = 5 * 60  # 5 minutes
+        credentials._mandatory_refresh_timeout = 2.5 * 60  # 2.5 minutes
 
     return session
 

--- a/src/deadline/client/api/_session.py
+++ b/src/deadline/client/api/_session.py
@@ -5,6 +5,7 @@ Provides functionality for boto3 Sessions, Clients, and properties
 of the Deadline-configured IAM credentials.
 """
 from __future__ import annotations
+from functools import lru_cache
 import logging
 from configparser import ConfigParser
 from contextlib import contextmanager
@@ -22,12 +23,6 @@ from botocore.session import get_session as get_botocore_session
 
 from ..config import get_setting
 from ..exceptions import DeadlineOperationError
-
-__cached_boto3_session = None
-__cached_boto3_session_profile_name = None
-__cached_boto3_queue_session = None
-__cached_farm_id_for_queue_session = None
-__cached_queue_id_for_queue_session = None
 
 
 class AwsCredentialsSource(Enum):
@@ -57,8 +52,6 @@ def get_boto3_session(
         force_refresh (bool, optional): If set to True, forces a cache refresh.
         config (ConfigParser, optional): If provided, the AWS Deadline Cloud config to use.
     """
-    global __cached_boto3_session
-    global __cached_boto3_session_profile_name
 
     profile_name: Optional[str] = get_setting("defaults.aws_profile_name", config)
 
@@ -67,36 +60,32 @@ def get_boto3_session(
     if profile_name in ("(default)", "default", ""):
         profile_name = None
 
-    # If a config was provided, don't use the Session caching mechanism.
-    if config:
-        return boto3.Session(profile_name=profile_name)
-
     if force_refresh:
         invalidate_boto3_session_cache()
 
-    # If this is the first call or the profile name has changed, make a fresh Session
-    if not __cached_boto3_session or __cached_boto3_session_profile_name != profile_name:
-        __cached_boto3_session = boto3.Session(profile_name=profile_name)
-        __cached_boto3_session_profile_name = profile_name
+    return _get_boto3_session_for_profile(profile_name)
 
-    return __cached_boto3_session
+
+@lru_cache
+def _get_boto3_session_for_profile(profile_name: str):
+    session = boto3.Session(profile_name=profile_name)
+
+    # By default, DCM returns creds that expire after 15 minutes, and boto3's RefreshableCredentials
+    # class refreshes creds that are within 15 minutes of expiring, so credentials would never be reused.
+    # Also DCM credentials currently take several seconds to refresh. Set the refresh timeouts to 1 and
+    # 2 minutes so they are reused between API calls to save time.
+    # See https://github.com/boto/botocore/blob/develop/botocore/credentials.py#L342-L362
+    credentials = session.get_credentials()
+    if isinstance(credentials, RefreshableCredentials):
+        credentials._advisory_refresh_timeout = 2 * 60  # 2 minutes
+        credentials._mandatory_refresh_timeout = 60  # 1 minute
+
+    return session
 
 
 def invalidate_boto3_session_cache() -> None:
-    """
-    Invalidates the cached boto3 session and boto3 queue session.
-    """
-    global __cached_boto3_session
-    global __cached_boto3_session_profile_name
-    global __cached_boto3_queue_session
-    global __cached_farm_id_for_queue_session
-    global __cached_queue_id_for_queue_session
-
-    __cached_boto3_session = None
-    __cached_boto3_session_profile_name = None
-    __cached_boto3_queue_session = None
-    __cached_farm_id_for_queue_session = None
-    __cached_queue_id_for_queue_session = None
+    _get_boto3_session_for_profile.cache_clear()
+    _get_boto3_session_for_profile.cache_clear()
 
 
 def get_boto3_client(service_name: str, config: Optional[ConfigParser] = None) -> BaseClient:
@@ -182,10 +171,6 @@ def get_queue_user_boto3_session(
         force_refresh (bool, optional): If True, forces a cache refresh.
     """
 
-    global __cached_boto3_queue_session
-    global __cached_farm_id_for_queue_session
-    global __cached_queue_id_for_queue_session
-
     base_session = get_boto3_session(config=config, force_refresh=force_refresh)
 
     if farm_id is None:
@@ -193,28 +178,12 @@ def get_queue_user_boto3_session(
     if queue_id is None:
         queue_id = get_setting("defaults.queue_id")
 
-    # If a config was provided, don't use the Session caching mechanism.
-    if config:
-        return _get_queue_user_boto3_session(
-            deadline, base_session, farm_id, queue_id, queue_display_name
-        )
-
-    # If this is the first call or the farm ID/queue ID has changed, make a fresh Session and cache it
-    if (
-        not __cached_boto3_queue_session
-        or __cached_farm_id_for_queue_session != farm_id
-        or __cached_queue_id_for_queue_session != queue_id
-    ):
-        __cached_boto3_queue_session = _get_queue_user_boto3_session(
-            deadline, base_session, farm_id, queue_id, queue_display_name
-        )
-
-        __cached_farm_id_for_queue_session = farm_id
-        __cached_queue_id_for_queue_session = queue_id
-
-    return __cached_boto3_queue_session
+    return _get_queue_user_boto3_session(
+        deadline, base_session, farm_id, queue_id, queue_display_name
+    )
 
 
+@lru_cache
 def _get_queue_user_boto3_session(
     deadline: BaseClient,
     base_session: boto3.Session,

--- a/src/deadline/client/api/_session.py
+++ b/src/deadline/client/api/_session.py
@@ -93,7 +93,7 @@ def _get_boto3_session_for_profile(profile_name: str):
 
 def invalidate_boto3_session_cache() -> None:
     _get_boto3_session_for_profile.cache_clear()
-    _get_boto3_session_for_profile.cache_clear()
+    _get_queue_user_boto3_session.cache_clear()
 
 
 def get_boto3_client(service_name: str, config: Optional[ConfigParser] = None) -> BaseClient:

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -14,7 +14,14 @@ from deadline.client.config import config_file
 def fresh_deadline_config():
     """
     Fixture to start with a blank AWS Deadline Cloud config file.
+
     """
+
+    # Clear the session cache. Importing the cache invalidator at runtime is necessary
+    # to make sure the import order doesn't bypass moto mocking in other areas.
+    from deadline.client.api._session import invalidate_boto3_session_cache
+
+    invalidate_boto3_session_cache()
 
     try:
         # Create an empty temp file to set as the AWS Deadline Cloud config

--- a/test/unit/deadline_client/cli/test_cli_auth.py
+++ b/test/unit/deadline_client/cli/test_cli_auth.py
@@ -31,8 +31,10 @@ def test_cli_deadline_cloud_monitor_login_and_logout(fresh_deadline_config):
     config.set_setting("defaults.aws_profile_name", profile_name)
 
     with patch.object(api._session, "get_boto3_session") as session_mock, patch.object(
-        api._session, "invalidate_boto3_session_cache"
-    ) as invalidate_session_mock, patch.object(
+        api._session._get_boto3_session_for_profile, "cache_clear"
+    ) as mock_profile_session_cache_clear, patch.object(
+        api._session._get_queue_user_boto3_session, "cache_clear"
+    ) as mock_queue_session_cache_clear, patch.object(
         api, "get_boto3_session", new=session_mock
     ), patch.object(
         subprocess, "Popen"
@@ -83,7 +85,8 @@ def test_cli_deadline_cloud_monitor_login_and_logout(fresh_deadline_config):
         )
 
         assert "Successfully logged out" in result.output
-        invalidate_session_mock.assert_called()
+        mock_profile_session_cache_clear.assert_called()
+        mock_queue_session_cache_clear.assert_called()
 
 
 def test_cli_auth_status(fresh_deadline_config):

--- a/test/unit/deadline_client/cli/test_cli_auth.py
+++ b/test/unit/deadline_client/cli/test_cli_auth.py
@@ -31,8 +31,12 @@ def test_cli_deadline_cloud_monitor_login_and_logout(fresh_deadline_config):
     config.set_setting("defaults.aws_profile_name", profile_name)
 
     with patch.object(api._session, "get_boto3_session") as session_mock, patch.object(
+        api._session, "invalidate_boto3_session_cache"
+    ) as invalidate_session_mock, patch.object(
         api, "get_boto3_session", new=session_mock
-    ), patch.object(subprocess, "Popen") as popen_mock, patch.object(
+    ), patch.object(
+        subprocess, "Popen"
+    ) as popen_mock, patch.object(
         subprocess, "check_output"
     ) as check_output_mock:
         # The profile name
@@ -79,10 +83,7 @@ def test_cli_deadline_cloud_monitor_login_and_logout(fresh_deadline_config):
         )
 
         assert "Successfully logged out" in result.output
-
-        # Verify that the logout call clears the session caches
-        assert api._session._get_boto3_session_for_profile.cache_info()[3] == 0
-        assert api._session._get_queue_user_boto3_session.cache_info()[3] == 0
+        invalidate_session_mock.assert_called()
 
 
 def test_cli_auth_status(fresh_deadline_config):

--- a/test/unit/deadline_client/cli/test_cli_auth.py
+++ b/test/unit/deadline_client/cli/test_cli_auth.py
@@ -80,8 +80,9 @@ def test_cli_deadline_cloud_monitor_login_and_logout(fresh_deadline_config):
 
         assert "Successfully logged out" in result.output
 
-        # Verify that the logout call resets the cached session to None
-        assert api._session.__cached_boto3_session is None
+        # Verify that the logout call clears the session caches
+        assert api._session._get_boto3_session_for_profile.cache_info()[3] == 0
+        assert api._session._get_queue_user_boto3_session.cache_info()[3] == 0
 
 
 def test_cli_auth_status(fresh_deadline_config):


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The CLI and especially GUI submitter were very slow to make API calls. The root cause was poorly matched TTLs that resulted in credentials being refreshed from DCM before every API call.

DCM vends credentials which are valid for 15 minutes, and by default boto's credential handling refreshes credential when they're within 15 minutes of expiring. As a result, credential were always marked as stale and constantly refreshed. Refreshing DCM creds takes ~5 seconds, so every API call takes at least that long to complete. 

### What was the solution? (How)
Configure the refresh mechanism to only refresh creds when they're within 2 minutes of expiring. Also strip out a custom caching mechanism we had and use the much simpler `@lru_cache` decorator instead.

### What is the impact of this change?
DCM credentials and boto sessions are effectively reused resulting in a much more responsive GUI submitter (among other DCM functionality).

### How was this change tested?
- Have you run `hatch run test` ?
Yes

- Have you run `hatch run integ:test` ? See `DEVELOPMENT.md` on "Run integration tests"
Yes

Manual tests:
- I opened the GUI submitter, waited 15 minutes for the DCM creds to expire, then opened the settings window to trigger more API calls. The client refreshed credentials as expected.
- I verified these changes work with non-DCM credentials.
- 
### Was this change documented?
Not needed

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*