### PR TITLE
fix: Remove OpenJD reference from timeout warning message.

### DIFF
--- a/src/deadline/client/ui/widgets/job_timeouts_widget.py
+++ b/src/deadline/client/ui/widgets/job_timeouts_widget.py
@@ -291,8 +291,7 @@ class TimeoutTableWidget(QGroupBox):
         """
         any_deactivated = any(not row.checkbox.isChecked() for row in self.timeout_rows.values())
         warning_text = (
-            "Warning: Without a specified timeout, tasks may run indefinitely if issues occur, "
-            "or they will use OpenJD's default timeouts if they exist."
+            "Warning: Without a specified timeout, tasks may run indefinitely if issues occur."
             if any_deactivated
             else ""
         )


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The warning labels when timeouts are deactivated are long and customers may not have context on what OpenJD is.  

### What was the solution? (How)

Update the warning message to remove mentions of OpenJD. 

### What is the impact of this change?

Less confusion for customers that use submitter and don't know what OpenJD even is. 

### How was this change tested?

Made the modifications and checked in the UI. 

![Screenshot 2025-03-26 at 3 19 04 PM](https://github.com/user-attachments/assets/06832fac-0434-43c7-b10b-ee07094be83c)

### Was this change documented?
Yes

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [X] This PR does not add any new dependencies.

### Is this a breaking change?

No

### Does this change impact security?

- Does the change need to be threat modeled? For example, does it create or modify files/directories that must only be readable by the process owner?
    - If so, then please label this pull request with the "security" label. We'll work with you to analyze the threats.


No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
