### PR TITLE
chore: add client version and submitter name to user agent

### DIFF
--- a/src/deadline/client/api/_submit_job_bundle.py
+++ b/src/deadline/client/api/_submit_job_bundle.py
@@ -42,6 +42,7 @@ from ...job_attachments.models import (
 )
 from ...job_attachments.progress_tracker import SummaryStatistics, ProgressReportMetadata
 from ...job_attachments.upload import S3AssetManager
+from ._session import session_context
 
 logger = logging.getLogger(__name__)
 
@@ -65,7 +66,7 @@ def create_job_from_job_bundle(
     upload_progress_callback: Optional[Callable[[ProgressReportMetadata], bool]] = None,
     create_job_result_callback: Optional[Callable[[], bool]] = None,
     require_paths_exist: bool = False,
-    submitter_name: str = "CLI",
+    submitter_name: Optional[str] = None,
 ) -> Union[str, None]:
     """
     Creates a job in the farm/queue configured as default for the
@@ -133,6 +134,11 @@ def create_job_from_job_bundle(
                 is to not cancel the operation. hashing_progress_callback and upload_progress_callback both receive
                 ProgressReport as a parameter, which can be used for projecting remaining time, as in done in the CLI.
     """
+
+    if not submitter_name:
+        submitter_name = "CLI"
+
+    session_context["submitter-name"] = submitter_name
 
     # Ensure the job bundle doesn't contain files that resolve outside of the bundle directory
     validate_directory_symlink_containment(job_bundle_dir)

--- a/src/deadline/client/ui/job_bundle_submitter.py
+++ b/src/deadline/client/ui/job_bundle_submitter.py
@@ -33,6 +33,7 @@ from .dialogs.submit_job_to_deadline_dialog import (
 )
 from .widgets.job_bundle_settings_tab import JobBundleSettingsWidget
 from ..job_bundle.submission import AssetReferences
+from ..api._session import session_context
 
 logger = getLogger(__name__)
 
@@ -43,7 +44,7 @@ def show_job_bundle_submitter(
     browse: bool = False,
     parent=None,
     f=Qt.WindowFlags(),
-    submitter_name="JobBundle",
+    submitter_name: Optional[str] = None,
 ) -> Optional[SubmitJobToDeadlineDialog]:
     """
     Opens an AWS Deadline Cloud job submission dialog for the provided job bundle.
@@ -51,6 +52,11 @@ def show_job_bundle_submitter(
     Pass f=Qt.Tool if running it within an application context and want it
     to stay on top.
     """
+
+    if not submitter_name:
+        submitter_name = "JobBundle"
+
+    session_context["submitter-name"] = submitter_name
 
     if parent is None:
         # Get the main application window so we can parent ours to it


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
It'd be useful to have the Deadline Client version and submitter name as part of the user agent string for API calls. The user agent string appears in CloudTrail and can help track down the source of API calls.

### What was the solution? (How)
Add the client version and submitter name to the user agent string for API requests.

### What is the impact of this change?
Better data on the source of API calls.

### How was this change tested?
I submitted bundles using the GUI submitter and CLI submitter and observed the user agent strings both in debug logs and in the actual requests. Specifically I tried:
- GUI submit without a custom submitter name
- GUI submit with a custom submitter name. I also used special characters to make sure boto sanitized them as expected
- CLI submit with and without custom submitter names

Example user agent string from testing (relevant info at the end):
```
Boto3/1.34.138 md/Botocore#1.34.138 ua/2.0 os/macos#23.6.0 md/arch#arm64 lang/python#3.12.4 md/pyimpl#CPython cfg/retry-mode#legacy Botocore/1.34.138 app/deadline-client#0.48.8.post25+g61df452 submitter/CLI
```

- Have you run the unit tests? Yes
- Have you run the integration tests? Yes
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass. No

### Was this change documented?

- Are relevant docstrings in the code base updated? Yes
- Has the README.md been updated? If you modified CLI arguments, for instance. n/a

### Is this a breaking change?
No

### Does this change impact security?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*