### PR TITLE
fix: Refresh queue parameter defaults when loading a new job bundle

### DIFF
--- a/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
@@ -121,6 +121,7 @@ class SubmitJobToDeadlineDialog(QDialog):
         job_settings: Optional[Any] = None,
         auto_detected_attachments: Optional[AssetReferences] = None,
         attachments: Optional[AssetReferences] = None,
+        load_new_bundle: bool = False,
     ):
         # Refresh the UI components
         self.refresh_deadline_settings()
@@ -130,7 +131,7 @@ class SubmitJobToDeadlineDialog(QDialog):
         if job_settings is not None:
             self.job_settings_type = type(job_settings)
             # Refresh shared job settings
-            self.shared_job_settings.refresh_ui(job_settings)
+            self.shared_job_settings.refresh_ui(job_settings, load_new_bundle)
             # Refresh job specific settings
             if hasattr(self.job_settings, "refresh_ui"):
                 self.job_settings.refresh_ui(job_settings)

--- a/src/deadline/client/ui/widgets/job_bundle_settings_tab.py
+++ b/src/deadline/client/ui/widgets/job_bundle_settings_tab.py
@@ -127,6 +127,7 @@ class JobBundleSettingsWidget(QWidget):
                 job_settings=job_settings,
                 auto_detected_attachments=asset_references,
                 attachments=None,
+                load_new_bundle=True,
             )
 
     def update_settings(self, settings: JobBundleSettings):


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Running `deadline bundle gui-submit --browse` and loading multiple job bundles in a row did not reset default queue parameters even if they were specified in the job template (for example, loading a Blender job and then a Maya job would not change the `CondaPackages` value in the UI from `blender` to `maya`).

### What was the solution? (How)
Added a flag when refreshing the Shared Job Settings tab to indicate that a new job bundle is being loaded. This triggers the default queue parameters to be reevaluated.

### What is the impact of this change?

Default queue parameters will show correctly when a user loads multiple job bundles in a row.

### How was this change tested?

An automated test for this specific fix will be included in a future squish test suite (already WIP; I believe it was blocked by this issue). For now, I've run the existing unit & integration tests to check that it doesn't break existing functionality.

### Was this change documented?
Shouldn't be necessary

### Does this PR introduce new dependencies?

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
