### PR TITLE
fix: De-duplicate error messages on expired credentials

### DIFF
--- a/src/deadline/client/ui/dialogs/deadline_config_dialog.py
+++ b/src/deadline/client/ui/dialogs/deadline_config_dialog.py
@@ -484,9 +484,10 @@ class DeadlineWorkstationConfigWidget(QWidget):
             self.aws_profiles_box.addItems(list(self.aws_profile_names))
 
     def refresh_lists(self):
-        self.default_farm_box.refresh_list()
-        self.default_queue_box.refresh_list()
-        self.default_storage_profile_box.refresh_list()
+        if api.check_deadline_api_available():
+            self.default_farm_box.refresh_list()
+            self.default_queue_box.refresh_list()
+            self.default_storage_profile_box.refresh_list()
 
     def refresh(self):
         """


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Users who open the workstation config dialog while having expired credentials will get 3 back-to-back error messages from different components trying to make API calls.

### What was the solution? (How)
Check that the Deadline API is available before trying to refresh farms/queues/storage profiles when opening the config dialog.

https://github.com/user-attachments/assets/fae6108f-85b9-4775-802d-9b7083f3d6f8



### What is the impact of this change?
Users with expired credentials won't be bombarded with error messages on opening the config dialog.

Error dialogs will still appear if the user tries to manually refresh the default farm or queue list.

### How was this change tested?

Unit & integration tests passed successfully. No tests added but could be included in a UI test suite.

### Was this change documented?

n/a

### Does this PR introduce new dependencies?

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?

no siree

### Does this change impact security?

n/a

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
