### PR TITLE
feat: Add configurable job timeouts widget.

### DIFF
--- a/src/deadline/client/job_bundle/__init__.py
+++ b/src/deadline/client/job_bundle/__init__.py
@@ -6,6 +6,7 @@ __all__ = [
     "read_job_bundle_parameters",
     "apply_job_parameters",
     "deadline_yaml_dump",
+    "timeouts",
 ]
 
 import datetime

--- a/src/deadline/client/job_bundle/timeouts.py
+++ b/src/deadline/client/job_bundle/timeouts.py
@@ -25,6 +25,42 @@ class TimeoutSettings:
             if timeout <= 0:
                 raise ValueError(f"Timeout value cannot be negative or zero: {timeout}")
 
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Convert the object to a dict for serialization.
+        """
+        return {
+            "is_activated": self.is_activated,
+            "on_enter_timeout_seconds": self.on_enter_timeout_seconds,
+            "on_exit_timeout_seconds": self.on_exit_timeout_seconds,
+            "on_run_timeout_seconds": self.on_run_timeout_seconds,
+        }
+
+    @classmethod
+    def from_dict(
+        cls,
+        data: Dict[str, Any],
+        default_is_activated: bool = True,
+        default_on_enter_timeout_seconds: int = SECONDS_IN_A_DAY,
+        default_on_exit_timeout_seconds: int = SECONDS_IN_A_DAY,
+        default_on_run_timeout_seconds: int = 5 * SECONDS_IN_A_DAY,
+    ) -> "TimeoutSettings":
+        """
+        Convert a dict to a TimeoutSettings object.
+        """
+        return cls(
+            is_activated=data.get("is_activated", default_is_activated),
+            on_enter_timeout_seconds=data.get(
+                "on_enter_timeout_seconds", default_on_enter_timeout_seconds
+            ),
+            on_exit_timeout_seconds=data.get(
+                "on_exit_timeout_seconds", default_on_exit_timeout_seconds
+            ),
+            on_run_timeout_seconds=data.get(
+                "on_run_timeout_seconds", default_on_run_timeout_seconds
+            ),
+        )
+
 
 def add_timeouts_to_job_template(
     template: Dict[str, Any], timeout_settings: Optional[TimeoutSettings] = None
@@ -66,6 +102,24 @@ def add_timeouts_to_job_template(
 
     if not timeout_settings.is_activated:
         return
+
+    if (
+        timeout_settings.on_enter_timeout_seconds == 0
+        or timeout_settings.on_exit_timeout_seconds == 0
+        or timeout_settings.on_run_timeout_seconds == 0
+    ):
+        msg = "The following timeout value(s) must be greater than 0: \n"
+        zero_timeouts = []
+        if not timeout_settings.on_enter_timeout_seconds:
+            zero_timeouts.append("Setup Timeout")
+        if not timeout_settings.on_exit_timeout_seconds:
+            zero_timeouts.append("Teardown Timeout")
+        if not timeout_settings.on_run_timeout_seconds:
+            zero_timeouts.append("Render Timeout")
+
+        msg += ", ".join(zero_timeouts)
+        msg += "\n\nPlease configure these value(s) in the 'Shared Job Settings' tab."
+        raise ValueError(msg)
 
     def _apply_timeouts_to_environment(environment: Dict):
         if "script" in environment:

--- a/src/deadline/client/ui/widgets/shared_job_settings_tab.py
+++ b/src/deadline/client/ui/widgets/shared_job_settings_tab.py
@@ -29,6 +29,7 @@ from ...config import get_setting
 from .. import CancelationFlag
 from .openjd_parameters_widget import OpenJDParametersWidget
 from ...api import get_queue_parameter_definitions
+from .shared_job_timeout_settings_widget import SharedJobTimeoutSettingsWidget
 
 
 class SharedJobSettingsWidget(QWidget):  # pylint: disable=too-few-public-methods
@@ -63,7 +64,11 @@ class SharedJobSettingsWidget(QWidget):  # pylint: disable=too-few-public-method
     _queue_parameters_update = Signal(int, list)
 
     def __init__(
-        self, *, initial_settings, initial_shared_parameter_values: dict[str, Any], parent=None
+        self,
+        *,
+        initial_settings,
+        initial_shared_parameter_values: dict[str, Any],
+        parent=None,
     ):
         super().__init__(parent=parent)
         layout = QVBoxLayout(self)
@@ -76,6 +81,13 @@ class SharedJobSettingsWidget(QWidget):  # pylint: disable=too-few-public-method
             initial_settings=initial_settings, parent=self
         )
         layout.addWidget(self.shared_job_properties_box)
+
+        # Only show timeout settings if render settings has 'timeout_settings'.
+        if hasattr(initial_settings, "timeout_settings"):
+            self.shared_timeout_settings_box = SharedJobTimeoutSettingsWidget(
+                initial_settings=initial_settings, parent=self
+            )
+            layout.addWidget(self.shared_timeout_settings_box)
 
         self.deadline_cloud_settings_box = DeadlineCloudSettingsWidget(parent=self)
         layout.addWidget(self.deadline_cloud_settings_box)
@@ -216,6 +228,8 @@ class SharedJobSettingsWidget(QWidget):  # pylint: disable=too-few-public-method
 
     def update_settings(self, settings):
         self.shared_job_properties_box.update_settings(settings)
+        if hasattr(settings, "timeout_settings"):
+            self.shared_timeout_settings_box.update_settings(settings)
 
     def get_parameters(self):
         """

