### PR TITLE
feat: add attachment upload command implementation

### DIFF
--- a/src/deadline/job_attachments/api/__init__.py
+++ b/src/deadline/job_attachments/api/__init__.py
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
-__all__ = ["attachment_download"]
+__all__ = ["attachment_download", "attachment_upload"]
 
-from .attachment import attachment_download
+from .attachment import attachment_download, attachment_upload

--- a/src/deadline/job_attachments/api/attachment.py
+++ b/src/deadline/job_attachments/api/attachment.py
@@ -6,6 +6,8 @@ import json
 
 from contextlib import ExitStack
 from typing import Optional, List, Dict
+from pathlib import Path
+from dataclasses import asdict
 
 from deadline.job_attachments.asset_manifests.base_manifest import BaseAssetManifest
 from deadline.job_attachments.asset_manifests.decode import decode_manifest
@@ -13,13 +15,16 @@ from deadline.job_attachments.download import download_files_from_manifests
 from deadline.job_attachments.models import JobAttachmentS3Settings, PathMappingRule
 from deadline.job_attachments.progress_tracker import DownloadSummaryStatistics
 from deadline.client.exceptions import NonValidInputError
+from deadline.job_attachments.upload import S3AssetUploader
+from deadline.client.cli._groups.click_logger import ClickLogger
 
 
 def attachment_download(
     manifests: List[str],
-    s3_root_path: str,
+    s3_root_uri: str,
     boto3_session: boto3.Session,
     path_mapping_rules: Optional[str] = None,
+    logger: ClickLogger = ClickLogger(False),
 ):
     """
     BETA API - This API is still evolving but will be made public in the near future.
@@ -28,56 +33,186 @@ def attachment_download(
     If path mapping rules file is given, map to corresponding destinations.
 
     Args:
-        manifests: File Path to the manifest file for upload.
-        s3_root_path: S3 root path including bucket name and root prefix.
-        boto_session: Boto3 session for interacting with customer s3.
-        path_mapping_rules: Optional file path to a list of path mapping.
+        manifests (List[str]): File Path to the manifest file for upload.
+        s3_root_uri (str): S3 root uri including bucket name and root prefix.
+        boto3_session (boto3.Session): Boto3 session for interacting with customer s3.
+        path_mapping_rules (Optional[str], optional): Optional file path to a JSON file contains list of path mapping. Defaults to None.
+        logger (ClickLogger, optional): Logger to provide visibility. Defaults to ClickLogger(False).
+
+    Raises:
+        NonValidInputError: raise when any of the input is not valid.
     """
 
-    # path validation
-    if not all([os.path.isfile(manifest) for manifest in manifests]):
-        raise NonValidInputError(f"Specified manifests {manifests} contain invalid file.")
+    file_name_manifest_dict: Dict[str, BaseAssetManifest] = _read_manifests(manifests=manifests)
+    path_mapping_rule_list: List[PathMappingRule] = _process_path_mapping(
+        path_mapping_rules=path_mapping_rules
+    )
 
-    parsed_mappings: List[PathMappingRule] = list()
-
-    if path_mapping_rules:
-        if not os.path.isfile(path_mapping_rules):
-            raise NonValidInputError(
-                f"Specified path mapping file {path_mapping_rules} is not valid."
-            )
-
-        with open(path_mapping_rules, encoding="utf8") as f:
-            parsed_mappings = [PathMappingRule(**mapping) for mapping in json.load(f)]
-
-    # Read in manifests
     merged_manifests_by_root: Dict[str, BaseAssetManifest] = dict()
