### PR TITLE
chore(ci): add Python 3.12 to CI runners

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
     uses: aws-deadline/.github/.github/workflows/reusable_python_build.yml@mainline
     with:
       os: ${{ matrix.os }}


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Python 3.12 is listed as supported on PyPI but we don't run our CI tests with 3.12 right now
### What was the solution? (How)
Add 3.12 to the Code Quality workflow that runs our unit tests
### What is the impact of this change?
Better testing coverage across versions of Python
### How was this change tested?

Ran the unit tests on Linux using 3.12

### Was this change documented?

No

### Does this PR introduce new dependencies?

No

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
