### PR TITLE
chore: override job attachments folder ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,7 @@
+# default ownership for deadline-cloud-developers
 * @aws-deadline/deadline-cloud-developers
+
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+# overriding directories for job attachments
+src/deadline/job_attachments/ @aws-deadline/job-attachments-developers
+test/*/deadline_job_attachments/ @aws-deadline/job-attachments-developers


### PR DESCRIPTION
https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file

Give job attachment team ownership of those folders, there's more finetuning we can do, but this should unblock them.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
