### PR TITLE
test: Squish test suite for Blender gui-submit dialogue

### DIFF
--- a/test/squish/deadline_cloud_samples/blender_render/template.yaml
+++ b/test/squish/deadline_cloud_samples/blender_render/template.yaml
@@ -1,0 +1,105 @@
+specificationVersion: 'jobtemplate-2023-09'
+name: Blender Render
+
+parameterDefinitions:
+
+# Render Parameters
+- name: BlenderSceneFile
+  type: PATH
+  objectType: FILE
+  dataFlow: IN
+  userInterface:
+    control: CHOOSE_INPUT_FILE
+    label: Blender Scene File
+    groupLabel: Render Parameters
+    fileFilters:
+    - label: Blender Scene Files
+      patterns: ["*.blend"]
+    - label: All Files
+      patterns: ["*"]
+  description: >
+    Choose the Blender scene file you want to render. Use the 'Job Attachments' tab
+    to add textures and other files that the job needs.
+- name: Frames
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Frames
+    groupLabel: Render Parameters
+  default: 1-10
+- name: OutputDir
+  type: PATH
+  objectType: DIRECTORY
+  dataFlow: OUT
+  userInterface:
+    control: CHOOSE_DIRECTORY
+    label: Output Directory
+    groupLabel: Render Parameters
+  default: "./output"
+  description: Choose the render output directory.
+- name: OutputPattern
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Output File Pattern
+    groupLabel: Render Parameters
+  default: "output_####"
+  description: Enter the output filename pattern (without extension).
+- name: Format
+  type: STRING
+  userInterface:
+    control: DROPDOWN_LIST
+    label: Output File Format
+    groupLabel: Render Parameters
+  description: Choose the file format to render as.
+  default: JPEG
+  allowedValues: [TGA, RAWTGA, JPEG, IRIS, IRIZ, PNG, HDR, TIFF, OPEN_EXR, OPEN_EXR_MULTILAYER, CINEON, DPX, DDS, JP2, WEBP]
+
+# Software Environment
+- name: CondaPackages
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Conda Packages
+    groupLabel: Software Environment
+  default: blender
+  description: >
+    If you have a Queue Environment that creates a Conda environment from a parameter called CondaPackages, this will
+    tell it to install blender.
+- name: RezPackages
+  type: STRING
+  userInterface:
+    control: LINE_EDIT
+    label: Rez Packages
+    groupLabel: Software Environment
+  default: blender
+  description: >
+    If you have a Queue Environment that creates a Rez environment from a parameter called RezPackages, this will
+    tell it to install blender.
+
+steps:
+- name: RenderBlender
+  parameterSpace:
+    taskParameterDefinitions:
+    - name: Frame
+      type: INT
+      range: "{{Param.Frames}}"
+  script:
+    actions:
+      onRun:
+        command: bash
+        args: ['{{Task.File.Run}}']
+    embeddedFiles:
+      - name: Run
+        type: TEXT
+        data: |
+          # Configure the task to fail if any individual command fails.
+          set -xeuo pipefail
+
+          mkdir -p '{{Param.OutputDir}}'
+
+          blender --background '{{Param.BlenderSceneFile}}' \
+                  --render-output '{{Param.OutputDir}}/{{Param.OutputPattern}}' \
+                  --render-format {{Param.Format}} \
+                  --use-extension 1 \
+                  --render-frame {{Task.Param.Frame}}

