### PR TITLE
test: default log level test was using existing machine config

### DIFF
--- a/test/unit/deadline_client/config/test_config_file.py
+++ b/test/unit/deadline_client/config/test_config_file.py
@@ -263,7 +263,7 @@ def test_str2bool():
         config_file.str2bool("")
 
 
-def test_default_log_level():
+def test_default_log_level(fresh_deadline_config):
     # To avoid excessive logging, the log level should not be DEBUG by default.
     assert config.get_setting("settings.log_level") != "DEBUG"
     # Verify the default log level exists and is less verbose than DEBUG


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

`hatch run test` could fail with:

```
================================================================================================== short test summary info ==================================================================================================
FAILED test/unit/deadline_client/config/test_config_file.py::test_default_log_level - AssertionError: assert 'ERROR' == 'WARNING'
================================================================================== 1 failed, 1400 passed, 55 skipped, 1 xfailed in 23.80s ===================================================================================
```

This would only happen if you had changed the log level in the config, which is why the code quality checks in github were passing, but failing locally for myself.

### What was the solution? (How)

Add the fresh config fixture to the test to ensure it's actually testing the default.

### What is the impact of this change?

Tests now pass locally

### How was this change tested?

`hatch run test`

```
Required test coverage of 80.0% reached. Total coverage: 81.32%
==================================================================================================== slowest 5 durations ====================================================================================================
3.17s call     test/unit/deadline_job_attachments/test_upload.py::TestUpload::test_asset_management_no_outputs_large_number_of_inputs_already_uploaded[2023-03-03-200]
3.10s call     test/unit/deadline_job_attachments/test_upload.py::TestUpload::test_asset_management_many_inputs[2023-03-03-200]
2.05s call     test/unit/deadline_job_attachments/test_upload.py::TestUpload::test_asset_management_many_inputs[2023-03-03-100]
1.81s call     test/unit/deadline_job_attachments/test_upload.py::TestUpload::test_asset_management_no_outputs_large_number_of_inputs_already_uploaded[2023-03-03-100]
1.45s call     test/unit/deadline_job_attachments/test_progress_tracker.py::TestProgressTracker::test_increment_race_condition
======================================================================================= 1401 passed, 55 skipped, 1 xfailed in 21.75s ========================================================================================
```

### Was this change documented?

no

### Does this PR introduce new dependencies?

no

### Is this a breaking change?

no

### Does this change impact security?

no

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
