### PR TITLE
chore: add macos to build installer workflow

### DIFF
--- a/.github/workflows/build_installer.yml
+++ b/.github/workflows/build_installer.yml
@@ -10,6 +10,7 @@ on:
         options:
         - Linux
         - Windows
+        - MacOS
       ref_type:
         required: true
         type: choice


### PR DESCRIPTION
Enabling MacOS for installer workflow

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
