### PR TITLE
test: Squish `deadline config gui` settings dialogue automated tests

### DIFF
--- a/test/squish/suite_VerifySettingsDialogue/config.xml
+++ b/test/squish/suite_VerifySettingsDialogue/config.xml
@@ -1,0 +1,8 @@
+<testconfig version="1.0">
+    <information>
+        <summary/>
+        <description/>
+    </information>
+    <testsettings/>
+    <passwords/>
+</testconfig>

--- a/test/squish/suite_VerifySettingsDialogue/envvars
+++ b/test/squish/suite_VerifySettingsDialogue/envvars
@@ -1,0 +1,1 @@
+LD_LIBRARY_PATH=./.local/lib/python3.9/site-packages/PySide6/Qt/lib

--- a/test/squish/suite_VerifySettingsDialogue/shared/scripts/config.py
+++ b/test/squish/suite_VerifySettingsDialogue/shared/scripts/config.py
@@ -1,0 +1,16 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# mypy: disable-error-code="attr-defined"
+
+profile_name = "(default)"
+job_hist_dir = "~/.deadline/job_history/(default)"
+farm_name = "Deadline Cloud Squish Farm"
+queue_name = "Squish Automation Queue"
+storage_profile = "Squish Storage Profile"
+job_attachments = "COPIED"
+tooltip_text_copied = (
+    "When selected, the worker downloads all job attachments to disk before rendering begins."
+)
+tooltip_text_lightbulb = "This setting determines how job attachments are loaded on the worker instance. 'COPIED' may be faster if every task needs all attachments, while 'VIRTUAL' may perform better if tasks only require a subset of attachments."
+conflict_res_option = "NOT\\_SELECTED"
+conflict_res_option_expected_text = conflict_res_option.replace("\\_", "_")
+logging_level = "WARNING"

--- a/test/squish/suite_VerifySettingsDialogue/shared/scripts/gui_helpers.py
+++ b/test/squish/suite_VerifySettingsDialogue/shared/scripts/gui_helpers.py
@@ -1,0 +1,151 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# mypy: disable-error-code="attr-defined"
+
+import gui_locators
+import squish
+
+import test
+
+snooze_timeout = 1  # seconds
+
+
+def launch_deadline_config_gui():
+    squish.startApplication("deadline config gui")
+    test.log("Launched Deadline Config GUI.")
+    test.log(
+        "Sleep for " + str(snooze_timeout) + " second(s) to allow GUI authentication to fully load."
+    )
+    squish.snooze(snooze_timeout)
+    test.compare(
+        squish.waitForObjectExists(gui_locators.deadline_config_dialog).visible,
+        True,
+        "Expect the Deadline Config GUI to be open.",
+    )
+
+
+def close_deadline_config_gui():
+    test.log("Hitting `OK` button to close Deadline Config GUI.")
+    # hit 'OK' button to close Deadline Config GUI
+    squish.clickButton(squish.waitForObject(gui_locators.deadlinedialog_ok_button))
+
+
+def hit_apply_button():
+    test.log("Hitting `Apply` button to apply selected settings.")
+    # hit 'Apply' button
+    squish.clickButton(squish.waitForObject(gui_locators.deadlinedialog_apply_button))
+    test.log("Settings have been applied.")
+
+
+def set_farm_name(farm_name: str):
+    # open Default farm drop down menu
+    squish.mouseClick(squish.waitForObject(gui_locators.profilesettings_defaultfarm_dropdown))
+    test.log("Opened farm name drop down menu.")
+    test.compare(
+        squish.waitForObjectExists(gui_locators.farm_name_locator(farm_name)).text,
+        farm_name,
+        "Expect farm name to be present in drop down.",
+    )
+    # select Default farm
+    squish.mouseClick(
+        squish.waitForObjectItem(gui_locators.profilesettings_defaultfarm_dropdown, farm_name)
+    )
+    test.log("Selected farm name.")
+
+
+def open_close_job_hist_directory():
+    # hit '...' button to open Choose Job history directory file browser
+    squish.clickButton(squish.waitForObject(gui_locators.open_job_hist_dir_button))
+    test.log("Opened job history directory dialogue.")
+    # verify job history directory dialogue is open
+    test.compare(
+        str(squish.waitForObjectExists(gui_locators.choosejobhistdir_filebrowser).windowTitle),
+        "Choose Job history directory",
+        "Expect Choose Job history directory dialogue window title to be present.",
+    )
+    test.compare(
+        squish.waitForObjectExists(gui_locators.choosejobhistdir_filebrowser).visible,
+        True,
+        "Expect Choose Job history directory dialogue to be open.",
+    )
+    # hit 'choose' button to set default and close file browser
+    squish.clickButton(squish.waitForObject(gui_locators.choosejobhistdir_choose_button))
+    test.log("Closed job history directory dialogue.")
+
+
+def set_queue_name(queue_name: str):
+    # open Default queue drop down menu
+    squish.mouseClick(squish.waitForObject(gui_locators.farmsettings_defaultqueue_dropdown))
+    test.log("Opened queue name drop down menu.")
+    test.compare(
+        squish.waitForObjectExists(gui_locators.queue_name_locator(queue_name)).text,
+        queue_name,
+        "Expect queue name to be present in drop down.",
+    )
+    # select Default queue
+    squish.mouseClick(
+        squish.waitForObjectItem(gui_locators.farmsettings_defaultqueue_dropdown, queue_name)
+    )
+    test.log("Selected queue name.")
+
+
+def set_storage_profile(storage_profile: str):
+    # open Default storage profile drop down menu
+    squish.mouseClick(
+        squish.waitForObject(gui_locators.farmsettings_defaultstorageprofile_dropdown)
+    )
+    test.log("Opened storage profile drop down menu.")
+    test.compare(
+        squish.waitForObjectExists(gui_locators.storage_profile_locator(storage_profile)).text,
+        storage_profile,
+        "Expect storage profile to be present in drop down.",
+    )
+    # select Default storage profile
+    squish.mouseClick(
+        squish.waitForObjectItem(
+            gui_locators.farmsettings_defaultstorageprofile_dropdown, storage_profile
+        )
+    )
+    test.log("Selected storage profile.")
+
+
+def set_job_attachments_filesystem_options(job_attachments: str):
+    # open Job attachments filesystem options drop down menu
+    squish.mouseClick(
+        squish.waitForObject(gui_locators.farmsettings_jobattachmentsoptions_dropdown)
+    )
+    test.log("Opened job attachments filesystem options drop down menu.")
+    # select Job attachments filesystem options
+    squish.mouseClick(
+        squish.waitForObjectItem(
+            gui_locators.farmsettings_jobattachmentsoptions_dropdown, job_attachments
+        )
+    )
+    test.log("Selected job attachments filesystem option.")
+
+
+def set_conflict_resolution_option(conflict_res_option: str):
+    # open Conflict resolution option drop down menu
+    squish.mouseClick(
+        squish.waitForObject(gui_locators.conflictresolution_option_dropdown),
+    )
+    test.log("Opened conflict resolution option drop down menu.")
+    # select Conflict resolution option
+    squish.mouseClick(
+        squish.waitForObjectItem(
+            gui_locators.conflictresolution_option_dropdown, conflict_res_option
+        ),
+    )
+    test.log("Selected conflict resolution option.")
+
+
+def set_current_logging_level(logging_level: str):
+    # open Current logging level drop down menu
+    squish.mouseClick(
+        squish.waitForObject(gui_locators.currentlogging_level_dropdown),
+    )
+    test.log("Opened current logging level drop down menu.")
+    # select Current logging level
+    squish.mouseClick(
+        squish.waitForObjectItem(gui_locators.currentlogging_level_dropdown, logging_level),
+    )
+    test.log("Selected current logging level.")

