### PR TITLE
chore: add maintenance label to maintenance GitHub template

### DIFF
--- a/.github/ISSUE_TEMPLATE/maintenance.yml
+++ b/.github/ISSUE_TEMPLATE/maintenance.yml
@@ -1,7 +1,7 @@
 name: "🛠️ Maintenance"
 description: Some type of improvement
 title: "Maintenance: (short description of the issue)"
-labels: ["needs triage"]
+labels: ["maintenance", "needs triage"]
 body:
   - type: textarea
     id: description


### PR DESCRIPTION
To help us organize GitHub issues, we are adding a maintenance label on maintenance-related GitHub issues by default