--- a/src/deadline/client/ui/widgets/shared_job_timeout_settings_widget.py
+++ b/src/deadline/client/ui/widgets/shared_job_timeout_settings_widget.py
@@ -1,0 +1,192 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+A UI Widget containing the timeout settings widget.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from qtpy.QtWidgets import (  # type: ignore
+    QFormLayout,
+    QGroupBox,
+    QLabel,
+    QMessageBox,
+    QSpinBox,
+    QCheckBox,
+    QGridLayout,
+    QAbstractSpinBox,
+)
+
+
+SECONDS_IN_A_MINUTE = 60
+SECONDS_IN_AN_HOUR = 60 * 60
+SECONDS_IN_A_DAY = SECONDS_IN_AN_HOUR * 24
+
+
+class SharedJobTimeoutSettingsWidget(QGroupBox):  # pylint: disable=too-few-public-methods
+    """
+    UI element to hold timeout settings of the submission
+
+    The settings object should be a dataclass with:
+      - `timeout_settings: TimeoutSettings`  The timeout settings to be applied for the job.
+    """
+
+    def __init__(self, *, initial_settings, parent=None):
+        super().__init__("Timeout settings", parent=parent)
+
+        self._build_ui()
+        self.refresh_ui(initial_settings)
+
+    def _build_ui(self):
+        self.layout = QFormLayout(self)
+        self.layout.setFieldGrowthPolicy(QFormLayout.AllNonFixedFieldsGrow)
+
+        self.activate_timeouts_checkbox = QCheckBox("Use timeouts", self)
+        self.activate_timeouts_checkbox.setChecked(True)
+        self.activate_timeouts_checkbox.clicked.connect(self.activate_timeouts_changed)
+        self.activate_timeouts_checkbox.setToolTip(
+            "Set a maximum duration for actions from this job. See AWS Deadline Cloud documentation to learn more."
+        )
+        self.activate_timeouts_checkbox_subtext = QLabel(
+            "Set a maximum duration for actions from this job."
+        )
+        self.activate_timeouts_checkbox_subtext.setStyleSheet("font-style: italic")
+        self.layout.addRow(self.activate_timeouts_checkbox, self.activate_timeouts_checkbox_subtext)
+
+        self.timeouts_box = QGroupBox()
+        timeouts_layout = QGridLayout(self.timeouts_box)
+
+        def create_timeout_row(label, tooltip, row):
+            qlabel = QLabel(label)
+            qlabel.setToolTip(tooltip)
+            timeouts_layout.addWidget(qlabel, row, 0)
+
+            days_box = QSpinBox(self, minimum=0, maximum=365)
+            days_box.setSuffix(" days")
+            days_box.setButtonSymbols(QAbstractSpinBox.UpDownArrows)
+            timeouts_layout.addWidget(days_box, row, 1)
+
+            hours_box = QSpinBox(self, minimum=0, maximum=23)
+            hours_box.setSuffix(" hours")
+            timeouts_layout.addWidget(hours_box, row, 2)
+
+            minutes_box = QSpinBox(self, minimum=0, maximum=59)
+            minutes_box.setSuffix(" minutes")
+            timeouts_layout.addWidget(minutes_box, row, 3)
+
+            return qlabel, days_box, hours_box, minutes_box
+
+        def hookup_zero_callback(timeout_boxes: tuple[QLabel, QSpinBox, QSpinBox, QSpinBox]):
+            def indicate_is_valid_callback(value: int):
+                self.indicate_if_valid(timeout_boxes)
+
+            for timeout_box in timeout_boxes[1:]:
+                timeout_box.valueChanged.connect(indicate_is_valid_callback)
+
+        self.on_run_timeouts = create_timeout_row(
+            label="Render Task Timeout",
+            tooltip="Maximum duration of each action which performs a render.",
+            row=0,
+        )
+        hookup_zero_callback(self.on_run_timeouts)
+
+        self.on_enter_timeouts = create_timeout_row(
+            label="Setup Timeout",
+            tooltip="Maximum duration of each action which sets up the job for rendering, such as scene load.",
+            row=1,
+        )
+        hookup_zero_callback(self.on_enter_timeouts)
+
+        self.on_exit_timeouts = create_timeout_row(
+            label="Teardown Timeout",
+            tooltip="Maximum duration of action which tears down the setup required for rendering.",
+            row=2,
+        )
+        hookup_zero_callback(self.on_exit_timeouts)
+
+        self.layout.addRow(self.timeouts_box)
+
+    def refresh_ui(self, settings: Any):
+        self.activate_timeouts_checkbox.setChecked(settings.timeout_settings.is_activated)
+
+        def _set_timeout(
+            timeout_boxes: tuple[QLabel, QSpinBox, QSpinBox, QSpinBox], timeout_seconds: int
+        ):
+            days = timeout_seconds // 86400
+            hours = (timeout_seconds % 86400) // 3600
+            minutes = (timeout_seconds % 3600) // 60
+            timeout_boxes[1].setValue(days)
+            timeout_boxes[2].setValue(hours)
+            timeout_boxes[3].setValue(minutes)
+
+        _set_timeout(self.on_run_timeouts, settings.timeout_settings.on_run_timeout_seconds)
+        _set_timeout(self.on_enter_timeouts, settings.timeout_settings.on_enter_timeout_seconds)
+        _set_timeout(self.on_exit_timeouts, settings.timeout_settings.on_exit_timeout_seconds)
+
+        self.activate_timeouts_changed(warn=False)  # don't warn when loading from sticky settings
+
+    def update_settings(self, settings: Any):
+        """
+        Update a given instance of scene settings with updated values.
+        """
+        settings.timeout_settings.is_activated = self.activate_timeouts_checkbox.isChecked()
+        settings.timeout_settings.on_run_timeout_seconds = self.on_run_timeout_seconds
+        settings.timeout_settings.on_enter_timeout_seconds = self.on_enter_timeout_seconds
+        settings.timeout_settings.on_exit_timeout_seconds = self.on_exit_timeout_seconds
+
+    def indicate_if_valid(self, timeout_boxes: tuple[QLabel, QSpinBox, QSpinBox, QSpinBox]):
+        if (
+            self._calculate_timeout_seconds(timeout_boxes) == 0
+            and not self.timeouts_box.isChecked()
+        ):
+            timeout_boxes[0].setStyleSheet("color: red")
+        else:
+            timeout_boxes[0].setStyleSheet("")
+
+        # If the spin box has a value of 1, we should not make the suffix plural.
+        for box in timeout_boxes[1:4]:
+            if box.value() == 1:
+                box.setSuffix(box.suffix().strip("s"))
+            elif not box.suffix().endswith("s"):
+                box.setSuffix(box.suffix() + "s")
+
+    def activate_timeouts_changed(self, _=None, warn=True):
+        is_checkbox_checked = self.activate_timeouts_checkbox.isChecked()
+        if not is_checkbox_checked and warn:
+            result = QMessageBox.warning(
+                self,
+                "Warning",
+                "Removing timeouts in your submission can result in a task that runs indefinitely. Are you sure you want to remove timeouts?",
+                QMessageBox.Yes | QMessageBox.No,
+                QMessageBox.No,
+            )
+            if result == QMessageBox.No:
+                self.activate_timeouts_checkbox.setChecked(True)
+        for timeout_boxes in (self.on_run_timeouts, self.on_enter_timeouts, self.on_exit_timeouts):
+            for timeout_box in timeout_boxes:
+                is_checkbox_checked = self.activate_timeouts_checkbox.isChecked()
+                timeout_box.setEnabled(is_checkbox_checked)
+            self.indicate_if_valid(timeout_boxes)
+
+    def _calculate_timeout_seconds(
+        self, timeout_boxes: tuple[QLabel, QSpinBox, QSpinBox, QSpinBox]
+    ):
+        return (
+            timeout_boxes[1].value() * SECONDS_IN_A_DAY
+            + timeout_boxes[2].value() * SECONDS_IN_AN_HOUR
+            + timeout_boxes[3].value() * SECONDS_IN_A_MINUTE
+        )
+
+    @property
+    def on_run_timeout_seconds(self):
+        return self._calculate_timeout_seconds(self.on_run_timeouts)
+
+    @property
+    def on_enter_timeout_seconds(self):
+        return self._calculate_timeout_seconds(self.on_enter_timeouts)
+
+    @property
+    def on_exit_timeout_seconds(self):
+        return self._calculate_timeout_seconds(self.on_exit_timeouts)


