### PR TITLE
fix: manifest destination directory not being used when path uses backslashes

### DIFF
--- a/src/deadline/job_attachments/api/manifest.py
+++ b/src/deadline/job_attachments/api/manifest.py
@@ -170,7 +170,9 @@ def _manifest_snapshot(
         # Encode the root path as
         root_hash: str = hash_data(root.encode("utf-8"), output_manifest.get_default_hash_alg())
         timestamp = datetime.datetime.now().strftime("%Y-%m-%dT%H-%M-%S")
-        manifest_name = name if name else root.replace("/", "_")
+        manifest_name = (
+            name if name else root.replace("/", "_").replace("\\", "_").replace(":", "_")
+        )
         manifest_name = manifest_name[1:] if manifest_name[0] == "_" else manifest_name
         manifest_name = f"{manifest_name}-{root_hash}-{timestamp}.manifest"
 


### PR DESCRIPTION
…

### What was the problem/requirement? (What/Why)
When using the `deadline manifest snapshot` CLI, if we are use backslashes for the path separators, the --destination CLI option is not respected if we don't pass in the `--name` option and instead uses the `--root` directory as fallback.

This is because during the result manifest name creation, we only replaced forward slashes with `_` in the file name, and not also backslashes. This caused the resulting file name to be an absolute path, overwriting the destination CLI option.
### What was the solution? (How)
Replace backslashes and colons with `_` in the result file name. This fixes the issue with the result manifest name being an absolute path.
Also replace colons with `_` as this fixes Windows drive name being excluded from the resulting manifest name.
### What is the impact of this change?
Users that use backslashes for path separators (usually on Windows) can get the manifest file output in the correct destination directory.
### How was this change tested?
Using `deadline manifest snapshot`, confirmed that after this fix, the manifest output file gets saved in the specified destination directory on both Linux and Windows correctly without `--name` option specified

`hatch run test`
`hatch run integ:test`

```
hatch run deadline manifest snapshot --root C:\\Users\\ryan\\path -d C:\Users\ryan\abcdef
Hashing Attachments  [####################################]  100%
Hashing Summary:
    Processed 0 files totaling 0.0 B.
    Skipped re-processing 16 files totaling 25.36 KB.
    Total processing time of 0.02656 seconds at 0.0 B/s.

Manifest Generated at C:\Users\ryan\abcdef\C___Users__ryan__path-2fcc508f47a4c41ff65363f8120d3fab-2025-01-15T13-56-33.manifest

```

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests? yes
- Have you run the integration tests? yes
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended 
  that you ensure that the docker-based unit tests pass. No

### Was this change documented?

- Are relevant docstrings in the code base updated? No
- Has the README.md been updated? If you modified CLI arguments, for instance. No

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [ x] This PR does not add any new dependencies.

### Is this a breaking change?

No



### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
