### PR TITLE
fix: use description from GUI submitter

### DIFF
--- a/src/deadline/client/ui/job_bundle_submitter.py
+++ b/src/deadline/client/ui/job_bundle_submitter.py
@@ -102,6 +102,12 @@ def show_job_bundle_submitter(
             file_contents, file_type, settings.input_job_bundle_dir, "template"
         )
         template["name"] = settings.name
+        if settings.description:
+            template["description"] = settings.description
+        else:
+            # remove description field since it can't be empty
+            # ignore if description is missing from template
+            template.pop("description", None)
 
         # If "HostRequirements" is provided, inject it into each of the "Step"
         if host_requirements:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The description from the AWS Deadline Cloud GUI was not being submitted to the service via the Deadline GUI

### What was the solution? (How)
The description field was not being captured and passed correctly to the service. Updated the relevant code.

### What is the impact of this change?
Description field now works as expected.

### How was this change tested?
Ran `hatch shell`, then `deadline bundle gui-submit sample_job` and input a description, then input no description to the GUI. The resulting job template had a description (or did not have a description), as expected.

### Was this change documented?
No, N/A

### Does this PR introduce new dependencies?
*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [X] This PR does not add any new dependencies.

### Is this a breaking change?
No

### Does this change impact security?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
