### PR TITLE
fix: state upperbound (3.12) for python version support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Notable features include:
 
 This library requires:
 
-1. Python 3.8 or higher; and
+1. Python 3.8 through 3.12; and
 2. Linux, Windows, or macOS operating system.
 
 ## Versioning

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 dynamic = ["version"]
 readme = "README.md"
 license = "Apache-2.0"
-requires-python = ">=3.8"
+requires-python = ">=3.8, <3.13"
 # https://pypi.org/classifiers/
 classifiers = [
   "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Fixes: #493

### What was the problem/requirement? (What/Why)
Dependencies required for the library do not exist for python 3.13
### What was the solution? (How)
put in version cap into pyproject.toml file to prevent pip installing on python 3.13

### What is the impact of this change?
Users will no longer be able to pip install the library if python version is >=3.13

### How was this change tested?

```
hatch build
```

### Was this change documented?

- Are relevant docstrings in the code base updated?
- Has the README.md been updated? If you modified CLI arguments, for instance.

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [X] This PR does not add any new dependencies.

### Is this a breaking change?
yes this removes pip support for python 3.13

### Does this change impact security?

no
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
