### PR TITLE
docs: add documentation and for default git hook containing DCO and c…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,8 @@ Table of contents:
     * [Talk with us first](#talk-with-us-first)
     * [Contributing via Pull Requests](#contributing-via-pull-requests)
     * [Conventional Commits](#conventional-commits)
+    * [Digital Certificate of Origin](#digital-certificate-of-origin)
+    * [Conventional Commit & DCO Automation](#automating-conventional-commits-and-dco)
 * [Licensing](#licensing)
 
 ## Reporting Bugs/Feature Requests
@@ -106,6 +108,58 @@ the command-line interface, or the like.
 If you need change a commit message, then please see the
 [GitHub documentation on the topic](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/changing-a-commit-message)
 to guide you.
+
+### Digital Certificate of Origin.
+
+This repository enforces the Developer Certificate of Origin (DCO) on Pull Requests. It requires all commit messages to contain the `Signed-off-by` line with an email address that matches the commit author.
+
+To generate the `Signed-off-by` line, make sure `git commit` is passed with the `-s` flag.
+
+### Automating Conventional Commits and DCO.
+
+To simplify Conventional Commit and DCO, it is recommended to setup a Git hook for the repository. Add the following as a git hook:
+
+- Edit `{repository}/.git/hooks/commit-msg`
+- `chmod +x {repository}/.git/hooks/commit-msg`
+- Paste in the following shell script, customize as necessary.
+```
+#!/bin/sh
+SIGNATURE="Signed-off-by: `git config --global --get user.name` <`git config --global --get user.email`>"
+grep -qs "^${SIGNATURE}" "$1" || echo "\n${SIGNATURE}" >> "$1"
+
+commitTitle="$(cat $1 | head -n1)"
+
+# ignore merge requests
+if echo "$commitTitle" | grep -qE "Merge branch"; then
+	echo "Commit hook: ignoring branch merge"
+	exit 0
+fi
+
+# check semantic versioning scheme
+if ! echo "$commitTitle" | grep -qE '^(feat|fix|docs|style|refactor|perf|test|chore|build|ci|revert)(\([a-z0-9\s\-\_\,]+\))?!?:\s\w'; then
+	echo "Your commit message did not follow semantic versioning: $commitTitle"
+	echo ""
+	echo "Format:   <type>(<optional-scope>): <subject>"
+	echo "Example:  feat(api): add endpoint"
+	echo ""
+	echo "Valid types: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test"
+	echo ""
+	echo "Please see"
+	echo "- https://www.conventionalcommits.org/en/v1.0.0/#summary"
+	exit 1
+fi
+```
+
+If you want to create this hook automatically on every new git repository you will create from now on (using git init, git clone...) you can use git-templates; to do so, just save the script described above into (duplicate files):
+
+```
+~/.git-templates/hooks/commit-msg
+```
+
+Configure the Git default as follows:
+```
+git config --global init.templatedir ~/.git-templates
+```
 
 ## Licensing
 

--- a/hatch.toml
+++ b/hatch.toml
@@ -20,6 +20,11 @@ lint = [
   "style",
   "typing",
 ]
+quality = [
+  "black {args:.}",
+  "typing",
+  "style",
+]
 
 [[envs.all.matrix]]
 python = ["3.8", "3.9", "3.10", "3.11"]


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
- We require developers and contributors to use Conventional Commits, DCO for all commit messages. This blocks on github PR review.
- We also require developers to run fmt, lint before submission to meet code standards.

### What was the solution? (How)
- Automate DCO and conventional commits with an example git commit hook. Added documentation how to use it. It is optional, but will help save developers time and energy.
- Added a new `hatch quality` target to run both fmt and lint together. I always run them back to back anyways.

### What is the impact of this change?
- Developer productivity!

### How was this change tested?
- I installed the git hook, and used it to generate this commit! 
- I tested with various git commit amends to make sure conventional commits is enforced.

### Was this change documented?

- Are relevant docstrings in the code base updated?
- Has the README.md been updated? If you modified CLI arguments, for instance.

### Does this PR introduce new dependencies?

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [X] This PR does not add any new dependencies.

### Is this a breaking change?
No, docs only.

### Does this change impact security?
- No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
