### PR TITLE
test: make installer tests work on Windows containers

### DIFF
--- a/test/installer/test_installer.py
+++ b/test/installer/test_installer.py
@@ -3,7 +3,6 @@ import getpass
 import glob
 import os
 import platform
-import pwd
 import re
 import shutil
 import stat
@@ -271,6 +270,9 @@ class TestLinuxAndMacOS:
     def _validate_posix_permissions(self, installation_path: Path):
         # assists mypy type checking to ignore this on Windows
         assert sys.platform != "win32"
+        # pwd is not available on Windows
+        import pwd
+
         # GIVEN
         current_user = pwd.getpwuid(os.getuid())[0]  # type: ignore
 
@@ -310,6 +312,23 @@ class TestWindows:
         # GIVEN / WHEN / THEN
         self._verify_windows_least_privilege(system_installation)
 
+    def _running_in_container(self) -> bool:
+        """
+        Check to see if the cexecsvc service exists and is running
+        to determine if we're running on a container.
+        """
+        # assists mypy type checking to ignore this on non-Windows
+        assert sys.platform == "win32"
+        import win32service
+        import win32serviceutil
+
+        try:
+            service_status = win32serviceutil.QueryServiceStatus("cexecsvc")
+            return service_status[1] == win32service.SERVICE_RUNNING
+        except win32service.error:
+            # Service doesn't exist, not on a container
+            return False
+
     def _verify_windows_least_privilege(self, installation_path: Path):
         # assists mypy type checking to ignore this on non-Windows
         assert sys.platform == "win32"
@@ -320,7 +339,15 @@ class TestWindows:
 
         # GIVEN
         windows_user = getpass.getuser()
-        builtin_admin_group_sid, _, _ = win32security.LookupAccountName(None, "Administrators")
+
+        if self._running_in_container():
+            # The admin group is different when running
+            # in a container.
+            admin_group = "ContainerAdministrator"
+        else:
+            admin_group = "Administrators"
+
+        builtin_admin_group_sid, _, _ = win32security.LookupAccountName(None, admin_group)
         user_sid, _, _ = win32security.LookupAccountName(None, windows_user)
 
         # WHEN
@@ -336,7 +363,7 @@ class TestWindows:
             if _is_admin():
                 if builtin_admin_group_sid != owner_sid:
                     bad_perms[path].append(
-                        f"Expected to be owned by 'Administrators' but got '{win32security.LookupAccountSid(None, owner_sid)}'"
+                        f"Expected to be owned by '{admin_group}' but got '{win32security.LookupAccountSid(None, owner_sid)}'"
                     )
             elif user_sid != owner_sid:
                 bad_perms[path].append(


### PR DESCRIPTION
Related to https://github.com/aws-deadline/deadline-cloud-for-blender/pull/213

### What was the problem/requirement? (What/Why)
Installer ownership tests were failing on Windows on Containers. We need to copy the changes over to this repo

### What was the solution? (How)
The admin group is `ContainerAdministrator` instead of `Administrators` on Windows containers. So check if the installer artifacts are owned by `ContainerAdministrator` on containers.

### What is the impact of this change?
Windows installer tests pass on CodeBuild

### How was this change tested?
Ran the installer tests locally on Windows. Ran the installers tests on Windows and Linux via CodeBuild

- Have you run the unit tests?
Yep
- Have you run the integration tests?
Yep, they passed.
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass.
No

### Was this change documented?

- Are relevant docstrings in the code base updated?
N/A
- Has the README.md been updated? If you modified CLI arguments, for instance.
N/A

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [X] This PR does not add any new dependencies.

### Is this a breaking change?
No

### Does this change impact security?
No
- Does the change need to be threat modeled? For example, does it create or modify files/directories that must only be readable by the process owner?
    - If so, then please label this pull request with the "security" label. We'll work with you to analyze the threats.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
