### PR TITLE
fix: limit the length of name and description fields to match OpenJD spec

### DIFF
--- a/src/deadline/client/ui/widgets/shared_job_settings_tab.py
+++ b/src/deadline/client/ui/widgets/shared_job_settings_tab.py
@@ -258,10 +258,12 @@ class SharedJobPropertiesWidget(QGroupBox):  # pylint: disable=too-few-public-me
         self.layout.setFieldGrowthPolicy(QFormLayout.AllNonFixedFieldsGrow)
 
         self.sub_name_edit = QLineEdit()
+        self.sub_name_edit.setMaxLength(128)
         self.layout.addRow("Name", self.sub_name_edit)
 
         self.desc_label = QLabel("Description")
         self.desc_edit = QLineEdit()
+        self.desc_edit.setMaxLength(2048)
         self.layout.addRow(self.desc_label, self.desc_edit)
 
         self.priority_box_label = QLabel("Priority")

--- a/test/unit/deadline_client/ui/widgets/conftest.py
+++ b/test/unit/deadline_client/ui/widgets/conftest.py
@@ -1,3 +1,3 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
-STRING_FIELD_MAX_LENGHTH = 32767
+STRING_FIELD_MAX_LENGTH = 32767

--- a/test/unit/deadline_client/ui/widgets/test_openjd_parameters_widget.py
+++ b/test/unit/deadline_client/ui/widgets/test_openjd_parameters_widget.py
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 import pytest
-from conftest import STRING_FIELD_MAX_LENGHTH
+from conftest import STRING_FIELD_MAX_LENGTH
 
 try:
     from deadline.client.ui.widgets.openjd_parameters_widget import (
@@ -21,9 +21,9 @@ def test_input_in_line_edit_widget_should_be_truncated(qtbot):
     widget = _JobTemplateLineEditWidget(None, {"type": "STRING", "name": "test-name"})
     qtbot.addWidget(widget)
 
-    invalid_str = "a" * (STRING_FIELD_MAX_LENGHTH + 1)
+    invalid_str = "a" * (STRING_FIELD_MAX_LENGTH + 1)
     widget.set_value(invalid_str)
-    assert widget.value() == invalid_str[:STRING_FIELD_MAX_LENGHTH]
+    assert widget.value() == invalid_str[:STRING_FIELD_MAX_LENGTH]
 
 
 def test_input_in_int_spin_box_widget_should_be_integer_within_range(qtbot):

--- a/test/unit/deadline_client/ui/widgets/test_shared_job_settings_tab.py
+++ b/test/unit/deadline_client/ui/widgets/test_shared_job_settings_tab.py
@@ -1,7 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 import pytest
-from conftest import STRING_FIELD_MAX_LENGHTH
 
 try:
     from deadline.client.ui.widgets.shared_job_settings_tab import SharedJobSettingsWidget
@@ -22,21 +21,27 @@ def shared_job_settings_tab(qtbot, temp_job_bundle_dir) -> SharedJobSettingsWidg
     return widget
 
 
-def test_name_should_be_truncated(shared_job_settings_tab: SharedJobSettingsWidget):
-    invalid_str = "a" * (STRING_FIELD_MAX_LENGHTH + 1)
+def test_name_should_be_truncated_to_openjd_spec_128_chars(
+    shared_job_settings_tab: SharedJobSettingsWidget,
+):
+    expected_max_job_name_length = 128
+    invalid_str = "a" * (expected_max_job_name_length + 1)
     shared_job_settings_tab.shared_job_properties_box.sub_name_edit.setText(invalid_str)
     assert (
         shared_job_settings_tab.shared_job_properties_box.sub_name_edit.text()
-        == invalid_str[:STRING_FIELD_MAX_LENGHTH]
+        == invalid_str[:expected_max_job_name_length]
     )
 
 
-def test_description_should_be_truncated(shared_job_settings_tab: SharedJobSettingsWidget):
-    invalid_str = "a" * (STRING_FIELD_MAX_LENGHTH + 1)
+def test_description_should_be_truncated_to_openjd_spec_2048_chars(
+    shared_job_settings_tab: SharedJobSettingsWidget,
+):
+    expected_max_job_description_length = 2048
+    invalid_str = "a" * (expected_max_job_description_length + 1)
     shared_job_settings_tab.shared_job_properties_box.desc_edit.setText(invalid_str)
     assert (
         shared_job_settings_tab.shared_job_properties_box.desc_edit.text()
-        == invalid_str[:STRING_FIELD_MAX_LENGHTH]
+        == invalid_str[:expected_max_job_description_length]
     )
 
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
If the job name or description submitted from the bundle GUI submitter exceeded the OpenJD spec, the job would fail to be created.

### What was the solution? (How)
To prevent these issues from occurring before we even submit the job, we limit the job name to 128 characters in the GUI submitter and the job description to 2048 characters. This helps the UI match the service/[OpenJD behaviour](https://github.com/OpenJobDescription/openjd-specifications/wiki/2023-09-Template-Schemas#111-jobname).

We use the built-in `setMaxLength` function to set the max length. The behaviour is that if the user attempts to add (or paste) more than 128 characters, any input beyond 128 characters is discarded in the UI. i.e. those characters won't show up in the GUI submitter.

### What is the impact of this change?
Reduces errors.

### How was this change tested?
`hatch build && hatch shell`
`deadline bundle gui-submit C:\Users\test-user\code\job_bundles\dep_chain_example`

Entered 128 characters in the job name field. Then, attempted to add another character. The input was ignored/discarded.
Entered 2048 characters in the job description field. Then, attempted to add another character. The input was ignored/discarded.

### Was this change documented?
No, N/A

### Does this PR introduce new dependencies?
* [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
* [X] This PR does not add any new dependencies.

### Is this a breaking change?
No. Jobs submitted with names longer than 128 characters or descriptions longer than 2048 characters would be rejected regardless.

### Does this change impact security?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
