### PR TITLE
fix: Removed exit code checks in integ test powershell script

### DIFF
--- a/pipeline/integ.ps1
+++ b/pipeline/integ.ps1
@@ -1,8 +1,7 @@
 $ErrorActionPreference = "Stop"
 
 pip install --upgrade pip
-if ($LASTEXITCODE -ne 0) { throw "Failed to update pip" }
 pip install --upgrade hatch
-if ($LASTEXITCODE -ne 0) { throw "Failed to update hatch" }
 hatch run integ:test
 if ($LASTEXITCODE -ne 0) { throw "Failed to run integration tests" }
+


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

In a previous PR I added exit code checks to all of our pipeline powershell scripts. For the integration test script specifically, these checks are failing.

Original change for reference: https://github.com/aws-deadline/deadline-cloud/pull/629/files#diff-b9272c9f65a2ab9ace0db767ffa55761e6e8757a18ffc47e6d340d2e0e25da78

### What was the solution? (How)

As a quick triage action to get the integration tests working again, I have just moved the exit code checks.

### What is the impact of this change?

Get the windows integ tests running again

### How was this change tested?

N/A

### Was this change documented?

No

### Does this PR introduce new dependencies?

No

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
