### PR TITLE
fix: Sets the min for custom host requirement spinbox to 0.

### DIFF
--- a/src/deadline/client/ui/widgets/host_requirements_tab.py
+++ b/src/deadline/client/ui/widgets/host_requirements_tab.py
@@ -500,11 +500,11 @@ class CustomAmountWidget(CustomCapabilityWidget):
         self.max_label = QLabel("Max")
         self.max_label.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
         self.min_spin_box = OptionalDoubleSpinBox(
-            min=MIN_INT_VALUE, max=MAX_INT_VALUE, decimal=DECIMAL_VALUE, parent=self
+            min=0, max=MAX_INT_VALUE, decimal=DECIMAL_VALUE, parent=self
         )
         self.min_spin_box.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         self.max_spin_box = OptionalDoubleSpinBox(
-            min=MIN_INT_VALUE, max=MAX_INT_VALUE, decimal=DECIMAL_VALUE, parent=self
+            min=0, max=MAX_INT_VALUE, decimal=DECIMAL_VALUE, parent=self
         )
         self.max_spin_box.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
 

--- a/test/unit/deadline_client/ui/widgets/test_host_requirements_tab.py
+++ b/test/unit/deadline_client/ui/widgets/test_host_requirements_tab.py
@@ -12,7 +12,6 @@ try:
         CustomRequirementsWidget,
         ATTRIBUTE_CAPABILITY_PREFIX,
         AMOUNT_CAPABILITY_PREFIX,
-        MIN_INT_VALUE,
         MAX_INT_VALUE,
     )
 except ImportError:
@@ -76,9 +75,9 @@ def test_value_in_custom_amount_widget_should_be_integer_within_range(qtbot):
     widget = CustomAmountWidget(MagicMock(), 1)
     qtbot.addWidget(widget)
 
-    assert widget.min_spin_box.min == MIN_INT_VALUE
+    assert widget.min_spin_box.min == 0
     assert widget.min_spin_box.max == MAX_INT_VALUE
-    assert widget.max_spin_box.min == MIN_INT_VALUE
+    assert widget.max_spin_box.min == 0
     assert widget.max_spin_box.max == MAX_INT_VALUE
 
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

OpenJD requires that the minimum value for AmountRequirements be non-negative. We're allowing the spinboxes to be non-negative values.  

### What was the solution? (How)

Set the minimum value of the spinboxes to be 0.

### What is the impact of this change?

Less risk for invalid Job templates.

### How was this change tested?

Ran and updated the unit tests. 

### Was this change documented?

None required.

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
