### PR TITLE
feat: Allow submitters to prepopulate HostRequirementsWidget

### DIFF
--- a/src/deadline/client/ui/dataclasses/__init__.py
+++ b/src/deadline/client/ui/dataclasses/__init__.py
@@ -7,8 +7,11 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass, field
+from typing import Literal, Dict, List, Union
 
 from ...job_bundle.parameters import JobParameter
+
+MAX_INT_VALUE = (2**31) - 1
 
 
 @dataclass
@@ -66,3 +69,292 @@ echo "Content for generated file {{Task.Param.Index}}" > task_output_file_{{Task
     array_parameter_values: str = field(default="1-5")
     data_dir: str = field(default=os.path.join("~", "CLIJobData"))
     file_format: str = field(default="YAML")
+
+
+@dataclass
+class OsRequirements:
+    """
+    Settings for a OSRequirementsWidget.
+    """
+
+    LINUX = "linux"
+    MACOS = "macos"
+    WINDOWS = "windows"
+    OPERATING_SYSTEMS = [LINUX, MACOS, WINDOWS]
+    X86_64 = "x86_64"
+    ARM_64 = "arm64"
+    CPU_ARCHITECTURES = [X86_64, ARM_64]
+    operating_systems: List[Literal[LINUX, MACOS, WINDOWS]] = field(default_factory=list)  # type: ignore
+    cpu_archs: List[Literal[X86_64, ARM_64]] = field(default_factory=list)  # type: ignore
+
+    def __post_init__(self):
+        for operating_system in self.operating_systems:
+            if operating_system not in self.OPERATING_SYSTEMS:
+                raise ValueError(
+                    f"Operating system {operating_system} is not in supported list: {self.OPERATING_SYSTEMS}."
+                )
+        for cpu in self.cpu_archs:
+            if cpu not in self.CPU_ARCHITECTURES:
+                raise ValueError(
+                    f"CPU architecture {cpu} is in supported list: {self.CPU_ARCHITECTURES}."
+                )
+
+    def serialize(self) -> list:
+        requirements: List[dict] = []
+        if self.operating_systems:
+            for operating_system in self.operating_systems:
+                if operating_system not in self.OPERATING_SYSTEMS:
+                    raise ValueError(
+                        f"Operating system {operating_system} is not in supported list: {self.OPERATING_SYSTEMS}."
+                    )
+            requirements.append(
+                {
+                    "name": "attr.worker.os.family",
+                    "anyOf": self.operating_systems,
+                }
+            )
+        if self.cpu_archs:
+            for cpu in self.cpu_archs:
+                if cpu not in self.CPU_ARCHITECTURES:
+                    raise ValueError(
+                        f"CPU architecture {cpu} is not in supported list: {self.CPU_ARCHITECTURES}."
+                    )
+            requirements.append(
+                {
+                    "name": "attr.worker.cpu.arch",
+                    "anyOf": self.cpu_archs,
+                }
+            )
+        return requirements
+
+
+@dataclass
+class HardwareRequirements:
+    """
+    Settings for a HardwareRequirementsWidget.
+    """
+
+    DEFAULT_VALUE = -1
+    cpu_min: int = field(default=DEFAULT_VALUE)
+    cpu_max: int = field(default=DEFAULT_VALUE)
+    memory_min: int = field(default=DEFAULT_VALUE)
+    memory_max: int = field(default=DEFAULT_VALUE)
+    acceleration_min: int = field(default=DEFAULT_VALUE)
+    acceleration_max: int = field(default=DEFAULT_VALUE)
+    acceleration_memory_min: int = field(default=DEFAULT_VALUE)
+    acceleration_memory_max: int = field(default=DEFAULT_VALUE)
+    scratch_space_min: int = field(default=DEFAULT_VALUE)
+    scratch_space_max: int = field(default=DEFAULT_VALUE)
+
+    def __post_init__(self):
+        self._validate(self.cpu_min, self.cpu_max, "CPU")
+        self._validate(self.memory_min, self.memory_max, "Memory")
+        self._validate(self.acceleration_min, self.acceleration_max, "Acceleration")
+        self._validate(
+            self.acceleration_memory_min, self.acceleration_memory_max, "Acceleration Memory"
+        )
+        self._validate(self.scratch_space_min, self.scratch_space_max, "Scratch Space")
+
+    def _validate(self, minimum: int, maximum: int, name: str):
+        if minimum != self.DEFAULT_VALUE and maximum != self.DEFAULT_VALUE and minimum > maximum:
+            raise ValueError(
+                f"{name} Minimum cannot be higher than {name} Maximum. {minimum} > {maximum}"
+            )
+
+    def _serialize(self, minimum, maximum, name):
+        requirements: List[dict] = []
+        if minimum != self.DEFAULT_VALUE or maximum != self.DEFAULT_VALUE:
+            _requirement = {
+                "name": name,
+            }
+            if minimum != self.DEFAULT_VALUE:
+                _requirement["min"] = max(minimum, self.DEFAULT_VALUE)
+            if maximum != self.DEFAULT_VALUE:
+                _requirement["max"] = min(maximum, MAX_INT_VALUE)
+            requirements.append(_requirement)
+        return requirements
+
+    def serialize(self) -> list:
+        requirements: List[dict] = []
+        requirements.extend(self._serialize(self.cpu_min, self.cpu_max, "amount.worker.vcpu"))
+        requirements.extend(
+            self._serialize(self.memory_min, self.memory_max, "amount.worker.memory")
+        )
+        requirements.extend(
+            self._serialize(self.acceleration_min, self.acceleration_max, "amount.worker.gpu")
+        )
+        requirements.extend(
+            self._serialize(
+                self.acceleration_memory_min,
+                self.acceleration_memory_max,
+                "amount.worker.gpu.memory",
+            )
+        )
+        requirements.extend(
+            self._serialize(
+                self.scratch_space_min, self.scratch_space_max, "amount.worker.disk.scratch"
+            )
+        )
+        return requirements
+
+
+@dataclass
+class CustomAmountRequirement:
+    """
+    Settings for a CustomAmountWidget
+    """
+
+    DEFAULT_VALUE = -(2**31) + 1
+    name: str = field(default="")
+    min: int = field(default=DEFAULT_VALUE)
+    max: int = field(default=DEFAULT_VALUE)
+
+    def __post_init__(self):
+        if not self.name:
+            raise ValueError(f"Custom Amount {self} has no name")
+        elif self.min and self.max and self.min > self.max:
+            raise ValueError(f"Custom Amount {self} has min higher than max")
+
+    def serialize(self) -> dict:
+        _requirement = {"name": "amount.worker." + self.name}
+        if self.min != self.DEFAULT_VALUE:
+            _requirement["min"] = max(self.min, self.DEFAULT_VALUE)
+        if self.max != self.DEFAULT_VALUE:
+            _requirement["max"] = min(self.max, MAX_INT_VALUE)
+        return _requirement
+
+
+@dataclass
+class CustomAttributeRequirement:
+    """
+    Settings for a CustomAttributeWidget
+    """
+
+    ANY_OF = "anyOf"
+    ALL_OF = "allOf"
+    OPTIONS = [ANY_OF, ALL_OF]
+    name: str = field(default="")
+    option: Literal[ANY_OF, ALL_OF] = field(default=ALL_OF)  # type: ignore
+    values: List[str] = field(default_factory=list)
+
+    def __post_init__(self):
+        if not self.name:
+            raise ValueError(f"Custom Amount {self} has no name")
+        elif not self.option or self.option not in CustomAttributeRequirement.OPTIONS:
+            raise ValueError(
+                f"Custom Amount {self} option is not in {CustomAttributeRequirement.OPTIONS}"
+            )
+
+    def serialize(self) -> dict:
+        if not self.name:
+            raise ValueError(f"Custom Attribute {self} has no name")
+        _requirement = {
+            "name": "attr.worker." + self.name,
+        }
+        if not self.option:
+            raise ValueError(f"Custom Attribute {self} has no option")
+        elif self.option not in ["anyOf", "allOf"]:
+            raise ValueError(
+                f'Custom Attribute {self} has option {self.option} which is not in list: ["anyOf", "allOf"]'
+            )
+        if not self.values:
+            raise ValueError(f"Custom Attribute {self} has no values")
+        _requirement[self.option] = self.values
+        return _requirement
+
+
+@dataclass
+class CustomRequirements:
+    """
+    Settings for a CustomRequirementsWidget.
+    """
+
+    amounts: List[CustomAmountRequirement] = field(default_factory=list)
+    attributes: List[CustomAttributeRequirement] = field(default_factory=list)
+
+    def __post_init__(self):
+        amounts = []
+        attributes = []
+        for amount in self.amounts:
+            amounts.append(self._validate_amount(amount))
+        for attribute in self.attributes:
+            attributes.append(self._validate_attribute(attribute))
+        self.amounts = amounts
+        self.attributes = attributes
+
+    @staticmethod
+    def _validate_amount(amount: Union[dict, CustomAmountRequirement]) -> CustomAmountRequirement:
+        if isinstance(amount, dict):
+            amount = CustomAmountRequirement(**amount)
+        return amount
+
+    @staticmethod
+    def _validate_attribute(
+        attribute: Union[dict, CustomAttributeRequirement]
+    ) -> CustomAttributeRequirement:
+        if isinstance(attribute, dict):
+            attribute = CustomAttributeRequirement(**attribute)
+        return attribute
+
+    def __iter__(self):
+        if self.amounts:
+            yield from self.amounts
+        if self.attributes:
+            yield from self.attributes
+
+    def _serialize_amounts(self):
+        requirements = []
+        for amount in self.amounts:
+            requirements.append(amount.serialize())
+        return requirements
+
+    def _serialize_attributes(self):
+        requirements = []
+        for attribute in self.attributes:
+            requirements.append(attribute.serialize())
+        return requirements
+
+    def serialize(self) -> Dict[str, List]:
+        requirements: Dict[str, List] = {}
+
+        if self.amounts:
+            requirements.setdefault("amounts", []).extend(self._serialize_amounts())
+
+        if self.attributes:
+            requirements.setdefault("attributes", []).extend(self._serialize_attributes())
+        return requirements
+
+
+@dataclass
+class HostRequirements:
+    """
+    Settings for a HostRequirementsWidget.
+    """
+
+    os_requirements: OsRequirements = field(default=None)
+    hardware_requirements: HardwareRequirements = field(default=None)
+    custom_requirements: CustomRequirements = field(default=None)
+
+    def __post_init__(self):
+        if isinstance(self.os_requirements, dict):
+            self.os_requirements = OsRequirements(**self.os_requirements)
+        if isinstance(self.hardware_requirements, dict):
+            self.hardware_requirements = HardwareRequirements(**self.hardware_requirements)
+        if isinstance(self.custom_requirements, dict):
+            self.custom_requirements = CustomRequirements(**self.custom_requirements)
+
+    def serialize(self) -> dict:
+        requirements: Dict[str, Union[List[str], List[int]]] = {}
+        if self.os_requirements is not None:
+            requirements.setdefault("attributes", []).extend(self.os_requirements.serialize())
+
+        if self.hardware_requirements:
+            requirements.setdefault("amounts", []).extend(self.hardware_requirements.serialize())
+
+        custom_requirements = self.custom_requirements.serialize()
+        if custom_requirements.get("amounts", []):
+            requirements.setdefault("amounts", []).extend(custom_requirements["amounts"])
+        if custom_requirements.get("attributes", []):
+            requirements.setdefault("attributes", []).extend(custom_requirements["attributes"])
+
+        return requirements

--- a/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
@@ -27,6 +27,7 @@ from deadline.client.ui.dialogs.submit_job_progress_dialog import SubmitJobProgr
 from deadline.job_attachments.models import JobAttachmentS3Settings
 from deadline.job_attachments.upload import S3AssetManager
 
+from ..dataclasses import HostRequirements
 from ... import api
 from ..deadline_authentication_status import DeadlineAuthenticationStatus
 from .. import block_signals
@@ -86,6 +87,7 @@ class SubmitJobToDeadlineDialog(QDialog):
         parent=None,
         f=Qt.WindowFlags(),
         show_host_requirements_tab=False,
+        host_requirements: Optional[HostRequirements] = None,
         submitter_name: Optional[str] = None,
     ):
         # The Qt.Tool flag makes sure our widget stays in front of the main application window
@@ -107,6 +109,7 @@ class SubmitJobToDeadlineDialog(QDialog):
             initial_shared_parameter_values,
             auto_detected_attachments,
             attachments,
+            host_requirements,
         )
 
         self.gui_update_counter: Any = None
