### PR TITLE
chore(deps): update to black 24.10

### DIFF
--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -9,7 +9,8 @@ freezegun == 1.*
 types-pyyaml == 6.*
 twine == 4.*; python_version == '3.7'
 twine == 5.*; python_version > '3.7'
-black == 24.8.*; python_version > '3.7'
+black == 24.8.*; python_version == '3.8'
+black == 24.10.*; python_version > '3.8'
 mypy == 1.11.*; python_version == '3.7'
 mypy == 1.*; python_version > '3.7'
 ruff == 0.6.*


### PR DESCRIPTION
Fixes: None

### What was the problem/requirement? (What/Why)

Our `black` dependency is out of date, but `black` dropped Python 3.8 support in version 24.9.

### What was the solution? (How)

Conditionally use the newer black in newer python versions. This *may* cause issues in future if newer black versions deviate from 24.8. We'll cross that bridge when we get to it; right now, it's fine.

### What is the impact of this change?

Updated deps.

### How was this change tested?

Running the linter. See the CI.

### Was this change documented?

N/A

### Does this PR introduce new dependencies?

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [X] This PR does not add any new dependencies.

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
