### PR TITLE
feat: show host requirements tab in default bundle gui submitter

### DIFF
--- a/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
@@ -86,7 +86,7 @@ class SubmitJobToDeadlineDialog(QDialog):
         on_create_job_bundle_callback,
         parent=None,
         f=Qt.WindowFlags(),
-        show_host_requirements_tab=False,
+        show_host_requirements_tab=True,
         host_requirements: Optional[HostRequirements] = None,
         submitter_name: Optional[str] = None,
     ):

--- a/src/deadline/client/ui/job_bundle_submitter.py
+++ b/src/deadline/client/ui/job_bundle_submitter.py
@@ -187,7 +187,7 @@ def show_job_bundle_submitter(
     submitter_dialog = SubmitJobToDeadlineDialog(
         job_setup_widget_type=JobBundleSettingsWidget,
         initial_job_settings=initial_settings,
-        # show_host_requirements_tab=True,  // Enable when we want to show the host requirement tab
+        show_host_requirements_tab=True,
         initial_shared_parameter_values=initial_shared_parameter_values,
         auto_detected_attachments=asset_references,
         attachments=AssetReferences(),


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
By default, the host requirements tab was hidden when running `deadline bundle gui-submit`. We will now show it! This will also show it in integrated DCC submitters by default.

### What is the impact of this change?
Host requirements are easier to test when using job bundles in `deadline bundle gui-submit`.

### How was this change tested?
`hatch clean && hatch build && hatch shell`
`deadline bundle gui-submit C:\ProgramData\job_bundles\example_bundle`
![image](https://github.com/user-attachments/assets/b6942061-1af6-4035-82df-c08480d846c2)

### Was this change documented?
No, N/A

### Does this PR introduce new dependencies?
No

### Is this a breaking change?
No

### Does this change impact security?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