--- a/test/squish/suite_VerifySettingsDialogue/shared/scripts/gui_locators.py
+++ b/test/squish/suite_VerifySettingsDialogue/shared/scripts/gui_locators.py
@@ -1,0 +1,251 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+# AWS Deadline Cloud workstation configuration dialogue
+deadline_config_dialog = {
+    "type": "DeadlineConfigDialog",
+    "unnamed": 1,
+    "visible": 1,
+    "windowTitle": "AWS Deadline Cloud workstation configuration",
+}
+# OK button
+deadlinedialog_ok_button = {
+    "text": "OK",
+    "type": "QPushButton",
+    "unnamed": 1,
+    "visible": 1,
+    "window": deadline_config_dialog,
+}
+# Apply button
+deadlinedialog_apply_button = {
+    "text": "Apply",
+    "type": "QPushButton",
+    "unnamed": 1,
+    "visible": 1,
+    "window": deadline_config_dialog,
+}
+
+# global settings box
+deadlinedialog_globalsettings_box = {
+    "title": "Global settings",
+    "type": "QGroupBox",
+    "unnamed": 1,
+    "visible": 1,
+    "window": deadline_config_dialog,
+}
+globalsettings_awsprofile_label = {
+    "container": deadlinedialog_globalsettings_box,
+    "text": "AWS profile",
+    "type": "QLabel",
+    "unnamed": 1,
+    "visible": 1,
+}
+globalsettings_awsprofile_dropdown = {
+    "container": deadlinedialog_globalsettings_box,
+    "leftWidget": globalsettings_awsprofile_label,
+    "type": "QComboBox",
+    "unnamed": 1,
+    "visible": 1,
+}
+# `(default)` aws profile element
+default_awsprofile_index = {
+    "container": globalsettings_awsprofile_dropdown,
+    "text": "(default)",
+    "type": "QModelIndex",
+}
+
+# profile settings box
+deadlinedialog_profilesettings_box = {
+    "title": "Profile settings",
+    "type": "QGroupBox",
+    "unnamed": 1,
+    "visible": 1,
+    "window": deadline_config_dialog,
+}
+profilesettings_defaultfarm_dropdown = {
+    "container": deadlinedialog_profilesettings_box,
+    "type": "QComboBox",
+    "unnamed": 1,
+    "visible": 1,
+}
+job_hist_dir_input = {
+    "container": deadlinedialog_profilesettings_box,
+    "type": "QLineEdit",
+    "unnamed": 1,
+    "visible": 1,
+}
+# Deadline Cloud Squish Farm element
+deadlinecloudsquish_defaultfarm_index = {
+    "container": profilesettings_defaultfarm_dropdown,
+    "text": "Deadline Cloud Squish Farm",
+    "type": "QModelIndex",
+}
+
+# choose job history directory file browser
+open_job_hist_dir_button = {
+    "container": deadlinedialog_profilesettings_box,
+    "text": "...",
+    "type": "QPushButton",
+    "unnamed": 1,
+    "visible": 1,
+}
+choosejobhistdir_filebrowser = {"name": "QFileDialog", "type": "QFileDialog", "visible": 1}
+choosejobhistdir_choose_button = {
+    "container": deadlinedialog_profilesettings_box,
+    "text": "Choose",
+    "type": "QPushButton",
+    "unnamed": 1,
+    "visible": 1,
+}
+
+# farm settings box
+deadlinedialog_farmsettings_box = {
+    "title": "Farm settings",
+    "type": "QGroupBox",
+    "unnamed": 1,
+    "visible": 1,
+    "window": deadline_config_dialog,
+}
+farmsettings_defaultqueue_dropdown = {
+    "container": deadlinedialog_farmsettings_box,
+    "type": "QComboBox",
+    "unnamed": 1,
+    "visible": 1,
+}
+farmsettings_defaultstorageprofile_dropdown = {
+    "container": deadlinedialog_farmsettings_box,
+    "occurrence": 2,
+    "type": "QComboBox",
+    "unnamed": 1,
+    "visible": 1,
+}
+farmsettings_jobattachmentsoptions_dropdown = {
+    "container": deadlinedialog_farmsettings_box,
+    "occurrence": 3,
+    "type": "QComboBox",
+    "unnamed": 1,
+    "visible": 1,
+}
+# Squish Automation Queue element
+squishautomationqueue_defaultqueue_index = {
+    "container": farmsettings_defaultqueue_dropdown,
+    "text": "Squish Automation Queue",
+    "type": "QModelIndex",
+}
+# Squish Storage Profile element
+squishstorageprofile_defaultstorageprofile_index = {
+    "container": farmsettings_defaultstorageprofile_dropdown,
+    "text": "Squish Storage Profile",
+    "type": "QModelIndex",
+}
+jobattachments_filesystemoptions_text_label = {
+    "container": deadlinedialog_farmsettings_box,
+    "text": "Job attachments filesystem options",
+    "type": "QLabel",
+    "unnamed": 1,
+    "visible": 1,
+}
+jobattachments_filesystemoptions_lightbulb_icon = {
+    "container": deadlinedialog_farmsettings_box,
+    "leftWidget": jobattachments_filesystemoptions_text_label,
+    "type": "QLabel",
+    "unnamed": 1,
+    "visible": 1,
+}
+
+
+# general settings box
+deadlinedialog_generalsettings_box = {
+    "title": "General settings",
+    "type": "QGroupBox",
+    "unnamed": 1,
+    "visible": 1,
+    "window": deadline_config_dialog,
+}
+autoaccept_promptdefaults_text_label = {
+    "container": deadlinedialog_generalsettings_box,
+    "text": "Auto accept prompt defaults",
+    "type": "QLabel",
+    "unnamed": 1,
+    "visible": 1,
+}
+autoaccept_promptdefaults_checkbox = {
+    "container": deadlinedialog_generalsettings_box,
+    "leftWidget": autoaccept_promptdefaults_text_label,
+    "type": "QCheckBox",
+    "unnamed": 1,
+    "visible": 1,
+}
+telemetry_optout_textlabel = {
+    "container": deadlinedialog_generalsettings_box,
+    "text": "Telemetry opt out",
+    "type": "QLabel",
+    "unnamed": 1,
+    "visible": 1,
+}
+telemetry_optout_checkbox = {
+    "container": deadlinedialog_generalsettings_box,
+    "leftWidget": telemetry_optout_textlabel,
+    "type": "QCheckBox",
+    "unnamed": 1,
+    "visible": 1,
+}
+conflictresolution_option_text_label = {
+    "container": deadlinedialog_generalsettings_box,
+    "text": "Conflict resolution option",
+    "type": "QLabel",
+    "unnamed": 1,
+    "visible": 1,
+}
+conflictresolution_option_dropdown = {
+    "container": deadlinedialog_generalsettings_box,
+    "leftWidget": conflictresolution_option_text_label,
+    "type": "QComboBox",
+    "unnamed": 1,
+    "visible": 1,
+}
+currentlogging_level_text_label = {
+    "container": deadlinedialog_generalsettings_box,
+    "text": "Current logging level",
+    "type": "QLabel",
+    "unnamed": 1,
+    "visible": 1,
+}
+currentlogging_level_dropdown = {
+    "container": deadlinedialog_generalsettings_box,
+    "leftWidget": currentlogging_level_text_label,
+    "type": "QComboBox",
+    "unnamed": 1,
+    "visible": 1,
+}
+
+
+def profile_name_locator(profile_name):
+    return {
+        "container": globalsettings_awsprofile_dropdown,
+        "text": profile_name,
+        "type": "QModelIndex",
+    }
+
+
+def farm_name_locator(farm_name):
+    return {
+        "container": profilesettings_defaultfarm_dropdown,
+        "text": farm_name,
+        "type": "QModelIndex",
+    }
+
+
+def queue_name_locator(queue_name):
+    return {
+        "container": farmsettings_defaultqueue_dropdown,
+        "text": queue_name,
+        "type": "QModelIndex",
+    }
+
+
+def storage_profile_locator(storage_profile):
+    return {
+        "container": farmsettings_defaultstorageprofile_dropdown,
+        "text": storage_profile,
+        "type": "QModelIndex",
+    }

