### PR TITLE
Reduce job history dir length

### DIFF
--- a/src/deadline/client/job_bundle/__init__.py
+++ b/src/deadline/client/job_bundle/__init__.py
@@ -61,6 +61,10 @@ def create_job_history_bundle_dir(submitter_name: str, job_name: str) -> str:
         max_job_name_prefix = min(
             207 - len(os.path.abspath(os.path.join(month_dir, job_dir_prefix))), max_job_name_prefix
         )
+        if max_job_name_prefix < 1:
+            raise RuntimeError(
+                "Job history directory is too long. Please update your 'settings.job_history_dir' to a shorter path."
+            )
 
     # Clean the job_name's characters and truncate for the filename
     job_name_cleaned = "".join(char for char in job_name if char.isalnum() or char in " -_")

--- a/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
@@ -417,7 +417,8 @@ class SubmitJobToDeadlineDialog(QDialog):
             deadline = api.get_boto3_client("deadline")
 
             self.job_history_bundle_dir = create_job_history_bundle_dir(
-                self.submitter_name, settings.name
+                self.submitter_name,
+                settings.name,
             )
 
             if self.show_host_requirements_tab:

--- a/test/unit/deadline_client/job_bundle/test_job_history_folders.py
+++ b/test/unit/deadline_client/job_bundle/test_job_history_folders.py
@@ -5,6 +5,7 @@ Tests the job bundle folders created for the user's history of jobs.
 """
 
 import os
+import sys
 import tempfile
 import pytest
 
@@ -53,6 +54,76 @@ def test_create_job_bundle_dir(fresh_deadline_config):
         assert sorted(os.listdir(tmpdir)) == ["2023-01", "2023-04"]
         assert sorted(os.listdir(os.path.join(tmpdir, "2023-01"))) == EXPECTED_DIRS[:3]
         assert sorted(os.listdir(os.path.join(tmpdir, "2023-04"))) == EXPECTED_DIRS[3:]
+
+
+def test_job_history_dir_truncation(fresh_deadline_config):
+    # Use a temporary directory for the job history
+    with tempfile.TemporaryDirectory() as tmpdir, freeze_time("2024-12-27T12:34:56"):
+        tmpdir_path_length = len(os.path.abspath(tmpdir))
+        long_tmpdir = os.path.join(
+            tmpdir,
+            "dir" + "1" * (140 - tmpdir_path_length),
+        )
+        config.set_setting("settings.job_history_dir", long_tmpdir)
+
+        job_name_127_chars = "job1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234"
+        output_path = job_bundle.create_job_history_bundle_dir(
+            "MySubmitter",
+            job_name_127_chars,
+        )
+
+        if sys.platform in ["win32", "cygwin"]:
+            assert len(os.path.abspath(output_path)) == 207
+            assert str(os.path.abspath(output_path)).startswith(
+                str(
+                    os.path.abspath(
+                        os.path.join(
+                            long_tmpdir, "2024-12", "2024-12-27-01-MySubmitter-job1234567890"
+                        )
+                    )
+                )
+            )
+            assert (
+                len(
+                    os.path.abspath(
+                        os.path.join(
+                            output_path, "manifests", "d2b2c3102af5a862db950a2e30255429_input"
+                        )
+                    )
+                )
+                == 256
+            )
+        else:
+            assert output_path == os.path.join(
+                long_tmpdir, "2024-12", f"2024-12-27-01-MySubmitter-{job_name_127_chars}"
+            )
+            assert len(output_path) > 256
+        assert os.path.isdir(output_path)
+
+
+def test_job_history_dir_truncation_from_job_name_with_129_chars(fresh_deadline_config):
+    # Use a temporary directory for the job history
+    if sys.platform in ["win32", "cygwin"]:
+        # Windows has a long tmp dir path so it will truncate anyway - we only want to test job name truncation
+        tmp_parent_dir = "C:\ProgramData"
+    else:
+        tmp_parent_dir = None
+    with tempfile.TemporaryDirectory(dir=tmp_parent_dir) as tmpdir, freeze_time(
+        "2024-08-26T18:42:05"
+    ):
+        config.set_setting("settings.job_history_dir", tmpdir)
+
+        job_name_129_chars = "test12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345"
+        output_path = job_bundle.create_job_history_bundle_dir(
+            "SubmitterFour",
+            job_name_129_chars,
+        )
+        assert output_path == os.path.join(
+            tmpdir,
+            "2024-08",
+            "2024-08-26-01-SubmitterFour-test1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234",
+        )
+        assert os.path.isdir(output_path)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Related to: https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/issues/105

### What was the problem/requirement? (What/Why)
When submitting jobs from DCCs which don't have long path support, the job history bundle will not be able to be created if the path is too long due to a long job name.

### What was the solution? (How)
Truncated the job history dir for the submitted bundle so that the job history bundle, including asset manifest, can be created.

### What is the impact of this change?
Previously failing submissions caused by long paths in the job history dir will succeed for DCCs which don't support long paths.

### How was this change tested?
`hatch build && hatch  shell`

Confirmed that paths were truncated when submitting a job with a long name but the job as still able to submit successfully.

Edited my `settings.job_history` dir to a very long directory and got the expected error

![image](https://github.com/user-attachments/assets/54d4e898-c550-4f40-8bad-de2a68a237ee)

### Was this change documented?
No, N/A

### Does this PR introduce new dependencies?
*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [X] This PR does not add any new dependencies.

### Is this a breaking change?
No

### Does this change impact security?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