--- a/test/squish/suite_VerifySettingsDialogue/shared/scripts/aws_submitter_helpers.py
+++ b/test/squish/suite_VerifySettingsDialogue/shared/scripts/aws_submitter_helpers.py
@@ -1,0 +1,224 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# -*- coding: utf-8 -*
+# mypy: disable-error-code="attr-defined"
+
+import aws_submitter_locators
+import gui_locators
+import gui_helpers
+import loginout_helpers
+import squish
+import test
+import config
+
+
+def open_settings_dialogue():
+    test.log("Hitting `Settings` button to open Deadline Settings dialogue.")
+    # click on Settings button to open Deadline Settings dialogue from Submitter
+    squish.clickButton(squish.waitForObject(aws_submitter_locators.settings_button))
+    test.log("Opened Settings dialogue.")
+    # verify Settings dialogue is opened
+    test.compare(
+        squish.waitForObjectExists(gui_locators.deadline_config_dialog).visible,
+        True,
+        "Expect the Deadline Settings dialogue to be open.",
+    )
+
+
+def close_settings_dialogue():
+    # click on 'OK' button to close Deadline Settings dialogue
+    gui_helpers.close_deadline_config_gui()
+    test.log("Closed Settings dialogue.")
+
+
+def authenticate_submitter_settings_dialogue():
+    # hit Settings button to open Deadline Settings dialogue
+    open_settings_dialogue()
+    # check for refresh error dialogues and close if present
+    test.log(
+        "Checking for refresh error dialogues prior to setting aws profile name for test setup."
+    )
+    loginout_helpers.check_and_close_refresh_error_dialogues()
+    # authenticate in settings dialogue (using default aws profile) if not authenticated before running blender tests
+    loginout_helpers.set_aws_profile_name_and_verify_auth(config.profile_name)
+    # close Settings dialogue
+    gui_helpers.close_deadline_config_gui()
+
+
+def navigate_shared_jobsettings_tab():
+    # click on Shared job settings tab
+    test.log("Navigate to Shared job settings tab.")
+    squish.clickTab(
+        squish.waitForObject(aws_submitter_locators.shared_jobsettings_tab), "Shared job settings"
+    )
+    # verify on shared job settings tab
+    test.compare(
+        squish.waitForObjectExists(
+            aws_submitter_locators.shared_jobsettings_properties_box
+        ).visible,
+        True,
+        "Expect user to be on Shared job settings tab.",
+    )
+
+
+def navigate_job_specificsettings_tab():
+    # click on Job-specific settings tab
+    test.log("Navigate to Job-specific settings tab.")
+    squish.clickTab(
+        squish.waitForObject(aws_submitter_locators.job_specificsettings_tab),
+        "Job-specific settings",
+    )
+    # verify on job specific settings tab
+    test.compare(
+        squish.waitForObjectExists(aws_submitter_locators.job_specificsettings_properties).visible,
+        True,
+        "Expect user to be on Job-specific settings tab.",
+    )
+
+
+def verify_shared_job_settings_tab(
+    job_name: str,
+    default_desc: str,
+    farm_name: str,
+    farm_desc: str,
+    queue_name: str,
+    conda_packages: str,
+    conda_channels: str,
+):
+    # click on shared job settings tab to navigate and ensure tests are on correct tab
+    navigate_shared_jobsettings_tab()
+    # verify default job name is set to correct name
+    test.compare(
+        str(
+            squish.waitForObjectExists(aws_submitter_locators.job_properties_name_input).displayText
+        ),
+        job_name,
+        "Expect correct job bundle job name to be displayed by default.",
+    )
+    # verify default description contains no text
+    test.compare(
+        str(
+            squish.waitForObjectExists(aws_submitter_locators.job_properties_desc_input).displayText
+        ),
+        default_desc,
+        "Expect empty job bundle description to be displayed by default.",
+    )
+    # verify correct farm name is displayed
+    test.compare(
+        str(
+            squish.waitForObjectExists(
+                aws_submitter_locators.deadlinecloud_farmname_locator(farm_name)
+            ).text
+        ),
+        farm_name,
+        "Expect correct farm name to be displayed.",
+    )
+    # verify farm name tooltip contains correct farm description
+    test.compare(
+        str(
+            squish.waitForObjectExists(
+                aws_submitter_locators.deadlinecloud_farmname_locator(farm_name)
+            ).toolTip
+        ),
+        farm_desc,
+        "Expect correct farm description to be displayed.",
+    )
+    # verify correct queue name is displayed
+    test.compare(
+        str(
+            squish.waitForObjectExists(
+                aws_submitter_locators.deadlinecloud_queuename_locator(queue_name)
+            ).text
+        ),
+        queue_name,
+        "Expect correct queue name to be displayed.",
+    )
+    # verify Conda Packages contains correct Conda Package name
+    test.compare(
+        str(
+            squish.waitForObjectExists(aws_submitter_locators.conda_packages_text_input).displayText
+        ),
+        conda_packages,
+        "Expect correct DCC Conda Package to be displayed.",
+    )
+    # verify Conda Channels contains correct Conda Channel name
+    test.compare(
+        str(
+            squish.waitForObjectExists(aws_submitter_locators.conda_channels_text_input).displayText
+        ),
+        conda_channels,
+        "Expect correct Conda Channel to be displayed.",
+    )
+
+
+def verify_job_specific_settings_tab(
+    frames: str, output_dir: str, output_pattern: str, output_format: str, conda_packages: str
+):
+    # click on job specific settings tab to test navigate and ensure tests are on correct tab
+    navigate_job_specificsettings_tab()
+    # verify correct frame range is displayed
+    test.compare(
+        str(
+            squish.waitForObjectExists(
+                aws_submitter_locators.render_parameters_frames_text_input
+            ).displayText
+        ),
+        frames,
+        "Expect correct frames to be input in dialogue from job bundle.",
+    )
+    # verify correct output directory file path is displayed
+    test.compare(
+        str(
+            squish.waitForObjectExists(
+                aws_submitter_locators.render_parameters_output_dir_filepath
+            ).displayText
+        ),
+        output_dir,
+        "Expect correct output directory file path to be input in dialogue from job bundle.",
+    )
+    # verify correct output file pattern is displayed
+    test.compare(
+        str(
+            squish.waitForObjectExists(
+                aws_submitter_locators.render_parameters_output_file_pattern_text_input
+            ).displayText
+        ),
+        output_pattern,
+        "Expect correct output file pattern to be input in dialogue from job bundle.",
+    )
+    # verify correct output file format is displayed
+    test.compare(
+        str(
+            squish.waitForObjectExists(
+                aws_submitter_locators.render_parameters_output_file_format_dropdown
+            ).currentText
+        ),
+        output_format,
+        "Expect correct output file format to be input in dialogue from job bundle.",
+    )
+    # verify correct Conda Packages is displayed
+    test.compare(
+        str(
+            squish.waitForObjectExists(
+                aws_submitter_locators.software_environment_condapackages_text_input
+            ).displayText
+        ),
+        conda_packages,
+        "Expect correct Conda Packages to be displayed under Software Environment.",
+    )
+
+
+def verify_conda_tooltip_texts():
+    # click on shared job settings tab to test navigate and ensure tests are on correct tab
+    navigate_shared_jobsettings_tab()
+    # verify Conda Packages contains correct tooltip text
+    test.compare(
+        str(squish.waitForObjectExists(aws_submitter_locators.conda_packages_text_label).toolTip),
+        config.tooltip_text_conda_packages,
+        "Expect Conda Packages to contain correct tooltip text.",
+    )
+    # verify Conda Channels contains correct tooltip text
+    test.compare(
+        str(squish.waitForObjectExists(aws_submitter_locators.conda_channels_text_label).toolTip),
+        config.tooltip_text_conda_channels,
+        "Expect Conda Channels to contain correct tooltip text.",
+    )

