### PR TITLE
refactor: rename helper function for windows long path registry

### DIFF
--- a/src/deadline/job_attachments/_utils.py
+++ b/src/deadline/job_attachments/_utils.py
@@ -92,7 +92,7 @@ def _is_relative_to(path1: Union[Path, str], path2: Union[Path, str]) -> bool:
         return False
 
 
-def _is_windows_file_path_limit() -> bool:
+def _is_windows_long_path_registry_enabled() -> bool:
     if sys.platform != "win32":
         return True
 

--- a/src/deadline/job_attachments/download.py
+++ b/src/deadline/job_attachments/download.py
@@ -69,7 +69,7 @@ from .os_file_permission import (
     _set_fs_group_for_posix,
     _set_fs_permission_for_windows,
 )
-from ._utils import _is_relative_to, _join_s3_paths, _is_windows_file_path_limit
+from ._utils import _is_relative_to, _join_s3_paths, _is_windows_long_path_registry_enabled
 
 download_logger = getLogger("deadline.job_attachments.download")
 
@@ -532,7 +532,7 @@ def download_file(
                     "Your file path is longer than what Windows allow.\n"
                     + "This could be the error if you do not enable longer file path in Windows"
                 )
-            elif not _is_windows_file_path_limit():
+            elif not _is_windows_long_path_registry_enabled():
                 # Path start with \\?\ but do not enable registry -> Undefined error
                 raise AssetSyncError(
                     f"{e}\nUNC notation exist, but long path registry not enabled. Undefined error"

--- a/test/integ/deadline_job_attachments/test_job_attachments.py
+++ b/test/integ/deadline_job_attachments/test_job_attachments.py
@@ -35,7 +35,7 @@ from deadline.job_attachments.progress_tracker import SummaryStatistics
 from deadline.job_attachments._utils import (
     _get_unique_dest_dir_name,
 )
-from deadline.job_attachments._utils import _is_windows_file_path_limit
+from deadline.job_attachments._utils import _is_windows_long_path_registry_enabled
 from .conftest import is_windows_non_admin
 
 
@@ -1503,7 +1503,7 @@ def test_download_outputs_bucket_wrong_account(
 
 @pytest.mark.integ
 @pytest.mark.skipif(
-    _is_windows_file_path_limit(),
+    _is_windows_long_path_registry_enabled(),
     reason="This test is for Windows max file path length error, skipping this if Windows path limit is extended",
 )
 def test_download_outputs_windows_max_file_path_length_exception(

--- a/test/unit/deadline_job_attachments/test_download.py
+++ b/test/unit/deadline_job_attachments/test_download.py
@@ -2077,7 +2077,7 @@ class TestFullDownload:
             f"{deadline.__package__}.job_attachments.download.get_s3_transfer_manager",
             return_value=mock_transfer_manager,
         ), patch(
-            f"{deadline.__package__}.job_attachments.download._is_windows_file_path_limit",
+            f"{deadline.__package__}.job_attachments.download._is_windows_long_path_registry_enabled",
             return_value=False,
         ), patch(
             f"{deadline.__package__}.job_attachments.download.Path.mkdir"
@@ -2123,7 +2123,7 @@ class TestFullDownload:
             f"{deadline.__package__}.job_attachments.download.get_s3_transfer_manager",
             return_value=mock_transfer_manager,
         ), patch(
-            f"{deadline.__package__}.job_attachments.download._is_windows_file_path_limit",
+            f"{deadline.__package__}.job_attachments.download._is_windows_long_path_registry_enabled",
             return_value=True,
         ), patch(
             f"{deadline.__package__}.job_attachments.download.Path.mkdir"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The previous naming for the helper function that checked whether the windows long path registry key was enabled was a bit confusing, and it would be better to change it so that it's more clear.
### What was the solution? (How)
Rename the function to `_is_windows_long_path_registry_enabled` from `_is_windows_file_path_limit` so that it is more clear. 
### What is the impact of this change?
Better and easier understanding of the function to check that windows long path registry is enabled.
### How was this change tested?

`hatch run fmt`
`hatch run integ:test`


- Have you run the unit tests? Yes
- Have you run the integration tests? Yes
- Have you made changes to the `download` or `asset_sync` modules? No

### Was this change documented?

Documentation unnecessary.

### Does this PR introduce new dependencies?

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x ] This PR does not add any new dependencies.

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
