### PR TITLE
test: fix S3 cross-account failure assertion error

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -167,7 +167,7 @@ Notes:
 * If you are adding/changing code related to the Job Attachments' file-upload interactions with S3, then if you have a second
   AWS account then we request that you also ensure that the tests marked with the `pytest.mark.cross_account` marker also pass.
   If you don't have a second account, then don't worry about it. These tests will run in our CI. To run these tests:
-  1. Create an S3 bucket in the same region as your testing resources but in your second AWS Account.
+  1. Create an S3 bucket in the same region as your testing resources but in your second AWS Account. If the bucket doesn't exist, you may see S3 PermanentRedirect error.
   2. Set the access policy of that S3 bucket to allow your first AWS Account to perform all operations on the bucket. Do
      NOT open the bucket up to the world for reading/writing!
   3. `export INTEG_TEST_JA_CROSS_ACCOUNT_BUCKET=<your-bucket-name-in-the-second-account>`

--- a/test/integ/conftest.py
+++ b/test/integ/conftest.py
@@ -1,0 +1,12 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import os
+import pytest
+
+
+@pytest.fixture()
+def external_bucket() -> str:
+    """
+    Return a bucket that all developers and test accounts have access to, but isn't in the testers account.
+    """
+    return os.environ.get("INTEG_TEST_JA_CROSS_ACCOUNT_BUCKET", "job-attachment-bucket-snipe-test")

--- a/test/integ/deadline_job_attachments/conftest.py
+++ b/test/integ/deadline_job_attachments/conftest.py
@@ -1,7 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 import getpass
-import os
 import json
 import sys
 import pytest
@@ -92,14 +91,6 @@ def default_job_template_one_task_one_step() -> str:
             ],
         }
     )
-
-
-@pytest.fixture()
-def external_bucket() -> str:
-    """
-    Return a bucket that all developers and test accounts have access to, but isn't in the testers account.
-    """
-    return os.environ.get("INTEG_TEST_JA_CROSS_ACCOUNT_BUCKET", "job-attachment-bucket-snipe-test")
 
 
 def is_windows_non_admin():


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
CI integ tests failure due to a different error message from local

### What was the solution? (How)
Reproduce locally to ensure the setup consistency, and fix the error message

### What is the impact of this change?
Test should pass - https://github.com/aws-deadline/deadline-cloud/actions/runs/11369721991/job/31627830072

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests? [Yes]
- Have you run the integration tests? [Yes]
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended that you ensure that the docker-based unit tests pass. [N/A]

### Was this change documented?
- Added more info to development guide.

- Are relevant docstrings in the code base updated? [N/A]
- Has the README.md been updated? If you modified CLI arguments, for instance. [N/A]

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?
No

### Does this change impact security?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
