### PR TITLE
chore: Updated PySide-essentials range.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ Source = "https://github.com/aws-deadline/deadline-cloud"
 [project.optional-dependencies]
 gui = [
     # If the version changes, update the version in deadline/client/ui/__init__.py
-    "PySide6-essentials == 6.6.*",
+    "PySide6-essentials >= 6.6,< 6.9",
 ]
 
 [project.scripts]

--- a/src/deadline/client/ui/__init__.py
+++ b/src/deadline/client/ui/__init__.py
@@ -84,7 +84,7 @@ def gui_context_for_cli(automatically_install_dependencies: bool):
                 sys.exit(1)
 
         # this should match what's in the pyproject.toml
-        pyside6_pypi = "PySide6-essentials==6.6.*"
+        pyside6_pypi = "PySide6-essentials >= 6.6,< 6.9"
         if "deadline" in basename(sys.executable).lower():
             # running with a deadline executable, not standard python.
             # So exit the deadline folder into the main deps dir


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

PySide essentials was originally updated to be a range in [this PR](https://github.com/aws-deadline/deadline-cloud/pull/470) but did not include the change required in client/ui/__init__.py.

### What was the solution? (How)

Added the updated range in both locations.

### What is the impact of this change?

Consistent dependency installations.

### How was this change tested?

Built debug wheels to ensure that when prompted, we were installing the expected PySide6-essentials version.

### Was this change documented?

No.

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
