### PR TITLE
fix: Fixed file number append to handle file name collisions while creating copy

### DIFF
--- a/src/deadline/job_attachments/download.py
+++ b/src/deadline/job_attachments/download.py
@@ -74,6 +74,7 @@ from ._utils import (
     _is_relative_to,
     _join_s3_paths,
 )
+from threading import Lock
 
 download_logger = getLogger("deadline.job_attachments.download")
 
@@ -312,6 +313,28 @@ def get_job_input_output_paths_by_asset_root(
     return combined_path_groups
 
 
+def _get_new_copy_file_path(
+    local_file_name: Path,
+    collision_lock: Lock,
+    collision_file_dict: DefaultDict[str, int],
+) -> Path:
+    with collision_lock:
+        file_str: str = str(local_file_name)
+        num: int = collision_file_dict[file_str]
+        new_file_name = local_file_name
+
+        # Iterate until we find a number we don't conflict with
+        while new_file_name.is_file():
+            num += 1
+            new_file_name = local_file_name.parent.joinpath(
+                f"{local_file_name.stem} ({num}){local_file_name.suffix}"
+            )
+
+        collision_file_dict[file_str] = num
+        local_file_name = new_file_name
+    return local_file_name
+
+
 def download_files_in_directory(
     s3_settings: JobAttachmentS3Settings,
     attachments: Attachments,
@@ -384,6 +407,8 @@ def download_file(
     file: RelativeFilePath,
     hash_algorithm: HashAlgorithm,
     local_download_dir: str,
+    collision_lock: Lock,
+    collision_file_dict: DefaultDict[str, int],
     s3_bucket: str,
     cas_prefix: Optional[str],
     s3_client: Optional[BaseClient] = None,
@@ -410,7 +435,7 @@ def download_file(
     file_bytes = file.size
 
     # Python will handle the path separator '/' correctly on every platform.
-    local_file_name: Path = _get_long_path_compatible_path(
+    local_file_path: Path = _get_long_path_compatible_path(
         Path(local_download_dir).joinpath(file.path)
     )
 
@@ -421,24 +446,21 @@ def download_file(
     )
 
     # If the file name already exists, resolve the conflict based on the file_conflict_resolution
-    if local_file_name.is_file():
+    if local_file_path.is_file():
         if file_conflict_resolution == FileConflictResolution.SKIP:
             return (file_bytes, None)
         elif file_conflict_resolution == FileConflictResolution.OVERWRITE:
             pass
         elif file_conflict_resolution == FileConflictResolution.CREATE_COPY:
-            # This loop resolves filename conflicts by appending " (1)"
-            # to the stem of the filename until a unique name is found.
-            while local_file_name.is_file():
-                local_file_name = local_file_name.parent.joinpath(
-                    local_file_name.stem + " (1)" + local_file_name.suffix
-                )
+            local_file_path = _get_new_copy_file_path(
+                local_file_path, collision_lock, collision_file_dict
+            )
         else:
             raise ValueError(
                 f"Unknown choice for file conflict resolution: {file_conflict_resolution}"
             )
 
-    local_file_name.parent.mkdir(parents=True, exist_ok=True)
+    local_file_path.parent.mkdir(parents=True, exist_ok=True)
 
     future: concurrent.futures.Future
 
@@ -456,7 +478,7 @@ def download_file(
     future = transfer_manager.download(
         bucket=s3_bucket,
         key=s3_key,
-        fileobj=str(local_file_name),
+        fileobj=str(local_file_path),
         extra_args={"ExpectedBucketOwner": get_account_id(session=session)},
         subscribers=subscribers,
     )
@@ -494,7 +516,7 @@ def download_file(
                 status_code=status_code,
                 bucket_name=s3_bucket,
                 key_or_prefix=s3_key,
-                message=f"{status_code_guidance.get(status_code, '')} {str(exc)} (Failed to download the file to {str(local_file_name)})",
+                message=f"{status_code_guidance.get(status_code, '')} {str(exc)} (Failed to download the file to {str(local_file_path)})",
             ) from exc
 
         # TODO: Temporary to prevent breaking backwards-compatibility; if file not found, try again without hash alg postfix
@@ -504,7 +526,7 @@ def download_file(
             future = transfer_manager.download(
                 bucket=s3_bucket,
                 key=s3_key,
-                fileobj=str(local_file_name),
+                fileobj=str(local_file_path),
                 extra_args={"ExpectedBucketOwner": get_account_id(session=session)},
                 subscribers=subscribers,
             )
@@ -528,10 +550,10 @@ def download_file(
     except Exception as e:
         raise AssetSyncError(e) from e
 
-    download_logger.debug(f"Downloaded {file.path} to {str(local_file_name)}")
-    os.utime(local_file_name, (modified_time_override, modified_time_override))  # type: ignore[arg-type]
+    download_logger.debug(f"Downloaded {file.path} to {str(local_file_path)}")
+    os.utime(local_file_path, (modified_time_override, modified_time_override))  # type: ignore[arg-type]
 
-    return (file_bytes, local_file_name)
+    return (file_bytes, local_file_path)
 
 
 def _download_files_parallel(
@@ -552,6 +574,8 @@ def _download_files_parallel(
     Returns a list of local paths of downloaded files.
     """
     downloaded_file_names: list[str] = []
+    collision_lock: Lock = Lock()
+    collision_file_dict: DefaultDict[str, int] = DefaultDict(int)
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=num_download_workers) as executor:
         futures = {
@@ -560,6 +584,8 @@ def _download_files_parallel(
                 file,
                 hash_algorithm,
                 local_download_dir,
+                collision_lock,
+                collision_file_dict,
                 s3_bucket,
                 cas_prefix,
                 s3_client,

--- a/src/deadline/job_attachments/download.py
+++ b/src/deadline/job_attachments/download.py
@@ -324,11 +324,17 @@ def _get_new_copy_file_path(
         new_file_name = local_file_name
 
         # Iterate until we find a number we don't conflict with
-        while new_file_name.is_file():
-            num += 1
-            new_file_name = local_file_name.parent.joinpath(
-                f"{local_file_name.stem} ({num}){local_file_name.suffix}"
-            )
+        while True:
+            try:
+                # Handle multi-process locks with creating and/or opening file to verify if it exists
+                with open(new_file_name, "x"):
+                    break
+            # If file exists we go here and increment num to find a unique path
+            except FileExistsError:
+                num += 1
+                new_file_name = local_file_name.parent.joinpath(
+                    f"{local_file_name.stem} ({num}){local_file_name.suffix}"
+                )
 
         collision_file_dict[file_str] = num
         local_file_name = new_file_name

--- a/test/unit/deadline_job_attachments/test_download.py
+++ b/test/unit/deadline_job_attachments/test_download.py
@@ -214,12 +214,9 @@ def assert_download_task_output(
             on_downloading_files=mock_on_downloading_files,
         )
 
-    # Ensure that only the expected files are there and no extras.
-    expected_files_set = set().union(*expected_files.values())
-    assert expected_files_set == set([path for path in tmp_path.glob("**/*") if path.is_file()])
-    # Ensure that all the files from the 2023-03-03 manifest have had the correct mtime set.
-    if manifest_version == ManifestVersion.v2023_03_03:
-        assert all(path.stat().st_mtime == 1234 for path in tmp_path.glob("**/*") if path.is_file())
+    check_expected_files_present(expected_files, tmp_path)
+
+    check_manifest_version_v2023_mtime(manifest_version, tmp_path)
 
     assert_progress_tracker_values(
         manifest_version=manifest_version,
@@ -228,6 +225,12 @@ def assert_download_task_output(
         expected_total_bytes=expected_total_bytes,
         mock_on_downloading_files=mock_on_downloading_files,
     )
+
+
+def check_manifest_version_v2023_mtime(manifest_version, tmp_path):
+    # Ensure that all the files from the 2023-03-03 manifest have had the correct mtime set.
+    if manifest_version == ManifestVersion.v2023_03_03:
+        assert all(path.stat().st_mtime == 1234 for path in tmp_path.glob("**/*") if path.is_file())
 
 
 def assert_download_step_output(
@@ -261,12 +264,9 @@ def assert_download_step_output(
             on_downloading_files=mock_on_downloading_files,
         )
 
-    # Ensure that only the expected files are there and no extras.
-    expected_files_set = set().union(*expected_files.values())
-    assert expected_files_set == set([path for path in tmp_path.glob("**/*") if path.is_file()])
-    # Ensure that all the files from the 2023-03-03 manifest have had the correct mtime set.
-    if manifest_version == ManifestVersion.v2023_03_03:
-        assert all(path.stat().st_mtime == 1234 for path in tmp_path.glob("**/*") if path.is_file())
+    check_expected_files_present(expected_files, tmp_path)
+
+    check_manifest_version_v2023_mtime(manifest_version, tmp_path)
 
     assert_progress_tracker_values(
         manifest_version=manifest_version,
@@ -310,9 +310,7 @@ def assert_download_job_output(
     # Ensure that only the expected files are there and no extras.
     expected_files_set = set().union(*expected_files.values())
     assert expected_files_set == set([path for path in tmp_path.glob("**/*") if path.is_file()])
-    # Ensure that all the files from the 2023-03-03 manifest have had the correct mtime set.
-    if manifest_version == ManifestVersion.v2023_03_03:
-        assert all(path.stat().st_mtime == 1234 for path in tmp_path.glob("**/*") if path.is_file())
+    check_manifest_version_v2023_mtime(manifest_version, tmp_path)
 
     assert_progress_tracker_values(
         manifest_version=manifest_version,
@@ -354,9 +352,7 @@ def assert_download_files_in_directory(
             on_downloading_files=mock_on_downloading_files,
         )
 
-    # Ensure that only the expected files are there and no extras.
-    expected_files_set = set().union(*expected_files.values())
-    assert expected_files_set == set([path for path in tmp_path.glob("**/*") if path.is_file()])
+    check_expected_files_present(expected_files, tmp_path)
 
     assert_progress_tracker_values(
         manifest_version=manifest_version,
@@ -365,6 +361,12 @@ def assert_download_files_in_directory(
         expected_total_bytes=expected_total_bytes,
         mock_on_downloading_files=mock_on_downloading_files,
     )
+
+
+def check_expected_files_present(expected_files, tmp_path):
+    # Ensure that only the expected files are there and no extras.
+    expected_files_set = set().union(*expected_files.values())
+    assert expected_files_set == set([path for path in tmp_path.glob("**/*") if path.is_file()])
 
 
 def assert_progress_tracker_values(
@@ -1297,41 +1299,8 @@ class TestFullDownload:
         `st_ctime` represents the time of the last metadata change, but on Windows, it represents
         the file creation time. So the skipping verification is only available on Linux.
         """
-        expected_files = [
-            tmp_path / "test1.txt",
-            tmp_path / "test" / "test2.txt",
-            tmp_path / "test" / "test3.txt",
-            tmp_path / "test4.txt",
-            tmp_path / "test13.txt",
-            tmp_path / "test" / "test14.txt",
-            tmp_path / "test5.txt",
-            tmp_path / "test" / "test6.txt",
-            tmp_path / "test7.txt",
-            tmp_path / "test" / "test8.txt",
-            tmp_path / "test" / "test9.txt",
-            tmp_path / "test10.txt",
-            tmp_path / "test11.txt",
-            tmp_path / "test" / "test12.txt",
-        ]
-
-        with patch(
-            f"{deadline.__package__}.job_attachments.download._get_asset_root_from_s3",
-            return_value=str(tmp_path.resolve()),
-        ):
-            output_downloader = OutputDownloader(
-                s3_settings=self.job_attachment_settings,
-                farm_id=farm_id,
-                queue_id=queue_id,
-                job_id="job-1",
-                step_id=None,
-                task_id=None,
-            )
-
-        # First download the files and check if the files are there.
-        # (Ensure that only the expected files are there and no extras.)
-        output_downloader.download_job_output()
-        assert set(expected_files) == set(
-            [path for path in tmp_path.glob("**/*") if path.is_file()]
+        expected_files, output_downloader = self.download_outputs_check_expected_files_exist(
+            farm_id, queue_id, tmp_path
         )
         # Record the last metadata modification times for each file.
         modified_time_before_second_trial = [path.stat().st_ctime for path in expected_files]
@@ -1349,16 +1318,7 @@ class TestFullDownload:
             modified_time_after_second_trial = [path.stat().st_ctime for path in expected_files]
             assert modified_time_before_second_trial == modified_time_after_second_trial
 
-    def test_OutputDownloader_download_job_output_when_overwrite(
-        self, farm_id, queue_id, tmp_path: Path
-    ):
-        """
-        When path conflicts occur during file download and the resolution method is set to OVERWRITE,
-        test whether the files has actually been overwritten.
-        Note: This test relies on `st_ctime` for checking if a file has been overwritten. On Linux,
-        `st_ctime` represents the time of the last metadata change, but on Windows, it represents
-        the file creation time. So the overwriting verification is only available on Linux.
-        """
+    def download_outputs_check_expected_files_exist(self, farm_id, queue_id, tmp_path):
         expected_files = [
             tmp_path / "test1.txt",
             tmp_path / "test" / "test2.txt",
@@ -1375,7 +1335,6 @@ class TestFullDownload:
             tmp_path / "test11.txt",
             tmp_path / "test" / "test12.txt",
         ]
-
         with patch(
             f"{deadline.__package__}.job_attachments.download._get_asset_root_from_s3",
             return_value=str(tmp_path.resolve()),
@@ -1388,12 +1347,26 @@ class TestFullDownload:
                 step_id=None,
                 task_id=None,
             )
-
         # First download the files and check if the files are there.
         # (Ensure that only the expected files are there and no extras.)
         output_downloader.download_job_output()
         assert set(expected_files) == set(
             [path for path in tmp_path.glob("**/*") if path.is_file()]
+        )
+        return expected_files, output_downloader
+
+    def test_OutputDownloader_download_job_output_when_overwrite(
+        self, farm_id, queue_id, tmp_path: Path
+    ):
+        """
+        When path conflicts occur during file download and the resolution method is set to OVERWRITE,
+        test whether the files has actually been overwritten.
+        Note: This test relies on `st_ctime` for checking if a file has been overwritten. On Linux,
+        `st_ctime` represents the time of the last metadata change, but on Windows, it represents
+        the file creation time. So the overwriting verification is only available on Linux.
+        """
+        expected_files, output_downloader = self.download_outputs_check_expected_files_exist(
+            farm_id, queue_id, tmp_path
         )
         # Record the last metadata modification times for each file.
         modified_time_before_overwrite = [path.stat().st_ctime for path in expected_files]
@@ -1599,6 +1572,9 @@ class TestFullDownload:
     def test_OutputDownloader_download_job_output_posix_invalid_file_path_fails(
         self, farm_id, queue_id, outputs_by_root: dict[str, ManifestPathGroup]
     ):
+        self.create_output_downloaded_and_validate_path(farm_id, outputs_by_root, queue_id)
+
+    def create_output_downloaded_and_validate_path(self, farm_id, outputs_by_root, queue_id):
         with patch(
             f"{deadline.__package__}.job_attachments.download.get_job_output_paths_by_asset_root",
             return_value=outputs_by_root,
@@ -1674,22 +1650,7 @@ class TestFullDownload:
     def test_OutputDownloader_download_job_output_windows_invalid_file_path_fails(
         self, farm_id, queue_id, outputs_by_root: dict[str, ManifestPathGroup]
     ):
-        with patch(
-            f"{deadline.__package__}.job_attachments.download.get_job_output_paths_by_asset_root",
-            return_value=outputs_by_root,
-        ):
-            output_downloader = OutputDownloader(
-                s3_settings=self.job_attachment_settings,
-                farm_id=farm_id,
-                queue_id=queue_id,
-                job_id="job-1",
-                step_id=None,
-                task_id=None,
-            )
-        with patch(
-            f"{deadline.__package__}.job_attachments.download.download_files", return_value=[]
-        ), pytest.raises((PathOutsideDirectoryError, ValueError)):
-            output_downloader.download_job_output()
+        self.create_output_downloaded_and_validate_path(farm_id, outputs_by_root, queue_id)
 
     def test_get_asset_root_from_s3_error_message_on_not_found(self):
         """
@@ -1970,6 +1931,24 @@ class TestFullDownload:
 
         local_path = "Users/path/to/a/very/long/file/path/that/exceeds/the/windows/max/path/length/for/testing/max/file/path/error/handling/when/download/or/syncing/assest/using/job/attachment"
 
+        self.download_file_and_check_exception(
+            file_path,
+            local_path,
+            mock_collision_dict,
+            mock_lock,
+            mock_s3_client,
+            mock_transfer_manager,
+        )
+
+    def download_file_and_check_exception(
+        self,
+        file_path,
+        local_path,
+        mock_collision_dict,
+        mock_lock,
+        mock_s3_client,
+        mock_transfer_manager,
+    ):
         with patch(
             f"{deadline.__package__}.job_attachments.download.get_s3_client",
             return_value=mock_s3_client,
@@ -1988,7 +1967,6 @@ class TestFullDownload:
                     "rootPrefix/Data",
                     mock_s3_client,
                 )
-
         expected_message = "Test exception"
         assert str(exc.value) == expected_message
         mock_lock.assert_not_called()
@@ -2016,50 +1994,28 @@ class TestFullDownload:
 
         local_path = "C:\\path\\to\\a\\very\\long\\file\\path\\that\\exceeds\\the\\windows\\max\\path\\length\\for\\testing\\max\\file\\path\\error\\handling\\when\\download\\or\\syncing\\assest\\using\\job\\attachment"
 
-        with patch(
-            f"{deadline.__package__}.job_attachments.download.get_s3_client",
-            return_value=mock_s3_client,
-        ), patch(
-            f"{deadline.__package__}.job_attachments.download.get_s3_transfer_manager",
-            return_value=mock_transfer_manager,
-        ), patch(f"{deadline.__package__}.job_attachments.download.Path.mkdir"):
-            with pytest.raises(AssetSyncError) as exc:
-                download_file(
-                    file_path,
-                    HashAlgorithm.XXH128,
-                    local_path,
-                    mock_lock,
-                    mock_collision_dict,
-                    "test-bucket",
-                    "rootPrefix/Data",
-                    mock_s3_client,
-                )
-        expected_message = "Test exception"
-        assert str(exc.value) == expected_message
-        mock_lock.assert_not_called()
-        mock_collision_dict.assert_not_called()
+        self.download_file_and_check_exception(
+            file_path,
+            local_path,
+            mock_collision_dict,
+            mock_lock,
+            mock_s3_client,
+            mock_transfer_manager,
+        )
 
     @pytest.mark.skipif(
         sys.platform != "win32",
         reason="This test is for Windows path only.",
     )
     def test_windows_long_path_UNC_notation_WindowsOS(self):
-        mock_s3_client = MagicMock()
-        mock_future = MagicMock()
-        mock_transfer_manager = MagicMock()
-        mock_transfer_manager.download.return_value = mock_future
-        mock_future.result.side_effect = Exception("Test exception")
-        mock_lock = MagicMock()
-        mock_collision_dict = MagicMock()
-
-        file_path = ManifestPathv2023_03_03(
-            path="very/long/input/to/test/windows/max/file/path/for/error/handling/when/downloading/assest/from/job/attachment.txt",
-            hash="path",
-            size=1,
-            mtime=1234000000,
-        )
-
-        local_path = "\\\\?\\C:\\path\\to\\a\\very\\long\\file\\path\\that\\exceeds\\the\\windows\\max\\path\\length\\for\\testing\\max\\file\\path\\error\\handling\\when\\download\\or\\syncing\\assest\\using\\job\\attachment"
+        (
+            file_path,
+            local_path,
+            mock_collision_dict,
+            mock_lock,
+            mock_s3_client,
+            mock_transfer_manager,
+        ) = self.setup_mocks_and_file_path()
 
         with patch(
             f"{deadline.__package__}.job_attachments.download.get_s3_client",
@@ -2087,11 +2043,7 @@ class TestFullDownload:
         mock_lock.assert_not_called()
         mock_collision_dict.assert_not_called()
 
-    @pytest.mark.skipif(
-        sys.platform != "win32",
-        reason="This test is for Windows path only.",
-    )
-    def test_windows_long_path_UNC_notation_and_registry_WindowsOS(self):
+    def setup_mocks_and_file_path(self):
         mock_s3_client = MagicMock()
         mock_future = MagicMock()
         mock_transfer_manager = MagicMock()
@@ -2099,15 +2051,35 @@ class TestFullDownload:
         mock_future.result.side_effect = Exception("Test exception")
         mock_lock = MagicMock()
         mock_collision_dict = MagicMock()
-
         file_path = ManifestPathv2023_03_03(
             path="very/long/input/to/test/windows/max/file/path/for/error/handling/when/downloading/assest/from/job/attachment.txt",
             hash="path",
             size=1,
             mtime=1234000000,
         )
-
         local_path = "\\\\?\\C:\\path\\to\\a\\very\\long\\file\\path\\that\\exceeds\\the\\windows\\max\\path\\length\\for\\testing\\max\\file\\path\\error\\handling\\when\\download\\or\\syncing\\assest\\using\\job\\attachment"
+        return (
+            file_path,
+            local_path,
+            mock_collision_dict,
+            mock_lock,
+            mock_s3_client,
+            mock_transfer_manager,
+        )
+
+    @pytest.mark.skipif(
+        sys.platform != "win32",
+        reason="This test is for Windows path only.",
+    )
+    def test_windows_long_path_UNC_notation_and_registry_WindowsOS(self):
+        (
+            file_path,
+            local_path,
+            mock_collision_dict,
+            mock_lock,
+            mock_s3_client,
+            mock_transfer_manager,
+        ) = self.setup_mocks_and_file_path()
 
         with patch(
             f"{deadline.__package__}.job_attachments.download.get_s3_client",

--- a/test/unit/deadline_job_attachments/test_download.py
+++ b/test/unit/deadline_job_attachments/test_download.py
@@ -14,7 +14,8 @@ import json
 from pathlib import Path
 import sys
 import tempfile
-from typing import Any, Callable, List
+from threading import Lock
+from typing import Any, Callable, DefaultDict, List
 from unittest.mock import MagicMock, call, patch
 
 import boto3
@@ -47,6 +48,7 @@ from deadline.job_attachments.download import (
     merge_asset_manifests,
     _ensure_paths_within_directory,
     _get_asset_root_from_s3,
+    _get_new_copy_file_path,
     _get_tasks_manifests_keys_from_s3,
     VFS_CACHE_REL_PATH_IN_SESSION,
     VFS_MANIFEST_FOLDER_IN_SESSION,
@@ -158,11 +160,9 @@ MANIFESTS_v2022_03_03: List[Manifest] = [
     ),
 ]
 
-
 MANIFEST_VERSION_TO_MANIFESTS: dict[ManifestVersion, List[Manifest]] = {
     ManifestVersion.v2023_03_03: MANIFESTS_v2022_03_03,
 }
-
 
 INPUT_ASSET_MANIFESTS_V2023_03_03: List[Manifest] = [
     Manifest(
@@ -177,7 +177,6 @@ INPUT_ASSET_MANIFESTS_V2023_03_03: List[Manifest] = [
         b'"totalSize":5}',
     ),
 ]
-
 
 MANIFEST_VERSION_TO_INPUT_ASSET_MANIFESTS: dict[ManifestVersion, List[Manifest]] = {
     ManifestVersion.v2023_03_03: INPUT_ASSET_MANIFESTS_V2023_03_03,
@@ -1713,7 +1712,8 @@ class TestFullDownload:
                 _get_asset_root_from_s3("not/existed/test.txt", "test-bucket")
             assert isinstance(err.value.__cause__, ClientError)
             assert (
-                err.value.__cause__.response["ResponseMetadata"]["HTTPStatusCode"] == 404  # type: ignore[attr-defined]
+                err.value.__cause__.response["ResponseMetadata"]["HTTPStatusCode"] == 404
+                # type: ignore[attr-defined]
             )
             assert (
                 "Error checking if object exists in bucket 'test-bucket', Target key or prefix: 'not/existed/test.txt', "
@@ -1764,7 +1764,8 @@ class TestFullDownload:
                 get_manifest_from_s3("test-key", "test-bucket")
             assert isinstance(exc.value.__cause__, ClientError)
             assert (
-                exc.value.__cause__.response["ResponseMetadata"]["HTTPStatusCode"] == 403  # type: ignore[attr-defined]
+                exc.value.__cause__.response["ResponseMetadata"]["HTTPStatusCode"] == 403
+                # type: ignore[attr-defined]
             )
             assert (
                 "Error downloading binary file in bucket 'test-bucket', Target key or prefix: 'test-key', "
@@ -1818,7 +1819,8 @@ class TestFullDownload:
                 )
             assert isinstance(exc.value.__cause__, ClientError)
             assert (
-                exc.value.__cause__.response["ResponseMetadata"]["HTTPStatusCode"] == 403  # type: ignore[attr-defined]
+                exc.value.__cause__.response["ResponseMetadata"]["HTTPStatusCode"] == 403
+                # type: ignore[attr-defined]
             )
             assert (
                 "Error listing bucket contents in bucket 'test-bucket', Target key or prefix: 'assetRoot', "
@@ -1865,6 +1867,9 @@ class TestFullDownload:
             http_status_code=403,
         )
 
+        mock_lock = MagicMock()
+        mock_collision_dict = MagicMock()
+
         file_path = ManifestPathv2023_03_03(
             path="inputs/input1.txt", hash="input1", size=1, mtime=1234000000
         )
@@ -1877,13 +1882,16 @@ class TestFullDownload:
                     file_path,
                     HashAlgorithm.XXH128,
                     "/home/username/assets",
+                    mock_lock,
+                    mock_collision_dict,
                     "test-bucket",
                     "rootPrefix/Data",
                     s3_client,
                 )
             assert isinstance(exc.value.__cause__, ClientError)
             assert (
-                exc.value.__cause__.response["ResponseMetadata"]["HTTPStatusCode"] == 403  # type: ignore[attr-defined]
+                exc.value.__cause__.response["ResponseMetadata"]["HTTPStatusCode"] == 403
+                # type: ignore[attr-defined]
             )
             assert (
                 "Error downloading file in bucket 'test-bucket', Target key or prefix: 'rootPrefix/Data/input1.xxh128', "
@@ -1891,6 +1899,8 @@ class TestFullDownload:
             ) in str(exc.value)
             failed_file_path = Path("/home/username/assets/inputs/input1.txt")
             assert (f"(Failed to download the file to {str(failed_file_path)})") in str(exc.value)
+            mock_lock.assert_not_called()
+            mock_collision_dict.assert_not_called()
 
     def test_download_file_error_message_on_timeout(self):
         """
@@ -1902,6 +1912,8 @@ class TestFullDownload:
         mock_transfer_manager = MagicMock()
         mock_transfer_manager.download.return_value = mock_future
         mock_future.result.side_effect = ReadTimeoutError(endpoint_url="test_url")
+        mock_lock = MagicMock()
+        mock_collision_dict = MagicMock()
 
         file_path = ManifestPathv2023_03_03(
             path="inputs/input1.txt", hash="input1", size=1, mtime=1234000000
@@ -1919,6 +1931,8 @@ class TestFullDownload:
                     file_path,
                     HashAlgorithm.XXH128,
                     "/home/username/assets",
+                    mock_lock,
+                    mock_collision_dict,
                     "test-bucket",
                     "rootPrefix/Data",
                     mock_s3_client,
@@ -1931,6 +1945,8 @@ class TestFullDownload:
                 "Please verify your credentials and network connection. If the problem persists, try again later"
                 " or contact support for further assistance."
             ) in str(exc.value)
+            mock_lock.assert_not_called()
+            mock_collision_dict.assert_not_called()
 
     @pytest.mark.skipif(
         sys.platform == "win32",
@@ -1942,6 +1958,8 @@ class TestFullDownload:
         mock_transfer_manager = MagicMock()
         mock_transfer_manager.download.return_value = mock_future
         mock_future.result.side_effect = Exception("Test exception")
+        mock_lock = MagicMock()
+        mock_collision_dict = MagicMock()
 
         file_path = ManifestPathv2023_03_03(
             path="very/long/input/to/test/windows/max/file/path/for/error/handling/when/downloading/assest/from/job/attachment.txt",
@@ -1964,6 +1982,8 @@ class TestFullDownload:
                     file_path,
                     HashAlgorithm.XXH128,
                     local_path,
+                    mock_lock,
+                    mock_collision_dict,
                     "test-bucket",
                     "rootPrefix/Data",
                     mock_s3_client,
@@ -1971,6 +1991,8 @@ class TestFullDownload:
 
         expected_message = "Test exception"
         assert str(exc.value) == expected_message
+        mock_lock.assert_not_called()
+        mock_collision_dict.assert_not_called()
 
     @pytest.mark.skipif(
         sys.platform != "win32",
@@ -1982,6 +2004,8 @@ class TestFullDownload:
         mock_transfer_manager = MagicMock()
         mock_transfer_manager.download.return_value = mock_future
         mock_future.result.side_effect = Exception("Test exception")
+        mock_lock = MagicMock()
+        mock_collision_dict = MagicMock()
 
         file_path = ManifestPathv2023_03_03(
             path="very/long/input/to/test/windows/max/file/path/for/error/handling/when/downloading/assest/from/job/attachment.txt",
@@ -2004,12 +2028,16 @@ class TestFullDownload:
                     file_path,
                     HashAlgorithm.XXH128,
                     local_path,
+                    mock_lock,
+                    mock_collision_dict,
                     "test-bucket",
                     "rootPrefix/Data",
                     mock_s3_client,
                 )
         expected_message = "Test exception"
         assert str(exc.value) == expected_message
+        mock_lock.assert_not_called()
+        mock_collision_dict.assert_not_called()
 
     @pytest.mark.skipif(
         sys.platform != "win32",
@@ -2021,6 +2049,8 @@ class TestFullDownload:
         mock_transfer_manager = MagicMock()
         mock_transfer_manager.download.return_value = mock_future
         mock_future.result.side_effect = Exception("Test exception")
+        mock_lock = MagicMock()
+        mock_collision_dict = MagicMock()
 
         file_path = ManifestPathv2023_03_03(
             path="very/long/input/to/test/windows/max/file/path/for/error/handling/when/downloading/assest/from/job/attachment.txt",
@@ -2046,12 +2076,16 @@ class TestFullDownload:
                     file_path,
                     HashAlgorithm.XXH128,
                     local_path,
+                    mock_lock,
+                    mock_collision_dict,
                     "test-bucket",
                     "rootPrefix/Data",
                     mock_s3_client,
                 )
         expected_message = "Test exception"
         assert str(exc.value) == expected_message
+        mock_lock.assert_not_called()
+        mock_collision_dict.assert_not_called()
 
     @pytest.mark.skipif(
         sys.platform != "win32",
@@ -2063,6 +2097,8 @@ class TestFullDownload:
         mock_transfer_manager = MagicMock()
         mock_transfer_manager.download.return_value = mock_future
         mock_future.result.side_effect = Exception("Test exception")
+        mock_lock = MagicMock()
+        mock_collision_dict = MagicMock()
 
         file_path = ManifestPathv2023_03_03(
             path="very/long/input/to/test/windows/max/file/path/for/error/handling/when/downloading/assest/from/job/attachment.txt",
@@ -2088,6 +2124,8 @@ class TestFullDownload:
                     file_path,
                     HashAlgorithm.XXH128,
                     local_path,
+                    mock_lock,
+                    mock_collision_dict,
                     "test-bucket",
                     "rootPrefix/Data",
                     mock_s3_client,
@@ -2095,6 +2133,8 @@ class TestFullDownload:
 
         expected_message = "Test exception"
         assert str(exc.value) == expected_message
+        mock_lock.assert_not_called()
+        mock_collision_dict.assert_not_called()
 
 
 @pytest.mark.parametrize("manifest_version", [ManifestVersion.v2023_03_03])
@@ -2532,3 +2572,54 @@ def test_mount_vfs_from_manifests(
         mock_vfs_start.assert_has_calls(
             [call(session_dir=temp_dir_path), call(session_dir=temp_dir_path)]
         )
+
+
+def test_get_new_copy_file_path_file_collisions(tmp_path: Path) -> None:
+    """Tests that copying files append the correct number"""
+    existing_files = [
+        tmp_path / "test_col.txt",
+        tmp_path / "test_col (1).txt",
+        tmp_path / "test_col (2).txt",
+        tmp_path / "test_col (3).txt",
+        tmp_path / "test_skip.txt",
+        tmp_path / "test_skip (1).txt",
+        tmp_path / "test_skip (2).txt",
+        tmp_path / "test_skip (4).txt",
+        tmp_path / "test_original.txt",
+        tmp_path / "test_overlapping_path_but_original.txt",
+        tmp_path / "test_overlapping_path_but_original (1).txt",
+    ]
+    for path in existing_files:
+        with open(str(path), "w") as f:
+            f.write("I am a pre-existing file, not downloaded by Job Attachment.")
+
+    assert set(existing_files) == set([path for path in tmp_path.glob("**/*") if path.is_file()])
+
+    expected_files = [
+        tmp_path / "test_col (4).txt",
+        tmp_path / "test_skip (3).txt",
+        tmp_path / "test_original (1).txt",
+        tmp_path / "test_overlapping_path_but_original (2).txt",
+        tmp_path / "test_overlapping_path_but_original (1) (1).txt",
+    ]
+
+    input_paths = [
+        tmp_path / "test_col.txt",
+        tmp_path / "test_skip.txt",
+        tmp_path / "test_original.txt",
+        tmp_path / "test_overlapping_path_but_original.txt",
+        tmp_path / "test_overlapping_path_but_original (1).txt",
+    ]
+
+    test_lock = Lock()
+    test_dict: DefaultDict[str, int] = DefaultDict(int)
+    results = []
+    for input_path in input_paths:
+        results.append(_get_new_copy_file_path(input_path, test_lock, test_dict))
+
+    assert set(expected_files) == set(results)
+    assert test_dict[str(tmp_path / "test_col.txt")] == 4
+    assert test_dict[str(tmp_path / "test_skip.txt")] == 3
+    assert test_dict[str(tmp_path / "test_original.txt")] == 1
+    assert test_dict[str(tmp_path / "test_overlapping_path_but_original.txt")] == 2
+    assert test_dict[str(tmp_path / "test_overlapping_path_but_original (1).txt")] == 1


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud/issues/514

### What was the problem/requirement? (What/Why)
Currently, if you download your output on top of an existing download and use the CREATE_COPY option (i.e. you get colliding files), [it appends " (1)" to the file name](https://github.com/aws-deadline/deadline-cloud/blob/b02b0387fd32701bcf72bc882e78de77b6ad7423/src/deadline/job_attachments/download.py#L423), over and over.

So if you download repeatedly, you could have a file like "output (1) (1) (1) (1) (1).png" which makes file names unnecessarily long.

### What was the solution? (How)
We increment a number to the file name for any collisions when using the CREATE_COPY option when downloading outputs. That is, if we have a file named "output.png", downloading it multiple times would create new files called "output (1).png", "output (2).png", etc. 

If a file is original named input (1).png and there is another file input.png that is being download a second time with CREATE_COPY option, it will be downloaded as input (2).png. The second copy of input (1).png will be downloaded as input (1) (1).png

### What is the impact of this change?
Better experience with downloading files with CREATE_COPY for customers

### How was this change tested?
Wrote unit tests to validate the logic works as expected. Also ran the download logic manually & verified files are created with the correct appended copy number, by using the download cli command:

```
deadline job download-output --job-id job-xxx --farm-id farm-xxx --queue-id queue-xxx --conflict-resolution CREATE_COPY
```

- Have you run the unit tests? yes
- Have you run the integration tests? yes
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass. N/A

### Was this change documented?
N/A

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?
No

### Does this change impact security?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
