### PR TITLE
chore(deps): disable dependabot from updating pyside6-essentials

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://json.schemastore.org/dependabot-2.0.json
 # To get started with Dependabot version updates, you'll need to specify which
 # package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:
@@ -9,6 +10,9 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "pyside6-essentials"
+        versions: [ "6" ]
     commit-message: 
       prefix: "chore(deps):"
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
we are sensitive to the exact `pyside-essentials` version used to build. updating without manual testing could have unforeseen breaks

### What was the solution? (How)
add `ignore` to dependebot's configureation to 
### What is the impact of this change?

### How was this change tested?

based off looking [this open issue](https://github.com/dependabot/dependabot-core/issues/4605) on dependabot there is no existing tool to validate dependabot configurations prior to merging

Implementation is based off example in [dependabot's docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#ignore-updates-for-a-specific-version)

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [X] This PR does not add any new dependencies.

### Is this a breaking change?

No

### Does this change impact security?

Yes, it disabled automatic updated to `pyside-essentials` repository owners

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
