### PR TITLE
feat: add python 3.13 support

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
     uses: aws-deadline/.github/.github/workflows/reusable_python_build.yml@mainline
     with:
       os: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Notable features include:
 
 This library requires:
 
-1. Python 3.8 through 3.12; and
+1. Python 3.8 through 3.13; and
 2. Linux, Windows, or macOS operating system.
 
 ## Versioning

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 dynamic = ["version"]
 readme = "README.md"
 license = "Apache-2.0"
-requires-python = ">=3.8, <3.13"
+requires-python = ">=3.8, <3.14"
 # https://pypi.org/classifiers/
 classifiers = [
   "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Fixes: #493
Fixed: #510 

### What was the problem/requirement? (What/Why)

We were locking support to python <3.13 until we had all of our dependencies available in python 3.13 (pywin32 and pyside6).

### What was the solution? (How)

Now that pywin32 and pyside6 deps are loosened, python 3.13 can pull in versions that work with it.

### What is the impact of this change?

Users can now use the deadline library in python 3.13

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests?
    - CI
- Have you run the integration tests?
    - yes

macOS
```
platform darwin -- Python 3.13.1, pytest-7.4.4, pluggy-1.5.0 -- /Users/morgane/Library/Application Support/hatch/env/virtual/deadline/QDIZvR3F/integ/bin/python
cachedir: .pytest_cache
rootdir: /Users/morgane/dev/github/deadline-cloud
configfile: pyproject.toml
plugins: cov-5.0.0, deadline-cloud-test-fixtures-0.17.2, timeout-2.3.1, xdist-3.6.1
1 worker [30 items]    
scheduling tests via LoadScheduling

test/integ/cli/test_cli_attachment.py::TestAttachment::test_attachment_s3_cross_account_access_denied 
[gw0] [  3%] PASSED test/integ/cli/test_cli_attachment.py::TestAttachment::test_attachment_s3_cross_account_access_denied 
test/integ/cli/test_cli_attachment.py::TestAttachment::test_attachment_basic_flow[TEST_CASE_1] 
[gw0] [  6%] PASSED test/integ/cli/test_cli_attachment.py::TestAttachment::test_attachment_basic_flow[TEST_CASE_1] 
test/integ/cli/test_cli_attachment.py::TestAttachment::test_attachment_basic_flow[TEST_CASE_2] 
[gw0] [ 10%] PASSED test/integ/cli/test_cli_attachment.py::TestAttachment::test_attachment_basic_flow[TEST_CASE_2] 
test/integ/cli/test_cli_attachment.py::TestAttachment::test_attachment_path_mapping_flow[TEST_CASE_1] 
[gw0] [ 13%] PASSED test/integ/cli/test_cli_attachment.py::TestAttachment::test_attachment_path_mapping_flow[TEST_CASE_1] 
test/integ/cli/test_cli_attachment.py::TestAttachment::test_attachment_path_mapping_flow[TEST_CASE_2] 
[gw0] [ 16%] PASSED test/integ/cli/test_cli_attachment.py::TestAttachment::test_attachment_path_mapping_flow[TEST_CASE_2] 
test/integ/cli/test_cli_manifest_download.py::TestManifestDownload::test_manifest_download_job[True] 
[gw0] [ 20%] PASSED test/integ/cli/test_cli_manifest_download.py::TestManifestDownload::test_manifest_download_job[True] 
test/integ/cli/test_cli_manifest_download.py::TestManifestDownload::test_manifest_download_job[False] 
[gw0] [ 23%] PASSED test/integ/cli/test_cli_manifest_download.py::TestManifestDownload::test_manifest_download_job[False] 
test/integ/cli/test_cli_manifest_download.py::TestManifestDownload::test_manifest_download_job_step_dependency[True] 
[gw0] [ 26%] PASSED test/integ/cli/test_cli_manifest_download.py::TestManifestDownload::test_manifest_download_job_step_dependency[True] 
test/integ/cli/test_cli_manifest_download.py::TestManifestDownload::test_manifest_download_job_step_dependency[False] 
[gw0] [ 30%] PASSED test/integ/cli/test_cli_manifest_download.py::TestManifestDownload::test_manifest_download_job_step_dependency[False] 
test/integ/cli/test_cli_manifest_snapshot.py::TestManifestSnapshot::test_manifest_diff[True] 
[gw0] [ 33%] PASSED test/integ/cli/test_cli_manifest_snapshot.py::TestManifestSnapshot::test_manifest_diff[True] 
test/integ/cli/test_cli_manifest_snapshot.py::TestManifestSnapshot::test_manifest_diff[False] 
[gw0] [ 36%] PASSED test/integ/cli/test_cli_manifest_snapshot.py::TestManifestSnapshot::test_manifest_diff[False] 
test/integ/cli/test_cli_manifest_upload.py::TestManifestUpload::test_manifest_upload 
[gw0] [ 40%] PASSED test/integ/cli/test_cli_manifest_upload.py::TestManifestUpload::test_manifest_upload 
test/integ/cli/test_cli_manifest_upload.py::TestManifestUpload::test_manifest_upload_by_farm_queue 
[gw0] [ 43%] PASSED test/integ/cli/test_cli_manifest_upload.py::TestManifestUpload::test_manifest_upload_by_farm_queue 
test/integ/deadline_job_attachments/test_job_attachments.py::test_upload_input_files_all_assets_in_cas[2023-03-03] 
[gw0] [ 46%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_upload_input_files_all_assets_in_cas[2023-03-03] 
test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_outputs_no_job_attachment_settings_in_job[2023-03-03] 
[gw0] [ 50%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_outputs_no_job_attachment_settings_in_job[2023-03-03] 
test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_outputs_no_job_attachment_s3_settings[2023-03-03] 
[gw0] [ 53%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_outputs_no_job_attachment_s3_settings[2023-03-03] 
test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_outputs_with_symlink[2023-03-03] 
[gw0] [ 56%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_outputs_with_symlink[2023-03-03] 
test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_inputs_with_step_dependencies[2023-03-03] 
[gw0] [ 60%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_inputs_with_step_dependencies[2023-03-03] 
test/integ/deadline_job_attachments/test_job_attachments.py::test_download_outputs_with_job_id_step_id_task_id_and_download_directory[2023-03-03] 
[gw0] [ 63%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_download_outputs_with_job_id_step_id_task_id_and_download_directory[2023-03-03] 
test/integ/deadline_job_attachments/test_job_attachments.py::test_download_outputs_with_job_id_step_id_and_download_directory[2023-03-03] 
[gw0] [ 66%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_download_outputs_with_job_id_step_id_and_download_directory[2023-03-03] 
test/integ/deadline_job_attachments/test_job_attachments.py::test_download_outputs_with_job_id_and_download_directory[2023-03-03] 
[gw0] [ 70%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_download_outputs_with_job_id_and_download_directory[2023-03-03] 
test/integ/deadline_job_attachments/test_job_attachments.py::test_upload_input_files_no_download_paths[2023-03-03] 
[gw0] [ 73%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_upload_input_files_no_download_paths[2023-03-03] 
test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_inputs_no_inputs[2023-03-03] 
[gw0] [ 76%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_inputs_no_inputs[2023-03-03] 
test/integ/deadline_job_attachments/test_job_attachments.py::test_upload_bucket_wrong_account[2023-03-03] 
[gw0] [ 80%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_upload_bucket_wrong_account[2023-03-03] 
test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_inputs_bucket_wrong_account[2023-03-03] 
[gw0] [ 83%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_inputs_bucket_wrong_account[2023-03-03] 
test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_outputs_bucket_wrong_account[2023-03-03] 
[gw0] [ 86%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_outputs_bucket_wrong_account[2023-03-03] 
test/integ/deadline_job_attachments/test_job_attachments.py::test_download_outputs_bucket_wrong_account[2023-03-03] 
[gw0] [ 90%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_download_outputs_bucket_wrong_account[2023-03-03] 
test/integ/deadline_job_attachments/test_job_attachments.py::test_download_outputs_windows_max_file_path_length_exception[2023-03-03] 
[gw0] [ 93%] SKIPPED test/integ/deadline_job_attachments/test_job_attachments.py::test_download_outputs_windows_max_file_path_length_exception[2023-03-03] 
test/integ/deadline_job_attachments/test_job_attachments.py::test_download_outputs_no_outputs_dir[2023-03-03] 
[gw0] [ 96%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_download_outputs_no_outputs_dir[2023-03-03] 
test/integ/deadline_job_attachments/test_job_attachments.py::test_download_outputs_windows_file_path_UNC[2023-03-03] 
[gw0] [100%] SKIPPED test/integ/deadline_job_attachments/test_job_attachments.py::test_download_outputs_windows_file_path_UNC[2023-03-03] 

====================================================================================================== warnings summary ======================================================================================================
test/integ/cli/test_cli_attachment.py:93
  /Users/morgane/dev/github/deadline-cloud/test/integ/cli/test_cli_attachment.py:93: PytestUnknownMarkWarning: Unknown pytest.mark.cross_account - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.cross_account

test/integ/deadline_job_attachments/test_job_attachments.py:1287
  /Users/morgane/dev/github/deadline-cloud/test/integ/deadline_job_attachments/test_job_attachments.py:1287: PytestUnknownMarkWarning: Unknown pytest.mark.cross_account - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.cross_account

test/integ/deadline_job_attachments/test_job_attachments.py:1337
  /Users/morgane/dev/github/deadline-cloud/test/integ/deadline_job_attachments/test_job_attachments.py:1337: PytestUnknownMarkWarning: Unknown pytest.mark.cross_account - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.cross_account

test/integ/deadline_job_attachments/test_job_attachments.py:1386
  /Users/morgane/dev/github/deadline-cloud/test/integ/deadline_job_attachments/test_job_attachments.py:1386: PytestUnknownMarkWarning: Unknown pytest.mark.cross_account - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.cross_account

test/integ/deadline_job_attachments/test_job_attachments.py:1470
  /Users/morgane/dev/github/deadline-cloud/test/integ/deadline_job_attachments/test_job_attachments.py:1470: PytestUnknownMarkWarning: Unknown pytest.mark.cross_account - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.cross_account

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
==================================================================================================== slowest 5 durations =====================================================================================================
5.65s call     test/integ/cli/test_cli_manifest_download.py::TestManifestDownload::test_manifest_download_job_step_dependency[True]
5.19s call     test/integ/cli/test_cli_manifest_download.py::TestManifestDownload::test_manifest_download_job_step_dependency[False]
3.95s call     test/integ/cli/test_cli_manifest_download.py::TestManifestDownload::test_manifest_download_job[True]
3.60s call     test/integ/cli/test_cli_manifest_download.py::TestManifestDownload::test_manifest_download_job[False]
3.04s setup    test/integ/cli/test_cli_manifest_download.py::TestManifestDownload::test_manifest_download_job[True]
========================================================================================= 28 passed, 2 skipped, 5 warnings in 52.02s =========================================================================================
```

Windows:

```
==================================================================== test session starts ==================================================================== platform win32 -- Python 3.13.1, pytest-7.4.4, pluggy-1.5.0 -- C:\Users\lucaseck\AppData\Local\hatch\env\virtual\deadline\6cpZG2in\integ\Scripts\python.exe
cachedir: .pytest_cache
rootdir: C:\Users\lucaseck\dev\deadline-clients\deadline-cloud
configfile: pyproject.toml
plugins: deadline-cloud-test-fixtures-0.17.2, cov-5.0.0, timeout-2.3.1, xdist-3.6.1
1 worker [30 items]
scheduling tests via LoadScheduling

test/integ/cli/test_cli_attachment.py::TestAttachment::test_attachment_s3_cross_account_access_denied
[gw0] [  3%] PASSED test/integ/cli/test_cli_attachment.py::TestAttachment::test_attachment_s3_cross_account_access_denied
test/integ/cli/test_cli_attachment.py::TestAttachment::test_attachment_basic_flow[TEST_CASE_1]
[gw0] [  6%] PASSED test/integ/cli/test_cli_attachment.py::TestAttachment::test_attachment_basic_flow[TEST_CASE_1]
test/integ/cli/test_cli_attachment.py::TestAttachment::test_attachment_basic_flow[TEST_CASE_2]
[gw0] [ 10%] PASSED test/integ/cli/test_cli_attachment.py::TestAttachment::test_attachment_basic_flow[TEST_CASE_2]
test/integ/cli/test_cli_attachment.py::TestAttachment::test_attachment_path_mapping_flow[TEST_CASE_1]
[gw0] [ 13%] PASSED test/integ/cli/test_cli_attachment.py::TestAttachment::test_attachment_path_mapping_flow[TEST_CASE_1]
test/integ/cli/test_cli_attachment.py::TestAttachment::test_attachment_path_mapping_flow[TEST_CASE_2]
[gw0] [ 16%] PASSED test/integ/cli/test_cli_attachment.py::TestAttachment::test_attachment_path_mapping_flow[TEST_CASE_2]
test/integ/cli/test_cli_manifest_download.py::TestManifestDownload::test_manifest_download_job[True]
[gw0] [ 20%] PASSED test/integ/cli/test_cli_manifest_download.py::TestManifestDownload::test_manifest_download_job[True]
test/integ/cli/test_cli_manifest_download.py::TestManifestDownload::test_manifest_download_job[False]
[gw0] [ 23%] PASSED test/integ/cli/test_cli_manifest_download.py::TestManifestDownload::test_manifest_download_job[False]
test/integ/cli/test_cli_manifest_download.py::TestManifestDownload::test_manifest_download_job_step_dependency[True]
[gw0] [ 26%] PASSED test/integ/cli/test_cli_manifest_download.py::TestManifestDownload::test_manifest_download_job_step_dependency[True]
test/integ/cli/test_cli_manifest_download.py::TestManifestDownload::test_manifest_download_job_step_dependency[False]
[gw0] [ 30%] PASSED test/integ/cli/test_cli_manifest_download.py::TestManifestDownload::test_manifest_download_job_step_dependency[False]
test/integ/cli/test_cli_manifest_snapshot.py::TestManifestSnapshot::test_manifest_diff[True]
[gw0] [ 33%] PASSED test/integ/cli/test_cli_manifest_snapshot.py::TestManifestSnapshot::test_manifest_diff[True]
test/integ/cli/test_cli_manifest_snapshot.py::TestManifestSnapshot::test_manifest_diff[False]
[gw0] [ 36%] PASSED test/integ/cli/test_cli_manifest_snapshot.py::TestManifestSnapshot::test_manifest_diff[False]
test/integ/cli/test_cli_manifest_upload.py::TestManifestUpload::test_manifest_upload
[gw0] [ 40%] PASSED test/integ/cli/test_cli_manifest_upload.py::TestManifestUpload::test_manifest_upload
test/integ/cli/test_cli_manifest_upload.py::TestManifestUpload::test_manifest_upload_by_farm_queue
[gw0] [ 43%] PASSED test/integ/cli/test_cli_manifest_upload.py::TestManifestUpload::test_manifest_upload_by_farm_queue
test/integ/deadline_job_attachments/test_job_attachments.py::test_upload_input_files_all_assets_in_cas[2023-03-03]
[gw0] [ 46%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_upload_input_files_all_assets_in_cas[2023-03-03]
test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_outputs_no_job_attachment_settings_in_job[2023-03-03]
[gw0] [ 50%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_outputs_no_job_attachment_settings_in_job[2023-03-03]
test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_outputs_no_job_attachment_s3_settings[2023-03-03]
[gw0] [ 53%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_outputs_no_job_attachment_s3_settings[2023-03-03]
test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_outputs_with_symlink[2023-03-03]
[gw0] [ 56%] SKIPPED test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_outputs_with_symlink[2023-03-03]
test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_inputs_with_step_dependencies[2023-03-03]
[gw0] [ 60%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_inputs_with_step_dependencies[2023-03-03]
test/integ/deadline_job_attachments/test_job_attachments.py::test_download_outputs_with_job_id_step_id_task_id_and_download_directory[2023-03-03]
[gw0] [ 63%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_download_outputs_with_job_id_step_id_task_id_and_download_directory[2023-03-03]
test/integ/deadline_job_attachments/test_job_attachments.py::test_download_outputs_with_job_id_step_id_and_download_directory[2023-03-03]
[gw0] [ 66%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_download_outputs_with_job_id_step_id_and_download_directory[2023-03-03] test/integ/deadline_job_attachments/test_job_attachments.py::test_download_outputs_with_job_id_and_download_directory[2023-03-03]
[gw0] [ 70%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_download_outputs_with_job_id_and_download_directory[2023-03-03]
test/integ/deadline_job_attachments/test_job_attachments.py::test_upload_input_files_no_download_paths[2023-03-03]
[gw0] [ 73%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_upload_input_files_no_download_paths[2023-03-03]
test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_inputs_no_inputs[2023-03-03]
[gw0] [ 76%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_inputs_no_inputs[2023-03-03]
test/integ/deadline_job_attachments/test_job_attachments.py::test_upload_bucket_wrong_account[2023-03-03]
[gw0] [ 80%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_upload_bucket_wrong_account[2023-03-03]
test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_inputs_bucket_wrong_account[2023-03-03]
[gw0] [ 83%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_inputs_bucket_wrong_account[2023-03-03]
test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_outputs_bucket_wrong_account[2023-03-03]
[gw0] [ 86%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_outputs_bucket_wrong_account[2023-03-03]
test/integ/deadline_job_attachments/test_job_attachments.py::test_download_outputs_bucket_wrong_account[2023-03-03]
[gw0] [ 90%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_download_outputs_bucket_wrong_account[2023-03-03]
test/integ/deadline_job_attachments/test_job_attachments.py::test_download_outputs_windows_max_file_path_length_exception[2023-03-03]
[gw0] [ 93%] SKIPPED test/integ/deadline_job_attachments/test_job_attachments.py::test_download_outputs_windows_max_file_path_length_exception[2023-03-03]
test/integ/deadline_job_attachments/test_job_attachments.py::test_download_outputs_no_outputs_dir[2023-03-03]
[gw0] [ 96%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_download_outputs_no_outputs_dir[2023-03-03]
test/integ/deadline_job_attachments/test_job_attachments.py::test_download_outputs_windows_file_path_UNC[2023-03-03]
[gw0] [100%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_download_outputs_windows_file_path_UNC[2023-03-03]

===================================================================== warnings summary ====================================================================== test\integ\cli\test_cli_attachment.py:93
  C:\Users\lucaseck\dev\deadline-clients\deadline-cloud\test\integ\cli\test_cli_attachment.py:93: PytestUnknownMarkWarning: Unknown pytest.mark.cross_account - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.cross_account

test\integ\deadline_job_attachments\test_job_attachments.py:1287
  C:\Users\lucaseck\dev\deadline-clients\deadline-cloud\test\integ\deadline_job_attachments\test_job_attachments.py:1287: PytestUnknownMarkWarning: Unknown pytest.mark.cross_account - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.cross_account

test\integ\deadline_job_attachments\test_job_attachments.py:1337
  C:\Users\lucaseck\dev\deadline-clients\deadline-cloud\test\integ\deadline_job_attachments\test_job_attachments.py:1337: PytestUnknownMarkWarning: Unknown pytest.mark.cross_account - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.cross_account

test\integ\deadline_job_attachments\test_job_attachments.py:1386
  C:\Users\lucaseck\dev\deadline-clients\deadline-cloud\test\integ\deadline_job_attachments\test_job_attachments.py:1386: PytestUnknownMarkWarning: Unknown pytest.mark.cross_account - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.cross_account

test\integ\deadline_job_attachments\test_job_attachments.py:1470
  C:\Users\lucaseck\dev\deadline-clients\deadline-cloud\test\integ\deadline_job_attachments\test_job_attachments.py:1470: PytestUnknownMarkWarning: Unknown pytest.mark.cross_account - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.cross_account

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
==================================================================== slowest 5 durations ==================================================================== 8.25s setup    test/integ/cli/test_cli_manifest_download.py::TestManifestDownload::test_manifest_download_job[True]
7.62s call     test/integ/cli/test_cli_manifest_download.py::TestManifestDownload::test_manifest_download_job_step_dependency[True]
7.39s call     test/integ/cli/test_cli_manifest_download.py::TestManifestDownload::test_manifest_download_job_step_dependency[False]
7.14s setup    test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_inputs_with_step_dependencies[2023-03-03]
6.01s call     test/integ/cli/test_cli_manifest_download.py::TestManifestDownload::test_manifest_download_job[True]
=================================================== 28 passed, 2 skipped, 5 warnings in 87.66s (0:01:27) ====================================================
```

- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass.
    - Nope

In addition, on macOS and windows I tried the different cli workflows that install pyside6 for the user and that succeeded

### Was this change documented?

Yes, I've updated the relevant documentation

### Does this PR introduce new dependencies?

No

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
