### PR TITLE
chore: add test for default log level

### DIFF
--- a/test/unit/deadline_client/config/test_config_file.py
+++ b/test/unit/deadline_client/config/test_config_file.py
@@ -263,7 +263,7 @@ def test_str2bool():
 
 
 def test_default_log_level():
-    # As a security precaution, the log level should not be DEBUG by default.
+    # To avoid excessive logging, the log level should not be DEBUG by default.
     assert config.get_setting("settings.log_level") != "DEBUG"
     # Verify the default log level exists and is less verbose than DEBUG
     assert config.get_setting("settings.log_level") == "WARNING"

--- a/test/unit/deadline_client/config/test_config_file.py
+++ b/test/unit/deadline_client/config/test_config_file.py
@@ -262,6 +262,13 @@ def test_str2bool():
         config_file.str2bool("")
 
 
+def test_default_log_level():
+    # As a security precaution, the log level should not be DEBUG by default.
+    assert config.get_setting("settings.log_level") != "DEBUG"
+    # Verify the default log level exists and is less verbose than DEBUG
+    assert config.get_setting("settings.log_level") == "WARNING"
+
+
 @pytest.mark.skipif(
     platform.system() != "Windows",
     reason="This test is for testing file permission changes in Windows.",


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We want to verify that the default log level is not DEBUG which might log data that a user doesn't want. Adding a test also makes accidental changes less likely.

### What was the solution? (How)
Add a unit test.

### What is the impact of this change?
More confidence that the default log level is appropriately set.

### How was this change tested?
Ran the unit tests.

### Was this change documented?
n/a

### Does this PR introduce new dependencies?
No

### Is this a breaking change?
No

### Does this change impact security?
Yes - more confidence that the logging is correctly configured by default.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