--- a/test/squish/suite_VerifySettingsDialogue/shared/scripts/aws_submitter_locators.py
+++ b/test/squish/suite_VerifySettingsDialogue/shared/scripts/aws_submitter_locators.py
@@ -1,0 +1,258 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# -*- coding: utf-8 -*-
+
+aws_submitter_dialogue = {
+    "type": "SubmitJobToDeadlineDialog",
+    "unnamed": 1,
+    "visible": 1,
+    "windowTitle": "Submit to AWS Deadline Cloud",
+}
+settings_button = {
+    "text": "Settings...",
+    "type": "QPushButton",
+    "unnamed": 1,
+    "visible": 1,
+    "window": aws_submitter_dialogue,
+}
+shared_jobsettings_tab = {
+    "type": "QTabWidget",
+    "unnamed": 1,
+    "visible": 1,
+    "window": aws_submitter_dialogue,
+}
+job_specificsettings_tab = {
+    "type": "QTabWidget",
+    "unnamed": 1,
+    "visible": 1,
+    "window": aws_submitter_dialogue,
+}
+tabs_and_properties_widget = {
+    "name": "qt_tabwidget_stackedwidget",
+    "type": "QStackedWidget",
+    "visible": 1,
+    "window": aws_submitter_dialogue,
+}
+# qt_tabwidget_stackedwidget_QScrollArea
+properties_only_widget = {
+    "container": tabs_and_properties_widget,
+    "type": "QScrollArea",
+    "unnamed": 1,
+    "visible": 1,
+}
+# shared job settings tab
+shared_jobsettings_jobproperties_widget = {
+    "container": properties_only_widget,
+    "type": "SharedJobSettingsWidget",
+    "unnamed": 1,
+    "visible": 1,
+}
+shared_jobsettings_properties_box = {
+    "container": properties_only_widget,
+    "title": "Job Properties",
+    "type": "SharedJobPropertiesWidget",
+    "unnamed": 1,
+    "visible": 1,
+}
+job_properties_name_label = {
+    "container": shared_jobsettings_properties_box,
+    "text": "Name",
+    "type": "QLabel",
+    "unnamed": 1,
+    "visible": 1,
+}
+job_properties_name_input = {
+    "buddy": job_properties_name_label,
+    "type": "QLineEdit",
+    "unnamed": 1,
+    "visible": 1,
+}
+
+job_properties_desc_label = {
+    "container": shared_jobsettings_properties_box,
+    "text": "Description",
+    "type": "QLabel",
+    "unnamed": 1,
+    "visible": 1,
+}
+job_properties_desc_input = {
+    "aboveWidget": job_properties_name_input,
+    "container": shared_jobsettings_properties_box,
+    "leftWidget": job_properties_desc_label,
+    "type": "QLineEdit",
+    "unnamed": 1,
+    "visible": 1,
+}
+deadline_cloud_settings_widget = {
+    "container": properties_only_widget,
+    "title": "Deadline Cloud settings",
+    "type": "DeadlineCloudSettingsWidget",
+    "unnamed": 1,
+    "visible": 1,
+}
+# Deadline Cloud Squish Farm text element
+deadline_cloud_settings_farm_name = {
+    "container": deadline_cloud_settings_widget,
+    "text": "Deadline Cloud Squish Farm",
+    "type": "QLabel",
+    "unnamed": 1,
+    "visible": 1,
+}
+# Squish Automation Queue text element
+deadline_cloud_settings_queue_name = {
+    "container": deadline_cloud_settings_widget,
+    "text": "Squish Automation Queue",
+    "type": "QLabel",
+    "unnamed": 1,
+    "visible": 1,
+}
+queue_environment_conda_widget = {
+    "container": properties_only_widget,
+    "name": "Queue Environment: Conda",
+    "type": "_JobTemplateGroupLayout",
+    "visible": 1,
+}
+conda_packages_text_label = {
+    "container": queue_environment_conda_widget,
+    "text": "Conda Packages",
+    "type": "QLabel",
+    "unnamed": 1,
+    "visible": 1,
+}
+conda_packages_text_input = {
+    "container": queue_environment_conda_widget,
+    "leftWidget": conda_packages_text_label,
+    "type": "QLineEdit",
+    "unnamed": 1,
+    "visible": 1,
+}
+conda_channels_text_label = {
+    "container": queue_environment_conda_widget,
+    "text": "Conda Channels",
+    "type": "QLabel",
+    "unnamed": 1,
+    "visible": 1,
+}
+conda_channels_text_input = {
+    "container": queue_environment_conda_widget,
+    "leftWidget": conda_channels_text_label,
+    "type": "QLineEdit",
+    "unnamed": 1,
+    "visible": 1,
+}
+# job-specific settings tab
+job_specificsettings_properties = {
+    "container": properties_only_widget,
+    "type": "JobBundleSettingsWidget",
+    "unnamed": 1,
+    "visible": 1,
+}
+render_parameters_widget = {
+    "container": properties_only_widget,
+    "name": "Render Parameters",
+    "type": "_JobTemplateGroupLayout",
+    "visible": 1,
+}
+render_parameters_frames_label = {
+    "container": render_parameters_widget,
+    "text": "Frames",
+    "type": "QLabel",
+    "unnamed": 1,
+    "visible": 1,
+}
+render_parameters_frames_text_input = {
+    "container": render_parameters_widget,
+    "leftWidget": render_parameters_frames_label,
+    "type": "QLineEdit",
+    "unnamed": 1,
+    "visible": 1,
+}
+render_parameters_output_dir_filepath = {
+    "container": render_parameters_widget,
+    "occurrence": 3,
+    "type": "QLineEdit",
+    "unnamed": 1,
+    "visible": 1,
+}
+render_parameters_output_file_pattern_label = {
+    "container": render_parameters_widget,
+    "text": "Output File Pattern",
+    "type": "QLabel",
+    "unnamed": 1,
+    "visible": 1,
+}
+render_parameters_output_file_pattern_text_input = {
+    "container": render_parameters_widget,
+    "leftWidget": render_parameters_output_file_pattern_label,
+    "type": "QLineEdit",
+    "unnamed": 1,
+    "visible": 1,
+}
+render_parameters_output_file_format_label = {
+    "container": render_parameters_widget,
+    "text": "Output File Format",
+    "type": "QLabel",
+    "unnamed": 1,
+    "visible": 1,
+}
+render_parameters_output_file_format_dropdown = {
+    "container": render_parameters_widget,
+    "leftWidget": render_parameters_output_file_format_label,
+    "type": "QComboBox",
+    "unnamed": 1,
+    "visible": 1,
+}
+software_environment_widget = {
+    "container": properties_only_widget,
+    "name": "Software Environment",
+    "type": "_JobTemplateGroupLayout",
+    "visible": 1,
+}
+software_environment_condapackages_label = {
+    "container": software_environment_widget,
+    "text": "Conda Packages",
+    "type": "QLabel",
+    "unnamed": 1,
+    "visible": 1,
+}
+software_environment_condapackages_text_input = {
+    "container": software_environment_widget,
+    "leftWidget": software_environment_condapackages_label,
+    "type": "QLineEdit",
+    "unnamed": 1,
+    "visible": 1,
+}
+# load different job bundle button in AWS Submitter dialogue (job-specific settings tab)
+load_different_job_bundle_button = {
+    "container": properties_only_widget,
+    "text": "Load a different job bundle",
+    "type": "QPushButton",
+    "unnamed": 1,
+    "visible": 1,
+}
+# job history directory default filepath input
+job_hist_dir_dropdown = {
+    "container": properties_only_widget,
+    "name": "lookInCombo",
+    "type": "QComboBox",
+    "visible": 1,
+}
+
+
+def deadlinecloud_farmname_locator(farm_name):
+    return {
+        "container": deadline_cloud_settings_widget,
+        "text": farm_name,
+        "type": "QLabel",
+        "unnamed": 1,
+        "visible": 1,
+    }
+
+
+def deadlinecloud_queuename_locator(queue_name):
+    return {
+        "container": deadline_cloud_settings_widget,
+        "text": queue_name,
+        "type": "QLabel",
+        "unnamed": 1,
+        "visible": 1,
+    }