@@ -143,6 +146,7 @@ class SubmitJobToDeadlineDialog(QDialog):
         initial_shared_parameter_values,
         auto_detected_attachments: AssetReferences,
         attachments: AssetReferences,
+        host_requirements: Optional[HostRequirements],
     ):
         self.lyt = QVBoxLayout(self)
         self.lyt.setContentsMargins(5, 5, 5, 5)
@@ -158,7 +162,7 @@ class SubmitJobToDeadlineDialog(QDialog):
 
         # Show host requirements only if requested by the constructor
         if self.show_host_requirements_tab:
-            self._build_host_requirements_tab()
+            self._build_host_requirements_tab(host_requirements)
 
         self.auth_status_box = DeadlineAuthenticationStatusWidget(self)
         self.lyt.addWidget(self.auth_status_box)
@@ -272,12 +276,14 @@ class SubmitJobToDeadlineDialog(QDialog):
         self.job_attachments_tab.setWidget(self.job_attachments)
         self.job_attachments_tab.setWidgetResizable(True)
 
-    def _build_host_requirements_tab(self):
+    def _build_host_requirements_tab(self, host_requirements: Optional[HostRequirements]):
         self.host_requirements = HostRequirementsWidget()
         self.host_requirements_tab = QScrollArea()
         self.tabs.addTab(self.host_requirements_tab, "Host requirements")
         self.host_requirements_tab.setWidget(self.host_requirements)
         self.host_requirements_tab.setWidgetResizable(True)