--- a/test/squish/suite_VerifySettingsDialogue/shared/scripts/loginout_helpers.py
+++ b/test/squish/suite_VerifySettingsDialogue/shared/scripts/loginout_helpers.py
@@ -1,0 +1,100 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# mypy: disable-error-code="attr-defined"
+
+import loginout_locators
+import gui_locators
+import squish
+
+import test
+
+
+def check_and_close_refresh_error_dialogues():
+    """
+    When launching deadline config gui/settings dialogue, up to three refresh error dialogues can appear, and they appear in any order.
+    These dialogues must be closed prior to being able to select the correct profile for authentication, or logging in.
+    A scenario in which these dialogues appear is when a DCM-created profile is pre-selected (vs an aws profile) and the user has not logged in.
+    """
+    dialogue_names = {
+        "Farms Refresh Error": (
+            loginout_locators.refreshfarmslist_error_dialog,
+            loginout_locators.refreshfarmslist_ok_button,
+        ),
+        "Queues Refresh Error": (
+            loginout_locators.refreshqueueslist_error_dialog,
+            loginout_locators.refreshqueueslist_ok_button,
+        ),
+        "Storage Profiles Refresh Error": (
+            loginout_locators.refreshstorageprofiles_error_dialog,
+            loginout_locators.refreshstorageprofiles_ok_button,
+        ),
+    }
+    timeout = 300  # milliseconds
+
+    for _ in range(3):  # three attempts are needed as the three dialogues may or may not appear
+        for name, (error_dialogue, ok_button) in dialogue_names.items():
+            if error_dialogue:  # only check if the dialogue hasn't been handled yet
+                try:
+                    squish.waitForObject(error_dialogue, timeout)
+                    squish.mouseClick(ok_button)
+                    test.log(f"{name} appeared and was closed.")
+                    dialogue_names[name] = (None, None)  # mark as handled by setting to None
+                except LookupError:
+                    test.log(f"{name} was not present.")
+        if all(d[0] is None for d in dialogue_names.values()):
+            break
+
+
+def set_aws_profile_name_and_verify_auth(profile_name: str):
+    # open AWS profile drop down menu
+    squish.mouseClick(
+        squish.waitForObjectExists(gui_locators.globalsettings_awsprofile_dropdown),
+    )
+    test.log("Opened AWS profile drop down menu.")
+    test.compare(
+        squish.waitForObjectExists(gui_locators.profile_name_locator(profile_name)).text,
+        profile_name,
+        "Expect AWS profile name to be present in drop down.",
+    )
+    # select AWS profile
+    squish.mouseClick(gui_locators.profile_name_locator(profile_name))
+    test.log("Selected AWS profile name.")
+    # verify user is authenticated - confirm statuses appear and text is correct
+    test.log("Verifying user is authenticated...")
+    test.compare(
+        squish.waitForObjectExists(loginout_locators.credential_source_hostprovided_label).visible,
+        True,
+        "Expect `Credential source: HOST_PROVIDED` to be visible when selected aws profile.",
+    )
+    test.compare(
+        str(
+            squish.waitForObjectExists(loginout_locators.credential_source_hostprovided_label).text
+        ),
+        "<b style='color:green;'>HOST_PROVIDED</b>",
+        "Expect `Credential source: HOST_PROVIDED` text to be correct when selected aws profile.",
+    )
+    test.compare(
+        squish.waitForObjectExists(
+            loginout_locators.authentication_status_authenticated_label
+        ).visible,
+        True,
+        "Expect `Authentication status: AUTHENTICATED` to be visible.",
+    )
+    test.compare(
+        str(
+            squish.waitForObjectExists(
+                loginout_locators.authentication_status_authenticated_label
+            ).text
+        ),
+        "<b style='color:green;'>AUTHENTICATED</b>",
+        "Expect `Authentication status: AUTHENTICATED` text to be correct.",
+    )
+    test.compare(
+        squish.waitForObjectExists(loginout_locators.deadlinecloud_api_authorized_label).visible,
+        True,
+        "Expect `AWS Deadline Cloud API: AUTHORIZED` to be visible.",
+    )
+    test.compare(
+        str(squish.waitForObjectExists(loginout_locators.deadlinecloud_api_authorized_label).text),
+        "<b style='color:green;'>AUTHORIZED</b>",
+        "Expect `AWS Deadline Cloud API: AUTHORIZED` text to be correct.",
+    )

