### PR TITLE
Revert "chore(deps): update pyinstaller requirement from ==5.13.* to …

### DIFF
--- a/requirements-installer.txt
+++ b/requirements-installer.txt
@@ -1,1 +1,1 @@
-pyinstaller == 6.11.*
+pyinstaller == 5.13.*


### PR DESCRIPTION
This reverts commit 0e416854e97213ed04786fc2e9df8124cb9b3a96.

### What was the problem/requirement? (What/Why)

An update to the pyinstaller dependency was merged unintentionally. It required more work than a simple version bump.
https://github.com/aws-deadline/deadline-cloud/pull/487

### What was the solution? (How)

Revert that commit. 

### What is the impact of this change?

Unblock release process for deadline installers.

### How was this change tested?

Ran `hatch run test`.

### Was this change documented?

No.

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?

No

### Does this change impact security?

No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
