### PR TITLE
fix: Revert limit number of hashing threads. This PR requires additio…

### DIFF
--- a/src/deadline/job_attachments/upload.py
+++ b/src/deadline/job_attachments/upload.py
@@ -852,14 +852,7 @@ class S3AssetManager:
         }:
             paths: list[base_manifest.BaseManifestPath] = []
 
-            # The [ThreadPoolExecutor](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ThreadPoolExecutor)
-            # has a different number of workers by default depending on the Python version, but as of Python 3.11,
-            # the default number of workers is `min(32, os.cpu_count() + 4)`. Hashing is a CPU-intensive operation,
-            # and we've previously encountered hanging processes when using the default number of workers.
-            # So we limit it to most N - 2 threads, where N is the number of CPUs on the computer.
-            with concurrent.futures.ThreadPoolExecutor(
-                max_workers=max(1, (os.cpu_count() or 1) - 2)
-            ) as executor:
+            with concurrent.futures.ThreadPoolExecutor() as executor:
                 futures = {
                     executor.submit(
                         self._process_input_path, path, root_path, hash_cache, progress_tracker


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
- Reverting https://github.com/aws-deadline/deadline-cloud/commit/4d7256350c4bc085dfe8f7dac50b55918c84040b
- The PR that is reverted sets the maximum thread pool size by CPU count. We are unsure if it can resolve other reported timing issues related to Cinema4d.
- For the moment, we have a workaround for Cinema4d, so the threading change is not needed.

### What was the solution? (How)
- Revert the threading change until the team does sufficient testing or finds a better solution.

### What is the impact of this change?
- NA

### How was this change tested?
- hatch run build.

- Have you run the unit tests? NA - revert
- Have you run the integration tests?  NA - revert
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass.

### Was this change documented?
- NA
- 
### Does this PR introduce new dependencies?
- NA

### Is this a breaking change?

A breaking change is one that modifies a public contract in a way that is not backwards compatible. See the 
[Public Contracts](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#public-contracts) section
of the DEVELOPMENT.md for more information on the public contracts.

If so, then please describe the changes that users of this package must make to update their scripts, or Python applications.

### Does this change impact security?

- Does the change need to be threat modeled? For example, does it create or modify files/directories that must only be readable by the process owner?
    - If so, then please label this pull request with the "security" label. We'll work with you to analyze the threats.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