### PR DESCRIPTION
## This PR is still marked as draft as I need to add few tests and want to get some general feedback about the UI before we merge it. 

### What was the problem/requirement? (What/Why)

DCCs that depend on `deadline-cloud` needed an easy way to patch their job templates with default timeouts for Env enter/exit/task run. 

### What was the solution? (How)

Discussed with @AWS-Samuel about the simplest way to provide this capability. Add Kudos to @AWS-Samuel for his changes in Nuke which we will be re-using to make it helpful for all DCCs. 

- Create a helper function which can be used by different DCCs directly. [PR](https://github.com/aws-deadline/deadline-cloud/pull/600)
- Add GUI components that adds the timeouts to the SubmitJobToDeadlineDialog with the render settings that can be applied when there is `on_create_job_bundle_callback`.  [This PR]

### What is the impact of this change?

Adds GUI for the submitters. 

### How was this change tested? [I'm currently testing this but want some quick feedback]

I tried applying the changes for my locally built Cinema 4D. I added this to the shared job settings because I believe this can be useful for all the DCCs and is not specific to a single DCC.

Here's how the submitter GUI would look like :

1. When the DCC's render submissions have `timeout_settings`. 

![Screenshot 2025-02-15 at 6 07 32 PM](https://github.com/user-attachments/assets/c0e8ffad-e537-4ddc-84bd-a95b28cc81a2)

2. When the timeouts field is unchecked. 

2.1. The alert when the field is unchecked. 

![Screenshot 2025-02-15 at 6 07 43 PM](https://github.com/user-attachments/assets/9ed7a8c7-44f8-4479-8552-e97c76fa0eca)

2.2. After the customer unchecks the field, the timeout fields are blocked. 

![Screenshot 2025-02-15 at 6 07 54 PM](https://github.com/user-attachments/assets/f2f41a35-2f2d-4090-8b71-f88f57d3f6f0)

3. When 0 second timeouts are added. 

3.1 The timeout with 0 seconds is highlighted in RED. 

![Screenshot 2025-02-15 at 6 08 07 PM](https://github.com/user-attachments/assets/7518a727-b182-4c01-8b29-f8cbb4b45142)

3.2 With 0 seconds timeouts, the submissions will not succeed. 

![Screenshot 2025-02-15 at 6 08 20 PM](https://github.com/user-attachments/assets/40269df5-4497-486f-9910-eb2fcedea013)


- Have you run the unit tests?

Yes

- Have you run the integration tests?

Currently running it. 


- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass.

No

### Was this change documented?

- Are relevant docstrings in the code base updated?
Yes

- Has the README.md been updated? If you modified CLI arguments, for instance.
No

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [X] This PR does not add any new dependencies.

### Is this a breaking change?

No

### Does this change impact security?

- Does the change need to be threat modeled? For example, does it create or modify files/directories that must only be readable by the process owner?
    - If so, then please label this pull request with the "security" label. We'll work with you to analyze the threats.

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
