### PR TITLE
fix: Deadline Cloud Job Attachments CLI did not expose file override modes to allow users to customize how files are downloaded.

### DIFF
--- a/src/deadline/client/cli/_groups/attachment_group.py
+++ b/src/deadline/client/cli/_groups/attachment_group.py
@@ -21,7 +21,7 @@ from deadline.client import api
 from deadline.job_attachments import api as attachment_api
 from deadline.job_attachments._aws.deadline import get_queue
 from deadline.job_attachments.exceptions import MissingJobAttachmentSettingsError
-from deadline.job_attachments.models import JobAttachmentS3Settings
+from deadline.job_attachments.models import FileConflictResolution, JobAttachmentS3Settings
 
 
 @click.group(name="attachment")
@@ -51,6 +51,21 @@ def cli_attachment():
 @click.option("--queue-id", help="The AWS Deadline Cloud Queue to use. ")
 @click.option(
     "--profile", help="The AWS profile to use for interacting with Job Attachments S3 bucket."
+)
+@click.option(
+    "--conflict-resolution",
+    type=click.Choice(
+        [
+            FileConflictResolution.SKIP.name,
+            FileConflictResolution.OVERWRITE.name,
+            FileConflictResolution.CREATE_COPY.name,
+        ],
+        case_sensitive=False,
+    ),
+    help="How to handle downloads if a file already exists:\n"
+    "CREATE_COPY (default): Download the file with a new name, appending '(X)' to the end. X is incremented for each duplicate\n"
+    "SKIP: Do not download the file\n"
+    "OVERWRITE: Download and replace the existing file",
 )
 @click.option("--json", default=None, is_flag=True, help="Output is printed as JSON for scripting.")
 @_handle_error
@@ -94,12 +109,24 @@ def attachment_download(
     if not s3_root_uri:
         raise MissingJobAttachmentSettingsError("No valid s3 root path available")
 
+    # Apply conflict resolution setting from Config.
+    conflict_resolution = FileConflictResolution.CREATE_COPY
+    conflict_resolution_setting = config_file.get_setting(
+        "settings.conflict_resolution", config=config
+    )
+    if (
+        conflict_resolution_setting
+        and conflict_resolution_setting != FileConflictResolution.NOT_SELECTED.name
+    ):
+        conflict_resolution = FileConflictResolution[conflict_resolution_setting]
+
     attachment_api.attachment_download(
         manifests=manifests,
         s3_root_uri=s3_root_uri,
         boto3_session=boto3_session,
         path_mapping_rules=path_mapping_rules,
         logger=logger,
+        conflict_resolution=conflict_resolution,
     )
 
 

--- a/src/deadline/job_attachments/api/attachment.py
+++ b/src/deadline/job_attachments/api/attachment.py
@@ -11,7 +11,11 @@ from dataclasses import asdict
 from deadline.job_attachments.api._utils import _read_manifests
 from deadline.job_attachments.asset_manifests.base_manifest import BaseAssetManifest
 from deadline.job_attachments.download import download_files_from_manifests
-from deadline.job_attachments.models import JobAttachmentS3Settings, PathMappingRule
+from deadline.job_attachments.models import (
+    FileConflictResolution,
+    JobAttachmentS3Settings,
+    PathMappingRule,
+)
 from deadline.job_attachments.progress_tracker import DownloadSummaryStatistics
 from deadline.job_attachments.upload import S3AssetUploader
 from deadline.client.cli._groups.click_logger import ClickLogger
@@ -25,6 +29,7 @@ def attachment_download(
     boto3_session: boto3.Session,
     path_mapping_rules: Optional[str] = None,
     logger: ClickLogger = ClickLogger(False),
+    conflict_resolution: FileConflictResolution = FileConflictResolution.CREATE_COPY,
 ):
     """
     BETA API - This API is still evolving.
@@ -79,6 +84,7 @@ def attachment_download(
         manifests_by_root=merged_manifests_by_root,
         cas_prefix=s3_settings.full_cas_prefix(),
         session=boto3_session,
+        conflict_resolution=conflict_resolution,
     )
     logger.echo(download_summary)
     logger.json(asdict(download_summary.convert_to_summary_statistics()))

--- a/src/deadline/job_attachments/download.py
+++ b/src/deadline/job_attachments/download.py
@@ -774,6 +774,7 @@ def download_files_from_manifests(
     session: Optional[boto3.Session] = None,
     on_downloading_files: Optional[Callable[[ProgressReportMetadata], bool]] = None,
     logger: Optional[Union[Logger, LoggerAdapter]] = None,
+    conflict_resolution: FileConflictResolution = FileConflictResolution.CREATE_COPY,
 ) -> DownloadSummaryStatistics:
     """
     Given manifests, downloads all files from a CAS in each manifest.
@@ -822,6 +823,7 @@ def download_files_from_manifests(
             session,
             file_mod_time,
             progress_tracker=progress_tracker,
+            file_conflict_resolution=conflict_resolution,
         )
 
         if fs_permission_settings is not None:

--- a/test/integ/cli/test_cli_attachment.py
+++ b/test/integ/cli/test_cli_attachment.py
@@ -6,6 +6,7 @@ Integ tests for the CLI attachment commands.
 
 import os
 import json
+from typing import Tuple
 from click.testing import CliRunner
 from dataclasses import asdict
 
@@ -148,7 +149,9 @@ class TestAttachment:
 
     @pytest.mark.integ
     @pytest.mark.parametrize("manifest_case_key", MOCK_MANIFEST_CASE.keys())
-    def test_attachment_basic_flow(self, temp_dir, job_attachment_resources, manifest_case_key):
+    def test_attachment_basic_flow(
+        self, temp_dir, job_attachment_resources, manifest_case_key
+    ) -> Tuple[str, str, str]:
         # Given
         file_name: str = f"{hash_data(temp_dir.encode('utf-8'), HashAlgorithm.XXH128)}_output"
         manifest_path: str = os.path.join(temp_dir, file_name)
@@ -208,6 +211,8 @@ class TestAttachment:
         )
         asset_files = os.listdir(os.path.join(os.getcwd(), file_name, "files"))
         assert len(asset_files) == 1