--- a/test/squish/suite_VerifySettingsDialogue/shared/scripts/loginout_locators.py
+++ b/test/squish/suite_VerifySettingsDialogue/shared/scripts/loginout_locators.py
@@ -1,0 +1,100 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# encoding: UTF-8
+
+import gui_locators
+
+# authentication status
+credential_source_auth_group = {
+    "title": "Credential source",
+    "type": "AuthenticationStatusGroup",
+    "unnamed": 1,
+    "visible": 1,
+    "window": gui_locators.deadline_config_dialog,
+}
+authentication_status_auth_group = {
+    "title": "Authentication status",
+    "type": "AuthenticationStatusGroup",
+    "unnamed": 1,
+    "visible": 1,
+    "window": gui_locators.deadline_config_dialog,
+}
+deadlinecloud_api_auth_group = {
+    "title": "AWS Deadline Cloud API",
+    "type": "AuthenticationStatusGroup",
+    "unnamed": 1,
+    "visible": 1,
+    "window": gui_locators.deadline_config_dialog,
+}
+credential_source_hostprovided_label = {
+    "container": credential_source_auth_group,
+    "text": "<b style='color:green;'>HOST_PROVIDED</b>",
+    "type": "QLabel",
+    "unnamed": 1,
+    "visible": 1,
+}
+credential_source_dcmlogin_label = {
+    "container": credential_source_auth_group,
+    "text": "<b style='color:green;'>DEADLINE_CLOUD_MONITOR_LOGIN</b>",
+    "type": "QLabel",
+    "unnamed": 1,
+    "visible": 1,
+}
+authentication_status_authenticated_label = {
+    "container": authentication_status_auth_group,
+    "text": "<b style='color:green;'>AUTHENTICATED</b>",
+    "type": "QLabel",
+    "unnamed": 1,
+    "visible": 1,
+}
+deadlinecloud_api_authorized_label = {
+    "container": deadlinecloud_api_auth_group,
+    "text": "<b style='color:green;'>AUTHORIZED</b>",
+    "type": "QLabel",
+    "unnamed": 1,
+    "visible": 1,
+}
+
+# refresh farms list error dialogue
+refreshfarmslist_error_dialog = {
+    "type": "QMessageBox",
+    "unnamed": 1,
+    "visible": 1,
+    "windowTitle": "Refresh Farms list",
+}
+refreshfarmslist_ok_button = {
+    "text": "OK",
+    "type": "QPushButton",
+    "unnamed": 1,
+    "visible": 1,
+    "window": refreshfarmslist_error_dialog,
+}
+
+# refresh queues list error dialogue
+refreshqueueslist_error_dialog = {
+    "type": "QMessageBox",
+    "unnamed": 1,
+    "visible": 1,
+    "windowTitle": "Refresh Queues list",
+}
+refreshqueueslist_ok_button = {
+    "text": "OK",
+    "type": "QPushButton",
+    "unnamed": 1,
+    "visible": 1,
+    "window": refreshqueueslist_error_dialog,
+}
+
+# refresh storage profiles list error dialogue
+refreshstorageprofiles_error_dialog = {
+    "type": "QMessageBox",
+    "unnamed": 1,
+    "visible": 1,
+    "windowTitle": "Refresh Storage profiles list",
+}
+refreshstorageprofiles_ok_button = {
+    "text": "OK",
+    "type": "QPushButton",
+    "unnamed": 1,
+    "visible": 1,
+    "window": refreshstorageprofiles_error_dialog,
+}

