### PR TITLE
fix: fix host requirements combo box checkability on Linux and macOS

### DIFF
--- a/src/deadline/client/ui/widgets/host_requirements_tab.py
+++ b/src/deadline/client/ui/widgets/host_requirements_tab.py
@@ -1089,18 +1089,10 @@ class OptionalMultiSelectComboBox(QComboBox):
 
     def __init__(self, items: List[str], parent=None):
         super().__init__(parent=parent)
-        self.view().pressed.connect(self.handleItemPressed)
         self.model().itemChanged.connect(self.handleModelChanged)
         self.setPlaceholderText("-")
         self.addItems(items)
         self._updateLineEdit()
-
-    def handleItemPressed(self, index):
-        item = self.model().itemFromIndex(index)
-        if item.checkState() == Qt.Checked:
-            item.setCheckState(Qt.Unchecked)
-        else:
-            item.setCheckState(Qt.Checked)
 
     def handleModelChanged(self, item):
         self._updateLineEdit()


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud/issues/587

### What was the problem/requirement? (What/Why)
The host requirements combo boxes would not work correctly on Linux and Mac. The selection would get unchecked right after clicking the option.

### What was the solution? (How)
The extra signal handling was unnecessary and was the cause of the issue. QComboBox can already handle selection logic on its own between the model and view. You only need to mark the item as selectable and it works.

### What is the impact of this change?
Control works as intended.

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests?
   - Yes.
- Have you run the integration tests?
   -  No.
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass.
   - No.

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [X] This PR does not add any new dependencies.

### Is this a breaking change?

No.

### Does this change impact security?

- Does the change need to be threat modeled? For example, does it create or modify files/directories that must only be readable by the process owner?
    - No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