+
+        return file_name, manifest_path, s3_root_uri
 
     @pytest.mark.integ
     @pytest.mark.parametrize("manifest_case_key", MOCK_MANIFEST_CASE.keys())
@@ -294,3 +299,58 @@ class TestAttachment:
         assert len(asset_files) == 3, (
             f"Expecting 3 asset files, 2 from upload and 1 from download, but got {len(asset_files)}."
         )
+
+    @pytest.mark.integ
+    @pytest.mark.parametrize(
+        "override_mode,expected_num_files, expected_files",
+        [
+            pytest.param("CREATE_COPY", 2, ["file1.txt", "file1 (1).txt"]),
+            pytest.param("SKIP", 1, ["file1.txt"]),
+            pytest.param("OVERWRITE", 1, ["file1.txt"]),
+        ],
+    )
+    def test_attachment_file_override(
+        self, temp_dir, job_attachment_resources, override_mode, expected_num_files, expected_files
+    ):
+        test_case_key = "TEST_CASE_1"
+        file_name, manifest_path, s3_root_uri = self.test_attachment_basic_flow(
+            temp_dir=temp_dir,
+            job_attachment_resources=job_attachment_resources,
+            manifest_case_key=test_case_key,
+        )
+
+        # When 2 - test download again with file override mode.
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "attachment",
+                "download",
+                "--manifests",
+                manifest_path,
+                "--profile",
+                "default",
+                "--s3-root-uri",
+                s3_root_uri,
+                "--conflict-resolution",
+                override_mode,
+                "--json",
+            ],
+        )
+        # Then
+        assert result.exit_code == 0, f"Non-Zeo exit code, CLI output {result.output}"
+
+        # How many bytes downloaded.
+        expected_processed_bytes = (
+            0 if override_mode == "SKIP" else len(MOCK_FILE_CASE[test_case_key])
+        )
+        assert json.loads(result.output)["processed_bytes"] == expected_processed_bytes
+        assert file_name in os.listdir(os.getcwd()), (
+            "Expecting downloaded folder named with data hash created in the working directory with downloaded files but not."
+        )
+        asset_files = os.listdir(os.path.join(os.getcwd(), file_name, "files"))
+        assert len(asset_files) == expected_num_files
+
+        # Make sure the files are named correctly and what we expected to download.
+        for file in expected_files:
+            assert file in asset_files

