### PR TITLE
fix: account for file modification time mismatch in snapshot diff comparison due to precision

### DIFF
--- a/src/deadline/job_attachments/_diff.py
+++ b/src/deadline/job_attachments/_diff.py
@@ -5,6 +5,7 @@ import logging
 import os
 from pathlib import Path, PurePosixPath
 from typing import Dict, List, Tuple
+from math import trunc
 from deadline.client.cli._groups.click_logger import ClickLogger
 from deadline.client.config import config_file
 from deadline.client.exceptions import NonValidInputError
@@ -176,7 +177,9 @@ def _fast_file_list_to_manifest_diff(
                 logger.echo(
                     f"Found size difference at: {root_relative_path}, Status: FileStatus.MODIFIED"
                 )
-            elif int(file_stat.st_mtime_ns // 1000) != input_file.mtime:
+            # Check file mtime, allow 1 microsecond diff to prevent false positive
+            # utime set from microsecond to nanosecond conversion could create 1 microsecond diff upon division
+            elif abs(trunc(file_stat.st_mtime_ns / 1000) - input_file.mtime) > 1:
                 changed_paths.append((return_path, FileStatus.MODIFIED))
                 logger.echo(
                     f"Found time difference at: {root_relative_path}, Status: FileStatus.MODIFIED"

--- a/test/unit/deadline_job_attachments/api/test_snapshot.py
+++ b/test/unit/deadline_job_attachments/api/test_snapshot.py
@@ -341,3 +341,41 @@ class TestSnapshotAPI:
 
         # Then. We should find no new manifest, there were no files to snapshot
         assert diffed_manifest is None
+
+    def test_snapshot_diff_no_diff_modified_mtime(self, temp_dir):
+        """
+        Create a snapshot with 1 file. Modify the mtime of the snapshot to simulate the attachment download operation.
+        Snapshot again and diff. It should have no manifest.
+        """
+        # Given snapshot folder and 1 test file
+        root_dir = os.path.join(temp_dir, "snapshot")
+
+        test_file_name = "test_file"
+        test_file = os.path.join(root_dir, test_file_name)
+        os.makedirs(os.path.dirname(test_file), exist_ok=True)
+        with open(test_file, "w") as f:
+            f.write("testing123")
+
+        # When
+        manifest: Optional[ManifestSnapshot] = _manifest_snapshot(
+            root=root_dir, destination=temp_dir, name="test"
+        )
+
+        # Then
+        assert manifest is not None
+        assert manifest.manifest is not None
+
+        with open(manifest.manifest, "r") as manifest_file:
+            manifest_payload = json.load(manifest_file)
+            assert len(manifest_payload["paths"]) == 1
+            modified_time_override = manifest_payload["paths"][0]["mtime"] / 1000000
+
+        # When simulate the file timestamp override from downloaded asset
+        os.utime(test_file, (modified_time_override, modified_time_override))
+
+        # When snapshot again.
+        diffed_manifest: Optional[ManifestSnapshot] = _manifest_snapshot(
+            root=root_dir, destination=temp_dir, name="test", diff=manifest.manifest
+        )
+        # Then. We should find no new manifest, there were no files to snapshot
+        assert diffed_manifest is None

--- a/test/unit/deadline_job_attachments/api/test_snapshot.py
+++ b/test/unit/deadline_job_attachments/api/test_snapshot.py
@@ -2,11 +2,13 @@
 
 import json
 import os
+from pathlib import Path
 import tempfile
 from typing import List, Optional
 from deadline.job_attachments.api.manifest import _manifest_snapshot
 from deadline.job_attachments.exceptions import ManifestCreationException
 from deadline.job_attachments.models import ManifestSnapshot
+from deadline.job_attachments._utils import _retry
 import pytest
 
 
@@ -342,6 +344,9 @@ class TestSnapshotAPI:
         # Then. We should find no new manifest, there were no files to snapshot
         assert diffed_manifest is None
 
+    @_retry(
+        tries=2, delay=0.1, backoff=0.1
+    )  # os.utime may take time for the file system to stablize.
     def test_snapshot_diff_no_diff_modified_mtime(self, temp_dir):
         """
         Create a snapshot with 1 file. Modify the mtime of the snapshot to simulate the attachment download operation.
@@ -372,6 +377,7 @@ class TestSnapshotAPI:
 
         # When simulate the file timestamp override from downloaded asset
         os.utime(test_file, (modified_time_override, modified_time_override))
+        assert Path(test_file).stat().st_mtime == modified_time_override
 
         # When snapshot again.
         diffed_manifest: Optional[ManifestSnapshot] = _manifest_snapshot(


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Manifest snapshot with `-diff` option treats file has no change as `MODIFIED` and generate diff manifest due to timestamp precision conversion.

The download API from the library override the modification time to microsecond precision (taken from manifest mtime). 
- https://github.com/aws-deadline/deadline-cloud/blob/mainline/src/deadline/job_attachments/download.py#L404
- https://github.com/aws-deadline/deadline-cloud/blob/mainline/src/deadline/job_attachments/download.py#L545

```
modified_time_override = file.mtime / 1000000 
os.utime(path, (modified_time_override, modified_time_override))
```

During the mtime diff comparison, `file_stat.st_mtime_ns // 1000` could lead to 1 microsecond diff. As a result, previously downloaded asset files are treated as MODIFIED even there is no change.

### What was the solution? (How)
Allow 1 microsecond diff to prevent false positive.

### What is the impact of this change?
Asset download with deadline API would not be mistaken as MODIFIED in snapshot diff comparison using mtime.

This is crucial for the Worker Agent, as it downloads input from the Deadline job attachment API and utilizes snapshot diff to determine which outputs to upload in the asset sync as job user approach.

### How was this change tested?
- Have you run the unit tests? [Y]
- Have you run the integration tests? [N/A]
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass. [N/A]

#### Manual Test (`deadline-cloud-worker-agent/scripts/submit_jobs`)
Before
```
2025-01-08 22:12:43,867 INFO Output:
2025-01-08 22:12:44,216 INFO Found difference at: computed_hashes.txt, Status: FileStatus.NEW
2025-01-08 22:12:44,216 INFO Found time difference at: files/file2.txt, Status: FileStatus.MODIFIED
2025-01-08 22:12:44,216 INFO Found time difference at: files/file1.txt, Status: FileStatus.MODIFIED
2025-01-08 22:12:44,313 INFO Hashing Attachments
2025-01-08 22:12:44,419 INFO Hashing Summary:
2025-01-08 22:12:44,420 INFO     Processed 3 files totaling 904.0 B.
2025-01-08 22:12:44,420 INFO     Skipped re-processing 0 files totaling 0.0 B.
2025-01-08 22:12:44,420 INFO     Total processing time of 0.02973 seconds at 30.41 KB/s.
```
After
```
2025-01-10 01:16:34,303 INFO Output:
2025-01-10 01:16:34,653 INFO Found difference at: computed_hashes.txt, Status: FileStatus.NEW
2025-01-10 01:16:34,748 INFO Hashing Attachments
2025-01-10 01:16:34,842 INFO Hashing Summary:
2025-01-10 01:16:34,843 INFO     Processed 1 file totaling 876.0 B.
2025-01-10 01:16:34,844 INFO     Skipped re-processing 0 files totaling 0.0 B.
2025-01-10 01:16:34,844 INFO     Total processing time of 0.01211 seconds at 72.35 KB/s.
```

### Was this change documented?

- Are relevant docstrings in the code base updated? [Y]
- Has the README.md been updated? If you modified CLI arguments, for instance. [N/A]

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?
No

### Does this change impact security?
No


----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
