### PR TITLE
chore: Added project name parameter to shared build installer workflow

### DIFF
--- a/.github/workflows/build_installer.yml
+++ b/.github/workflows/build_installer.yml
@@ -40,3 +40,4 @@ jobs:
       ref_type: ${{inputs.ref_type}}
       ref: ${{inputs.ref}}
       oses: "['${{inputs.os}}']"
+      project_name: "deadline-cloud"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The updated shared installer building workflow will have a `project_name` input that needs to be added here.

### What was the solution? (How)

Add it

### What is the impact of this change?

We will be able to use the shared workflow once it goes in.

### How was this change tested?

Ran the workflow

### Was this change documented?

No

### Does this PR introduce new dependencies?

No

### Is this a breaking change?

No

### Does this change impact security?

No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