--- a/test/squish/suite_VerifySettingsDialogue/shared/scripts/names.py
+++ b/test/squish/suite_VerifySettingsDialogue/shared/scripts/names.py
@@ -1,0 +1,290 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+# from objectmaphelper import *
+refresh_Farms_list_QMessageBox = {
+    "type": "QMessageBox",
+    "unnamed": 1,
+    "visible": 1,
+    "windowTitle": "Refresh Farms list",
+}
+refresh_Farms_list_OK_QPushButton = {
+    "text": "OK",
+    "type": "QPushButton",
+    "unnamed": 1,
+    "visible": 1,
+    "window": refresh_Farms_list_QMessageBox,
+}
+refresh_Queues_list_QMessageBox = {
+    "type": "QMessageBox",
+    "unnamed": 1,
+    "visible": 1,
+    "windowTitle": "Refresh Queues list",
+}
+refresh_Queues_list_OK_QPushButton = {
+    "text": "OK",
+    "type": "QPushButton",
+    "unnamed": 1,
+    "visible": 1,
+    "window": refresh_Queues_list_QMessageBox,
+}
+refresh_Storage_profiles_list_QMessageBox = {
+    "type": "QMessageBox",
+    "unnamed": 1,
+    "visible": 1,
+    "windowTitle": "Refresh Storage profiles list",
+}
+refresh_Storage_profiles_list_OK_QPushButton = {
+    "text": "OK",
+    "type": "QPushButton",
+    "unnamed": 1,
+    "visible": 1,
+    "window": refresh_Storage_profiles_list_QMessageBox,
+}
+aWS_Deadline_Cloud_workstation_configuration_DeadlineConfigDialog = {
+    "type": "DeadlineConfigDialog",
+    "unnamed": 1,
+    "visible": 1,
+    "windowTitle": "AWS Deadline Cloud workstation configuration",
+}
+aWS_Deadline_Cloud_workstation_configuration_Credential_source_AuthenticationStatusGroup = {
+    "title": "Credential source",
+    "type": "AuthenticationStatusGroup",
+    "unnamed": 1,
+    "visible": 1,
+    "window": aWS_Deadline_Cloud_workstation_configuration_DeadlineConfigDialog,
+}
+aWS_Deadline_Cloud_workstation_configuration_Authentication_status_AuthenticationStatusGroup = {
+    "title": "Authentication status",
+    "type": "AuthenticationStatusGroup",
+    "unnamed": 1,
+    "visible": 1,
+    "window": aWS_Deadline_Cloud_workstation_configuration_DeadlineConfigDialog,
+}
+aWS_Deadline_Cloud_workstation_configuration_AWS_Deadline_Cloud_API_AuthenticationStatusGroup = {
+    "title": "AWS Deadline Cloud API",
+    "type": "AuthenticationStatusGroup",
+    "unnamed": 1,
+    "visible": 1,
+    "window": aWS_Deadline_Cloud_workstation_configuration_DeadlineConfigDialog,
+}
+credential_source_b_style_color_green_HOST_PROVIDED_b_QLabel = {
+    "container": aWS_Deadline_Cloud_workstation_configuration_Credential_source_AuthenticationStatusGroup,
+    "text": "<b style='color:green;'>HOST_PROVIDED</b>",
+    "type": "QLabel",
+    "unnamed": 1,
+    "visible": 1,
+}
+credential_source_b_style_color_green_DEADLINE_CLOUD_MONITOR_LOGIN_b_QLabel = {
+    "container": aWS_Deadline_Cloud_workstation_configuration_Credential_source_AuthenticationStatusGroup,
+    "text": "<b style='color:green;'>DEADLINE_CLOUD_MONITOR_LOGIN</b>",
+    "type": "QLabel",
+    "unnamed": 1,
+    "visible": 1,
+}
+authentication_status_b_style_color_green_AUTHENTICATED_b_QLabel = {
+    "container": aWS_Deadline_Cloud_workstation_configuration_Authentication_status_AuthenticationStatusGroup,
+    "text": "<b style='color:green;'>AUTHENTICATED</b>",
+    "type": "QLabel",
+    "unnamed": 1,
+    "visible": 1,
+}
+aWS_Deadline_Cloud_API_b_style_color_green_AUTHORIZED_b_QLabel = {
+    "container": aWS_Deadline_Cloud_workstation_configuration_AWS_Deadline_Cloud_API_AuthenticationStatusGroup,
+    "text": "<b style='color:green;'>AUTHORIZED</b>",
+    "type": "QLabel",
+    "unnamed": 1,
+    "visible": 1,
+}
+aWS_Deadline_Cloud_workstation_configuration_OK_QPushButton = {
+    "text": "OK",
+    "type": "QPushButton",
+    "unnamed": 1,
+    "visible": 1,
+    "window": aWS_Deadline_Cloud_workstation_configuration_DeadlineConfigDialog,
+}
+aWS_Deadline_Cloud_workstation_configuration_Apply_QPushButton = {
+    "text": "Apply",
+    "type": "QPushButton",
+    "unnamed": 1,
+    "visible": 1,
+    "window": aWS_Deadline_Cloud_workstation_configuration_DeadlineConfigDialog,
+}
+aWS_Deadline_Cloud_workstation_configuration_Global_settings_QGroupBox = {
+    "title": "Global settings",
+    "type": "QGroupBox",
+    "unnamed": 1,
+    "visible": 1,
+    "window": aWS_Deadline_Cloud_workstation_configuration_DeadlineConfigDialog,
+}
+global_settings_AWS_profile_QLabel = {
+    "container": aWS_Deadline_Cloud_workstation_configuration_Global_settings_QGroupBox,
+    "text": "AWS profile",
+    "type": "QLabel",
+    "unnamed": 1,
+    "visible": 1,
+}
+global_settings_AWS_profile_QComboBox = {
+    "container": aWS_Deadline_Cloud_workstation_configuration_Global_settings_QGroupBox,
+    "leftWidget": global_settings_AWS_profile_QLabel,
+    "type": "QComboBox",
+    "unnamed": 1,
+    "visible": 1,
+}
+aWS_profile_default_QModelIndex = {
+    "container": global_settings_AWS_profile_QComboBox,
+    "text": "(default)",
+    "type": "QModelIndex",
+}
+aWS_Deadline_Cloud_workstation_configuration_Profile_settings_QGroupBox = {
+    "title": "Profile settings",
+    "type": "QGroupBox",
+    "unnamed": 1,
+    "visible": 1,
+    "window": aWS_Deadline_Cloud_workstation_configuration_DeadlineConfigDialog,
+}
+profile_settings_QComboBox = {
+    "container": aWS_Deadline_Cloud_workstation_configuration_Profile_settings_QGroupBox,
+    "type": "QComboBox",
+    "unnamed": 1,
+    "visible": 1,
+}
+profile_settings_QLineEdit = {
+    "container": aWS_Deadline_Cloud_workstation_configuration_Profile_settings_QGroupBox,
+    "type": "QLineEdit",
+    "unnamed": 1,
+    "visible": 1,
+}
+deadline_Cloud_Squish_Farm_QModelIndex = {
+    "container": profile_settings_QComboBox,
+    "text": "Deadline Cloud Squish Farm",
+    "type": "QModelIndex",
+}
+profile_settings_QPushButton = {
+    "container": aWS_Deadline_Cloud_workstation_configuration_Profile_settings_QGroupBox,
+    "text": "...",
+    "type": "QPushButton",
+    "unnamed": 1,
+    "visible": 1,
+}
+qFileDialog_QFileDialog = {"name": "QFileDialog", "type": "QFileDialog", "visible": 1}
+profile_settings_Choose_QPushButton = {
+    "container": aWS_Deadline_Cloud_workstation_configuration_Profile_settings_QGroupBox,
+    "text": "Choose",
+    "type": "QPushButton",
+    "unnamed": 1,
+    "visible": 1,
+}
+aWS_Deadline_Cloud_workstation_configuration_Farm_settings_QGroupBox = {
+    "title": "Farm settings",
+    "type": "QGroupBox",
+    "unnamed": 1,
+    "visible": 1,
+    "window": aWS_Deadline_Cloud_workstation_configuration_DeadlineConfigDialog,
+}
+farm_settings_QComboBox = {
+    "container": aWS_Deadline_Cloud_workstation_configuration_Farm_settings_QGroupBox,
+    "type": "QComboBox",
+    "unnamed": 1,
+    "visible": 1,
+}
+farm_settings_QComboBox_2 = {
+    "container": aWS_Deadline_Cloud_workstation_configuration_Farm_settings_QGroupBox,
+    "occurrence": 2,
+    "type": "QComboBox",
+    "unnamed": 1,
+    "visible": 1,
+}
+farm_settings_QComboBox_3 = {
+    "container": aWS_Deadline_Cloud_workstation_configuration_Farm_settings_QGroupBox,
+    "occurrence": 3,
+    "type": "QComboBox",
+    "unnamed": 1,
+    "visible": 1,
+}
+squish_Automation_Queue_QModelIndex = {
+    "container": farm_settings_QComboBox,
+    "text": "Squish Automation Queue",
+    "type": "QModelIndex",
+}
+squish_Storage_Profile_QModelIndex = {
+    "container": farm_settings_QComboBox_2,
+    "text": "Squish Storage Profile",
+    "type": "QModelIndex",
+}
+farm_settings_Job_attachments_filesystem_options_QLabel = {
+    "container": aWS_Deadline_Cloud_workstation_configuration_Farm_settings_QGroupBox,
+    "text": "Job attachments filesystem options",
+    "type": "QLabel",
+    "unnamed": 1,
+    "visible": 1,
+}
+farm_settings_Job_attachments_filesystem_options_QLabel_2 = {
+    "container": aWS_Deadline_Cloud_workstation_configuration_Farm_settings_QGroupBox,
+    "leftWidget": farm_settings_Job_attachments_filesystem_options_QLabel,
+    "type": "QLabel",
+    "unnamed": 1,
+    "visible": 1,
+}
+aWS_Deadline_Cloud_workstation_configuration_General_settings_QGroupBox = {
+    "title": "General settings",
+    "type": "QGroupBox",
+    "unnamed": 1,
+    "visible": 1,
+    "window": aWS_Deadline_Cloud_workstation_configuration_DeadlineConfigDialog,
+}
+general_settings_Auto_accept_prompt_defaults_QLabel = {
+    "container": aWS_Deadline_Cloud_workstation_configuration_General_settings_QGroupBox,
+    "text": "Auto accept prompt defaults",
+    "type": "QLabel",
+    "unnamed": 1,
+    "visible": 1,
+}
+general_settings_Auto_accept_prompt_defaults_QCheckBox = {
+    "container": aWS_Deadline_Cloud_workstation_configuration_General_settings_QGroupBox,
+    "leftWidget": general_settings_Auto_accept_prompt_defaults_QLabel,
+    "type": "QCheckBox",
+    "unnamed": 1,
+    "visible": 1,
+}
+general_settings_Telemetry_opt_out_QLabel = {
+    "container": aWS_Deadline_Cloud_workstation_configuration_General_settings_QGroupBox,
+    "text": "Telemetry opt out",
+    "type": "QLabel",
+    "unnamed": 1,
+    "visible": 1,
+}
+general_settings_Telemetry_opt_out_QCheckBox = {
+    "container": aWS_Deadline_Cloud_workstation_configuration_General_settings_QGroupBox,
+    "leftWidget": general_settings_Telemetry_opt_out_QLabel,
+    "type": "QCheckBox",
+    "unnamed": 1,
+    "visible": 1,
+}
+general_settings_Conflict_resolution_option_QLabel = {
+    "container": aWS_Deadline_Cloud_workstation_configuration_General_settings_QGroupBox,
+    "text": "Conflict resolution option",
+    "type": "QLabel",
+    "unnamed": 1,
+    "visible": 1,
+}
+general_settings_Conflict_resolution_option_QComboBox = {
+    "container": aWS_Deadline_Cloud_workstation_configuration_General_settings_QGroupBox,
+    "leftWidget": general_settings_Conflict_resolution_option_QLabel,
+    "type": "QComboBox",
+    "unnamed": 1,
+    "visible": 1,
+}
+general_settings_Current_logging_level_QLabel = {
+    "container": aWS_Deadline_Cloud_workstation_configuration_General_settings_QGroupBox,
+    "text": "Current logging level",
+    "type": "QLabel",
+    "unnamed": 1,
+    "visible": 1,
+}
+general_settings_Current_logging_level_QComboBox = {
+    "container": aWS_Deadline_Cloud_workstation_configuration_General_settings_QGroupBox,
+    "leftWidget": general_settings_Current_logging_level_QLabel,
+    "type": "QComboBox",
+    "unnamed": 1,
+    "visible": 1,
+}

