### PR TITLE
feat: allow attachments commands to read openjd path mapping, allow upload with given manifest name and attach metadata

### DIFF
--- a/src/deadline/job_attachments/README.md
+++ b/src/deadline/job_attachments/README.md
@@ -76,7 +76,7 @@ $ deadline attachment upload
 $ deadline attachment download
 ```
 
-Manifest subcommands work with asset manifest files that capture local asset lifecycle. Currently only `manifest snapshot` is availble.
+Manifest subcommands work with asset manifest files that capture local asset lifecycle.
 
 ```sh
 $ deadline manifest snapshot

--- a/src/deadline/job_attachments/download.py
+++ b/src/deadline/job_attachments/download.py
@@ -183,7 +183,7 @@ def _get_tasks_manifests_keys_from_s3(
             Prefix=manifest_prefix,
         )
 
-        # 1. Find all files that match the pattern: task-{any}/{any}/{any}-output
+        # 1. Find all files that match the pattern: task-{any}/{any}/{any}output{any}
         task_prefixes = defaultdict(list)
         for page in page_iterator:
             contents = page.get("Contents", None)
@@ -192,7 +192,7 @@ def _get_tasks_manifests_keys_from_s3(
                     f"Unable to find asset manifest in s3://{s3_bucket}/{manifest_prefix}"
                 )
             for content in contents:
-                if re.search(r"task-.*/.*/.*_output", content["Key"]):
+                if re.search(r"task-.*/.*/.*output.*", content["Key"]):
                     parts = content["Key"].split("/")
                     for i, part in enumerate(parts):
                         if "task-" in part:

--- a/src/deadline/job_attachments/upload.py
+++ b/src/deadline/job_attachments/upload.py
@@ -149,6 +149,8 @@ class S3AssetUploader:
         s3_check_cache_dir: Optional[str] = None,
         manifest_write_dir: Optional[str] = None,
         manifest_name_suffix: str = "input",
