### PR TITLE
feat: add latency telemetry

### DIFF
--- a/src/deadline/client/api/__init__.py
+++ b/src/deadline/client/api/__init__.py
@@ -24,6 +24,7 @@ __all__ = [
     "get_deadline_cloud_library_telemetry_client",
     "get_storage_profile_for_queue",
     "record_success_fail_telemetry_event",
+    "record_function_latency_telemetry_event",
 ]
 
 # The following import is needed to prevent the following sporadic failure:
@@ -34,6 +35,15 @@ from configparser import ConfigParser
 from logging import getLogger
 from typing import Any, Dict, Optional
 
+
+# Telemetry must be imported before Submit Job Bundle to avoid circular dependencies.
+from ._telemetry import (
+    get_telemetry_client,
+    get_deadline_cloud_library_telemetry_client,
+    TelemetryClient,
+    record_success_fail_telemetry_event,
+    record_function_latency_telemetry_event,
+)
 from ._loginout import login, logout
 from ._session import (
     AwsAuthenticationStatus,
@@ -53,14 +63,6 @@ from ._list_apis import (
     list_storage_profiles_for_queue,
 )
 from ._queue_parameters import get_queue_parameter_definitions
-
-# Telemetry must be imported before Submit Job Bundle to avoid circular dependencies.
-from ._telemetry import (
-    get_telemetry_client,
-    get_deadline_cloud_library_telemetry_client,
-    TelemetryClient,
-    record_success_fail_telemetry_event,
-)
 from ._submit_job_bundle import (
     create_job_from_job_bundle,
     wait_for_create_job_to_complete,

--- a/src/deadline/client/api/_get_storage_profile_for_queue.py
+++ b/src/deadline/client/api/_get_storage_profile_for_queue.py
@@ -8,6 +8,7 @@ from typing import Optional
 from botocore.client import BaseClient  # type: ignore[import]
 
 from ._session import get_boto3_client
+from .. import api
 from ...job_attachments.models import (
     FileSystemLocation,
     FileSystemLocationType,
@@ -16,6 +17,7 @@ from ...job_attachments.models import (
 )
 
 
+@api.record_function_latency_telemetry_event()
 def get_storage_profile_for_queue(
     farm_id: str,
     queue_id: str,

--- a/src/deadline/client/api/_list_apis.py
+++ b/src/deadline/client/api/_list_apis.py
@@ -4,6 +4,7 @@ from ._session import (
     get_boto3_client,
     get_user_and_identity_store_id,
 )
+from .. import api
 
 
 def _call_paginated_deadline_list_api(list_api, list_property_name, **kwargs):
@@ -29,6 +30,7 @@ def _call_paginated_deadline_list_api(list_api, list_property_name, **kwargs):
     return result
 
 
+@api.record_function_latency_telemetry_event()
 def list_farms(config=None, **kwargs):
     """
     Calls the deadline:ListFarms API call, applying the filter for user membership
@@ -44,6 +46,7 @@ def list_farms(config=None, **kwargs):
     return _call_paginated_deadline_list_api(deadline.list_farms, "farms", **kwargs)
 
 
+@api.record_function_latency_telemetry_event()
 def list_queues(config=None, **kwargs):
     """
     Calls the deadline:ListQueues API call, applying the filter for user membership
@@ -59,6 +62,7 @@ def list_queues(config=None, **kwargs):
     return _call_paginated_deadline_list_api(deadline.list_queues, "queues", **kwargs)
 
 
+@api.record_function_latency_telemetry_event()
 def list_jobs(config=None, **kwargs):
     """
     Calls the deadline:ListJobs API call, applying the filter for user membership
@@ -74,6 +78,7 @@ def list_jobs(config=None, **kwargs):
     return _call_paginated_deadline_list_api(deadline.list_jobs, "jobs", **kwargs)
 
 
+@api.record_function_latency_telemetry_event()
 def list_fleets(config=None, **kwargs):
     """
     Calls the deadline:ListFleets API call, applying the filter for user membership
@@ -89,6 +94,7 @@ def list_fleets(config=None, **kwargs):
     return _call_paginated_deadline_list_api(deadline.list_fleets, "fleets", **kwargs)
 
 
+@api.record_function_latency_telemetry_event()
 def list_storage_profiles_for_queue(config=None, **kwargs):
     """
     Calls the deadline:ListStorageProfilesForQueue API call, applying the filter for user membership

--- a/src/deadline/client/api/_loginout.py
+++ b/src/deadline/client/api/_loginout.py
@@ -11,7 +11,6 @@ from typing import Callable, Optional
 import subprocess
 import sys
 
-
 from ._session import (
     get_credentials_source,
     check_authentication_status,
@@ -19,6 +18,7 @@ from ._session import (
     AwsAuthenticationStatus,
 )
 from . import _session
+from .. import api
 from ..config import get_setting
 from ..exceptions import DeadlineOperationError
 import time
@@ -85,6 +85,7 @@ def _login_deadline_cloud_monitor(
         time.sleep(0.5)
 
 
+@api.record_function_latency_telemetry_event()
 def login(
     on_pending_authorization: Optional[Callable],
     on_cancellation_check: Optional[Callable],
@@ -111,6 +112,7 @@ def login(
     )
 
 
+@api.record_function_latency_telemetry_event()
 def logout(config: Optional[ConfigParser] = None) -> str:
     """
     For AWS profiles created by Deadline Cloud monitor, logs out of Deadline Cloud.

--- a/src/deadline/client/api/_queue_parameters.py
+++ b/src/deadline/client/api/_queue_parameters.py
@@ -5,6 +5,7 @@ __all__ = ["get_queue_parameter_definitions"]
 
 import yaml
 
+from .. import api
 from ._list_apis import _call_paginated_deadline_list_api
 from ._session import get_boto3_client
 from ..exceptions import DeadlineOperationError
@@ -16,6 +17,7 @@ from ..job_bundle.parameters import (
 )
 
 
+@api.record_function_latency_telemetry_event()
 def get_queue_parameter_definitions(
     *, farmId: str, queueId: str, config=None
 ) -> list[JobParameter]:

--- a/src/deadline/client/api/_submit_job_bundle.py
+++ b/src/deadline/client/api/_submit_job_bundle.py
@@ -48,6 +48,7 @@ from ._session import session_context
 logger = logging.getLogger(__name__)
 
 
+@api.record_function_latency_telemetry_event()
 def create_job_from_job_bundle(
     job_bundle_dir: str,
     job_parameters: list[dict[str, Any]] = [],


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We don't have any telemetry around how long our calls to the service take on the local client. This information is useful to understand our local performance and if any regressions have been introduced with other changes.

### What was the solution? (How)
Add telemetry to our calls to the main service.

### What is the impact of this change?
Increased telemetry coverage.

### How was this change tested?
- Have you run the unit tests?
  - Yes.
- Have you run the integration tests?
  - Yes.
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass.
  - No.

### Was this change documented?
Yes.

### Does this PR introduce new dependencies?
*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [X] This PR does not add any new dependencies.

### Is this a breaking change?
No.

### Does this change impact security?
No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