--- a/test/unit/deadline_job_attachments/api/test_attachment.py
+++ b/test/unit/deadline_job_attachments/api/test_attachment.py
@@ -25,7 +25,11 @@ from deadline.job_attachments.asset_manifests.decode import decode_manifest
 from deadline.job_attachments.asset_manifests.base_manifest import BaseAssetManifest
 from deadline.job_attachments.api.attachment import _process_path_mapping
 from deadline.job_attachments.upload import S3AssetUploader
-from deadline.job_attachments.models import JobAttachmentS3Settings, PathMappingRule
+from deadline.job_attachments.models import (
+    FileConflictResolution,
+    JobAttachmentS3Settings,
+    PathMappingRule,
+)
 
 PATH_MAPPING = {
     "source_path_format": "posix",
@@ -137,8 +141,17 @@ class TestAttachmentDownload:
                 path_mapping_rules=mapping_file_path,
             )
 
-    def test_download_single_to_mapped(
-        self, temp_assets_dir, session_mock, mock_download_files_from_manifests
+    @pytest.mark.parametrize(
+        "conflict_resolution",
+        [
+            FileConflictResolution.CREATE_COPY,
+            FileConflictResolution.OVERWRITE,
+            FileConflictResolution.SKIP,
+            None,
+        ],
+    )
+    def test_download_conflict_resolution(
+        self, temp_assets_dir, session_mock, mock_download_files_from_manifests, conflict_resolution
     ):
         with open(
             os.path.join(temp_assets_dir, PATH_MAPPING_HASH),
@@ -151,12 +164,21 @@ class TestAttachmentDownload:
         with open(mapping_file_path, "w", encoding="utf8") as f:
             json.dump([PATH_MAPPING], f)
 
-        attachment_api.attachment_download(
-            manifests=[os.path.join(temp_assets_dir, PATH_MAPPING_HASH)],
-            s3_root_uri="s3://bucket/assetRoot",
-            boto3_session=session_mock,
-            path_mapping_rules=mapping_file_path,
-        )
+        if conflict_resolution:
+            attachment_api.attachment_download(
+                manifests=[os.path.join(temp_assets_dir, PATH_MAPPING_HASH)],
+                s3_root_uri="s3://bucket/assetRoot",
+                boto3_session=session_mock,
+                path_mapping_rules=mapping_file_path,
+                conflict_resolution=conflict_resolution,
+            )
+        else:
+            attachment_api.attachment_download(
+                manifests=[os.path.join(temp_assets_dir, PATH_MAPPING_HASH)],
+                s3_root_uri="s3://bucket/assetRoot",
+                boto3_session=session_mock,
+                path_mapping_rules=mapping_file_path,
+            )
 
         mock_download_files_from_manifests.assert_called_once_with(
             s3_bucket="bucket",
@@ -167,6 +189,9 @@ class TestAttachmentDownload:
             },
             cas_prefix="assetRoot/Data",
             session=session_mock,
+            conflict_resolution=conflict_resolution
+            if conflict_resolution
+            else FileConflictResolution.CREATE_COPY,
         )
 
     @pytest.mark.parametrize("manifest_case_key", MOCK_MANIFEST_CASE.keys())
@@ -195,6 +220,7 @@ class TestAttachmentDownload:
             },
             cas_prefix="assetRoot/Data",
             session=session_mock,
+            conflict_resolution=FileConflictResolution.CREATE_COPY,
         )
 
     def test_download_multiple_to_current(
@@ -224,6 +250,7 @@ class TestAttachmentDownload:
             manifests_by_root=expected_merged,
             cas_prefix="assetRoot/Data",
             session=session_mock,
+            conflict_resolution=FileConflictResolution.CREATE_COPY,
         )
 
     def test_download_invalid_input_manifests(self, session_mock):


### PR DESCRIPTION
Fixes: Deadline Cloud Job Attachments CLI did not expose file override modes that allow users to customize how files are downloaded.

### What was the problem/requirement? (What/Why)
- `deadline cloud` CLI supports Attachment download CLIs (beta). For attachment downloads, we also support file collision handling. Either skip, override, or download to a new name. This was not supported in `attachment download`, and only worked in `job download`.

