### PR TITLE
fix: remove default host requirements tab from DCCs that don't support it

### DIFF
--- a/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
@@ -86,7 +86,7 @@ class SubmitJobToDeadlineDialog(QDialog):
         on_create_job_bundle_callback,
         parent=None,
         f=Qt.WindowFlags(),
-        show_host_requirements_tab=True,
+        show_host_requirements_tab=False,
         host_requirements: Optional[HostRequirements] = None,
         submitter_name: Optional[str] = None,
     ):


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
I discovered that https://github.com/aws-deadline/deadline-cloud/pull/558 was not compatible with some of our DCCs. Removed the default setting - it will now show up in `deadline bundle gui-submit` but not in our DCCs by default since some DCCs can't handle the `host_requirements` argument.

https://github.com/aws-deadline/deadline-cloud/blob/mainline/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py#L357-L377

### How was this change tested?
`hatch clean && hatch build && hatch shell`
`deadline bundle gui-submit`
![image](https://github.com/user-attachments/assets/abe549c0-190c-4fae-ae10-f428dd6efc25)

### Was this change documented?
No, N/A

### Does this PR introduce new dependencies?
No

### Is this a breaking change?
No

### Does this change impact security?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
