### PR TITLE
revert: "chore(deps): update pyside6-essentials requirement (#470)"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ Source = "https://github.com/aws-deadline/deadline-cloud"
 [project.optional-dependencies]
 gui = [
     # If the version changes, update the version in deadline/client/ui/__init__.py
-    "PySide6-essentials >= 6.6,< 6.9",
+    "PySide6-essentials == 6.6.*",
 ]
 
 [project.scripts]


### PR DESCRIPTION
This reverts commit f0ffa1b05b92cedc079d7d86cb100031d84fe66c.

### What was the problem/requirement? (What/Why)

Allowed versions of PySide6-essentials was expanded in pyproject.toml but not updated in  `deadline/client/ui/__init__.py`. Unknown if the expanded versions work. 

### What was the solution? (How)

Revert the change.

### What is the impact of this change?

More certainty of functionality.

### How was this change tested?
Ran `hatch run test`.
### Was this change documented?
No

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?

No

### Does this change impact security?

No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
