### PR TITLE
test: skip windows long paths tests when long path registry key is enabled

### DIFF
--- a/test/integ/cli/test_cli_manifest_snapshot.py
+++ b/test/integ/cli/test_cli_manifest_snapshot.py
@@ -8,10 +8,12 @@ import json
 import math
 import os
 from pathlib import Path, WindowsPath
-import sys
 from typing import List
 from click.testing import CliRunner
-from deadline.job_attachments._utils import WINDOWS_MAX_PATH_LENGTH
+from deadline.job_attachments._utils import (
+    WINDOWS_MAX_PATH_LENGTH,
+    _is_windows_long_path_registry_enabled,
+)
 import pytest
 import tempfile
 from deadline.client.cli import main
@@ -106,8 +108,8 @@ class TestManifestSnapshot:
 
     @pytest.mark.integ
     @pytest.mark.skipif(
-        sys.platform != "win32",
-        reason="This test is related to Windows file path length limit, skipping this if os not Windows",
+        _is_windows_long_path_registry_enabled(),
+        reason="This test is related to Windows file path length limit, skipping this if os not Windows or if the long path registry is enabled",
     )
     def test_manifest_snapshot_over_windows_path_limit(self, tmp_path: WindowsPath):
         """
@@ -171,8 +173,8 @@ class TestManifestSnapshot:
 
     @pytest.mark.integ
     @pytest.mark.skipif(
-        sys.platform != "win32",
-        reason="This test is related to Windows file path length limit, skipping this if os not Windows",
+        _is_windows_long_path_registry_enabled(),
+        reason="This test is related to Windows file path length limit, skipping this if os not Windows or if the long path registry is enabled",
     )
     def test_manifest_snapshot_over_windows_path_limit_json(self, tmp_path: WindowsPath):
         """

--- a/test/integ/cli/test_cli_manifest_upload.py
+++ b/test/integ/cli/test_cli_manifest_upload.py
@@ -7,13 +7,15 @@ Integ tests for the CLI manifest upload commands.
 import math
 import os
 from pathlib import Path
-import sys
 from typing import Optional
 import boto3
 from click.testing import CliRunner
 from deadline.client.cli._groups.manifest_group import cli_manifest
 from deadline.job_attachments._aws.deadline import get_queue
-from deadline.job_attachments._utils import WINDOWS_MAX_PATH_LENGTH
+from deadline.job_attachments._utils import (
+    WINDOWS_MAX_PATH_LENGTH,
+    _is_windows_long_path_registry_enabled,
+)
 from deadline.job_attachments.api.manifest import _manifest_snapshot
 from deadline.job_attachments.models import ManifestSnapshot
 import pytest
@@ -147,8 +149,8 @@ class TestManifestUpload:
         s3_client.delete_object(Bucket=s3_bucket, Key=manifest_s3_path)
 
     @pytest.mark.skipif(
-        sys.platform != "win32",
-        reason="This test is related to Windows file path length limit, skipping this if os not Windows",
+        _is_windows_long_path_registry_enabled(),
+        reason="This test is related to Windows file path length limit, skipping this if os not Windows or if the long path registry is enabled",
     )
     def test_manifest_upload_over_windows_path_limit(self, tmp_path):
         """


### PR DESCRIPTION

### What was the problem/requirement? (What/Why)
Some integration tests for windows long paths assume that the machine doesn't have the long path registry key enabled. However when the registry key is enabled, the tests don't have the expected behaviour since there's no code checking whether there's a long path.

This caused these tests to fail in Github.


### What was the solution? (How)
Disable these tests when the long path registry key is enabled.

### What is the impact of this change?

### How was this change tested?

Enabled `LongPathsEnabled` registry key on Windows and ran the tests using `hatch run integ:test` to made sure they pass. Disabled the `LongPathsEnabled` registry key to make sure they pass too.

- Have you run the unit tests? Yes
- Have you run the integration tests? Yes
- Have you made changes to the `download` or `asset_sync` modules? No

### Was this change documented?

No

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [ x] This PR does not add any new dependencies.

### Is this a breaking change?

No

### Does this change impact security?

No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
