### PR TITLE
fix: use default deadline configured profile when --profile is not specified for attachment cli

### DIFF
--- a/src/deadline/client/cli/_groups/attachment_group.py
+++ b/src/deadline/client/cli/_groups/attachment_group.py
@@ -72,24 +72,23 @@ def attachment_download(
     # TODO - add type for profile, if queue type, get queue sesson directly
     boto3_session: boto3.session = api.get_boto3_session(config=config)
 
+    # If profile is not provided via args, default to use local config file
     if not args.pop("profile", None):
         queue_id: str = config_file.get_setting("defaults.queue_id", config=config)
         farm_id: str = config_file.get_setting("defaults.farm_id", config=config)
 
-        deadline_client = boto3_session.client("deadline")
-        boto3_session = api.get_queue_user_boto3_session(
-            deadline=deadline_client,
-            config=None,
+        s3_settings: Optional[JobAttachmentS3Settings] = get_queue(
             farm_id=farm_id,
             queue_id=queue_id,
-        )
-        s3_settings: Optional[JobAttachmentS3Settings] = get_queue(
-            farm_id=farm_id, queue_id=queue_id
+            session=boto3_session,
         ).jobAttachmentSettings
         if not s3_settings:
             raise MissingJobAttachmentSettingsError(f"Queue {queue_id} has no attachment settings")
 
-        s3_root_uri = s3_settings.to_root_path()
+        s3_root_uri = s3_settings.to_s3_root_uri()
+
+        deadline_client = boto3_session.client("deadline")
+        boto3_session = api.get_queue_user_boto3_session(deadline=deadline_client, config=config)
 
     if not s3_root_uri:
         raise MissingJobAttachmentSettingsError("No valid s3 root path available")
@@ -155,24 +154,23 @@ def attachment_upload(
     # TODO - add type for profile, if queue type, get queue sesson directly
     boto3_session: boto3.session = api.get_boto3_session(config=config)
 
+    # If profile is not provided via args, default to use local config file
     if not args.pop("profile", None):
         queue_id: str = config_file.get_setting("defaults.queue_id", config=config)
         farm_id: str = config_file.get_setting("defaults.farm_id", config=config)
 
-        deadline_client = boto3_session.client("deadline")
-        boto3_session = api.get_queue_user_boto3_session(
-            deadline=deadline_client,
-            config=None,
+        s3_settings: Optional[JobAttachmentS3Settings] = get_queue(
             farm_id=farm_id,
             queue_id=queue_id,
-        )
-        s3_settings: Optional[JobAttachmentS3Settings] = get_queue(
-            farm_id=farm_id, queue_id=queue_id
+            session=boto3_session,
         ).jobAttachmentSettings
         if not s3_settings:
             raise MissingJobAttachmentSettingsError(f"Queue {queue_id} has no attachment settings")
 
         s3_root_uri = s3_settings.to_s3_root_uri()
+
+        deadline_client = boto3_session.client("deadline")
+        boto3_session = api.get_queue_user_boto3_session(deadline=deadline_client, config=config)
 
     if not s3_root_uri:
         raise MissingJobAttachmentSettingsError("No valid s3 root path available")


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
`deadline attachment upload` and `deadline attachment download` cannot get queue due to `Unable to locate credentials` until after getting aws configured credentials.

### What was the solution? (How)
Specify the boto_session created with deadline config when `--profile` is not specified. 

### What is the impact of this change?
Making attachment commands' default auth process consistent with other commands using deadline configured profile in ` ~/.deadline/config` file.

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests? [Yes]
- Have you run the integration tests? [Yes]
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended that you ensure that the docker-based unit tests pass. [N/A]
- Manual test
```
(deadline-cloud-worker-agent) (attachment-cli)> rm -r ~/.aws/credentials 
(deadline-cloud-worker-agent) (attachment-cli)> less ~/.aws/credentials
/Users/.aws/config: No such file or directory

(deadline-cloud-worker-agent)  (attachment-cli) [1]> deadline attachment download -m ~/Downloads/Users-Documents_code_thinkbox_bealine-clients_deadline-cloud-worker-agent_scripts_submit_jobs_asset_
example-hash-2024-12-02T13-21-49.manifest
Processed 4 files totaling 8.42 KB.
Skipped re-processing 0 files totaling 0.0 B.
Total processing time of 1.93833 seconds at 4.34 KB/s.

(deadline-cloud-worker-agent)  (attachment-cli)> less ~/.aws/credentials
/Users/.aws/config: No such file or directory

```
```
(deadline-cloud-worker-agent) (attachment-cli) [2]  
deadline attachment upload -m /Users/Library/code/thinkbox/bealine-clients/deadline-cloud-worker-agent/bealine-clients_deadline-cloud-worker-agent_scripts_submit_jobs-2830f34a7d7534b8f5c6c815d25de90a-2024-12-02T15-49-16.manifest -r /Users/Library/code/thinkbox/bealine-clients/deadline-cloud-worker-agent/scripts/submit_jobs
Uploaded assets from /Users/Library/code/thinkbox/bealine-clients/deadline-cloud-worker-agent/scripts/submit_jobs, to s3://xxxxxx/DeadlineCloud/Manifests/bealine-clients_deadline-cloud-worker-agent_scripts_submit_jobs-2830f34a7d7534b8f5c6c815d25de90a-2024-12-02T15-49-16.manifest, hashed data 74c0999f407e88aceed0e2db4d21de0c
```

### Was this change documented?

- Are relevant docstrings in the code base updated? Yes
- Has the README.md been updated? If you modified CLI arguments, for instance. N/A

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?
No

### Does this change impact security?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