--- a/test/squish/suite_VerifySettingsDialogue/shared/scripts/choose_jobbundledir_helpers.py
+++ b/test/squish/suite_VerifySettingsDialogue/shared/scripts/choose_jobbundledir_helpers.py
@@ -1,0 +1,93 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# -*- coding: utf-8 -*
+# mypy: disable-error-code="attr-defined"
+
+import choose_jobbundledir_locators
+import aws_submitter_helpers
+import aws_submitter_locators
+import squish
+import test
+
+
+def launch_jobbundle_dir_and_select_jobbundle(filepath: str):
+    squish.startApplication("deadline bundle gui-submit --browse")
+    test.log("Launched Choose Job Bundle Directory.")
+    # verify Choose Job Bundle directory is open
+    test.compare(
+        str(
+            squish.waitForObjectExists(
+                choose_jobbundledir_locators.choose_job_bundle_dir
+            ).windowTitle
+        ),
+        "Choose job bundle directory",
+        "Expect Choose job bundle directory window title to be present.",
+    )
+    test.compare(
+        squish.waitForObjectExists(choose_jobbundledir_locators.choose_job_bundle_dir).visible,
+        True,
+        "Expect Choose job bundle directory to be open.",
+    )
+    # enter job bundle directory file path in directory text input
+    squish.type(
+        squish.waitForObject(choose_jobbundledir_locators.jobbundle_filepath_input), filepath
+    )
+    test.log("Entered job bundle file path in Choose Job Bundle Directory.")
+    # verify text input appears
+    test.compare(
+        str(
+            squish.waitForObjectExists(
+                choose_jobbundledir_locators.jobbundle_filepath_input
+            ).displayText
+        ),
+        filepath,
+        "Expect job bundle file path to be input in dialogue.",
+    )
+    # hit 'choose' button
+    test.log("Hitting 'Choose' button to open Submitter dialogue for selected job bundle.")
+    squish.clickButton(
+        squish.waitForObject(choose_jobbundledir_locators.choose_jobbundledir_button)
+    )
+
+
+def verify_load_different_jobbundle_dir():
+    # click on job specific settings tab to navigate and ensure tests are on correct tab
+    aws_submitter_helpers.navigate_job_specificsettings_tab()
+    # verify load different job bundle button exists and contains correct button text
+    test.compare(
+        str(
+            squish.waitForObjectExists(aws_submitter_locators.load_different_job_bundle_button).text
+        ),
+        "Load a different job bundle",
+        "Expect Load a different job bundle button to contain correct text.",
+    )
+    # verify load a different job bundle button is enabled
+    test.compare(
+        squish.waitForObjectExists(aws_submitter_locators.load_different_job_bundle_button).enabled,
+        True,
+        "Expect Load a different job bundle button to be enabled.",
+    )
+    # click on load a different job bundle button
+    test.log("Hitting `Load a different job bundle` button.")
+    squish.clickButton(
+        squish.waitForObject(aws_submitter_locators.load_different_job_bundle_button)
+    )
+    # verify Choose Job Bundle directory is open
+    test.compare(
+        str(
+            squish.waitForObjectExists(
+                choose_jobbundledir_locators.choose_job_bundle_dir
+            ).windowTitle
+        ),
+        "Choose job bundle directory",
+        "Expect Choose job bundle directory window title to be present.",
+    )
+    test.compare(
+        squish.waitForObjectExists(choose_jobbundledir_locators.choose_job_bundle_dir).visible,
+        True,
+        "Expect Choose job bundle directory to be open.",
+    )
+    # hit cancel button to close out of choose job bundle directory
+    test.log("Hitting `Cancel` button to close Choose job bundle directory.")
+    squish.clickButton(
+        squish.waitForObject(choose_jobbundledir_locators.jobbundledir_cancel_button)
+    )

