### PR TITLE
chore: fix pyversion badges

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Operating System :: POSIX :: Linux",
   "Operating System :: Microsoft :: Windows",
   "Operating System :: MacOS",


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

We support python 3.13 in deadline cloud, but it doesn't show in the badges

<img width="449" alt="image" src="https://github.com/user-attachments/assets/25d44322-a60b-4514-a03d-73d1ba5481d6" />

### What was the solution? (How)

update the project metadata

### What is the impact of this change?

accurate versions!

### How was this change tested?

N/A

### Was this change documented?

It is documentation :)

### Does this PR introduce new dependencies?

No

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
