### PR TITLE
chore: test pywin32 ==307

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "xxhash >= 3.4,< 3.6",
     # Pinning due to new 4.18 dependencies breaking pyinstaller implementation
     "jsonschema == 4.17.*",
-    "pywin32 == 308; sys_platform == 'win32'",
+    "pywin32 == 307; sys_platform == 'win32'",
     "QtPy == 2.4.*",
 ]
 


### PR DESCRIPTION
This PR is simply tests that the Windows CI runners pass when pywin32 307 is used. For more information, please see https://github.com/aws-deadline/deadline-cloud/pull/518