--- a/test/squish/suite_VerifySettingsDialogue/shared/scripts/choose_jobbundledir_locators.py
+++ b/test/squish/suite_VerifySettingsDialogue/shared/scripts/choose_jobbundledir_locators.py
@@ -1,0 +1,31 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# -*- coding: utf-8 -*-
+
+# choose job bundle directory
+choose_job_bundle_dir = {"name": "QFileDialog", "type": "QFileDialog", "visible": 1}
+directory_text_label = {
+    "name": "fileNameLabel",
+    "type": "QLabel",
+    "visible": 1,
+    "window": choose_job_bundle_dir,
+}
+jobbundle_filepath_input = {
+    "buddy": directory_text_label,
+    "name": "fileNameEdit",
+    "type": "QLineEdit",
+    "visible": 1,
+}
+choose_jobbundledir_button = {
+    "text": "Choose",
+    "type": "QPushButton",
+    "unnamed": 1,
+    "visible": 1,
+    "window": choose_job_bundle_dir,
+}
+jobbundledir_cancel_button = {
+    "text": "Cancel",
+    "type": "QPushButton",
+    "unnamed": 1,
+    "visible": 1,
+    "window": choose_job_bundle_dir,
+}

--- a/test/squish/suite_VerifySettingsDialogue/shared/scripts/config.py
+++ b/test/squish/suite_VerifySettingsDialogue/shared/scripts/config.py
@@ -1,9 +1,11 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # mypy: disable-error-code="attr-defined"
 
+# deadline config gui workstation config
 profile_name = "(default)"
 job_hist_dir = "~/.deadline/job_history/(default)"
 farm_name = "Deadline Cloud Squish Farm"
+farm_desc = "Squish Automation Test Framework"
 queue_name = "Squish Automation Queue"
 storage_profile = "Squish Storage Profile"
 job_attachments = "COPIED"
@@ -14,3 +16,18 @@ tooltip_text_lightbulb = "This setting determines how job attachments are loaded
 conflict_res_option = "NOT\\_SELECTED"
 conflict_res_option_expected_text = conflict_res_option.replace("\\_", "_")
 logging_level = "WARNING"
+
+# AWS Submitter dialogue job properties
+empty_desc = ""
+tooltip_text_conda_packages = 'This is a space-separated list of Conda package match specifications to install for the job. E.g. "blender=3.6" for a job that renders frames in Blender 3.6.\nSee https://docs.conda.io/projects/conda/en/latest/user-guide/concepts/pkg-specs.html#package-match-specifications\n'
+tooltip_text_conda_channels = 'This is a space-separated list of Conda channels from which to install packages. Deadline Cloud SMF packages are installed from the "deadline-cloud" channel that is configured by Deadline Cloud.\nAdd "conda-forge" to get packages from the https://conda-forge.org/ community, and "defaults" to get packages from Anaconda Inc (make sure your usage complies with https://www.anaconda.com/terms-of-use).\n'
+conda_channel = "deadline-cloud"
+
+# blender job bundle directory
+blender_filepath = "./deadline-cloud/test/squish/deadline_cloud_samples/blender_render"
+blender_job_name = "Blender Render"
+blender_conda_package = "blender"
+blender_frames = "1-10"
+blender_output_dir = "./deadline-cloud/test/squish/deadline_cloud_samples/blender_render/output"
+blender_output_pattern = "output_####"
+blender_output_format = "JPEG"

--- a/test/squish/suite_VerifySettingsDialogue/shared/scripts/gui_helpers.py
+++ b/test/squish/suite_VerifySettingsDialogue/shared/scripts/gui_helpers.py
@@ -24,7 +24,7 @@ def launch_deadline_config_gui():
 
 
 def close_deadline_config_gui():
-    test.log("Hitting `OK` button to close Deadline Config GUI.")
+    test.log("Hitting `OK` button to close Deadline Settings.")
     # hit 'OK' button to close Deadline Config GUI
     squish.clickButton(squish.waitForObject(gui_locators.deadlinedialog_ok_button))
 

--- a/test/squish/suite_VerifySettingsDialogue/shared/scripts/names.py
+++ b/test/squish/suite_VerifySettingsDialogue/shared/scripts/names.py
@@ -288,3 +288,293 @@ general_settings_Current_logging_level_QComboBox = {
     "unnamed": 1,
     "visible": 1,
 }
