### PR TITLE
feat: Glob utilities and misc functions

### DIFF
--- a/src/deadline/client/exceptions.py
+++ b/src/deadline/client/exceptions.py
@@ -19,3 +19,7 @@ class UserInitiatedCancel(Exception):
 
 class NonValidInputError(Exception):
     """Error for when the user input is nonvalid"""
+
+
+class ManifestOutdatedError(Exception):
+    """Error for when local files are different from version captured in manifest"""

--- a/src/deadline/job_attachments/_glob.py
+++ b/src/deadline/job_attachments/_glob.py
@@ -1,0 +1,70 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import json
+from pathlib import Path
+from typing import List, Optional
+from deadline.client.exceptions import NonValidInputError
+from deadline.job_attachments.models import GlobConfig
+
+
+def _process_glob_inputs(glob_arg_input: str) -> GlobConfig:
+    """
+    Helper function to process glob inputs.
+    glob_input: String, can represent a json, filepath, or general include glob syntax.
+    """
+
+    # Default Glob config.
+    glob_config = GlobConfig()
+    if glob_arg_input is None or len(glob_arg_input) == 0:
+        # Not configured, or not passed in.
+        return glob_config
+
+    try:
+        input_as_path = Path(glob_arg_input)
+        if input_as_path.is_file():
+            # Read the file so it can be parsed as JSON.
+            with open(glob_arg_input) as f:
+                glob_arg_input = f.read()
+    except Exception:
+        # If this cannot be processed as a file, try it as JSON.
+        pass
+
+    try:
+        # Parse the input as JSON, default to Glob Config defaults.
+        input_as_json = json.loads(glob_arg_input)
+        glob_config.include_glob = input_as_json.get(GlobConfig.INCLUDE, glob_config.include_glob)
+        glob_config.exclude_glob = input_as_json.get(GlobConfig.EXCLUDE, glob_config.exclude_glob)
+    except Exception:
+        # This is not a JSON blob, bad input.
+        raise NonValidInputError(f"Glob input {glob_arg_input} cannot be deserialized as JSON")
+
+    return glob_config
+
+
+def _glob_paths(
+    path: str, include: List[str] = ["**/*"], exclude: Optional[List[str]] = None
+) -> List[str]:
+    """
+    Glob routine that supports Unix style pathname pattern expansion for includes and excludes.
+    path: Root path to glob.
+    include: Optional, pattern syntax for files to include.
+    exlucde: Optional, pattern syntax for files to exclude.
+    """
+    include_files: List[Optional[str]] = []
+    for input_glob in include:
+        include_files.extend(
+            [str(path) if path.is_file() else None for path in Path(path).glob(input_glob)]
+        )
+    include_files = list(filter(None, include_files))
+
+    if exclude:
+        exclude_files = []
+        for exclude_glob in exclude:
+            exclude_files.extend(
+                [str(path) if path.is_file() else None for path in Path(path).glob(exclude_glob)]
+            )
+
+        # use sets to remove duplicates and remove all excluded file.
+        exclude_files = list(filter(None, exclude_files))
+        include_files = list(set(include_files) - set(exclude_files))
+    return include_files  # type: ignore[return-value]

--- a/src/deadline/job_attachments/models.py
+++ b/src/deadline/job_attachments/models.py
@@ -9,14 +9,13 @@ import sys
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import List, Optional, Set, Any
+from typing import Any, List, Optional, Set
 
 from deadline.job_attachments.asset_manifests import HashAlgorithm
 from deadline.job_attachments.asset_manifests.base_manifest import (
     BaseAssetManifest,
     BaseManifestPath,
 )
-
 from deadline.job_attachments.exceptions import MissingS3RootPrefixError
 
 from ._utils import (
@@ -330,3 +329,50 @@ class FileConflictResolution(Enum):
     SKIP = 1
     OVERWRITE = 2
     CREATE_COPY = 3
+
+
+def default_glob_all() -> List[str]:
+    return ["**/*"]
+
+
+@dataclass
+class GlobConfig:
+    """Include and Exclude configuration for glob input files"""
+
+    include_glob: List[str] = field(default_factory=default_glob_all)
+    exclude_glob: List[str] = field(default_factory=list)
+
+    INCLUDE = "include"
+    EXCLUDE = "exclude"
+
+
+@dataclass
+class ManifestSnapshot:
+    """Data structure to store the results of a manifest snapshot"""
+
+    manifest: str = field(default_factory=str)
+
+
+@dataclass
+class ManifestDiff:
+    """Data structure to store new, modified, or deleted files when comparing manifest to a local file system"""
+
+    new: List[str] = field(default_factory=list)
+    modified: List[str] = field(default_factory=list)
+    deleted: List[str] = field(default_factory=list)
+
+
+@dataclass
+class ManifestDownload:
+    """Data structure to store the S3 and local paths of a manifest"""
+
+    s3_key: str = field(default_factory=str)
+    local: str = field(default_factory=str)
+
+
+@dataclass
+class ManifestDownloadResponse:
+    """Data structure to capture the response for manifest download"""
+
+    downloaded: list[ManifestDownload] = field(default_factory=list)
+    failed: list[str] = field(default_factory=list)

--- a/test/unit/deadline_job_attachments/conftest.py
+++ b/test/unit/deadline_job_attachments/conftest.py
@@ -482,3 +482,17 @@ def posix_target_group() -> str:
 def posix_disjoint_group() -> str:
     # Intentionally fail if the var is not defined.
     return os.environ["DEADLINE_JOB_ATTACHMENT_TEST_SUDO_DISJOINT_GROUP"]
+
+
+@pytest.fixture(scope="function")
+def test_glob_folder() -> str:
+    glob_data_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "data", "glob"))
+    return glob_data_dir
+
+
+@pytest.fixture(scope="function")
+def glob_config_file() -> str:
+    manifest_file = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "data", "glob_config.txt")
+    )
+    return manifest_file