--- a/test/squish/suite_VerifySettingsDialogue/suite.conf
+++ b/test/squish/suite_VerifySettingsDialogue/suite.conf
@@ -1,0 +1,9 @@
+AUT=deadline config gui
+ENVVARS=envvars
+HOOK_SUB_PROCESSES=true
+IMPLICITAUTSTART=0
+LANGUAGE=Python
+OBJECTMAPSTYLE=script
+TEST_CASES=tst_VerifySettingsDialogue
+VERSION=3
+WRAPPERS=Qt

--- a/test/squish/suite_VerifySettingsDialogue/tst_VerifySettingsDialogue/test.py
+++ b/test/squish/suite_VerifySettingsDialogue/tst_VerifySettingsDialogue/test.py
@@ -1,0 +1,147 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# mypy: disable-error-code="attr-defined"
+
+import config
+import gui_helpers
+import gui_locators
+import loginout_helpers
+import squish
+
+import test
+
+
+def init():
+    # launch deadline config gui
+    gui_helpers.launch_deadline_config_gui()
+    # check for refresh error dialogues and close if present
+    loginout_helpers.check_and_close_refresh_error_dialogues()
+    # using aws credential/non-DCM profile, set aws profile name to `(default)`
+    loginout_helpers.set_aws_profile_name_and_verify_auth(config.profile_name)
+    # verify correct aws profile name is set
+    test.compare(
+        squish.waitForObjectExists(gui_locators.globalsettings_awsprofile_dropdown).currentText,
+        config.profile_name,
+        "Expect selected AWS profile name to be set.",
+    )
+
+
+def main():
+    # verify default job history directory file path is correct
+    test.compare(
+        squish.waitForObjectExists(gui_locators.job_hist_dir_input).displayText,
+        config.job_hist_dir,
+        "Expect correct job history directory file path to be displayed by default.",
+    )
+    # open and close job history directory file browser
+    gui_helpers.open_close_job_hist_directory()
+    # verify selected job history directory path is set
+    test.compare(
+        str(squish.waitForObjectExists(gui_locators.job_hist_dir_input).displayText),
+        config.job_hist_dir,
+        "Expect selected job history directory file path to be set.",
+    )
+    # set farm name
+    gui_helpers.set_farm_name(config.farm_name)
+    # verify correct farm name is set
+    test.compare(
+        str(
+            squish.waitForObjectExists(
+                gui_locators.profilesettings_defaultfarm_dropdown
+            ).currentText
+        ),
+        config.farm_name,
+        "Expect selected farm name to be set.",
+    )
+    # set queue name
+    gui_helpers.set_queue_name(config.queue_name)
+    # verify correct queue name is set
+    test.compare(
+        str(
+            squish.waitForObjectExists(gui_locators.farmsettings_defaultqueue_dropdown).currentText
+        ),
+        config.queue_name,
+        "Expect selected queue name to be set.",
+    )
+    # set storage profile
+    gui_helpers.set_storage_profile(config.storage_profile)
+    # verify correct storage profile name is set
+    test.compare(
+        str(
+            squish.waitForObjectExists(
+                gui_locators.farmsettings_defaultstorageprofile_dropdown
+            ).currentText
+        ),
+        config.storage_profile,
+        "Expect selected storage profile to be set.",
+    )
+    # set job attachments filesystem options
+    gui_helpers.set_job_attachments_filesystem_options(config.job_attachments)
+    # verify job attachments filesystem options is set to 'COPIED'
+    test.compare(
+        str(
+            squish.waitForObjectExists(
+                gui_locators.farmsettings_jobattachmentsoptions_dropdown
+            ).currentText
+        ),
+        config.job_attachments,
+        "Expect selected job attachment filesystem option to be set.",
+    )
+    # verify 'COPIED' contains correct tooltip text
+    test.compare(
+        str(
+            squish.waitForObjectExists(
+                gui_locators.farmsettings_jobattachmentsoptions_dropdown
+            ).toolTip
+        ),
+        config.tooltip_text_copied,
+        "Expect COPIED to contain correct tooltip text.",
+    )
+    # verify job attachments filesystem options lightbulb icon contains correct tooltip text
+    test.compare(
+        str(
+            squish.waitForObjectExists(
+                gui_locators.jobattachments_filesystemoptions_lightbulb_icon
+            ).toolTip
+        ),
+        config.tooltip_text_lightbulb,
+        "Expect job attachments filesystem options lightbulb icon to contain correct tooltip text.",
+    )
+    # verify auto accept prompt defaults checkbox is checkable
+    test.compare(
+        squish.waitForObjectExists(gui_locators.autoaccept_promptdefaults_checkbox).checkable,
+        True,
+        "Expect auto accept prompt defaults checkbox to be checkable.",
+    )
+    # verify telemetry opt out checkbox is checkable
+    test.compare(
+        squish.waitForObjectExists(gui_locators.telemetry_optout_checkbox).checkable,
+        True,
+        "Expect telemetry opt out checkbox to be checkable.",
+    )
+    # set conflict resolution option
+    gui_helpers.set_conflict_resolution_option(config.conflict_res_option)
+    # verify conflict resolution option is set to 'NOT_SELECTED'
+    test.compare(
+        str(
+            squish.waitForObjectExists(gui_locators.conflictresolution_option_dropdown).currentText
+        ),
+        config.conflict_res_option_expected_text,
+        "Expect selected conflict resolution option to be set.",
+    )
+    # set current logging level option
+    gui_helpers.set_current_logging_level(config.logging_level)
+    # verify current logging level option is set to 'WARNING'
+    test.compare(
+        str(squish.waitForObjectExists(gui_locators.currentlogging_level_dropdown).currentText),
+        config.logging_level,
+        "Expect selected current logging level to be set.",
+    )
+    test.log("All deadline config GUI settings have been set.")
+
+
+def cleanup():
+    # reset aws profile name to `(default)`
+    loginout_helpers.set_aws_profile_name_and_verify_auth(config.profile_name)
+    test.log("Reset aws profile name to `(default)` for test cleanup.")
+    # close deadline config gui
+    gui_helpers.close_deadline_config_gui()


