### PR TITLE
fix: only override queue environment settings if empty

### DIFF
--- a/src/deadline/client/ui/widgets/shared_job_settings_tab.py
+++ b/src/deadline/client/ui/widgets/shared_job_settings_tab.py
@@ -184,7 +184,8 @@ class SharedJobSettingsWidget(QWidget):  # pylint: disable=too-few-public-method
             # Apply the initial queue parameter values
             for parameter in queue_parameters:
                 if parameter["name"] in self.initial_shared_parameter_values:
-                    parameter["value"] = self.initial_shared_parameter_values[parameter["name"]]
+                    if parameter["default"] == "":
+                        parameter["value"] = self.initial_shared_parameter_values[parameter["name"]]
             self.queue_parameters_box.rebuild_ui(parameter_definitions=queue_parameters)
 
     def _load_queue_parameters_thread_function(self, refresh_id: int, farm_id: str, queue_id: str):


### PR DESCRIPTION
Fixes: CondaPackages queue environment setting is overridden in deadline-cloud-for-blender submitter

### What was the problem/requirement? (What/Why)
Initial shared parameter values are populated from the CondaPackages queue environment as expected, then the blender submitter overrides with its own Conda package list.
See:
https://github.com/aws-deadline/deadline-cloud-for-blender/blob/aac1bc731302d0780b3e077e4b389befe47f969d/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/open_deadline_cloud_dialog.py#L79
These defaults are reasonable, but if you're running a local version of blender that differs from the cloud version, or if your conda packages have different names, this override isn't always useful, and would need changing on each submission.

### What was the solution? (How)
If the variable default value is empty (which is how it's shipped for the CondaPackages variable), allow the blender submitter to override, otherwise keep what is in the Queue Environment variable.  This is more consistent with how the CondaChannels variable is working.

### What is the impact of this change?
Should allow the default Conda Queue Environment to work as-is.  If any value is entered into the Conda Queue Environment for CondaPackages, it will override the default/empty value.

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests?
- Have you run the integration tests?
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass.

1. In Blender, Render->Submit to AWS Deadline Cloud, find CondaPackages = blender=a.b.* blender-openjd=x.y.*, Conda Channels = deadline-cloud
2. Modify the default "Conda" Queue Environment, set a different default value for CondaPackages and CondaChannels.
3.  In Blender, Render->Submit to AWS Deadline Cloud, find CondaPackages = blender=a.b.* blender-openjd=x.y.*, Conda Channels = <new channels value>.  Regardless of what CondaPackages is set in Deadline "Conda" Queue Environment, the value in the Blender submitter will always start with this value.
4. Apply this change
5. In Blender, Render->Submit to AWS Deadline Cloud, find CondaPackages = <new packages value>, Conda Channels = <new channels value>.  Having a value set in the CondaPackages variable in the "Conda" Queue Environment will flow through to the submitter dialog box.
6. Modify the default "Conda" Queue Environment, set the default value for CondaPackages back to an empty string "".
7. In Blender, Render->Submit to AWS Deadline Cloud, find CondaPackages = blender=a.b.* blender-openjd=x.y.*, Conda Channels = <new channels value>.  The reasonable default is given for CondaPackages.

I don't have a full setup of all deadline-cloud-for-xyz software packages installed/setup and am unable to fully test.  If any assistance is available, that would be great.

### Was this change documented?

- Are relevant docstrings in the code base updated?
- Has the README.md been updated? If you modified CLI arguments, for instance.

Not applicable.

### Is this a breaking change?

A breaking change is one that modifies a public contract in a way that is not backwards compatible. See the 
[Public Contracts](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#public-contracts) section
of the DEVELOPMENT.md for more information on the public contracts.

If so, then please describe the changes that users of this package must make to update their scripts, or Python applications.

I would say no.  This is a change in behavior, but Queue Environment variables can still be modified.

### Does this change impact security?

- Does the change need to be threat modeled? For example, does it create or modify files/directories that must only be readable by the process owner?
    - If so, then please label this pull request with the "security" label. We'll work with you to analyze the threats.

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*