+        manifest_metadata: dict[str, dict[str, str]] = dict(),
+        manifest_file_name: Optional[str] = None,
         asset_root: Optional[Path] = None,
     ) -> tuple[str, str]:
         """
@@ -163,6 +165,8 @@ class S3AssetUploader:
             job_attachment_settings: The settings for the job attachment configured in Queue.
             progress_tracker: Optional progress tracker to track progress.
             manifest_name_suffix: Suffix for given manifest naming.
+            manifest_metadata: File metadata for given manifest to be uploaded.
+            manifest_file_name: Optional file name for given manifest to be uploaded, otherwise use default name.
             asset_root: The root in which asset actually in to facilitate path mapping.
 
         Returns:
@@ -176,6 +180,7 @@ class S3AssetUploader:
             file_system_location_name=file_system_location_name,
             manifest_name_suffix=manifest_name_suffix,
         )
+        manifest_name = manifest_file_name if manifest_file_name else manifest_name
 
         if partial_manifest_prefix:
             partial_manifest_key = _join_s3_paths(partial_manifest_prefix, manifest_name)
@@ -199,6 +204,7 @@ class S3AssetUploader:
                 bytes=BytesIO(manifest_bytes),
                 bucket=job_attachment_settings.s3BucketName,
                 key=full_manifest_key,
+                extra_args=manifest_metadata,
             )
 
         # Upload assets

--- a/test/unit/deadline_job_attachments/api/test_attachment.py
+++ b/test/unit/deadline_job_attachments/api/test_attachment.py
@@ -32,6 +32,17 @@ PATH_MAPPING = {
     "source_path": "/local/home/test",
     "destination_path": "/local/home/test/output",
 }
+
+OPENJD_PATH_MAPPING = {
+    "version": "pathmapping-1.0",
+    "path_mapping_rules": [
+        {
+            "source_path_format": "posix",
+            "source_path": "/local/home/test",
+            "destination_path": "/local/home/test/output",
+        }
+    ],
+}
 PATH_MAPPING_HASH = "4ab97c97c825551aaa963888278ef9ec"
 
 MOCK_MANIFEST_CASE = {
@@ -66,10 +77,21 @@ MOCK_MANIFEST_CASE = {
 TEST_S3_URI = "s3://bucket/root"
 
 
-def test_process_path_mappint(temp_assets_dir):
+def test_process_path_mapping(temp_assets_dir):
     mapping_file_path = os.path.join(temp_assets_dir, "mapping")
     with open(mapping_file_path, "w", encoding="utf8") as f:
         json.dump([PATH_MAPPING], f)
+
+    path_mappings: List[PathMappingRule] = _process_path_mapping(
+        mapping_file_path, [temp_assets_dir]
+    )
+    assert len(path_mappings) == 2
+
+
+def test_process_openjd_path_mapping(temp_assets_dir):
+    mapping_file_path = os.path.join(temp_assets_dir, "mapping")
+    with open(mapping_file_path, "w", encoding="utf8") as f:
+        json.dump(OPENJD_PATH_MAPPING, f)
 
     path_mappings: List[PathMappingRule] = _process_path_mapping(
         mapping_file_path, [temp_assets_dir]
@@ -92,6 +114,29 @@ class TestAttachmentDownload:
             return_value=DownloadSummaryStatistics(),
         ) as mock_download_files_from_manifests:
             yield mock_download_files_from_manifests
+
+    def test_download_single_to_mapped_invalid_path_mapping(self, temp_assets_dir, session_mock):
+        with open(
+            os.path.join(temp_assets_dir, PATH_MAPPING_HASH),
+            "w",
+            encoding="utf8",
+        ) as f:
+            json.dump(MOCK_MANIFEST_CASE[PATH_MAPPING_HASH], f)
+
+        mapping_file_path = os.path.join(temp_assets_dir, "mapping")
+        with open(mapping_file_path, "w", encoding="utf8") as f:
+            json.dump(PATH_MAPPING, f)
+
+        with pytest.raises(
+            AssertionError,
+            match="Path mapping rules have to be a list of dict.",
+        ):
+            attachment_api.attachment_download(
+                manifests=[os.path.join(temp_assets_dir, PATH_MAPPING_HASH)],
+                s3_root_uri="s3://bucket/assetRoot",
+                boto3_session=session_mock,
+                path_mapping_rules=mapping_file_path,
+            )
 
     def test_download_single_to_mapped(
         self, temp_assets_dir, session_mock, mock_download_files_from_manifests
@@ -244,8 +289,9 @@ class TestAttachmentUpload:
             )
 
     def test_upload_single_from_mapped(self, temp_assets_dir, session_mock, mock_upload_assets):
+        file_name: str = f"{PATH_MAPPING_HASH}.manifest"
         with open(
-            os.path.join(temp_assets_dir, PATH_MAPPING_HASH),
+            os.path.join(temp_assets_dir, file_name),
             "w",
             encoding="utf8",
         ) as f:
@@ -256,7 +302,7 @@ class TestAttachmentUpload:
             json.dump([PATH_MAPPING], f)
 
         attachment_api.attachment_upload(
-            manifests=[os.path.join(temp_assets_dir, PATH_MAPPING_HASH)],
+            manifests=[os.path.join(temp_assets_dir, file_name)],
             s3_root_uri=TEST_S3_URI,
             boto3_session=session_mock,
             path_mapping_rules=mapping_file_path,
@@ -267,6 +313,13 @@ class TestAttachmentUpload:
             job_attachment_settings=JobAttachmentS3Settings.from_s3_root_uri(TEST_S3_URI),
             manifest=decode_manifest(json.dumps(MOCK_MANIFEST_CASE[PATH_MAPPING_HASH])),
             partial_manifest_prefix="test",
+            manifest_file_name=file_name,
+            manifest_metadata={
+                "Metadata": {
+                    "asset-root": PATH_MAPPING["source_path"],
+                    "file-system-location-name": PATH_MAPPING["source_path_format"],
+                }
+            },
             source_root=Path(PATH_MAPPING["source_path"]),
             asset_root=Path(PATH_MAPPING["destination_path"]),
             s3_check_cache_dir=config_file.get_cache_directory(),
@@ -298,6 +351,8 @@ class TestAttachmentUpload:
             job_attachment_settings=JobAttachmentS3Settings.from_s3_root_uri(TEST_S3_URI),
             manifest=decode_manifest(json.dumps(MOCK_MANIFEST_CASE[manifest_case_key])),
             partial_manifest_prefix="test",
+            manifest_file_name=file_name,
+            manifest_metadata={"Metadata": {"asset-root": temp_assets_dir}},
             source_root=Path(temp_assets_dir),
             asset_root=Path(temp_assets_dir),
             s3_check_cache_dir=config_file.get_cache_directory(),

--- a/test/unit/deadline_job_attachments/test_asset_sync.py
+++ b/test/unit/deadline_job_attachments/test_asset_sync.py
@@ -1545,12 +1545,6 @@ class TestAssetSync:
             assert len(manifest_paths_by_root) == manifest_count
             assert "/root/tmp/movie1" in manifest_paths_by_root
             assert str(tmp_path.joinpath(dest_dir)) in manifest_paths_by_root
-            assert manifest_paths_by_root["/root/tmp/movie1"] == str(
-                path_write_local_input_manifest
-            )
-            assert manifest_paths_by_root[str(tmp_path.joinpath(dest_dir))] == str(
-                path_write_local_input_manifest
-            )
 
     def test_attachment_sync_inputs_with_storage_profiles_path_mapping_rules(
         self,

--- a/test/unit/deadline_job_attachments/test_asset_sync.py
+++ b/test/unit/deadline_job_attachments/test_asset_sync.py
@@ -1505,6 +1505,7 @@ class TestAssetSync:
         storage_profiles_path_mapping_rules = {
             "/home/user/movie1": "/root/tmp/movie1",
         }
+        path_write_local_input_manifest = tmp_path.joinpath("manifest/hash_manifest")
 
         with patch(
             f"{deadline.__package__}.job_attachments.asset_sync.get_manifest_from_s3",
@@ -1517,7 +1518,7 @@ class TestAssetSync:
             side_effect=[dest_dir],
         ), patch(
             f"{deadline.__package__}.job_attachments.asset_sync.S3AssetUploader._write_local_input_manifest",
-            return_value=tmp_path.joinpath("manifest/hasn_manifest"),
+            return_value=path_write_local_input_manifest,
         ) as mock__write_local_input_manifest:
 
             merged_manifests_by_root = self.default_asset_sync._aggregate_asset_root_manifests(
@@ -1534,11 +1535,22 @@ class TestAssetSync:
             assert mock_merge_asset_manifests.call_count == manifest_count
             assert mock_get_manifest_from_s3.call_count == manifest_count
 
-            paths = self.default_asset_sync._check_and_write_local_manifests(
+            manifest_paths_by_root = self.default_asset_sync._check_and_write_local_manifests(
                 merged_manifests_by_root=merged_manifests_by_root, manifest_write_dir=str(tmp_path)
             )
             assert mock__write_local_input_manifest.call_count == manifest_count
-            assert len(paths) == manifest_count
+            assert len(self.default_asset_sync._local_root_to_src_map) == len(
+                manifest_paths_by_root
+            )
+            assert len(manifest_paths_by_root) == manifest_count
+            assert "/root/tmp/movie1" in manifest_paths_by_root
+            assert str(tmp_path.joinpath(dest_dir)) in manifest_paths_by_root
+            assert manifest_paths_by_root["/root/tmp/movie1"] == str(
+                path_write_local_input_manifest
+            )
+            assert manifest_paths_by_root[str(tmp_path.joinpath(dest_dir))] == str(
+                path_write_local_input_manifest
+            )
 
     def test_attachment_sync_inputs_with_storage_profiles_path_mapping_rules(
         self,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
1. attachments commands should be able to read path mapping files generated by openjd, customer can directly grab the file from worker.
2. attachment upload now upload manifest files with name `_input` suffix by root hash, this doesn't fit well for output attachment upload use case.
3. attachment upload doesn't attach metadata, which prevent download job-output by job id from working.
4. fix: AssetSync `_check_and_write_local_manifests` currently hashes worker root rather than source root as file name, this doesn't work with attachment upload since hash in the file name should be from hashing submission local source root.

### What was the solution? (How)
1. additionally allow attachments commands to read openjd path mapping file format
2. use given manifest name as s3 object name
3. attach manifest metadata
4. keeping class variable for lookup and hash source root for manifest name

### What is the impact of this change?
more flexibility for attachments commands and make sure they work as expected

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests? [Yes]
- Have you run the integration tests? [Yes]
```
============== 28 passed, 2 skipped, 5 warnings in 31.39s ===============
```
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended that you ensure that the docker-based unit tests pass. [N/A]
```
%deadline job download-output --job-id job-ff3c4a430ce74c0397d38fbe7e194fac --farm-i
d $FARM_ID --queue-id $QUEUE_ID
Downloading output from Job 'AssetsExample'

Summary of files to download:
    /bealine-clients/deadline-cloud-worker-agent/scripts/submit_jobs/asset_example (6 files)

You are about to download files which may come from multiple root directories. Here are a list of the current root directories:
[0] bealine-clients/deadline-cloud-worker-agent/scripts/submit_jobs/asset_example
> Please enter the index of root directory to edit, y to proceed without changes, or n to cancel the download (0, y, n) [y]: y
The following files already exist in your local directory:
        /bealine-clients/deadline-cloud-worker-agent/scripts/submit_jobs/asset_example/files/file1.txt
        bealine-clients/deadline-cloud-worker-agent/scripts/submit_jobs/asset_example/files/file1.txt
        bealine-clients/deadline-cloud-worker-agent/scripts/submit_jobs/asset_example/files/file2.txt
       bealine-clients/deadline-cloud-worker-agent/scripts/submit_jobs/asset_example/files/file2.txt
        bealine-clients/deadline-cloud-worker-agent/scripts/submit_jobs/asset_example/template.json
        bealine-clients/deadline-cloud-worker-agent/scripts/submit_jobs/asset_example/template.json
You have three options to choose from:
[1] Skip: Do not download these files
[2] Overwrite: Download these files and overwrite existing files
[3] Create a copy: Download the file with a new name, appending '(1)' to the end
> Please enter your choice (1, 2, 3, or n to cancel the download) (1, 2, 3, n) [3]: 2

Downloading Outputs  [####################################]  100%
Download Summary:
    Downloaded 6 files totaling 4.51 KB.
    Total download time of 0.14941 seconds at 30.2 KB/s.
    Download locations (total file counts):
        /local/home/yuanbian/bea/bealine-clients/deadline-cloud-worker-agent/scripts/submit_jobs/asset_example (6 files)
```

### Was this change documented?

- Are relevant docstrings in the code base updated? [Yes]
- Has the README.md been updated? If you modified CLI arguments, for instance.

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?

A breaking change is one that modifies a public contract in a way that is not backwards compatible. See the 
[Public Contracts](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#public-contracts) section
of the DEVELOPMENT.md for more information on the public contracts.

If so, then please describe the changes that users of this package must make to update their scripts, or Python applications.

### Does this change impact security?

- Does the change need to be threat modeled? For example, does it create or modify files/directories that must only be readable by the process owner?
    - If so, then please label this pull request with the "security" label. We'll work with you to analyze the threats.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