### PR DESCRIPTION
In the latest PR revision (08/30/2024), I've incorporated the following changes (which are now all in one commit):
- renamed/updated what was probably over 100 Squish locators into more friendly/readable names; preserved the `.names.py` file so we can still keep the old names that Squish automatically generates. Note that as more tests are recorded, the new locators will get added into the file. I also decided not to add this file into .gitignore etc since as new locators get added into the repo, they should get updated in the `.names.py` file, and they actually will not be different for those working in the suite (as mentioned in a comment below).  
- create a separate config file for the test resources (ie: profile name, farm name, etc). 
- re-organized some locators/functions into `loginout` pages as the authentication-related locators/statuses made more sense there (than in gui_locator/helpers file which is where it was previously). 
- fixed a couple typos, formatting issues, etc. 
_______________________________________________________________________________________________________


### What was the problem/requirement? (What/Why)
The same details from this old PR can still be referenced in this current PR: https://github.com/aws-deadline/deadline-cloud/pull/399

One notable change I incorporated was adding setup/tear down functions (in which I had login and logout functions in mind). After some discussion, we decided to use `default aws profile` (versus a DCM profile) for authentication, so that logging in is not necessary. Additionally, I added a function to clear refresh error dialogues (as part of setup) as those can occasionally appear if a DCM profile was pre-selected in the dialogue prior to starting the tests (as a developer or anyone working locally can have a different profile setup prior to running the tests.)