### What was the solution? (How)
- Connect the missing argument, and also make it available in the API. Default is to CREATE_COPY to a new name.

- Updated CLI text:
```
Usage: deadline attachment download [OPTIONS]

  BETA - Download Job Attachment data files for given manifest(s).

Options:
  -m, --manifests TEXT            File path(s) to manifest formatted file(s).
                                  File name has to contain the hash of
                                  corresponding source path.  [required]
  --s3-root-uri TEXT              Job Attachments S3 root uri including bucket
                                  name and root prefix.
  --path-mapping-rules TEXT       Path to a file with the path mapping rules
                                  to use.
  --farm-id TEXT                  The AWS Deadline Cloud Farm to use.
  --queue-id TEXT                 The AWS Deadline Cloud Queue to use.
  --profile TEXT                  The AWS profile to use for interacting with
                                  Job Attachments S3 bucket.
  --conflict-resolution [SKIP|OVERWRITE|CREATE_COPY]
                                  How to handle downloads if a file already
                                  exists: CREATE_COPY (default): Download the
                                  file with a new name, appending '(X)' to the
                                  end. X is incremented for each duplicate
                                  SKIP: Do not download the file OVERWRITE:
                                  Download and replace the existing file
  --json                          Output is printed as JSON for scripting.
  -h, --help                      Show this message and exit.
```
### What is the impact of this change?
- Bridge the feature gap between `job download` and `attachment download`!

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests?
Yes, hatch run test 100% passes

- Have you run the integration tests?

Yes 
```
================================================================== warnings summary ==================================================================
test/integ/cli/test_cli_attachment.py:92
  /Users/leongdl/work/deadline-cloud/test/integ/cli/test_cli_attachment.py:92: PytestUnknownMarkWarning: Unknown pytest.mark.cross_account - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.cross_account

test/integ/deadline_job_attachments/test_job_attachments.py:1289
  /Users/leongdl/work/deadline-cloud/test/integ/deadline_job_attachments/test_job_attachments.py:1289: PytestUnknownMarkWarning: Unknown pytest.mark.cross_account - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.cross_account

test/integ/deadline_job_attachments/test_job_attachments.py:1339
  /Users/leongdl/work/deadline-cloud/test/integ/deadline_job_attachments/test_job_attachments.py:1339: PytestUnknownMarkWarning: Unknown pytest.mark.cross_account - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.cross_account

test/integ/deadline_job_attachments/test_job_attachments.py:1388
  /Users/leongdl/work/deadline-cloud/test/integ/deadline_job_attachments/test_job_attachments.py:1388: PytestUnknownMarkWarning: Unknown pytest.mark.cross_account - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.cross_account

test/integ/deadline_job_attachments/test_job_attachments.py:1472
  /Users/leongdl/work/deadline-cloud/test/integ/deadline_job_attachments/test_job_attachments.py:1472: PytestUnknownMarkWarning: Unknown pytest.mark.cross_account - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.cross_account

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================ slowest 5 durations =================================================================
16.81s call     test/integ/cli/test_cli_manifest_download.py::TestManifestDownload::test_manifest_download_job_asset_type_with_no_step_dependency[input-True]
13.46s call     test/integ/cli/test_cli_manifest_download.py::TestManifestDownload::test_manifest_download_job_asset_type_with_no_step_dependency[all-True]
10.86s call     test/integ/cli/test_cli_manifest_download.py::TestManifestDownload::test_manifest_download_asset_type_with_job_step_dependency[None-True]
10.76s call     test/integ/cli/test_cli_manifest_download.py::TestManifestDownload::test_manifest_download_asset_type_with_job_step_dependency[all-True]
10.72s call     test/integ/cli/test_cli_manifest_download.py::TestManifestDownload::test_manifest_download_asset_type_with_job_step_dependency[all-False]
=============================================== 49 passed, 4 skipped, 5 warnings in 274.21s (0:04:34) ================================================
```
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass.

### Was this change documented?

- Are relevant docstrings in the code base updated?
CLI Argument is updated.

- Has the README.md been updated? If you modified CLI arguments, for instance.
NA

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [X] This PR does not add any new dependencies.

### Is this a breaking change?
No

### Does this change impact security?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
