### PR TITLE
fix: using operating system dependent path conversion to create file name hash

### DIFF
--- a/src/deadline/job_attachments/asset_sync.py
+++ b/src/deadline/job_attachments/asset_sync.py
@@ -356,9 +356,9 @@ class AssetSync:
         manifest_paths_by_root: dict[str, str] = dict()
 
         for root, manifest in merged_manifests_by_root.items():
-            (_, _, manifest_name) = S3AssetUploader._gather_upload_metadata(
+            (_, manifest_name) = S3AssetUploader._get_hashed_file_name_from_root_str(
                 manifest=manifest,
-                source_root=Path(self._local_root_to_src_map[root]),
+                source_root=self._local_root_to_src_map[root],
                 manifest_name_suffix=manifest_name_suffix,
             )
 

--- a/src/deadline/job_attachments/upload.py
+++ b/src/deadline/job_attachments/upload.py
@@ -233,6 +233,7 @@ class S3AssetUploader:
         """
         hash_alg = manifest.get_default_hash_alg()
         manifest_bytes = manifest.encode().encode("utf-8")
+        # Converting Path to str uses OS-specific separators (\ vs /), which can produce different hashes across OS
         manifest_name_prefix = hash_data(str(source_root).encode(), hash_alg)
         manifest_name = f"{manifest_name_prefix}_{manifest_name_suffix}"
 
@@ -253,6 +254,21 @@ class S3AssetUploader:
         self._write_local_input_manifest(manifest_write_dir, manifest_name, manifest, root_dir_name)
 
         self._write_local_manifest_s3_mapping(manifest_write_dir, manifest_name, full_manifest_key)
+
+    @staticmethod
+    def _get_hashed_file_name_from_root_str(
+        manifest: BaseAssetManifest,
+        source_root: str,
+        manifest_name_suffix: str,
+    ) -> tuple[HashAlgorithm, str]:
+        """
+        Gathers metadata information of manifest to be used for writing the local manifest
+        """
+        hash_alg = manifest.get_default_hash_alg()
+        manifest_name_prefix = hash_data(source_root.encode(), hash_alg)
+        manifest_name = f"{manifest_name_prefix}_{manifest_name_suffix}"
+
+        return (hash_alg, manifest_name)
 
     @staticmethod
     def _write_local_input_manifest(

--- a/test/unit/deadline_job_attachments/test_upload.py
+++ b/test/unit/deadline_job_attachments/test_upload.py
@@ -2642,6 +2642,26 @@ class TestUpload:
         assert hash_alg == HashAlgorithm.XXH128
         assert manifest_name == "73addc7c69ddec53bd8d9df653add3c4_suffix"
 
+    def test_get_hashed_file_name_from_root_str(self):
+        # Given
+        manifest = AssetManifest(
+            hash_alg=HashAlgorithm("xxh128"),
+            total_size=10,
+            paths=[
+                BaseManifestPath(path="output_file", hash="a", size=1, mtime=167907934333848),
+                BaseManifestPath(
+                    path="output/nested_output_file", hash="b", size=1, mtime=1479079344833848
+                ),
+            ],
+        )
+        # When
+        (hash_alg, manifest_name) = S3AssetUploader._get_hashed_file_name_from_root_str(
+            manifest, "C:\\Program Files\\My App\\data.txt", "suffix"
+        )
+        # Then
+        assert hash_alg == HashAlgorithm.XXH128
+        assert manifest_name == "da20652d1ff9f1dc55050b28b3ab6d36_suffix"
+
 
 def assert_progress_report_last_callback(
     num_input_files: int,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Converting Path to str uses OS-specific separators (\ vs /) can produce different hashes across OS. This is a problem when a job is submitted and run on different operating systems with the `attachment upload` and `attachment download` commands.

For example, a job is submitted using linux and run on windows generate different str encoding for the give path.

```
>>> from pathlib import Path
>>> path_str = "/private/var/folders/qz/djsmwst123b1b0gv040qvv900000gq/T/pytest-of/pytest-40/test_worker_uses_step_step_dep0/job_attachment_bundle_step_step_dependencies"
>>> path_path = Path("/private/var/folders/qz/djsmwst123b1b0gv040qvv900000gq/T/pytest-of/pytest-40/test_worker_uses_step_step_dep0/job_attachment_bundle_step_step_dependencies")
>>> path_str.encode()
b'/private/var/folders/qz/djsmwst123b1b0gv040qvv900000gq/T/pytest-of/pytest-40/test_worker_uses_step_step_dep0/job_attachment_bundle_step_step_dependencies'
>>> str(path_path).encode()
b'\\private\\var\\folders\\qz\\djsmwst123b1b0gv040qvv900000gq\\T\\pytest-of\\pytest-40\\test_worker_uses_step_step_dep0\\job_attachment_bundle_step_step_dependencies'
```

The hash for source root was used for comparison in to correlate path and manifest file in attachment commands. The inconsistent hash leads to no path find and default to working directory.

### What was the solution? (How)
Use the string path directly passed in.

### What is the impact of this change?
Fix a bug for the caller where Path were passed in that's not matching the current operating system that lead to unexpected behaviour.

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests? [Yes]
- Have you run the integration tests? [N/A]
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended that you ensure that the docker-based unit tests pass. [Yes]
- Ran E2E tests for cross-OS use case, i.e. submit job from Linux and run on Windows via `hatch run pytest -- test/e2e/test_job_submissions.py`
```
============================= slowest 5 durations ==============================
390.88s setup    test/e2e/test_job_submissions.py::TestJobSubmission::test_success
378.04s setup    test/e2e/test_job_submissions.py::TestJobSubmission::test_worker_enters_stopping_state_while_draining
121.04s call     test/e2e/test_job_submissions.py::TestJobSubmission::test_worker_uses_step_step_dependencies
114.68s call     test/e2e/test_job_submissions.py::TestJobSubmission::test_worker_fails_job_attachment_sync_when_file_does_not_exist_in_bucket
114.67s call     test/e2e/test_job_submissions.py::TestJobSubmission::test_worker_reports_canceled_session_actions_as_canceled[envEnter]
============ 22 passed, 5 skipped, 1 warning in 2010.04s (0:33:30) =============
```



### Was this change documented?

- Are relevant docstrings in the code base updated? [N/A]
- Has the README.md been updated? If you modified CLI arguments, for instance. [N/A]

### Does this PR introduce new dependencies?

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?
No

### Does this change impact security?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
