### PR TITLE
test: add farm and queue cli tests

### DIFF
--- a/test/integ/cli/conftest.py
+++ b/test/integ/cli/conftest.py
@@ -6,7 +6,16 @@ from deadline.job_attachments import upload
 from deadline.job_attachments._aws.deadline import get_queue
 from deadline.job_attachments.asset_manifests.hash_algorithms import HashAlgorithm, hash_file
 from deadline.job_attachments.asset_manifests.versions import ManifestVersion
-from .test_utils import JobAttachmentTest, UploadInputFilesOneAssetInCasOutputs
+from .test_utils import JobAttachmentTest, UploadInputFilesOneAssetInCasOutputs, DeadlineCliTest
+
+
+@pytest.fixture(scope="session")
+def deadline_cli_test() -> DeadlineCliTest:
+    """
+    Fixture to get the sessions DeadlineCliTest object.
+    """
+
+    return DeadlineCliTest()
 
 
 @pytest.fixture(scope="session")

--- a/test/integ/cli/test_cli_farm.py
+++ b/test/integ/cli/test_cli_farm.py
@@ -1,0 +1,44 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from .test_utils import DeadlineCliTest
+from deadline.client.cli import main
+
+from click.testing import CliRunner
+
+
+def test_farm_get(deadline_cli_test: DeadlineCliTest) -> None:
+
+    runner = CliRunner()
+
+    result = runner.invoke(
+        main,
+        ["farm", "get", "--farm-id", deadline_cli_test.farm_id],
+    )
+
+    assert result.exit_code == 0
+
+    assert f"farmId: {deadline_cli_test.farm_id}" in result.output
+    # The following vary from farm to farm, so just make sure the general layout is there.
+    # Unit tests are able to test the output more throughly. We'll only look for the required fields.
+    assert "displayName:" in result.output
+    assert "description:" in result.output
+
+
+def test_farm_list(deadline_cli_test: DeadlineCliTest) -> None:
+
+    runner = CliRunner()
+
+    result = runner.invoke(
+        main,
+        [
+            "farm",
+            "list",
+        ],
+    )
+
+    assert result.exit_code == 0
+
+    assert f"- farmId: {deadline_cli_test.farm_id}" in result.output
+    # The following vary from farm to farm, so just make sure the general layout is there.
+    # Unit tests are able to test the output more throughly. We'll only look for the required fields.
+    assert "displayName:" in result.output

--- a/test/integ/cli/test_cli_queue.py
+++ b/test/integ/cli/test_cli_queue.py
@@ -1,0 +1,50 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from .test_utils import DeadlineCliTest
+from deadline.client.cli import main
+
+from click.testing import CliRunner
+
+
+def test_queue_get(deadline_cli_test: DeadlineCliTest) -> None:
+
+    runner = CliRunner()
+
+    result = runner.invoke(
+        main,
+        [
+            "queue",
+            "get",
+            "--queue-id",
+            deadline_cli_test.queue_id,
+            "--farm-id",
+            deadline_cli_test.farm_id,
+        ],
+    )
+
+    assert result.exit_code == 0
+
+    assert f"queueId: {deadline_cli_test.queue_id}" in result.output
+    # The following vary from queue to queue, so just make sure the general layout is there.
+    # Unit tests are able to test the output more throughly. We'll only look for the required fields.
+    assert "displayName:" in result.output
+    assert f"farmId: {deadline_cli_test.farm_id}" in result.output
+    assert "status" in result.output
+    assert "defaultBudgetAction" in result.output
+
+
+def test_queue_list(deadline_cli_test: DeadlineCliTest) -> None:
+
+    runner = CliRunner()
+
+    result = runner.invoke(
+        main,
+        ["queue", "list", "--farm-id", deadline_cli_test.farm_id],
+    )
+
+    assert result.exit_code == 0
+
+    assert f"- queueId: {deadline_cli_test.queue_id}" in result.output
+    # The following vary from queue to queue, so just make sure the general layout is there.
+    # Unit tests are able to test the output more throughly. We'll only look for the required fields.
+    assert "displayName:" in result.output

--- a/test/integ/cli/test_utils.py
+++ b/test/integ/cli/test_utils.py
@@ -13,6 +13,20 @@ from deadline.job_attachments.models import Attachments, JobAttachmentS3Settings
 from deadline_test_fixtures.deadline import DeadlineClient
 
 
+class DeadlineCliTest:
+    """
+    Hold information used across all Deadline CLI integration tests.
+    """
+
+    def __init__(self):
+        """
+        Sets up resources that the integ tests will need
+        """
+
+        self.farm_id: str = os.environ["FARM_ID"]
+        self.queue_id: str = os.environ["QUEUE_ID"]
+
+
 class JobAttachmentTest:
     """
     Hold information used across all job attachment integration tests.


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
A lot of our CLI commands don't have integration tests, so we have to manually test them.

### What was the solution? (How)
Add the tests! This change adds the tests for the `farm` and `queue` cli commands.

### What is the impact of this change?
More test coverage!

### How was this change tested?

Ran the integ tests :)

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests?
  - Yes
- Have you run the integration tests?
  - Yes
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass.
  - No

### Was this change documented?

- Are relevant docstrings in the code base updated?
  - Yes
- Has the README.md been updated? If you modified CLI arguments, for instance.
  - Uses the same mechanisms as the other integ tests, so no documentation update is needed.

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [X] This PR does not add any new dependencies.

### Is this a breaking change?

Nope

### Does this change impact security?

Nope

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
