### PR TITLE
feat: add sticky settings for deadline bundle gui-submit

### DIFF
--- a/src/deadline/client/ui/job_bundle_submitter.py
+++ b/src/deadline/client/ui/job_bundle_submitter.py
@@ -139,6 +139,7 @@ def show_job_bundle_submitter(
             AssetReferences(),
         )
 
+        # save to job history dir
         save_yaml_or_json_to_file(
             bundle_dir=job_bundle_dir, filename="template", file_type=file_type, data=template
         )
@@ -150,6 +151,14 @@ def show_job_bundle_submitter(
         )
         save_yaml_or_json_to_file(
             bundle_dir=job_bundle_dir,
+            filename="parameter_values",
+            file_type=file_type,
+            data={"parameterValues": parameters_values},
+        )
+
+        # save parameter values to input job bundle dir for sticky settings
+        save_yaml_or_json_to_file(
+            bundle_dir=input_job_bundle_dir,
             filename="parameter_values",
             file_type=file_type,
             data={"parameterValues": parameters_values},


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Sticky settings did not work on `deadline bundle gui-submit`.

### What was the solution? (How)
Sticky settings are read from `parameter_values.yaml`. However, we don't save them to a job bundle directly after submission, only the job history directory! Saved the parameter settings after submission.

Note that some settings like job name and description will still not be persistent with this change.

### What is the impact of this change?
Sticky settings work for most use-configurable fields.

### How was this change tested?
`hatch build && hatch shell`
`deadline bundle gui-submit`

### Was this change documented?
No, N/A

### Does this PR introduce new dependencies?
*  [X] This PR does not add any new dependencies.

### Is this a breaking change?
No

### Does this change impact security?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