+qFileDialog_fileNameLabel_QLabel = {
+    "name": "fileNameLabel",
+    "type": "QLabel",
+    "visible": 1,
+    "window": qFileDialog_QFileDialog,
+}
+fileNameEdit_QLineEdit = {
+    "buddy": qFileDialog_fileNameLabel_QLabel,
+    "name": "fileNameEdit",
+    "type": "QLineEdit",
+    "visible": 1,
+}
+qFileDialog_Choose_QPushButton = {
+    "text": "Choose",
+    "type": "QPushButton",
+    "unnamed": 1,
+    "visible": 1,
+    "window": qFileDialog_QFileDialog,
+}
+qFileDialog_Cancel_QPushButton = {
+    "text": "Cancel",
+    "type": "QPushButton",
+    "unnamed": 1,
+    "visible": 1,
+    "window": qFileDialog_QFileDialog,
+}
+error_running_deadline_bundle_gui_submit_browse_QMessageBox = {
+    "type": "QMessageBox",
+    "unnamed": 1,
+    "visible": 1,
+    "windowTitle": 'Error running "deadline bundle gui-submit --browse"',
+}
+error_running_deadline_bundle_gui_submit_browse_OK_QPushButton = {
+    "text": "OK",
+    "type": "QPushButton",
+    "unnamed": 1,
+    "visible": 1,
+    "window": error_running_deadline_bundle_gui_submit_browse_QMessageBox,
+}
+submit_to_AWS_Deadline_Cloud_SubmitJobToDeadlineDialog = {
+    "type": "SubmitJobToDeadlineDialog",
+    "unnamed": 1,
+    "visible": 1,
+    "windowTitle": "Submit to AWS Deadline Cloud",
+}
+submit_to_AWS_Deadline_Cloud_Settings_QPushButton = {
+    "text": "Settings...",
+    "type": "QPushButton",
+    "unnamed": 1,
+    "visible": 1,
+    "window": submit_to_AWS_Deadline_Cloud_SubmitJobToDeadlineDialog,
+}
+submit_to_AWS_Deadline_Cloud_qt_tabwidget_stackedwidget_QStackedWidget = {
+    "name": "qt_tabwidget_stackedwidget",
+    "type": "QStackedWidget",
+    "visible": 1,
+    "window": submit_to_AWS_Deadline_Cloud_SubmitJobToDeadlineDialog,
+}
+qt_tabwidget_stackedwidget_QScrollArea = {
+    "container": submit_to_AWS_Deadline_Cloud_qt_tabwidget_stackedwidget_QStackedWidget,
+    "type": "QScrollArea",
+    "unnamed": 1,
+    "visible": 1,
+}
+job_Properties_SharedJobPropertiesWidget = {
+    "container": qt_tabwidget_stackedwidget_QScrollArea,
+    "title": "Job Properties",
+    "type": "SharedJobPropertiesWidget",
+    "unnamed": 1,
+    "visible": 1,
+}
+job_Properties_Name_QLabel = {
+    "container": job_Properties_SharedJobPropertiesWidget,
+    "text": "Name",
+    "type": "QLabel",
+    "unnamed": 1,
+    "visible": 1,
+}
+name_QLineEdit = {
+    "buddy": job_Properties_Name_QLabel,
+    "type": "QLineEdit",
+    "unnamed": 1,
+    "visible": 1,
+}
+qFileDialog_splitter_QSplitter = {
+    "name": "splitter",
+    "type": "QSplitter",
+    "visible": 1,
+    "window": qFileDialog_QFileDialog,
+}
+splitter_frame_QFrame = {
+    "container": qFileDialog_splitter_QSplitter,
+    "name": "frame",
+    "type": "QFrame",
+    "visible": 1,
+}
+frame_stackedWidget_QStackedWidget = {
+    "container": splitter_frame_QFrame,
+    "name": "stackedWidget",
+    "type": "QStackedWidget",
+    "visible": 1,
+}
+stackedWidget_treeView_QTreeView = {
+    "container": frame_stackedWidget_QStackedWidget,
+    "name": "treeView",
+    "type": "QTreeView",
+    "visible": 1,
+}
+job_Properties_Description_QLabel = {
+    "container": job_Properties_SharedJobPropertiesWidget,
+    "text": "Description",
+    "type": "QLabel",
+    "unnamed": 1,
+    "visible": 1,
+}
+job_Properties_Description_QLineEdit = {
+    "aboveWidget": name_QLineEdit,
+    "container": job_Properties_SharedJobPropertiesWidget,
+    "leftWidget": job_Properties_Description_QLabel,
+    "type": "QLineEdit",
+    "unnamed": 1,
+    "visible": 1,
+}
+deadline_Cloud_settings_DeadlineCloudSettingsWidget = {
+    "container": qt_tabwidget_stackedwidget_QScrollArea,
+    "title": "Deadline Cloud settings",
+    "type": "DeadlineCloudSettingsWidget",
+    "unnamed": 1,
+    "visible": 1,
+}
+deadline_Cloud_settings_Deadline_Cloud_Squish_Farm_QLabel = {
+    "container": deadline_Cloud_settings_DeadlineCloudSettingsWidget,
+    "text": "Deadline Cloud Squish Farm",
+    "type": "QLabel",
+    "unnamed": 1,
+    "visible": 1,
+}
+deadline_Cloud_settings_Squish_Automation_Queue_QLabel = {
+    "container": deadline_Cloud_settings_DeadlineCloudSettingsWidget,
+    "text": "Squish Automation Queue",
+    "type": "QLabel",
+    "unnamed": 1,
+    "visible": 1,
+}
+queue_Environment_Conda_JobTemplateGroupLayout = {
+    "container": qt_tabwidget_stackedwidget_QScrollArea,
+    "name": "Queue Environment: Conda",
+    "type": "_JobTemplateGroupLayout",
+    "visible": 1,
+}
+queue_Environment_Conda_Conda_Packages_QLabel = {
+    "container": queue_Environment_Conda_JobTemplateGroupLayout,
+    "text": "Conda Packages",
+    "type": "QLabel",
+    "unnamed": 1,
+    "visible": 1,
+}
+queue_Environment_Conda_Conda_Channels_QLabel = {
+    "container": queue_Environment_Conda_JobTemplateGroupLayout,
+    "text": "Conda Channels",
+    "type": "QLabel",
+    "unnamed": 1,
+    "visible": 1,
+}
+o_SharedJobSettingsWidget = {
+    "container": qt_tabwidget_stackedwidget_QScrollArea,
+    "type": "SharedJobSettingsWidget",
+    "unnamed": 1,
+    "visible": 1,
+}
+submit_to_AWS_Deadline_Cloud_DeadlineAuthenticationStatusWidget = {
+    "type": "DeadlineAuthenticationStatusWidget",
+    "unnamed": 1,
+    "visible": 1,
+    "window": submit_to_AWS_Deadline_Cloud_SubmitJobToDeadlineDialog,
+}
+queue_Environment_Conda_Conda_Packages_QLineEdit = {
+    "container": queue_Environment_Conda_JobTemplateGroupLayout,
+    "leftWidget": queue_Environment_Conda_Conda_Packages_QLabel,
+    "type": "QLineEdit",
+    "unnamed": 1,
+    "visible": 1,
+}
+queue_Environment_Conda_Conda_Channels_QLineEdit = {
+    "container": queue_Environment_Conda_JobTemplateGroupLayout,
+    "leftWidget": queue_Environment_Conda_Conda_Channels_QLabel,
+    "type": "QLineEdit",
+    "unnamed": 1,
+    "visible": 1,
+}
+submit_to_AWS_Deadline_Cloud_QTabWidget = {
+    "type": "QTabWidget",
+    "unnamed": 1,
+    "visible": 1,
+    "window": submit_to_AWS_Deadline_Cloud_SubmitJobToDeadlineDialog,
+}
+software_Environment_JobTemplateGroupLayout = {
+    "container": qt_tabwidget_stackedwidget_QScrollArea,
+    "name": "Software Environment",
+    "type": "_JobTemplateGroupLayout",
+    "visible": 1,
+}
+software_Environment_Conda_Packages_QLabel = {
+    "container": software_Environment_JobTemplateGroupLayout,
+    "text": "Conda Packages",
+    "type": "QLabel",
+    "unnamed": 1,
+    "visible": 1,
+}
+software_Environment_Conda_Packages_QLineEdit = {
+    "container": software_Environment_JobTemplateGroupLayout,
+    "leftWidget": software_Environment_Conda_Packages_QLabel,
+    "type": "QLineEdit",
+    "unnamed": 1,
+    "visible": 1,
+}
+render_Parameters_JobTemplateGroupLayout = {
+    "container": qt_tabwidget_stackedwidget_QScrollArea,
+    "name": "Render Parameters",
+    "type": "_JobTemplateGroupLayout",
+    "visible": 1,
+}
+render_Parameters_QLineEdit = {
+    "container": render_Parameters_JobTemplateGroupLayout,
+    "occurrence": 3,
+    "type": "QLineEdit",
+    "unnamed": 1,
+    "visible": 1,
+}
+render_Parameters_Output_File_Pattern_QLabel = {
+    "container": render_Parameters_JobTemplateGroupLayout,
+    "text": "Output File Pattern",
+    "type": "QLabel",
+    "unnamed": 1,
+    "visible": 1,
+}
+render_Parameters_Output_File_Pattern_QLineEdit = {
+    "container": render_Parameters_JobTemplateGroupLayout,
+    "leftWidget": render_Parameters_Output_File_Pattern_QLabel,
+    "type": "QLineEdit",
+    "unnamed": 1,
+    "visible": 1,
+}
+render_Parameters_Output_File_Format_QLabel = {
+    "container": render_Parameters_JobTemplateGroupLayout,
+    "text": "Output File Format",
+    "type": "QLabel",
+    "unnamed": 1,
+    "visible": 1,
+}
+render_Parameters_Output_File_Format_QComboBox = {
+    "container": render_Parameters_JobTemplateGroupLayout,
+    "leftWidget": render_Parameters_Output_File_Format_QLabel,
+    "type": "QComboBox",
+    "unnamed": 1,
+    "visible": 1,
+}
+render_Parameters_Frames_QLabel = {
+    "container": render_Parameters_JobTemplateGroupLayout,
+    "text": "Frames",
+    "type": "QLabel",
+    "unnamed": 1,
+    "visible": 1,
+}
+render_Parameters_Frames_QLineEdit = {
+    "container": render_Parameters_JobTemplateGroupLayout,
+    "leftWidget": render_Parameters_Frames_QLabel,
+    "type": "QLineEdit",
+    "unnamed": 1,
+    "visible": 1,
+}
+o_JobBundleSettingsWidget = {
+    "container": qt_tabwidget_stackedwidget_QScrollArea,
+    "type": "JobBundleSettingsWidget",
+    "unnamed": 1,
+    "visible": 1,
+}
+load_a_different_job_bundle_QPushButton = {
+    "container": qt_tabwidget_stackedwidget_QScrollArea,
+    "text": "Load a different job bundle",
+    "type": "QPushButton",
+    "unnamed": 1,
+    "visible": 1,
+}
+lookInCombo_QComboBox = {
+    "container": qt_tabwidget_stackedwidget_QScrollArea,
+    "name": "lookInCombo",
+    "type": "QComboBox",
+    "visible": 1,
+}