+        if host_requirements:
+            self.host_requirements.set_requirements(host_requirements)
 
     def on_shared_job_parameter_changed(self, parameter: dict[str, Any]):
         """

--- a/test/unit/deadline_client/ui/test_host_requirements_dataclass_serialize.py
+++ b/test/unit/deadline_client/ui/test_host_requirements_dataclass_serialize.py
@@ -1,0 +1,169 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+tests the deadline.client.ui.dataclasses functions relating to serializing.
+"""
+import pytest
+
+from deadline.client.ui.dataclasses import (
+    HostRequirements,
+    OsRequirements,
+    HardwareRequirements,
+    CustomRequirements,
+    CustomAmountRequirement,
+    CustomAttributeRequirement,
+)
+
+
+HOST_REQUIREMENTS_1 = {
+    "attributes": [
+        {"name": "attr.worker.os.family", "anyOf": ["windows"]},
+        {"name": "attr.worker.cpu.arch", "anyOf": ["x86_64"]},
+        {"name": "attr.worker.pipelineFeatures", "anyOf": ["feature1", "feature2"]},
+    ],
+    "amounts": [
+        {"name": "amount.worker.vcpu", "min": 8, "max": 64},
+        {"name": "amount.worker.memory", "min": 16384, "max": 131072},
+        {"name": "amount.worker.Bugs", "min": 1, "max": 10},
+    ],
+}
+
+
+def _compare_requirements(first, second):
+    assert len(first.get("amounts")) == len(second.get("amounts"))
+    assert len(first.get("attributes")) == len(second.get("attributes"))
+    for amount in first.get("amounts"):
+        name = amount.get("name")
+        _min = amount.get("min")
+        _max = amount.get("max")
+        for ref_amount in second.get("amounts"):
+            if ref_amount.get("name") == name:
+                assert ref_amount.get("min") == _min
+                assert ref_amount.get("max") == _max
+                break
+        else:
+            raise ValueError("Could not find amount with name: {}".format(name))
+
+    for attribute in first.get("attributes"):
+        name = attribute.get("name")
+        operation = "anyOf" if attribute.get("anyOf") else "allOf"
+        values = attribute.get(operation)
+        for ref_attribute in second.get("attributes"):
+            if ref_attribute.get("name") == name:
+                assert ("anyOf" if attribute.get("anyOf") else "allOf") == operation
+                assert set(values) == set(ref_attribute.get(operation))
+                break
+        else:
+            raise ValueError("Could not find attribute with name: {}".format(name))
+
+
+def test_host_requirements_as_objects_serialize():
+    requirements = HostRequirements(
+        os_requirements=OsRequirements(
+            operating_systems=[OsRequirements.WINDOWS],  # type: ignore
+            cpu_archs=[OsRequirements.X86_64],  # type: ignore
+        ),
+        hardware_requirements=HardwareRequirements(
+            cpu_min=8,
+            cpu_max=64,
+            memory_min=16 * 1024,
+            memory_max=128 * 1024,
+        ),
+        custom_requirements=CustomRequirements(
+            amounts=[
+                CustomAmountRequirement(name="Bugs", min=1, max=10),
+            ],
+            attributes=[
+                CustomAttributeRequirement(
+                    name="pipelineFeatures",
+                    option=CustomAttributeRequirement.ANY_OF,
+                    values=["feature1", "feature2"],
+                ),
+            ],
+        ),
+    )
+    open_jd_requirements = requirements.serialize()
+    _compare_requirements(open_jd_requirements, HOST_REQUIREMENTS_1)
+
+
+def test_host_requirements_as_dictionary_serialize():
+    requirements = HostRequirements(
+        os_requirements={  # type: ignore
+            "operating_systems": ["windows"],
+            "cpu_archs": ["x86_64"],
+        },
+        hardware_requirements={  # type: ignore
+            "cpu_min": 8,
+            "cpu_max": 64,
+            "memory_min": 16 * 1024,
+            "memory_max": 128 * 1024,
+        },
+        custom_requirements={  # type: ignore
+            "amounts": [
+                {"name": "Bugs", "min": 1, "max": 10},
+            ],
+            "attributes": [
+                {"name": "pipelineFeatures", "option": "anyOf", "values": ["feature1", "feature2"]},
+            ],
+        },
+    )
+    open_jd_requirements = requirements.serialize()
+    _compare_requirements(open_jd_requirements, HOST_REQUIREMENTS_1)
+
+
+def test_host_requirements_invalid_os():
+    with pytest.raises(ValueError):
+        requirements = HostRequirements(
+            os_requirements=OsRequirements(
+                operating_systems=["freebsd"],  # type: ignore
+                cpu_archs=[OsRequirements.X86_64],  # type: ignore
+            ),
+            hardware_requirements=HardwareRequirements(
+                cpu_min=8,
+                cpu_max=64,
+                memory_min=16 * 1024,
+                memory_max=128 * 1024,
+            ),
+            custom_requirements=CustomRequirements(
+                amounts=[
+                    CustomAmountRequirement(name="Bugs", min=1, max=10),
+                ],
+                attributes=[
+                    CustomAttributeRequirement(
+                        name="pipelineFeatures",
+                        option=CustomAttributeRequirement.ANY_OF,
+                        values=["feature1", "feature2"],
+                    ),
+                ],
+            ),
+        )
+        requirements.serialize()
+
+
+def test_host_requirements_invalid_arch():
+    with pytest.raises(ValueError):
+        requirements = HostRequirements(
+            os_requirements=OsRequirements(
+                operating_systems=[OsRequirements.LINUX],  # type: ignore
+                cpu_archs=["risc-v"],  # type: ignore
+            ),
+            hardware_requirements=HardwareRequirements(
+                cpu_min=8,
+                cpu_max=64,
+                memory_min=16 * 1024,
+                memory_max=128 * 1024,
+            ),
+            custom_requirements=CustomRequirements(
+                amounts=[
+                    CustomAmountRequirement(name="Bugs", min=1, max=10),
+                ],
+                attributes=[
+                    CustomAttributeRequirement(
+                        name="pipelineFeatures",
+                        option=CustomAttributeRequirement.ANY_OF,
+                        values=["feature1", "feature2"],
+                    ),
+                ],
+            ),
+        )
+        requirements.serialize()


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud/issues/535

### What was the problem/requirement? (What/Why)
Submitters were unable to prepopulate the Host Requirements and had to resort to forcing the values in the job template (cinema-4d). This caused issues if the "default" workflow wasn't the one that the artist wanted as they had no idea of the defaults in the job template
### What was the solution? (How)
Implement setters on the HostRequirementsWidget and allow a `host_requirements` parameter to the SubmitToDeadlineDialog
### What is the impact of this change?
New functionality in the submitter dialog
### How was this change tested?
Ran local testing to confirm it is working.
I have added a few unit tests for the dataclasses as well.

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [X] This PR does not add any new dependencies.

### Is this a breaking change?
I don't believe it is breaking

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
