### PR TITLE
feat!: better cache expiry behavior

### DIFF
--- a/docs/mcp_guide.md
+++ b/docs/mcp_guide.md
@@ -61,6 +61,8 @@ With the AWS Deadline Cloud MCP Server, you can use natural language for various
 - "Submit the render job in /path/to/my-job-bundle"
 - "Submit a job with priority 80 to my render queue"
 - "Show me the status of job job-3a907bac684841f69fc344867ee166de"
+- "Get the logs for session session-abc123 to see why my task failed"
+- "Show me the CloudWatch logs for session session-xyz789"
 - "Download output from job job-3a907bac684841f69fc344867ee166de"
 - "Download output from step step-render in job job-3a907bac684841f69fc344867ee166de"
 ```
@@ -76,7 +78,7 @@ The MCP server provides access to all allowlisted/configured Deadline Cloud API 
 - `deadline_list_storage_profiles_for_queue()`: List storage profiles for a queue
 
 - `deadline_check_authentication_status()`: Check current authentication status
-
+- `deadline_get_session_logs()`: Get CloudWatch logs for a specific session
 - `deadline_submit_job()`: Submit an Open Job Description job bundle to AWS Deadline Cloud
 - `deadline_download_job_output()`: Download job output files from AWS Deadline Cloud
 

--- a/src/deadline/_mcp/registry.py
+++ b/src/deadline/_mcp/registry.py
@@ -59,6 +59,10 @@ TOOL_REGISTRY: Dict[str, ToolDefinition] = {
         "func": api.check_authentication_status,
         "param_names": None,
     },
+    "get_session_logs": {
+        "func": api.get_session_logs,
+        "param_names": ["farm_id", "queue_id", "session_id", "limit", "start_time", "end_time", "next_token"],
+    },
     "submit_job": {
         "func": job.submit_job,
         "param_names": None,

--- a/src/deadline/client/api/_job_monitoring.py
+++ b/src/deadline/client/api/_job_monitoring.py
@@ -4,7 +4,6 @@
 Functions for monitoring job status and retrieving job information.
 """
 
-from __future__ import annotations
 import datetime
 import time
 from typing import List, Dict, Any, Optional, Callable

--- a/test/unit/deadline_mcp/test_mcp.py
+++ b/test/unit/deadline_mcp/test_mcp.py
@@ -39,7 +39,9 @@ class TestToolRegistry:
 
     def test_expected_functions(self):
         """Test that expected functions are in the registry."""
-        expected = ["list_farms", "submit_job", "download_job_output"]
+        expected = [
+            "list_farms", "submit_job", "download_job_output", "get_session_logs"
+        ]
         for func_name in expected:
             assert func_name in TOOL_REGISTRY
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Customers could not expire files in their S3 bucket without running into cache errors, where the local cache would insist a file should exist in the S3 job attachment bucket, and thus not upload to it. The job would then fail in Deadline Cloud, because the file had been deleted from the bucket.

### What was the solution? (How)

This feature does 2 things:

1. Cache expiry can now be set with an environment variable, giving customers full control of how often a file is expected to stick around in S3
2. When a submission finds the file already in S3, it sets `last_seen` to the upload time of the file. Combined with the above change, customers can now use lifecycle policies on their S3 bucket and have this behave as expected.

### What is the impact of this change?

Customers can now set an S3 lifecycle policy without causing their farm jobs to fail.
Customers who have no S3 lifecycle policy will incur more head fetches, as this library will continue to attempt to set a last seen date of the original upload, which might be much longer than 30 days. It will then keep refetching the head.....

### How was this change tested?

![image](https://github.com/user-attachments/assets/4be35a59-392f-49c1-b660-46662633d271)

It was not. The actual functionality of this function did not seem to be tested in unit tests (ಠ_ಠ) and the existing errors were not modified. There are 2 test failures- one because I adjusted the log message to be more specific about upload time, and MagicMock does not like the datetime f string formatting, and another because a dependent function is no longer asserting False (not sure why)

### Was this change documented?

Updated typing. Saw no references in documentation.

### Does this PR introduce new dependencies?

*   [ ] This PR adds one or more new dependency Python packages.
*   [X] This PR does not add any new dependencies.

### Is this a breaking change?

API breaking, as the modified function previously returned True/False and now returns `Optional[datetime]`. If present, datetime will always return `True`, but this will be cold comfort to anyone expecting a real bool. To behave exactly like it used to, the return should be wrapped in a `bool()`

### Does this change impact security?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