--- a/test/squish/suite_VerifySettingsDialogue/suite.conf
+++ b/test/squish/suite_VerifySettingsDialogue/suite.conf
@@ -1,9 +1,9 @@
-AUT=deadline config gui
+AUT=deadline
 ENVVARS=envvars
 HOOK_SUB_PROCESSES=true
 IMPLICITAUTSTART=0
 LANGUAGE=Python
 OBJECTMAPSTYLE=script
-TEST_CASES=tst_VerifySettingsDialogue
+TEST_CASES=tst_VerifySettingsDialogue tst_VerifyBlenderSubmitter
 VERSION=3
 WRAPPERS=Qt

--- a/test/squish/suite_VerifySettingsDialogue/tst_VerifyBlenderSubmitter/test.py
+++ b/test/squish/suite_VerifySettingsDialogue/tst_VerifyBlenderSubmitter/test.py
@@ -1,0 +1,69 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# -*- coding: utf-8 -*-
+# mypy: disable-error-code="attr-defined"
+
+import config
+import choose_jobbundledir_helpers
+import aws_submitter_helpers
+import aws_submitter_locators
+import squish
+import test
+
+
+def init():
+    # launch deadline bundle gui-submit --browse and select Blender job bundle
+    choose_jobbundledir_helpers.launch_jobbundle_dir_and_select_jobbundle(config.blender_filepath)
+    # verify AWS Deadline Cloud Submitter dialogue is open
+    test.compare(
+        str(squish.waitForObjectExists(aws_submitter_locators.aws_submitter_dialogue).windowTitle),
+        "Submit to AWS Deadline Cloud",
+        "Expect AWS Deadline Cloud Submitter window title to be present.",
+    )
+    test.compare(
+        squish.waitForObjectExists(aws_submitter_locators.aws_submitter_dialogue).visible,
+        True,
+        "Expect AWS Deadline Cloud Submitter to be open.",
+    )
+    # open settings dialogue and authenticate using aws default profile
+    aws_submitter_helpers.authenticate_submitter_settings_dialogue()
+
+
+def main():
+    # verify shared job settings tab contains correct job properties defaults based on selected blender job bundle
+    test.log("Start verifying Shared Job Settings tests...")
+    aws_submitter_helpers.verify_shared_job_settings_tab(
+        config.blender_job_name,
+        config.empty_desc,
+        config.farm_name,
+        config.farm_desc,
+        config.queue_name,
+        config.blender_conda_package,
+        config.conda_channel,
+    )
+    # verify job-specific settings tab contains correct defaults based on selected blender job bundle
+    test.log("Start verifying Job-Specific Settings tests...")
+    aws_submitter_helpers.verify_job_specific_settings_tab(
+        config.blender_frames,
+        config.blender_output_dir,
+        config.blender_output_pattern,
+        config.blender_output_format,
+        config.blender_conda_package,
+    )
+    # verify AWS Submitter dialogue contains correct tool tip texts (on shared job settings tab)
+    test.log("Start verifying correct tooltip texts...")
+    aws_submitter_helpers.verify_conda_tooltip_texts()
+    # verify load different job bundle directory
+    test.log("Start verifying Load a different job bundle tests...")
+    choose_jobbundledir_helpers.verify_load_different_jobbundle_dir()
+
+
+def cleanup():
+    test.log("Start test cleanup...")
+    # reset aws profile name to `(default)`
+    aws_submitter_helpers.authenticate_submitter_settings_dialogue()
+    test.log("Reset aws profile name to `default` for test cleanup.")
+    # close AWS Submitter dialogue by sending QCloseEvent to 'x' button
+    test.log("Closing AWS Submitter dialogue by sending QCloseEvent to 'x' button.")
+    squish.sendEvent(
+        "QCloseEvent", squish.waitForObject(aws_submitter_locators.aws_submitter_dialogue)
+    )


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Preface: 
I am working on implementing an automated test suite using Squish framework to test the GUI interface of the Deadline GUI Submitter dialogues. The goal is to eventually achieve at least 95% automation coverage of the GUI interface. 

