### PR TITLE
fix: Fix skipped test. Should not hard code root prefix of Queue CAS. Also fixed Windows tests.

### DIFF
--- a/src/deadline/job_attachments/_diff.py
+++ b/src/deadline/job_attachments/_diff.py
@@ -142,7 +142,7 @@ def _fast_file_list_to_manifest_diff(
     input_files_map: Dict[str, BaseManifestPath] = {}
     for input_file in diff_manifest.paths:
         # Normalize paths so we can compare different OSes
-        normalized_path = os.path.normpath(input_file.path)
+        normalized_path = Path(os.path.normpath(input_file.path)).as_posix()
         input_files_map[normalized_path] = input_file
 
     # Iterate for each file that we found in glob.
@@ -155,7 +155,7 @@ def _fast_file_list_to_manifest_diff(
 
         # Compare the glob against the relative path we store in the manifest.
         # Save it to a list so we can look for deleted files.
-        root_relative_path = str(PurePosixPath(*local_file_path.relative_to(root).parts))
+        root_relative_path = str(PurePosixPath(*local_file_path.relative_to(root).parts).as_posix())
         root_relative_paths.append(root_relative_path)
 
         return_path = select_path(

--- a/test/integ/cli/test_cli_manifest_snapshot.py
+++ b/test/integ/cli/test_cli_manifest_snapshot.py
@@ -13,9 +13,6 @@ import tempfile
 from deadline.client.cli import main
 
 
-@pytest.mark.skip(
-    "Skipping for Windows Test Failure. Disable to unblock integration since this is a BETA API."
-)
 class TestManifestSnapshot:
 
     @pytest.fixture


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
- A few tests were commented out due to windows failures. These were all due to path `\` vs `/` issues.

### What was the solution? (How)
- Lets fix the tests. Normalize the code to always use posix paths. This makes it always apples to apples comparisons regardless of OS directory listing.

### What is the impact of this change?
- Better test coverage!

### How was this change tested?

- Have you run the unit tests?
  - Yes, `hatch run test`.
- Have you run the integration tests?
  - Yes, `hatch run integ:test`, on both windows and osx

- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass.
  - NA, fixing tests.

### Was this change documented?
- Not applicable.
- 
### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [X] This PR does not add any new dependencies.

### Is this a breaking change?
- No.
 
### Does this change impact security?
- No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
