### PR TITLE
feat: adds --storage-profile-id option to the bundle submit command

### DIFF
--- a/src/deadline/client/cli/_common.py
+++ b/src/deadline/client/cli/_common.py
@@ -96,6 +96,12 @@ def _apply_cli_options_to_config(
         if queue_id:
             config_file.set_setting("defaults.queue_id", queue_id, config=config)
 
+        storage_profile_id = args.pop("storage_profile_id", None)
+        if storage_profile_id:
+            config_file.set_setting(
+                "settings.storage_profile_id", storage_profile_id, config=config
+            )
+
         job_id = args.pop("job_id", None)
         if job_id:
             config_file.set_setting("defaults.job_id", job_id, config=config)
@@ -111,7 +117,7 @@ def _apply_cli_options_to_config(
             )
     else:
         # Remove the standard option names from the args list
-        for name in ["profile", "farm_id", "queue_id", "job_id"]:
+        for name in ["profile", "farm_id", "queue_id", "job_id", "storage_profile_id"]:
             args.pop(name, None)
 
     # Check that the required options have values

--- a/src/deadline/client/cli/_groups/bundle_group.py
+++ b/src/deadline/client/cli/_groups/bundle_group.py
@@ -82,6 +82,7 @@ def validate_parameters(ctx, param, value):
 @click.option("--profile", help="The AWS profile to use.")
 @click.option("--farm-id", help="The farm to use.")
 @click.option("--queue-id", help="The queue to use.")
+@click.option("--storage-profile-id", help="The storage profile to use.")
 @click.option("--name", help="The job name to use in place of the one in the job bundle.")
 @click.option(
     "--priority",
@@ -140,7 +141,7 @@ def bundle_submit(
     """
     Submits an Open Job Description job bundle.
     """
-    # Get a temporary config object with the standard options handled
+    # Apply the CLI args to the config
     config = _apply_cli_options_to_config(required_options={"farm_id", "queue_id"}, **args)
 
     hash_callback_manager = _ProgressBarCallbackManager(length=100, label="Hashing Attachments")
@@ -226,6 +227,7 @@ def bundle_submit(
             and args.get("profile") is None
             and args.get("farm_id") is None
             and args.get("queue_id") is None
+            and args.get("storage_profile_id") is None
         ):
             set_setting("defaults.job_id", job_id)
 

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -34,6 +34,11 @@ def fresh_deadline_config():
         # Yield the temp file name with it patched in as the
         # AWS Deadline Cloud config file
         with patch.object(config_file, "CONFIG_FILE_PATH", str(temp_file_path)):
+            # Write a telemetry id to force it getting saved to the config file. If we don't, then
+            # an ID will get generated and force a save of the config file in the middle of a test.
+            # Writing the config file may be undesirable in the middle of a test.
+            config_file.set_setting("telemetry.identifier", "00000000-0000-0000-0000-000000000000")
+
             yield str(temp_file_path)
     finally:
         temp_dir.cleanup()

--- a/test/unit/deadline_job_attachments/test_download.py
+++ b/test/unit/deadline_job_attachments/test_download.py
@@ -2430,7 +2430,7 @@ def test_download_files_from_manifests(
 
     with patch(
         f"{deadline.__package__}.job_attachments.download.download_file", side_effect=download_file
-    ):
+    ), patch(f"{deadline.__package__}.job_attachments.download.get_s3_client"):
         download_files_from_manifests(
             s3_bucket="s3_settings.s3BucketName",
             manifests_by_root={"/test": merged_manifest},


### PR DESCRIPTION
Fixes:  No github issue created.

### What was the problem/requirement? (What/Why)

Customers have expressed the need to be able to provide an override for the storage profile id when submitting jobs using `deadline bundle submit`, but that command doesn't provide a way to override that setting. The use-case is submitting many jobs, in parallel, from the same host where jobs need different storage profile ids.

### What was the solution? (How)

Add an override. Using the override does not store the given storage profile id to the user's configuration file.

### What is the impact of this change?

Those creating pipeline automation have one less barrier in their way.

### How was this change tested?

I've run added to and run the unit tests. I have also run the new command option to ensure that the command submits jobs with the default as well as overriden storage profile id, and that the overriden id is not saved to the config. Log below:

```bash
% deadline config get settings.storage_profile_id                                    
sp-44e420f6a725493ba4067a89c60ce01c

% deadline bundle submit test_bundle
Submitting to Queue: MainQueue
Waiting for Job to be created...
Submitted job bundle:
   test_bundle
Job creation completed successfully
job-61473d1df8ba42ada64a74966171d644

% deadline job get
jobId: job-61473d1df8ba42ada64a74966171d644
...
storageProfileId: sp-44e420f6a725493ba4067a89c60ce01c
...     

% deadline config get settings.storage_profile_id                                    
sp-44e420f6a725493ba4067a89c60ce01c

% deadline bundle submit test_bundle --storage-profile-id sp-ef65fd46b42e46f19e4bb28dd2da7537
Submitting to Queue: MainQueue
Waiting for Job to be created...
Submitted job bundle:
   test_bundle
Job creation completed successfully
job-d711a6c9b1734e8f8bb826f7dffe1ea4

% deadline config get settings.storage_profile_id                                            
sp-44e420f6a725493ba4067a89c60ce01c
```

### Was this change documented?

The new CLI option does have help text that indicates what it is.

### Is this a breaking change?

No. The change is purely additive, and 100% optional.

### Does this change impact security?

It does not.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*