Other changes include refactoring the test suite as I'd previously added verifications in helper functions themselves (which can be fine if the helper functions need verifications to ensure they are working) and so I added the main test verifications into `test.py` instead. I also refactored the variable names from `camelCase` to `snake_case` (to remain consistent with the naming conventions with the rest of the repo and given that we're using Python anyway). 

All in all, there's a total of 33 tests added for the `deadline config gui` settings dialogue. 

### What was the solution? (How)
Note that if one is working locally and developing the tests and running the test with the default aws profile, you'll need to authenticate first with credentials (or another option is to add them to the environment variable config). You'll need to specify region as well (and add it to your env var config) if you are running the tests on a different region (in my case, I was automating using a farm on `us-east-1` region. 

There are two ways to run Squish tests and where you can input these credential/env vars:
1. Using the terminal. Be sure to set any authentication credentials in the terminal, set the region using `export AWS_DEFAULT_REGION=` env var and then you can run the squish tests (which, you'll also need to be in the correect folder for) (example command: `./squishrunner --testsuite <../../../<squish_folder>/suite_VerifySettingsDialogue --local`
2. Using the Squish IDE. You'll need to set any authentication credentials which are env vars in the config file, in addition to the `export AWS_DEFAULT_PROFILE=` env var. Once set, the default aws profile should authenticate when running the Squish tests directly from the IDE. 

Additionally, as mentioned in the previous PR, you'll need to point the `LD_LIBRARY_PATH` env var to where the `PySide6/Qt` libraries live on your system in the config. 

For reference, below are some screenshots from the Logs when the tests have finished running. In this case, all the tests successfully passed: 
![Screenshot 2024-08-25 at 10 27 37 PM](https://github.com/user-attachments/assets/c978006f-51f5-4163-a6e4-ee7f78c588af)
![Screenshot 2024-08-25 at 10 28 07 PM](https://github.com/user-attachments/assets/1680730a-a264-480f-99a7-c12e6451d6c6)

### What is the impact of this change?
--See old PR.

### How was this change tested?
- Have you run `hatch run test` ?
Yes, 83% of the tests are passing (where is says at least 80% of tests is minimum for passing criteria). I'm not sure why this is but I'm looking into it so 100% of tests can pass. 

- Have you run `hatch run integ:test` ? See `DEVELOPMENT.md` on "Run integration tests"
Yes, and all the tests passed. 
![Screenshot 2024-08-27 at 1 39 48 AM](https://github.com/user-attachments/assets/75db6af8-7d47-495b-a53c-461f06bb9776)

Additionally,
I've run a couple failure-case tests for the Squish suite itself, to ensure that things error out or fail as expected when some expected errors/failures occur:
- When selecting a DCM profile - (ensured that things error out as expected, ensured that the refresh error dialogues where checked and/or found and then closed out correctly)
![Screenshot 2024-08-25 at 11 18 01 PM](https://github.com/user-attachments/assets/20f2cf42-f9a3-4c0b-b7dc-340cc84e6a48)

- When selecting resources that are missing or don't exist - (ensured that things errored out as expected)
![Screenshot 2024-08-25 at 11 08 19 PM](https://github.com/user-attachments/assets/d09eac35-04af-495e-b52a-20435feeb8bc)

### Was this change documented?
The only documentation that has been asked of me is a doc describing how we are planning to use this test suite (and I will have that alongside writing additional tests). 

### Is this a breaking change?
--See old PR.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*