### PR TITLE
fix: pass in cache directory for attachment upload

### DIFF
--- a/src/deadline/job_attachments/api/attachment.py
+++ b/src/deadline/job_attachments/api/attachment.py
@@ -14,9 +14,10 @@ from deadline.job_attachments.asset_manifests.decode import decode_manifest
 from deadline.job_attachments.download import download_files_from_manifests
 from deadline.job_attachments.models import JobAttachmentS3Settings, PathMappingRule
 from deadline.job_attachments.progress_tracker import DownloadSummaryStatistics
-from deadline.client.exceptions import NonValidInputError
 from deadline.job_attachments.upload import S3AssetUploader
 from deadline.client.cli._groups.click_logger import ClickLogger
+from deadline.client.config import config_file
+from deadline.client.exceptions import NonValidInputError
 
 
 def attachment_download(
@@ -146,6 +147,7 @@ def attachment_upload(
             partial_manifest_prefix=upload_manifest_path,
             source_root=Path(rule.source_path),
             asset_root=Path(rule.destination_path),
+            s3_check_cache_dir=config_file.get_cache_directory(),
         )
         logger.echo(
             f"Uploaded assets from {rule.source_path}, to {s3_settings.to_s3_root_uri()}/{key}, hashed data {data}"

--- a/test/unit/deadline_job_attachments/api/test_attachment.py
+++ b/test/unit/deadline_job_attachments/api/test_attachment.py
@@ -15,8 +15,9 @@ import json
 import deadline
 
 from deadline.client import api
-from deadline.job_attachments import api as attachment_api
+from deadline.client.config import config_file
 from deadline.client.exceptions import NonValidInputError
+from deadline.job_attachments import api as attachment_api
 from deadline.job_attachments.exceptions import MalformedAttachmentSettingError
 from deadline.job_attachments.progress_tracker import DownloadSummaryStatistics
 from deadline.job_attachments.asset_manifests import HashAlgorithm, hash_data
@@ -268,6 +269,7 @@ class TestAttachmentUpload:
             partial_manifest_prefix="test",
             source_root=Path(PATH_MAPPING["source_path"]),
             asset_root=Path(PATH_MAPPING["destination_path"]),
+            s3_check_cache_dir=config_file.get_cache_directory(),
         )
 
     @pytest.mark.parametrize("manifest_case_key", MOCK_MANIFEST_CASE.keys())
@@ -298,6 +300,7 @@ class TestAttachmentUpload:
             partial_manifest_prefix="test",
             source_root=Path(temp_assets_dir),
             asset_root=Path(temp_assets_dir),
+            s3_check_cache_dir=config_file.get_cache_directory(),
         )
 
     @pytest.mark.parametrize("manifest_case_key", MOCK_MANIFEST_CASE.keys())


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
https://github.com/aws-deadline/deadline-cloud/actions/runs/11373317048

Windows test failure suggests it's using the default cache directory constructed from $HOME, which is not available on windows. 

### What was the solution? (How)
Explicitly passing in the cache directory from config.

### What is the impact of this change?
Test should pass on windows, and attachment should use cache directory similar to other job attachment library functionality.

### How was this change tested?
Tested by unsetting the env var `set -e HOME`.

#### Reproduce the failure locally
```
(windows-test-fix)> echo $HOME

(windows-test-fix)> hatch run integ:test
=============================================== short test summary info ================================================
FAILED test/integ/cli/test_cli_attachment.py::TestAttachment::test_attachment_s3_cross_account_access_denied - assert 'deadline.job_attachments.exceptions.JobAttachmentsS3ClientError' in 'The AWS Deadline Cloud CLI encountered...
FAILED test/integ/cli/test_cli_attachment.py::TestAttachment::test_attachment_basic_flow[TEST_CASE_1] - AssertionError: Non-Zeo exit code, CLI output The AWS Deadline Cloud CLI encountered the following exception:
FAILED test/integ/cli/test_cli_attachment.py::TestAttachment::test_attachment_basic_flow[TEST_CASE_2] - AssertionError: Non-Zeo exit code, CLI output The AWS Deadline Cloud CLI encountered the following exception:
FAILED test/integ/cli/test_cli_attachment.py::TestAttachment::test_attachment_path_mapping_flow[TEST_CASE_1] - AssertionError: Non-Zeo exit code, CLI output The AWS Deadline Cloud CLI encountered the following exception:
FAILED test/integ/cli/test_cli_attachment.py::TestAttachment::test_attachment_path_mapping_flow[TEST_CASE_2] - AssertionError: Non-Zeo exit code, CLI output The AWS Deadline Cloud CLI encountered the following exception:
================================= 5 failed, 16 passed, 2 skipped, 5 warnings in 47.85s =================================
```
#### After the fix
```
(windows-test-fix)> echo $HOME

(windows-test-fix)> hatch run integ:test
====================================== 21 passed, 2 skipped, 5 warnings in 52.89s ======================================
```



- Have you run the unit tests? [YES]
- Have you run the integration tests? [YES]
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended that you ensure that the docker-based unit tests pass. [N/A]

### Was this change documented?

- Are relevant docstrings in the code base updated?
- Has the README.md been updated? If you modified CLI arguments, for instance.

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?
No

### Does this change impact security?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
