### PR TITLE
feat(JA): Add a fast mode for snapshot diff which compares using time…

### DIFF
--- a/src/deadline/job_attachments/_diff.py
+++ b/src/deadline/job_attachments/_diff.py
@@ -2,8 +2,9 @@
 import concurrent.futures
 
 import os
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Dict, List, Tuple
+from deadline.client.cli._groups.click_logger import ClickLogger
 from deadline.client.config import config_file
 from deadline.client.exceptions import NonValidInputError
 from deadline.job_attachments.asset_manifests.base_manifest import (
@@ -113,3 +114,50 @@ def compare_manifest(
             differences.append((FileStatus.DELETED, manifest_path))
 
     return differences
+
+
+def _fast_file_list_to_manifest_diff(
+    root: str, current_files: List[str], diff_manifest: BaseAssetManifest, logger: ClickLogger
+) -> List[str]:
+    """
+    Perform a fast difference of the current list of files to a previous manifest to diff against using time stamps and file sizes.
+    :param root: Root folder of files to diff against.
+    :param current_files: List of files to compare with.
+    :param diff_manifest: Manifest containing files to diff against.
+    :return List[str]: List of files that are new, or modified.
+    """
+    changed_paths: List[str] = []
+    input_files_map: Dict[str, BaseManifestPath] = {}
+    for input_file in diff_manifest.paths:
+        # Normalize paths so we can compare different OSes
+        normalized_path = os.path.normpath(input_file.path)
+        input_files_map[normalized_path] = input_file
+
+    # Iterate for each file that we found in glob.
+    for local_file in current_files:
+        # Get the file's time stamp and size. We want to compare both.
+        # From enabling CRT, sometimes timestamp update can fail.
+        local_file_path = Path(local_file)
+        file_stat = local_file_path.stat()
+
+        # Compare the glob against the relative path we store in the manifest.
+        root_relative_path = str(PurePosixPath(*local_file_path.relative_to(root).parts))
+        if root_relative_path not in input_files_map:
+            # This is a new file
+            logger.echo(f"Found difference at: {root_relative_path}, Status: FileStatus.NEW")
+            changed_paths.append(local_file)
+        else:
+            # This is a modified file, compare with manifest relative timestamp.
+            input_file = input_files_map[root_relative_path]
+            # Check file size first as it is easier to test. Usually modified files will also have size diff.
+            if file_stat.st_size != input_file.size:
+                changed_paths.append(local_file)
+                logger.echo(
+                    f"Found size difference at: {root_relative_path}, Status: FileStatus.MODIFIED"
+                )
+            elif int(file_stat.st_mtime_ns // 1000) != input_file.mtime:
+                changed_paths.append(local_file)
+                logger.echo(
+                    f"Found time difference at: {root_relative_path}, Status: FileStatus.MODIFIED"
+                )
+    return changed_paths

--- a/src/deadline/job_attachments/asset_manifests/_create_manifest.py
+++ b/src/deadline/job_attachments/asset_manifests/_create_manifest.py
@@ -1,0 +1,59 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from typing import List, Optional
+
+from deadline.client.api._job_attachment import _hash_attachments
+from deadline.client.cli._common import _ProgressBarCallbackManager
+from deadline.client.cli._groups.click_logger import ClickLogger
+from deadline.job_attachments.asset_manifests.base_manifest import BaseAssetManifest
+from deadline.job_attachments.exceptions import ManifestCreationException
+from deadline.job_attachments.models import JobAttachmentS3Settings
+from deadline.job_attachments.upload import S3AssetManager
+
+
+def _create_manifest_for_single_root(
+    files: List[str], root: str, logger: ClickLogger
+) -> Optional[BaseAssetManifest]:
+    """
+    Shared logic to create a manifest file from a single root.
+    :param files: Input files to create a manifest with.
+    :param root: Asset root of the files.
+    :param logger: Click logger for stdout.
+    :return
+    """
+    # Placeholder Asset Manager
+    asset_manager = S3AssetManager(
+        farm_id=" ", queue_id=" ", job_attachment_settings=JobAttachmentS3Settings(" ", " ")
+    )
+
+    hash_callback_manager = _ProgressBarCallbackManager(length=100, label="Hashing Attachments")
+
+    upload_group = asset_manager.prepare_paths_for_upload(
+        input_paths=files, output_paths=[root], referenced_paths=[]
+    )
+    # We only provided 1 root path, so output should only have 1 group.
+    assert len(upload_group.asset_groups) == 1
+
+    if upload_group.asset_groups:
+        _, manifests = _hash_attachments(
+            asset_manager=asset_manager,
+            asset_groups=upload_group.asset_groups,
+            total_input_files=upload_group.total_input_files,
+            total_input_bytes=upload_group.total_input_bytes,
+            print_function_callback=logger.echo,
+            hashing_progress_callback=hash_callback_manager.callback,
+        )
+
+    if not manifests or len(manifests) == 0:
+        logger.echo("No manifest generated")
+        return None
+    else:
+        # This is a hard failure, we are snapshotting 1 directory.
+        assert len(manifests) == 1
+
+        output_manifest = manifests[0].asset_manifest
+        if output_manifest is None:
+            raise ManifestCreationException()
+
+        # Return the generated manifest.
+        return output_manifest


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
- While integrating with the new `deadline attachment` APIs, we found snapshot diff missed one performance feature of the prior `sync_output` function. When computing "new" or "modified" files, the snapshot command still did a full hash of all files. This is not as efficient as directly checking the file timestamp and size.

- Doing a full snapshot including hash can be useful too depending on the use case! In a follow up PR, I will also add a "--rehash" check to fully compare all files by hash. This is the 100% guarantee check mode.

### What was the solution? (How)
- Adding a fast mode for `deadline snapshot diff` (default). Iterating all files found by `glob`, compare the existence, file size and timestamp provided by the given manifest.

### What is the impact of this change?
- Faster for manifest computation!

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Manual testing
```
# Comparison of an existing manifest of files changed by this CR!
deadline manifest snapshot --root ./src --destination ~/work/manifest/ --name diff-time --diff ~/work/manifest/diff-time-2024-10-07T16-30-21.manifest

Found time difference at: deadline/job_attachments/_version.py, Status: FileStatus.MODIFIED
.....
Found difference at: deadline/client/cli/_groups/__pycache__/attachment_group.cpython-312.pyc, Status: FileStatus.NEW
Hashing Attachments  [####################################]  100%
Hashing Summary:
    Processed 15 files totaling 157.4 KB.
    Skipped re-processing 3 files totaling 7.75 KB.
    Total processing time of 0.01709 seconds at 9.21 MB/s.

Manifest Generated at ~/work/manifest/diff-time-2024-10-07T17-02-19.manifest
```

- Manual testing, new file, touched file, and different sized file. All passed.
   - Did a `snapshot` of the `./src` directory
   - Created a file `helloworld` in the src directory -> run `snapshot diff`
   - Modified the file contents of `helloworld` -> run `snapshot diff`. Notice the size changed log.
   - Touched the file `hello world` -> run `snapshot diff`. Notice the time changed log.


- Have you run the unit tests?
   - `hatch run test` 100% passes
```
================================================================ 
1365 passed, 51 skipped, 1 xfailed, 2 warnings in 21.88s =================================================================
``` 
- Have you run the integration tests?
   - Yes, 100% passed.
```
=================================================================================== slowest 5 durations ===================================================================================
10.40s setup    test/integ/deadline_job_attachments/test_job_attachments.py::test_upload_input_files_all_assets_in_cas[2023-03-03]
9.02s call     test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_outputs_no_job_attachment_settings_in_job[2023-03-03]
7.15s setup    test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_inputs_with_step_dependencies[2023-03-03]
5.75s teardown test/integ/deadline_job_attachments/test_job_attachments.py::test_download_outputs_windows_file_path_UNC[2023-03-03]
4.39s call     test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_inputs_with_step_dependencies[2023-03-03]
================================================================== 16 passed, 2 skipped, 4 warnings in 69.50s (0:01:09) ===================================================================
(
```
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass.
     - NA.

### Was this change documented?

- Are relevant docstrings in the code base updated?
    - Yes.
- Has the README.md been updated? If you modified CLI arguments, for instance.
    - NA
### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [X] This PR does not add any new dependencies.

### Is this a breaking change?
Not Applicable.

### Does this change impact security?
Not Applicable.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
