### PR TITLE
fix: fixed how we get the current user in our Linux and Mac permissio…

### DIFF
--- a/test/installer/test_installer.py
+++ b/test/installer/test_installer.py
@@ -3,6 +3,7 @@ import getpass
 import glob
 import os
 import platform
+import pwd
 import re
 import shutil
 import stat
@@ -271,7 +272,7 @@ class TestLinuxAndMacOS:
         # assists mypy type checking to ignore this on Windows
         assert sys.platform != "win32"
         # GIVEN
-        current_user = getpass.getuser()
+        current_user = pwd.getpwuid(os.getuid())[0]  # type: ignore
 
         # WHEN
         bad_perms: DefaultDict[Path, List[str]] = defaultdict(list)


### PR DESCRIPTION
…ns test.

### What was the problem/requirement? (What/Why)
This test wasn't getting the user correctly. 

### What was the solution? (How)
Instead of using `getpass`, we're now using `pwd` and `os`.

### What is the impact of this change?
Should more accurately get the current user. 

### How was this change tested?

Ran the tests through the pipeline.

### Was this change documented?

No

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