This PR focuses on testing the Blender gui-submitter dialogue using the `deadline bundle gui-submit --browse` command (where no user interface automation exists right now). It utilizes test files/job bundles grabbed from the [deadline-cloud-samples repo](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/job_bundles) (rather than creating my own for the time being) as we need existing job bundles to open/test these dialogues, and these files from the deadline-cloud-samples are already vetted/public (so I am not planning to create any of my own at the moment). These files must live in the same repo as the Squish tests as the tests need to pull those files while running (both locally and CI/CD). 

### What was the solution? (How)

I identified four test cases for the Blender GUI Submit dialogue utilizing the "Blender Render" file from [deadline-cloud-samples repo](https://github.com/aws-deadline/deadline-cloud-samples/tree/mainline/job_bundles). Those test cases contain numerous verifications (with a total of 43 tests/verifications). 

As I have several test cases and Squish follows a framework where tests are only run in a single "main()" block, each test case has been organized into a single function/line in the main() block, in which if tests need to be disabled, they can be easily commented out. Additionally, this allows us to easily organize the test suites efficiently (so that we don't have dozens of separate test suites running the same GUI interface. This follows E2E test fundamentals you see in other frameworks where "it" blocks allow you to run multiple test cases in a single file (which Squish doesn't allow and hence each test case being a single line of code in main()) -- hopefully that makes sense.

The four test cases I decide to automate (and more can be added):
1. Verify defaults are correct on shared job settings tab based on selected Blender job bundle.
2. Verify defaults are correct on job-specific settings tab based on selected Blender job bundle.
3. Verify a few tooltip texts (and that they contain correct text). 
4. Verify 'Load a different job bundle' button works. 

Additionally, to implement/write this suite, I followed the similar/same test conventions I had written for the `deadline config gui` tests. This includes the following:
- Authenticating using default AWS profile in test setup, and test cleanup (this also includes clearing out any refresh error dialogues)
- Renaming all pre-named locators created by Squish, as they are less-user friendly. (This amounted to having to rename probably over 100 locators, again).

Note that the `deadline config gui` tests (which is in the `tst_VerifySettingsDialogue` folder) does not currently follow the above convention for the main() block, however, that is due to that test being one test case itself (and more test cases will need to be added). 

### What is the impact of this change?

Currently none as the tests cannot be run in a CI/CD pipeline, and you will need a Squish licenses in order to run these tests. 

### How was this change tested?

Running locally on my Linux Workstation. 

See attached logs. 

![Screenshot 2024-10-15 at 9 45 14 PM](https://github.com/user-attachments/assets/3538a4f7-e531-4132-af3e-8e621146c522)
![Screenshot 2024-10-15 at 9 45 41 PM](https://github.com/user-attachments/assets/833aa8b6-a232-4d42-a3ff-28611db6993d)


See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests? N/A
- Have you run the integration tests? 
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass. N/A

### Was this change documented?
Yes. 

- Are relevant docstrings in the code base updated? N/A
- Has the README.md been updated? If you modified CLI arguments, for instance. N/A

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?
No. 

A breaking change is one that modifies a public contract in a way that is not backwards compatible. See the 
[Public Contracts](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#public-contracts) section
of the DEVELOPMENT.md for more information on the public contracts.

If so, then please describe the changes that users of this package must make to update their scripts, or Python applications.

### Does this change impact security?
No. 

- Does the change need to be threat modeled? For example, does it create or modify files/directories that must only be readable by the process owner?
    - If so, then please label this pull request with the "security" label. We'll work with you to analyze the threats.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
