### PR TITLE
test(installer): find signtool on PATH

### DIFF
--- a/test/installer/test_installer.py
+++ b/test/installer/test_installer.py
@@ -491,7 +491,12 @@ class TestVerifySigning:
             Number of errors: 1
         """
         # GIVEN
-        signtool = next(glob.iglob("C:/Program Files*/Windows Kits/*/bin/*/x64/signtool.exe"), None)
+        # Check PATH, then SDK installation location
+        signtool = shutil.which("signtool")
+        if not signtool:
+            signtool = next(
+                glob.iglob("C:/Program Files*/Windows Kits/*/bin/*/x64/signtool.exe"), None
+            )
         assert signtool, "signtool not found in expected location"
 
         # WHEN


### PR DESCRIPTION
Unable to find signtool via glob, but it should be on the PATH in codebuild

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