-    with ExitStack() as stack:
-        for file_path in manifests:
-            manifest: BaseAssetManifest = decode_manifest(
-                stack.enter_context(open(file_path)).read()
+    for file_name in file_name_manifest_dict:
+        manifest: BaseAssetManifest = file_name_manifest_dict[file_name]
+        # File name is supposed to be prefixed by a hash of source path in path mapping, use that to determine destination
+        # If it doesn't appear in path mapping or mapping doesn't exist, download to current directory instead
+        destination = next(
+            (
+                rule.destination_path
+                for rule in path_mapping_rule_list
+                if rule.get_hashed_source_path(manifest.get_default_hash_alg()) in file_name
+            ),
+            # Write to current directory partitioned by manifest name when no path mapping defined
+            f"{os.getcwd()}/{file_name}",
+        )
+        # Assuming the manifest is already aggregated and correspond to a single destination
+        if merged_manifests_by_root.get(destination):
+            raise NonValidInputError(
+                f"{destination} is already in use, one desination path maps to one manifest file only."
             )
 
-            # File name is supposed to be a hash of source path in path mapping, use that to determine destination
-            # If it doesn't appear in path mapping or mapping doesn't exist, download to current directory instead
-            file_name: str = os.path.basename(file_path)
-            destination = next(
-                (
-                    rule.destination_path
-                    for rule in parsed_mappings
-                    if rule.get_hashed_source_path(manifest.get_default_hash_alg()) == file_name
-                ),
-                # Write to current directory partitioned by manifest name when no path mapping defined
-                f"{os.getcwd()}/{file_name}",
-            )
-            print(f"local root is {destination}")
-            merged_manifests_by_root[destination] = manifest
+        merged_manifests_by_root[destination] = manifest
 
     # Given manifests and S3 bucket + root, downloads all files from a CAS in each manifest.
-    s3_settings: JobAttachmentS3Settings = JobAttachmentS3Settings.from_root_path(s3_root_path)
+    s3_settings: JobAttachmentS3Settings = JobAttachmentS3Settings.from_s3_root_uri(s3_root_uri)
     download_summary: DownloadSummaryStatistics = download_files_from_manifests(
         s3_bucket=s3_settings.s3BucketName,
         manifests_by_root=merged_manifests_by_root,
         cas_prefix=s3_settings.full_cas_prefix(),
         session=boto3_session,
     )
-    print(f"Download summary \n{download_summary}")
+    logger.echo(download_summary)
+    logger.json(asdict(download_summary.convert_to_summary_statistics()))
+
+
+def attachment_upload(
+    manifests: List[str],
+    s3_root_uri: str,
+    boto3_session: boto3.Session,
+    root_dirs: List[str] = [],
+    path_mapping_rules: Optional[str] = None,
+    upload_manifest_path: Optional[str] = None,
+    logger: ClickLogger = ClickLogger(False),
+):
+    """
+    BETA API - This API is still evolving but will be made public in the near future.
+
+    API to download job attachments based on given list of manifests.
+    If path mapping rules file is given, map to corresponding destinations.
+
+    Args:
+        manifests (List[str]): File Path to the manifest file for upload.
+        s3_root_uri (str): S3 root uri including bucket name and root prefix.
+        boto3_session (boto3.Session): Boto3 session for interacting with customer s3.
+        root_dirs (List[str]): List of root directories holding attachments. Defaults to empty.
+        path_mapping_rules (Optional[str], optional): Optional file path to a JSON file contains list of path mapping. Defaults to None.
+        upload_manifest_path (Optional[str], optional): Optional prefix for uploading given manifests. Defaults to None.
+        logger (ClickLogger, optional): Logger to provide visibility. Defaults to ClickLogger(False).
+
+    Raises:
+        NonValidInputError: raise when any of the input is not valid.
+    """
+
+    file_name_manifest_dict: Dict[str, BaseAssetManifest] = _read_manifests(manifests=manifests)
+
+    if bool(path_mapping_rules) == bool(root_dirs):
+        raise NonValidInputError("One of path mapping rule and root dir must exist, and not both.")
+
+    path_mapping_rule_list: List[PathMappingRule] = _process_path_mapping(
+        path_mapping_rules=path_mapping_rules, root_dirs=root_dirs
+    )
+
+    s3_settings: JobAttachmentS3Settings = JobAttachmentS3Settings.from_s3_root_uri(s3_root_uri)
+    asset_uploader: S3AssetUploader = S3AssetUploader(session=boto3_session)
+    for file_name in file_name_manifest_dict:
+        manifest: BaseAssetManifest = file_name_manifest_dict[file_name]
+
+        # File name is supposed to be prefixed by a hash of source path in path mapping or provided root dirs
+        rule: Optional[PathMappingRule] = next(
+            # search in path mapping to determine source and destination
+            (
+                rule
+                for rule in path_mapping_rule_list
+                if rule.get_hashed_source_path(manifest.get_default_hash_alg()) in file_name
+            ),
+            None,
+        )
+        if not rule:
+            raise NonValidInputError(
+                f"No valid root defined for given manifest {file_name}, please check input root dirs and path mapping rule."
+            )
+
+        # Uploads all files to a CAS in the manifest, optionally upload manifest file
+        key, data = asset_uploader.upload_assets(
+            job_attachment_settings=s3_settings,
+            manifest=manifest,
+            partial_manifest_prefix=upload_manifest_path,
+            source_root=Path(rule.source_path),
+            asset_root=Path(rule.destination_path),
+        )
+        logger.echo(
+            f"Uploaded assets from {rule.source_path}, to {s3_settings.to_s3_root_uri()}/{key}, hashed data {data}"
+        )
+
+
+def _process_path_mapping(
+    path_mapping_rules: Optional[str] = None, root_dirs: List[str] = []
+) -> List[PathMappingRule]:
+    """
+    Process list of path mapping rules from the input path mapping file or root directories.
+
+    Args:
+        path_mapping_rules (Optional[str], optional): File path to path mapping rules. Defaults to None.
+        root_dirs (List[str], optional): List of root directories path. Defaults to [].
+
+    Raises:
+        NonValidInputError: Raise if any of the path mapping rule file or root dirs are not valid.
+
+    Returns:
+        List[PathMappingRule]: List of processed PathMappingRule
+    """
+
+    path_mapping_rule_list: List[PathMappingRule] = list()
+
+    if path_mapping_rules:
+        if not os.path.isfile(path_mapping_rules):
+            raise NonValidInputError(
+                f"Specified path mapping file {path_mapping_rules} is not valid."
+            )
+        with open(path_mapping_rules, encoding="utf8") as f:
+            path_mapping_rule_list.extend([PathMappingRule(**mapping) for mapping in json.load(f)])
+
+    if nonvalid_dirs := [root for root in root_dirs if not os.path.isdir(root)]:
+        raise NonValidInputError(f"Specified root dir {nonvalid_dirs} are not valid.")
+
+    path_mapping_rule_list.extend(
+        PathMappingRule(source_path_format="", source_path=root, destination_path=root)
+        for root in root_dirs
+    )
+
+    return path_mapping_rule_list
+
+
+def _read_manifests(manifests: List[str]) -> Dict[str, BaseAssetManifest]:
+    """
+    Read in manfiests from the give file path list, and produce file name to manifest mapping.
+
+    Args:
+        manifests (List[str]): List of file paths to manifest file.
+
+    Raises:
+        NonValidInputError: Raise when any of the file is not valid.
+
+    Returns:
+        Dict[str, BaseAssetManifest]: File name to encoded manifest mapping
+    """
+
+    if nonvalid_files := [manifest for manifest in manifests if not os.path.isfile(manifest)]:
+        raise NonValidInputError(f"Specified manifests {nonvalid_files} are not valid.")
+
+    with ExitStack() as stack:
+        file_name_manifest_dict: Dict[str, BaseAssetManifest] = {
+            os.path.basename(file_path): decode_manifest(
+                stack.enter_context(open(file_path)).read()
+            )
+            for file_path in manifests
+        }
+
+    return file_name_manifest_dict

--- a/src/deadline/job_attachments/models.py
+++ b/src/deadline/job_attachments/models.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
 from typing import Any, List, Optional, Set
+from urllib.parse import urlparse
 
 from deadline.job_attachments.asset_manifests import HashAlgorithm, hash_data
 from deadline.job_attachments.asset_manifests.base_manifest import (
@@ -230,8 +231,22 @@ class JobAttachmentS3Settings:
 
         return JobAttachmentS3Settings(path_split[0], "/".join(path_split[1:]))
 
+    @staticmethod
+    def from_s3_root_uri(uri: str) -> JobAttachmentS3Settings:
+        res = urlparse(uri)
+
+        if not res.netloc or not res.path[1:] or res.scheme != "s3":
+            raise MalformedAttachmentSettingError(
+                "Invalid root uri format, should be s3://s3BucketName/rootPrefix."
+            )
+
+        return JobAttachmentS3Settings(res.netloc, res.path[1:])
+
     def to_root_path(self) -> str:
         return _join_s3_paths(self.s3BucketName, self.rootPrefix)
+
+    def to_s3_root_uri(self) -> str:
+        return f"s3://{self.to_root_path()}"
 
     def full_cas_prefix(self) -> str:
         self._validate_root_prefix()
@@ -406,9 +421,6 @@ class PathMappingRule:
 
     destination_path: str
     """The path to transform the source path to"""
-
-    def get_hashed_source(self, hash_alg: HashAlgorithm) -> str:
-        return hash_data(f"{self.source_path_format}{self.source_path}".encode("utf-8"), hash_alg)
 
     def get_hashed_source_path(self, hash_alg: HashAlgorithm) -> str:
         return hash_data(self.source_path.encode("utf-8"), hash_alg)

--- a/test/unit/deadline_job_attachments/api/test_attachment.py
+++ b/test/unit/deadline_job_attachments/api/test_attachment.py
@@ -5,7 +5,8 @@ Test the deadline.client.api functions relating to attachment
 """
 
 from unittest.mock import patch
-from typing import Dict
+from typing import Dict, List
+from pathlib import Path
 
 import os
 import pytest
@@ -18,8 +19,12 @@ from deadline.job_attachments import api as attachment_api
 from deadline.client.exceptions import NonValidInputError
 from deadline.job_attachments.exceptions import MalformedAttachmentSettingError
 from deadline.job_attachments.progress_tracker import DownloadSummaryStatistics
+from deadline.job_attachments.asset_manifests import HashAlgorithm, hash_data
 from deadline.job_attachments.asset_manifests.decode import decode_manifest
 from deadline.job_attachments.asset_manifests.base_manifest import BaseAssetManifest
+from deadline.job_attachments.api.attachment import _process_path_mapping
+from deadline.job_attachments.upload import S3AssetUploader
+from deadline.job_attachments.models import JobAttachmentS3Settings, PathMappingRule
 
 PATH_MAPPING = {
     "source_path_format": "posix",
@@ -57,9 +62,39 @@ MOCK_MANIFEST_CASE = {
     },
 }
 
+TEST_S3_URI = "s3://bucket/root"
 
-def test_attachment_download_single_to_mapped(temp_assets_dir):
+
+def test_process_path_mappint(temp_assets_dir):
+    mapping_file_path = os.path.join(temp_assets_dir, "mapping")
+    with open(mapping_file_path, "w", encoding="utf8") as f:
+        json.dump([PATH_MAPPING], f)
+
+    path_mappings: List[PathMappingRule] = _process_path_mapping(
+        mapping_file_path, [temp_assets_dir]
+    )
+    assert len(path_mappings) == 2
+
+
+@pytest.fixture
+def session_mock():
     with patch.object(api._session, "get_boto3_session") as session_mock:
+        yield session_mock
+
+
+class TestAttachmentDownload:
+
+    @pytest.fixture
+    def mock_download_files_from_manifests(self):
+        with patch(
+            f"{deadline.__package__}.job_attachments.api.attachment.download_files_from_manifests",
+            return_value=DownloadSummaryStatistics(),
+        ) as mock_download_files_from_manifests:
+            yield mock_download_files_from_manifests
+
+    def test_download_single_to_mapped(
+        self, temp_assets_dir, session_mock, mock_download_files_from_manifests
+    ):
         with open(
             os.path.join(temp_assets_dir, PATH_MAPPING_HASH),
             "w",
@@ -71,32 +106,28 @@ def test_attachment_download_single_to_mapped(temp_assets_dir):
         with open(mapping_file_path, "w", encoding="utf8") as f:
             json.dump([PATH_MAPPING], f)
 
-        with patch(
-            f"{deadline.__package__}.job_attachments.api.attachment.download_files_from_manifests",
-            return_value=DownloadSummaryStatistics(),
-        ) as mock_download_files_from_manifests:
-            attachment_api.attachment_download(
-                manifests=[os.path.join(temp_assets_dir, PATH_MAPPING_HASH)],
-                s3_root_path="bucket/assetRoot",
-                boto3_session=session_mock,
-                path_mapping_rules=mapping_file_path,
-            )
+        attachment_api.attachment_download(
+            manifests=[os.path.join(temp_assets_dir, PATH_MAPPING_HASH)],
+            s3_root_uri="s3://bucket/assetRoot",
+            boto3_session=session_mock,
+            path_mapping_rules=mapping_file_path,
+        )
 
-            mock_download_files_from_manifests.assert_called_once_with(
-                s3_bucket="bucket",
-                manifests_by_root={
-                    PATH_MAPPING["destination_path"]: decode_manifest(
-                        json.dumps(MOCK_MANIFEST_CASE[PATH_MAPPING_HASH])
-                    ),
-                },
-                cas_prefix="assetRoot/Data",
-                session=session_mock,
-            )
+        mock_download_files_from_manifests.assert_called_once_with(
+            s3_bucket="bucket",
+            manifests_by_root={
+                PATH_MAPPING["destination_path"]: decode_manifest(
+                    json.dumps(MOCK_MANIFEST_CASE[PATH_MAPPING_HASH])
+                ),
+            },
+            cas_prefix="assetRoot/Data",
+            session=session_mock,
+        )
 
-
-@pytest.mark.parametrize("manifest_case_key", MOCK_MANIFEST_CASE.keys())
-def test_attachment_download_single_to_current(temp_assets_dir, manifest_case_key):
-    with patch.object(api._session, "get_boto3_session") as session_mock:
+    @pytest.mark.parametrize("manifest_case_key", MOCK_MANIFEST_CASE.keys())
+    def test_download_single_to_current(
+        self, temp_assets_dir, session_mock, mock_download_files_from_manifests, manifest_case_key
+    ):
         with open(
             os.path.join(temp_assets_dir, manifest_case_key),
             "w",
@@ -104,30 +135,26 @@ def test_attachment_download_single_to_current(temp_assets_dir, manifest_case_ke
         ) as f:
             json.dump(MOCK_MANIFEST_CASE[manifest_case_key], f)
 
-        with patch(
-            f"{deadline.__package__}.job_attachments.api.attachment.download_files_from_manifests",
-            return_value=DownloadSummaryStatistics(),
-        ) as mock_download_files_from_manifests:
-            attachment_api.attachment_download(
-                manifests=[os.path.join(temp_assets_dir, manifest_case_key)],
-                s3_root_path="bucket/assetRoot",
-                boto3_session=session_mock,
-            )
+        attachment_api.attachment_download(
+            manifests=[os.path.join(temp_assets_dir, manifest_case_key)],
+            s3_root_uri="s3://bucket/assetRoot",
+            boto3_session=session_mock,
+        )
 
-            mock_download_files_from_manifests.assert_called_once_with(
-                s3_bucket="bucket",
-                manifests_by_root={
-                    f"{os.getcwd()}/{manifest_case_key}": decode_manifest(
-                        json.dumps(MOCK_MANIFEST_CASE[manifest_case_key])
-                    ),
-                },
-                cas_prefix="assetRoot/Data",
-                session=session_mock,
-            )
+        mock_download_files_from_manifests.assert_called_once_with(
+            s3_bucket="bucket",
+            manifests_by_root={
+                f"{os.getcwd()}/{manifest_case_key}": decode_manifest(
+                    json.dumps(MOCK_MANIFEST_CASE[manifest_case_key])
+                ),
+            },
+            cas_prefix="assetRoot/Data",
+            session=session_mock,
+        )
 
-
-def test_attachment_download_multiple_to_current(temp_assets_dir):
-    with patch.object(api._session, "get_boto3_session") as session_mock:
+    def test_download_multiple_to_current(
+        self, temp_assets_dir, session_mock, mock_download_files_from_manifests
+    ):
         expected_merged: Dict[str, BaseAssetManifest] = dict()
 
         for manifest_case_key in MOCK_MANIFEST_CASE.keys():
@@ -141,50 +168,178 @@ def test_attachment_download_multiple_to_current(temp_assets_dir):
             ) as f:
                 json.dump(MOCK_MANIFEST_CASE[manifest_case_key], f)
 
-        with patch(
-            f"{deadline.__package__}.job_attachments.api.attachment.download_files_from_manifests",
-            return_value=DownloadSummaryStatistics(),
-        ) as mock_download_files_from_manifests:
-            attachment_api.attachment_download(
-                manifests=[os.path.join(temp_assets_dir, key) for key in MOCK_MANIFEST_CASE.keys()],
-                s3_root_path="bucket/assetRoot",
-                boto3_session=session_mock,
-            )
+        attachment_api.attachment_download(
+            manifests=[os.path.join(temp_assets_dir, key) for key in MOCK_MANIFEST_CASE.keys()],
+            s3_root_uri="s3://bucket/assetRoot",
+            boto3_session=session_mock,
+        )
 
-            mock_download_files_from_manifests.assert_called_once_with(
-                s3_bucket="bucket",
-                manifests_by_root=expected_merged,
-                cas_prefix="assetRoot/Data",
-                session=session_mock,
-            )
+        mock_download_files_from_manifests.assert_called_once_with(
+            s3_bucket="bucket",
+            manifests_by_root=expected_merged,
+            cas_prefix="assetRoot/Data",
+            session=session_mock,
+        )
 
-
-def test_attachment_download_invalid_input_manifests(fresh_deadline_config):
-    with patch.object(api._session, "get_boto3_session") as session_mock:
+    def test_download_invalid_input_manifests(self, session_mock):
         with pytest.raises(NonValidInputError):
             attachment_api.attachment_download(
                 manifests=["file-not-found"],
-                s3_root_path="bucket/root",
+                s3_root_uri=TEST_S3_URI,
                 boto3_session=session_mock,
             )
 
-
-def test_attachment_download_invalid_input_path_mapping_rules(fresh_deadline_config):
-    with patch.object(api._session, "get_boto3_session") as session_mock:
+    def test_download_invalid_input_path_mapping_rules(self, session_mock):
         with pytest.raises(NonValidInputError):
             attachment_api.attachment_download(
                 manifests=[],
-                s3_root_path="bucket/root",
+                s3_root_uri=TEST_S3_URI,
                 boto3_session=session_mock,
                 path_mapping_rules="file-not-found",
             )
 
-
-def test_attachment_download_invalid_input_s3_root_path(fresh_deadline_config):
-    with patch.object(api._session, "get_boto3_session") as session_mock:
+    def test_download_invalid_input_s3_root_uri(self, session_mock):
         with pytest.raises(MalformedAttachmentSettingError):
             attachment_api.attachment_download(
                 manifests=[],
-                s3_root_path="MalformedPath",
+                s3_root_uri="MalformedPath",
                 boto3_session=session_mock,
             )
+
+
+class TestAttachmentUpload:
+
+    @pytest.fixture
+    def mock_upload_assets(self):
+        with patch.object(
+            S3AssetUploader, "upload_assets", return_value=("key", "data")
+        ) as mock_upload_assets:
+            yield mock_upload_assets
+
+    def test_upload_invalid_input_manifests(self, session_mock):
+        with pytest.raises(NonValidInputError):
+            attachment_api.attachment_upload(
+                manifests=["file-not-found"],
+                s3_root_uri=TEST_S3_URI,
+                boto3_session=session_mock,
+            )
+
+    def test_upload_invalid_input_path_mapping_rules(self, session_mock):
+        with pytest.raises(NonValidInputError):
+            attachment_api.attachment_upload(
+                manifests=[],
+                s3_root_uri=TEST_S3_URI,
+                boto3_session=session_mock,
+                path_mapping_rules="file-not-found",
+            )
+
+    def test_upload_invalid_input_s3_root_uri(self, temp_assets_dir, session_mock):
+        with pytest.raises(MalformedAttachmentSettingError):
+            attachment_api.attachment_upload(
+                manifests=[],
+                s3_root_uri="MalformedPath",
+                root_dirs=[temp_assets_dir],
+                boto3_session=session_mock,
+            )
+
+    def test_upload_single_from_mapped(self, temp_assets_dir, session_mock, mock_upload_assets):
+        with open(
+            os.path.join(temp_assets_dir, PATH_MAPPING_HASH),
+            "w",
+            encoding="utf8",
+        ) as f:
+            json.dump(MOCK_MANIFEST_CASE[PATH_MAPPING_HASH], f)
+
+        mapping_file_path = os.path.join(temp_assets_dir, "mapping")
+        with open(mapping_file_path, "w", encoding="utf8") as f:
+            json.dump([PATH_MAPPING], f)
+
+        attachment_api.attachment_upload(
+            manifests=[os.path.join(temp_assets_dir, PATH_MAPPING_HASH)],
+            s3_root_uri=TEST_S3_URI,
+            boto3_session=session_mock,
+            path_mapping_rules=mapping_file_path,
+            upload_manifest_path="test",
+        )
+
+        mock_upload_assets.assert_called_once_with(
+            job_attachment_settings=JobAttachmentS3Settings.from_s3_root_uri(TEST_S3_URI),
+            manifest=decode_manifest(json.dumps(MOCK_MANIFEST_CASE[PATH_MAPPING_HASH])),
+            partial_manifest_prefix="test",
+            source_root=Path(PATH_MAPPING["source_path"]),
+            asset_root=Path(PATH_MAPPING["destination_path"]),
+        )
+
+    @pytest.mark.parametrize("manifest_case_key", MOCK_MANIFEST_CASE.keys())
+    def test_upload_single_map_from_root(
+        self, temp_assets_dir, session_mock, mock_upload_assets, manifest_case_key
+    ):
+        file_name_prefix: str = hash_data(temp_assets_dir.encode("utf-8"), HashAlgorithm.XXH128)
+        file_name: str = f"{file_name_prefix}_output"
+
+        with open(
+            os.path.join(temp_assets_dir, file_name),
+            "w",
+            encoding="utf8",
+        ) as f:
+            json.dump(MOCK_MANIFEST_CASE[manifest_case_key], f)
+
+        attachment_api.attachment_upload(
+            manifests=[os.path.join(temp_assets_dir, file_name)],
+            s3_root_uri=TEST_S3_URI,
+            boto3_session=session_mock,
+            root_dirs=[temp_assets_dir],
+            upload_manifest_path="test",
+        )
+
+        mock_upload_assets.assert_called_once_with(
+            job_attachment_settings=JobAttachmentS3Settings.from_s3_root_uri(TEST_S3_URI),
+            manifest=decode_manifest(json.dumps(MOCK_MANIFEST_CASE[manifest_case_key])),
+            partial_manifest_prefix="test",
+            source_root=Path(temp_assets_dir),
+            asset_root=Path(temp_assets_dir),
+        )
+
+    @pytest.mark.parametrize("manifest_case_key", MOCK_MANIFEST_CASE.keys())
+    def test_upload_no_mapped_root(
+        self, temp_assets_dir, session_mock, mock_upload_assets, manifest_case_key
+    ):
+        with open(
+            os.path.join(temp_assets_dir, manifest_case_key),
+            "w",
+            encoding="utf8",
+        ) as f:
+            json.dump(MOCK_MANIFEST_CASE[manifest_case_key], f)
+
+        # Test No valid root defined for given manifest
+        with pytest.raises(NonValidInputError) as error:
+            attachment_api.attachment_upload(
+                manifests=[os.path.join(temp_assets_dir, manifest_case_key)],
+                s3_root_uri="s3://bucket/assetRoot",
+                root_dirs=[temp_assets_dir],
+                boto3_session=session_mock,
+            )
+
+        assert f"No valid root defined for given manifest {manifest_case_key}" in str(error.value)
+
+    def test_upload_no_root_dir_or_mapping(self, temp_assets_dir, session_mock):
+        with pytest.raises(NonValidInputError) as error:
+            attachment_api.attachment_upload(
+                manifests=[],
+                s3_root_uri="s3://bucketName/rootPrefix",
+                boto3_session=session_mock,
+            )
+
+        assert str(error.value) == "One of path mapping rule and root dir must exist, and not both."
+
+    def test_upload_both_root_dir_and_mapping(self, temp_assets_dir, session_mock):
+        with pytest.raises(NonValidInputError) as error:
+            attachment_api.attachment_upload(
+                manifests=[],
+                path_mapping_rules="fakefilepath",
+                root_dirs=[temp_assets_dir],
+                s3_root_uri="s3://bucketName/rootPrefix",
+                boto3_session=session_mock,
+            )
+
+        assert str(error.value) == "One of path mapping rule and root dir must exist, and not both."

--- a/test/unit/deadline_job_attachments/test_models.py
+++ b/test/unit/deadline_job_attachments/test_models.py
@@ -62,13 +62,10 @@ class TestModels:
         """
         path_mapping = PathMappingRule(
             source_path_format="posix",
-            source_path="/local/home/test",
-            destination_path="/loca/home/test/output",
+            source_path="/tmp",
+            destination_path="/local/home/test/output",
         )
-        assert "f59f1ffe44f9a64aa7330625e3b70447" == path_mapping.get_hashed_source(
-            HashAlgorithm.XXH128
-        )
-        assert "4ab97c97c825551aaa963888278ef9ec" == path_mapping.get_hashed_source_path(
+        assert "a0271fe0c8b1c1f99b82b442cd878122" == path_mapping.get_hashed_source_path(
             HashAlgorithm.XXH128
         )
 
@@ -92,3 +89,24 @@ class TestModels:
         """
         with pytest.raises(MalformedAttachmentSettingError):
             JobAttachmentS3Settings.from_root_path("s3BucketOnly")
+
+    @pytest.mark.parametrize(
+        ("input", "output"),
+        [
+            ("s3://BucketName/rootPrefix", JobAttachmentS3Settings("BucketName", "rootPrefix")),
+            ("s3://BucketName/root/Prefix", JobAttachmentS3Settings("BucketName", "root/Prefix")),
+        ],
+    )
+    def test_job_attachment_setting_root_uri(self, input: str, output: JobAttachmentS3Settings):
+        """
+        Test Job Attachment S3 Settings from and to S3 root uri
+        """
+        assert output == JobAttachmentS3Settings.from_s3_root_uri(input)
+        assert input == output.to_s3_root_uri()
+
+    def test_job_attachment_setting_from_s3_root_uri_error(self):
+        """
+        Test Job Attachment S3 Settings from malformed S3 root uri
+        """
+        with pytest.raises(MalformedAttachmentSettingError):
+            JobAttachmentS3Settings.from_s3_root_uri("s3://s3BucketOnly")


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We'd like to introduce `attachment upload` CLI to improve asset manage workflow.

### What was the solution? (How)
Add a CLI to upload assets based specified in manifests.

### What is the impact of this change?
Help customer to better manage and potentially automate asset upload workflow.

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests? [Yes]
- Have you run the integration tests? [Yes]
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended that you ensure that the docker-based unit tests pass. [N/A]

#### Manual Testing

Upload to given directory
```
(attachment-cli)> deadline attachment upload --manifests "/Users/yuanbian/Downloads/a027
1fe0c8b1c1f99b82b442cd878122_input" -r "/tmp" --upload-manifest-path Test
Uploaded assets from /tmp, to s3 s3://smf-queue/DeadlineCloud key Test/a0271fe0c8b1c1f99b82b442cd878122_input, hashed data 5e3a52261d2d5d542713f832c57ce197
```
Upload with path mapping
```
(attachment-cli) [0|1]> deadline attachment upload --manifest
s "/Users/XXXXXXXX/Downloads/0bb7eb91fdf8780c4a7e6174de6dfc5e_input" --path-mapping-rules "/Users/XXXXXXXX/Library/CloudS
torage/WorkDocsDrive-Documents/code/thinkbox/deadline-clients/deadline-cloud/path_mapping.json" --upload-manifest-path Tes
t
Uploaded assets from /local/home/XXXXXXXX/bea/deadline-clients/deadline-cloud-worker-agent/scripts/submit_jobs/asset_example, to s3 s3://smf-queue/DeadlineCloud key Test/0bb7eb91fdf8780c4a7e6174de6dfc5e_input, hashed data 5e3a52261d2d5d542713f832c57ce197
```

Error Handling - directory not valid
```
(attachment-cli)> deadline attachment upload --manifests "/Us
ers/XXXXXXXX/Downloads/0bb7eb91fdf8780c4a7e6174de6dfc5e_input" -r "/local/home/XXXXXXXX/bea/deadline-clients/deadline-clou
d-worker-agent/scripts/submit_jobs/asset_example" --upload-manifest-path Test
The AWS Deadline Cloud CLI encountered the following exception:
Specified root dir ('/local/home/XXXXXXXX/bea/deadline-clients/deadline-cloud-worker-agent/scripts/submit_jobs/asset_example',) contains nonvalid directory.
Traceback (most recent call last):
  File "/Users/XXXXXXXX/.local/share/mise/installs/python/3.11/lib/python3.11/site-packages/deadline/client/cli/_common.py", line 54, in wraps
    func(*args, **kwargs)
  File "/Users/XXXXXXXX/.local/share/mise/installs/python/3.11/lib/python3.11/site-packages/deadline/client/cli/_groups/attachment_group.py", line 174, in attachment_upload
    attachment_api.attachment_upload(
  File "/Users/XXXXXXXX/.local/share/mise/installs/python/3.11/lib/python3.11/site-packages/deadline/job_attachments/api/attachment.py", line 108, in attachment_upload
    raise NonValidInputError(f"Specified root dir {root_dirs} contains nonvalid directory.")
deadline.client.exceptions.NonValidInputError: Specified root dir ('/local/home/XXXXXXXX/bea/deadline-clients/deadline-cloud-worker-agent/scripts/submit_jobs/asset_example',) contains nonvalid directory.
```

Error Handling - no such file
```
(attachment-cli)> deadline attachment upload --manifests "/Us
ers/XXXXXXXX/Downloads/0bb7eb91fdf8780c4a7e6174de6dfc5e_input" --path-mapping-rules "/Users/XXXXXXXX/deadline-cloud/path_mapping.json" --upload-manifest-path Test
The AWS Deadline Cloud CLI encountered the following exception:

FileNotFoundError: [Errno 2] No such file or directory: '/Users/XXXXXXXX/deadline-cloud-worker-agent/scripts/submit_jobs/asset_example/files/file1.txt'
````


### Was this change documented?

- Are relevant docstrings in the code base updated? [Yes]
- Has the README.md been updated? If you modified CLI arguments, for instance.
  - The CLI is still beta under feature flag, will collect feedback and improve before formally document them.

### Does this PR introduce new dependencies?
*   [v] This PR does not add any new dependencies.

### Is this a breaking change?
No

### Does this change impact security?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
