### PR TITLE
feat: add maxWorkerCount support for jobs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
 # Applications that consume this library should be the ones that are more strictly
 # limiting dependencies if they want/need to.
 dependencies = [
-    "boto3 >= 1.34.75",
+    "boto3 >= 1.36.8",
     "click >= 8.1.7",
     "pyyaml >= 6.0",
     # Job Attachments

--- a/src/deadline/client/api/_submit_job_bundle.py
+++ b/src/deadline/client/api/_submit_job_bundle.py
@@ -59,6 +59,7 @@ def create_job_from_job_bundle(
     priority: Optional[int] = None,
     max_failed_tasks_count: Optional[int] = None,
     max_retries_per_task: Optional[int] = None,
+    max_worker_count: Optional[int] = None,
     print_function_callback: Callable[[str], None] = lambda msg: None,
     decide_cancel_submission_callback: Callable[
         [AssetUploadGroup], bool
@@ -121,6 +122,7 @@ def create_job_from_job_bundle(
         config (ConfigParser, optional): The AWS Deadline Cloud configuration
                 object to use instead of the config file.
         priority (int, optional): explicit value for the priority of the job.
+        max_worker_count (int, optional): explicit value for the max worker count of the job.
         max_failed_tasks_count (int, optional): explicit value for the maximum allowed failed tasks.
         max_retries_per_task (int, optional): explicit value for the maximum retries per task.
         print_function_callback (Callable str -> None, optional): Callback to print messages produced in this function.
@@ -308,6 +310,8 @@ def create_job_from_job_bundle(
 
     if priority is not None:
         create_job_args["priority"] = priority
+    if max_worker_count is not None:
+        create_job_args["maxWorkerCount"] = max_worker_count
     if max_failed_tasks_count is not None:
         create_job_args["maxFailedTasksCount"] = max_failed_tasks_count
     if max_retries_per_task is not None:

--- a/src/deadline/client/cli/_groups/bundle_group.py
+++ b/src/deadline/client/cli/_groups/bundle_group.py
@@ -99,6 +99,11 @@ def validate_parameters(ctx, param, value):
     help="The maximum number of times to retry a task before it is marked as failed.",
 )
 @click.option(
+    "--max-worker-count",
+    type=int,
+    help="The max worker count of the job.",
+)
+@click.option(
     "--job-attachments-file-system",
     help="The method workers use to access job attachments. "
     "COPIED means to copy files to the worker and VIRTUAL means to load "
@@ -132,6 +137,7 @@ def bundle_submit(
     priority,
     max_failed_tasks_count,
     max_retries_per_task,
+    max_worker_count,
     require_paths_exist,
     submitter_name,
     **args,
@@ -208,6 +214,7 @@ def bundle_submit(
             priority=priority,
             max_failed_tasks_count=max_failed_tasks_count,
             max_retries_per_task=max_retries_per_task,
+            max_worker_count=max_worker_count,
             hashing_progress_callback=hash_callback_manager.callback,
             upload_progress_callback=upload_callback_manager.callback,
             create_job_result_callback=_check_create_job_wait_canceled,

--- a/src/deadline/client/job_bundle/submission.py
+++ b/src/deadline/client/job_bundle/submission.py
@@ -20,6 +20,7 @@ DEFAULT_SUPPORTED_APP_PARAMETER_NAMES = [
     "priority",
     "maxFailedTasksCount",
     "maxRetriesPerTask",
+    "maxWorkerCount",
 ]
 
 

--- a/test/unit/deadline_client/api/test_job_bundle_submission.py
+++ b/test/unit/deadline_client/api/test_job_bundle_submission.py
@@ -204,6 +204,10 @@ parameterValues: []
     {
         "name": "deadline:maxRetriesPerTask",
         "value": 5
+    },
+    {
+        "name": "deadline:maxWorkerCount",
+        "value": 10
     }
  ]
 }
@@ -213,6 +217,7 @@ parameterValues: []
             "targetTaskRunStatus": "SUSPENDED",
             "maxFailedTasksCount": 20,
             "maxRetriesPerTask": 5,
+            "maxWorkerCount": 10,
         },
     ),
     "DEADLINE_ONLY_YAML": (
@@ -227,12 +232,15 @@ parameterValues:
   value: 250
 - name: "deadline:maxRetriesPerTask"
   value: 15
+- name: "deadline:maxWorkerCount"
+  value: 10
 """,
         {
             "priority": 45,
             "targetTaskRunStatus": "SUSPENDED",
             "maxFailedTasksCount": 250,
             "maxRetriesPerTask": 15,
+            "maxWorkerCount": 10,
         },
     ),
     # A parameter_values.json/yaml file with just job template values

--- a/test/unit/deadline_client/cli/test_cli_bundle.py
+++ b/test/unit/deadline_client/cli/test_cli_bundle.py
@@ -201,7 +201,7 @@ def test_cli_bundle_explicit_parameters(fresh_deadline_config):
 
 def test_cli_bundle_priority_retries(fresh_deadline_config):
     """
-    Confirm that --priority, --max-failed-tasks-count, and --max-retries-per-task get passed in from the CLI.
+    Confirm that --priority, --max-failed-tasks-count, --max_worker_count and --max-retries-per-task get passed in from the CLI.
     """
     # Use a temporary directory for the job bundle
     with tempfile.TemporaryDirectory() as tmpdir, patch.object(boto3, "Session") as session_mock:
@@ -230,6 +230,8 @@ def test_cli_bundle_priority_retries(fresh_deadline_config):
                 "12",
                 "--max-retries-per-task",
                 "4",
+                "--max-worker-count",
+                "123",
             ],
         )
 
@@ -244,6 +246,7 @@ def test_cli_bundle_priority_retries(fresh_deadline_config):
         priority=25,
         maxFailedTasksCount=12,
         maxRetriesPerTask=4,
+        maxWorkerCount=123,
     )
     assert result.exit_code == 0
 

--- a/test/unit/deadline_client/ui/widgets/test_shared_job_settings_tab.py
+++ b/test/unit/deadline_client/ui/widgets/test_shared_job_settings_tab.py
@@ -73,3 +73,10 @@ def test_max_retries_per_task_should_be_integer_within_range(
 ):
     shared_job_settings_tab.shared_job_properties_box.max_retries_per_task_box.setValue(-1)
     assert shared_job_settings_tab.shared_job_properties_box.max_retries_per_task_box.value() == 0
+
+
+def test_max_worker_count_should_be_integer_within_range(
+    shared_job_settings_tab: SharedJobSettingsWidget,
+):
+    shared_job_settings_tab.shared_job_properties_box.max_worker_count_box.setValue(-1)
+    assert shared_job_settings_tab.shared_job_properties_box.max_worker_count_box.value() == 1


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
* The requirement is to support the new `maxWorkerCount` feature of AWS Deadline Cloud which enables customers to specify a maximum worker count on a per job basis. This will allow customers to control how many instances at any given point of time would be dedicated to processing of that job. 

### What was the solution? (How)
* Add support for the `maxWorkerCount` to the CLI
* Add support for the `maxWorkerCount` to the Deadline Cloud GUI.
* ![Screenshot 2025-01-24 at 11 25 20 AM](https://github.com/user-attachments/assets/293f78e7-668a-4eb3-b024-61a69034ab0e)

### What is the impact of this change?
* Allows customers to specify `maxWorkerCount` as a parameter when using the Deadline Cloud CLI to create jobs
* Allows customers to specify `maxWorkerCount` in their job bundles and appropriately passes it into the Deadline Cloud CreateJob API call
* Adds support for the `maxWorkerCount` parameter to the Deadline Cloud CLI GUI.

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests? - YES
- Have you run the integration tests? - Will work on running them now, but I dont think my changes should be breaking anything here. 
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass. - NO

- Ran manual tests
  - Verified that using `deadline bundle submit <path_to_job_bundle>` maxWorkerCount is correctly passed to Deadline
  - Verified that using `deadline bundle submit <path_to_job_bundle> --max-worker-count <number>` correctly overrode the maxWorkerCount specified in the job bundle and the number specified in the CLI call was passed to Deadline.
  - Verified that maxWorkerCount in the GUI is correctly populated when specified in the job bundle
  - Verified that changing maxWorkerCount in the GUI and clicking 'Export Bundle' results in the maxWorkerCount value being correctly populated in exported `parameter_values.yaml`
  - Verified that specifying `maxWorkerCount` in the GUI and submitting results in the maxWorkerCount parameter being passed to Deadline by calling GetJob API and verifying that maxWorkerCount was returned correctly.

### Was this change documented?

- Are relevant docstrings in the code base updated? - YES
- Has the README.md been updated? If you modified CLI arguments, for instance. - NO

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [ ✅ ] This PR does not add any new dependencies.

### Is this a breaking change?

A breaking change is one that modifies a public contract in a way that is not backwards compatible. See the 
[Public Contracts](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#public-contracts) section
of the DEVELOPMENT.md for more information on the public contracts.

If so, then please describe the changes that users of this package must make to update their scripts, or Python applications.

* We are adding support for a new optional parameter, so this should not be considered backward incompatible. 

### Does this change impact security?

- Does the change need to be threat modeled? For example, does it create or modify files/directories that must only be readable by the process owner?
    - If so, then please label this pull request with the "security" label. We'll work with you to analyze the threats.

* No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