--- a/test/unit/deadline_job_attachments/data/glob/exclude.txt
+++ b/test/unit/deadline_job_attachments/data/glob/exclude.txt
@@ -1,0 +1,1 @@
+hello world - test file

--- a/test/unit/deadline_job_attachments/data/glob/include.txt
+++ b/test/unit/deadline_job_attachments/data/glob/include.txt
@@ -1,0 +1,1 @@
+hello world - test file

--- a/test/unit/deadline_job_attachments/data/glob/nested/nested_exclude.txt
+++ b/test/unit/deadline_job_attachments/data/glob/nested/nested_exclude.txt
@@ -1,0 +1,1 @@
+hello world - test file

--- a/test/unit/deadline_job_attachments/data/glob/nested/nested_include.txt
+++ b/test/unit/deadline_job_attachments/data/glob/nested/nested_include.txt
@@ -1,0 +1,1 @@
+hello world - test file

--- a/test/unit/deadline_job_attachments/data/glob_config.txt
+++ b/test/unit/deadline_job_attachments/data/glob_config.txt
@@ -1,0 +1,8 @@
+{
+  "include": [
+    "include.file"
+  ],
+  "exclude": [
+    "exclude.file"
+  ]
+}

--- a/test/unit/deadline_job_attachments/test_glob.py
+++ b/test/unit/deadline_job_attachments/test_glob.py
@@ -1,0 +1,79 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import os
+from deadline.client.exceptions import NonValidInputError
+import pytest
+from typing import List
+from deadline.job_attachments._glob import _glob_paths, _process_glob_inputs
+
+
+def test_glob_inputs_string(glob_config_file):
+    """
+    Test case to test glob config as a string.
+    """
+    glob: str
+    with open(glob_config_file) as f:
+        glob = f.read()
+    glob_config = _process_glob_inputs(glob)
+    assert "include.file" in glob_config.include_glob
+    assert "exclude.file" in glob_config.exclude_glob
+
+
+def test_glob_inputs_file(glob_config_file):
+    """
+    Test case to test glob config as a file.
+    """
+    glob_config = _process_glob_inputs(glob_config_file)
+    assert "include.file" in glob_config.include_glob
+    assert "exclude.file" in glob_config.exclude_glob
+
+
+def test_bad_glob_string():
+    """
+    Test case to test a bad glob config will raise an exception.
+    """
+    glob: str = "This is not a json"
+    with pytest.raises(NonValidInputError):
+        _process_glob_inputs(glob)
+
+
+def test_glob_path_default(test_glob_folder: str):
+    """
+    Test case to glob all files.
+    """
+    globbed_files: List[str] = _glob_paths(path=test_glob_folder)
+
+    # There are 4 files
+    assert len(globbed_files) == 4
+    assert os.path.join(os.sep, test_glob_folder, "include.txt") in globbed_files
+    assert os.path.join(os.sep, test_glob_folder, "exclude.txt") in globbed_files
+    assert os.path.join(os.sep, test_glob_folder, "nested", "nested_include.txt") in globbed_files
+    assert os.path.join(os.sep, test_glob_folder, "nested", "nested_exclude.txt") in globbed_files
+
+
+def test_glob_path_default_include(test_glob_folder: str):
+    """
+    Test case to glob all files.
+    """
+    globbed_files: List[str] = _glob_paths(
+        path=test_glob_folder, include=["*include.txt", "*/*include.txt"]
+    )
+
+    # There are 2 files
+    assert len(globbed_files) == 2
+    assert os.path.join(os.sep, test_glob_folder, "include.txt") in globbed_files
+    assert os.path.join(os.sep, test_glob_folder, "nested", "nested_include.txt") in globbed_files
+
+
+def test_glob_path_exclude(test_glob_folder: str):
+    """
+    Test case to glob all files and exclude some.
+    """
+    globbed_files: List[str] = _glob_paths(
+        path=test_glob_folder, exclude=["*exclude.txt", "*/*exclude.txt"]
+    )
+
+    # There are 4 files
+    assert len(globbed_files) == 2
+    assert os.path.join(os.sep, test_glob_folder, "include.txt") in globbed_files
+    assert os.path.join(os.sep, test_glob_folder, "nested", "nested_include.txt") in globbed_files


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
- We are introducing Job Attachment Manifest and Attachments APIs.
- There will be snapshot, diff, upload and download functionalities to create and manage manifests.
- There will be upload and download attachment of assets captured by manifests.
 
### What was the solution? (How)
- This PR is the first part of submitting
 - https://github.com/aws-deadline/deadline-cloud/pull/446
- In this PR, I am introducing utilities for Globbing file systems, processing a glob config file and misc utility functions.
 
### What is the impact of this change?
- Utilities to get Job Attachments user interfaces launched.

### How was this change tested?
- hatch build, hatch run fmt, hatch run lint, hatch run test.
- Integration tests are not applicable here, and will be added with subsequent CLI / API tests.

### Was this change documented?
- These are internal classes.

### Is this a breaking change?
No.

### Does this change impact security?
- No, these are internal utilities. Standard AWS security review best practices.