### PR TITLE
feat: reduce calls to S3 when fetching output asset manifests

### DIFF
--- a/src/deadline/job_attachments/download.py
+++ b/src/deadline/job_attachments/download.py
@@ -741,17 +741,15 @@ def get_output_manifests_by_asset_root(
     except JobAttachmentsError:
         return outputs
 
-    for key in manifests_keys:
-        asset_root, asset_manifest = get_asset_root_and_manifest_from_s3(
-            manifest_key=key,
-            s3_bucket=s3_settings.s3BucketName,
-            session=session,
-        )
-        if not asset_root:
-            raise MissingAssetRootError(
-                f"Failed to get asset root from metadata of output manifest: {key}"
-            )
-        outputs[asset_root].append(asset_manifest)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=S3_DOWNLOAD_MAX_CONCURRENCY) as executor:
+        futures = [executor.submit(get_asset_root_and_manifest_from_s3, key, s3_settings.s3BucketName, session) for key in manifests_keys]
+        for key, future in zip(manifests_keys, futures):
+            asset_root, asset_manifest = future.result()
+            if not asset_root:
+                raise MissingAssetRootError(
+                    f"Failed to get asset root from metadata of output manifest: {key}"
+                )
+            outputs[asset_root].append(asset_manifest)
 
     return outputs
 

--- a/src/deadline/job_attachments/download.py
+++ b/src/deadline/job_attachments/download.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 import concurrent.futures
-import io
 import json
 import os
 import re
@@ -95,33 +94,16 @@ def get_asset_root_and_manifest_from_s3(
 ) -> Tuple[Optional[str], BaseAssetManifest]:
     s3_client = get_s3_client(session=session)
     try:
-        # Attempt to get the manifest and metadata in a single request. If it's larger than a single 8MB
-        # chunk, fetch it in chunks using the S3 transfer manager.
-        max_chunk_length = 8 * 1024 * 1024  # 8MB
+        # Assumption: the manifest is less than 5GB. S3 objects larger than 5GB will be truncated.
+        # Using the assumption because it simplifies the code. A large manifest might be:
+        # 1 million files * 256 bytes per file path = 256MB so this assumption is safe.
         res = s3_client.get_object(
             Bucket=s3_bucket,
             Key=manifest_key,
-            Range=f"bytes=0-{max_chunk_length}",
             ExpectedBucketOwner=get_account_id(session=session),
         )
-        metadata = res["Metadata"]
-        content_length = res["ContentLength"]
-        body = res["Body"]
-        asset_root = _get_asset_root_from_metadata(metadata=metadata)
-
-        if content_length < max_chunk_length:
-            contents = body.read().decode("utf-8")
-        else:
-            file_buffer = io.BytesIO()
-            s3_client.download_fileobj(
-                s3_bucket,
-                manifest_key,
-                file_buffer,
-                ExtraArgs={"ExpectedBucketOwner": get_account_id(session=session)},
-            )
-            byte_value = file_buffer.getvalue()
-            contents = byte_value.decode("utf-8")
-
+        asset_root = _get_asset_root_from_metadata(metadata=res["Metadata"])
+        contents = res["Body"].read().decode("utf-8")
         asset_manifest = decode_manifest(contents)
 
         return (asset_root, asset_manifest)
@@ -742,7 +724,12 @@ def get_output_manifests_by_asset_root(
         return outputs
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=S3_DOWNLOAD_MAX_CONCURRENCY) as executor:
-        futures = [executor.submit(get_asset_root_and_manifest_from_s3, key, s3_settings.s3BucketName, session) for key in manifests_keys]
+        futures = [
+            executor.submit(
+                get_asset_root_and_manifest_from_s3, key, s3_settings.s3BucketName, session
+            )
+            for key in manifests_keys
+        ]
         for key, future in zip(manifests_keys, futures):
             asset_root, asset_manifest = future.result()
             if not asset_root:

--- a/src/deadline/job_attachments/download.py
+++ b/src/deadline/job_attachments/download.py
@@ -86,20 +86,45 @@ TEMP_DOWNLOAD_ADDED_CHARS_LENGTH = 9
 def get_manifest_from_s3(
     manifest_key: str, s3_bucket: str, session: Optional[boto3.Session] = None
 ) -> BaseAssetManifest:
+    _, manifest = get_asset_root_and_manifest_from_s3(manifest_key, s3_bucket, session)
+    return manifest
+
+
+def get_asset_root_and_manifest_from_s3(
+    manifest_key: str, s3_bucket: str, session: Optional[boto3.Session] = None
+) -> Tuple[Optional[str], BaseAssetManifest]:
     s3_client = get_s3_client(session=session)
     try:
-        file_buffer = io.BytesIO()
-        s3_client.download_fileobj(
-            s3_bucket,
-            manifest_key,
-            file_buffer,
-            ExtraArgs={"ExpectedBucketOwner": get_account_id(session=session)},
+        # Attempt to get the manifest and metadata in a single request. If it's larger than a single 8MB
+        # chunk, fetch it in chunks using the S3 transfer manager.
+        max_chunk_length = 8 * 1024 * 1024  # 8MB
+        res = s3_client.get_object(
+            Bucket=s3_bucket,
+            Key=manifest_key,
+            Range=f"bytes=0-{max_chunk_length}",
+            ExpectedBucketOwner=get_account_id(session=session),
         )
-        byte_value = file_buffer.getvalue()
-        string_value = byte_value.decode("utf-8")
-        asset_manifest = decode_manifest(string_value)
-        file_buffer.close()
-        return asset_manifest
+        metadata = res["Metadata"]
+        content_length = res["ContentLength"]
+        body = res["Body"]
+        asset_root = _get_asset_root_from_metadata(metadata=metadata)
+
+        if content_length < max_chunk_length:
+            contents = body.read().decode("utf-8")
+        else:
+            file_buffer = io.BytesIO()
+            s3_client.download_fileobj(
+                s3_bucket,
+                manifest_key,
+                file_buffer,
+                ExtraArgs={"ExpectedBucketOwner": get_account_id(session=session)},
+            )
+            byte_value = file_buffer.getvalue()
+            contents = byte_value.decode("utf-8")
+
+        asset_manifest = decode_manifest(contents)
+
+        return (asset_root, asset_manifest)
     except ClientError as exc:
         status_code = int(exc.response["ResponseMetadata"]["HTTPStatusCode"])
         status_code_guidance = {
@@ -132,6 +157,13 @@ def get_manifest_from_s3(
         ) from bce
     except Exception as e:
         raise AssetSyncError(e) from e
+
+
+def _get_asset_root_from_metadata(metadata: dict[str, str]) -> Optional[str]:
+    if "asset-root-json" in metadata:
+        return json.loads(metadata["asset-root-json"])
+    else:
+        return metadata.get("asset-root", None)
 
 
 def _get_output_manifest_prefix(
@@ -257,7 +289,7 @@ def get_job_input_paths_by_asset_root(
     for manifest_properties in attachments.manifests:
         if manifest_properties.inputManifestPath:
             key = _join_s3_paths(manifest_properties.inputManifestPath)
-            asset_manifest = get_manifest_from_s3(
+            _, asset_manifest = get_asset_root_and_manifest_from_s3(
                 manifest_key=key,
                 s3_bucket=s3_settings.s3BucketName,
                 session=session,
@@ -655,47 +687,6 @@ def download_files(
     )
 
 
-def _get_asset_root_from_s3(
-    manifest_key: str, s3_bucket: str, session: Optional[boto3.Session] = None
-) -> Optional[str]:
-    """
-    Gets asset root from metadata (of output manifest) stored in S3.
-    If neither of the keys "asset-root-json" or "asset-root" exist in the metadata, returns None.
-    """
-    s3_client = get_s3_client(session=session)
-    try:
-        head = s3_client.head_object(Bucket=s3_bucket, Key=manifest_key)
-    except ClientError as exc:
-        status_code = int(exc.response["ResponseMetadata"]["HTTPStatusCode"])
-        status_code_guidance = {
-            **COMMON_ERROR_GUIDANCE_FOR_S3,
-            403: (
-                "Access denied. Ensure that the bucket is in the AWS account, "
-                "and your AWS IAM Role or User has the 's3:ListBucket' permission for this bucket."
-            ),
-            404: "Not found. Please check your bucket name and object key, and ensure that they exist in the AWS account.",
-        }
-        raise JobAttachmentsS3ClientError(
-            action="checking if object exists",
-            status_code=status_code,
-            bucket_name=s3_bucket,
-            key_or_prefix=manifest_key,
-            message=f"{status_code_guidance.get(status_code, '')} {str(exc)}",
-        ) from exc
-    except BotoCoreError as bce:
-        raise JobAttachmentS3BotoCoreError(
-            action="checking for the existence of an object in the S3 bucket",
-            error_details=str(bce),
-        ) from bce
-    except Exception as e:
-        raise AssetSyncError(e) from e
-
-    if "asset-root-json" in head["Metadata"]:
-        return json.loads(head["Metadata"]["asset-root-json"])
-    else:
-        return head["Metadata"].get("asset-root", None)
-
-
 def get_job_output_paths_by_asset_root(
     s3_settings: JobAttachmentS3Settings,
     farm_id: str,
@@ -751,12 +742,11 @@ def get_output_manifests_by_asset_root(
         return outputs
 
     for key in manifests_keys:
-        asset_manifest = get_manifest_from_s3(
+        asset_root, asset_manifest = get_asset_root_and_manifest_from_s3(
             manifest_key=key,
             s3_bucket=s3_settings.s3BucketName,
             session=session,
         )
-        asset_root = _get_asset_root_from_s3(key, s3_settings.s3BucketName, session)
         if not asset_root:
             raise MissingAssetRootError(
                 f"Failed to get asset root from metadata of output manifest: {key}"

--- a/test/unit/deadline_job_attachments/test_download.py
+++ b/test/unit/deadline_job_attachments/test_download.py
@@ -39,6 +39,7 @@ from deadline.job_attachments.download import (
     download_file,
     download_files_from_manifests,
     download_files_in_directory,
+    get_asset_root_and_manifest_from_s3,
     get_job_input_output_paths_by_asset_root,
     get_job_input_paths_by_asset_root,
     get_job_output_paths_by_asset_root,
@@ -47,7 +48,7 @@ from deadline.job_attachments.download import (
     mount_vfs_from_manifests,
     merge_asset_manifests,
     _ensure_paths_within_directory,
-    _get_asset_root_from_s3,
+    _get_asset_root_from_metadata,
     _get_new_copy_file_path,
     _get_tasks_manifests_keys_from_s3,
     VFS_CACHE_REL_PATH_IN_SESSION,
@@ -196,7 +197,7 @@ def assert_download_task_output(
     Assert that the expected files are downloaded when download_job_output is called with a task id.
     """
     with patch(
-        f"{deadline.__package__}.job_attachments.download._get_asset_root_from_s3",
+        f"{deadline.__package__}.job_attachments.download._get_asset_root_from_metadata",
         return_value=str(tmp_path.resolve()),
     ):
         mock_on_downloading_files = MagicMock(return_value=True)
@@ -246,7 +247,7 @@ def assert_download_step_output(
     Assert that the expected files are downloaded when download_job_output is called with a step id.
     """
     with patch(
-        f"{deadline.__package__}.job_attachments.download._get_asset_root_from_s3",
+        f"{deadline.__package__}.job_attachments.download._get_asset_root_from_metadata",
         return_value=str(tmp_path.resolve()),
     ):
         mock_on_downloading_files = MagicMock(return_value=True)
@@ -290,7 +291,7 @@ def assert_download_job_output(
     Assert that the expected files are downloaded when download_job_output is called.
     """
     with patch(
-        f"{deadline.__package__}.job_attachments.download._get_asset_root_from_s3",
+        f"{deadline.__package__}.job_attachments.download._get_asset_root_from_metadata",
         return_value=str(tmp_path.resolve()),
     ):
         mock_on_downloading_files = MagicMock(return_value=True)
@@ -336,7 +337,7 @@ def assert_download_files_in_directory(
     Assert that the expected files are downloaded when download_files_in_directory is called.
     """
     with patch(
-        f"{deadline.__package__}.job_attachments.download._get_asset_root_from_s3",
+        f"{deadline.__package__}.job_attachments.download._get_asset_root_from_metadata",
         return_value=str(tmp_path.resolve()),
     ):
         mock_on_downloading_files = MagicMock(return_value=True)
@@ -499,7 +500,7 @@ def assert_get_job_output_paths_by_asset_root(
     Assert that get_job_output_paths_by_asset_root returns a list of (hash, path) pairs of all output files.
     """
     with patch(
-        f"{deadline.__package__}.job_attachments.download._get_asset_root_from_s3",
+        f"{deadline.__package__}.job_attachments.download._get_asset_root_from_metadata",
         return_value="/test",
     ):
         paths_by_root = get_job_output_paths_by_asset_root(
@@ -525,7 +526,7 @@ def assert_get_job_output_paths_by_asset_root_when_no_asset_root_throws_error(
     Assert that get_job_output_paths_by_asset_root raises MissingAssetRootError when fail to get manifest.
     """
     with patch(
-        f"{deadline.__package__}.job_attachments.download._get_asset_root_from_s3",
+        f"{deadline.__package__}.job_attachments.download._get_asset_root_from_metadata",
         return_value=None,
     ), pytest.raises(MissingAssetRootError) as raised_err:
         get_job_output_paths_by_asset_root(s3_settings, farm_id, queue_id, "job-1")
@@ -546,7 +547,7 @@ def assert_get_job_input_output_paths_by_asset_root(
     asset files and output files.
     """
     with patch(
-        f"{deadline.__package__}.job_attachments.download._get_asset_root_from_s3",
+        f"{deadline.__package__}.job_attachments.download._get_asset_root_from_metadata",
         return_value="/tmp",
     ):
         paths_by_root = get_job_input_output_paths_by_asset_root(
@@ -1157,7 +1158,7 @@ class TestFullDownload:
         tmp_path: Path,
     ):
         with patch(
-            f"{deadline.__package__}.job_attachments.download._get_asset_root_from_s3",
+            f"{deadline.__package__}.job_attachments.download._get_asset_root_from_metadata",
             return_value=str(tmp_path.resolve()),
         ):
             output_downloader = OutputDownloader(
@@ -1190,7 +1191,7 @@ class TestFullDownload:
 
     def test_OutputDownloader_set_root_path(self, farm_id, queue_id, tmp_path: Path):
         with patch(
-            f"{deadline.__package__}.job_attachments.download._get_asset_root_from_s3",
+            f"{deadline.__package__}.job_attachments.download._get_asset_root_from_metadata",
             return_value=str(tmp_path.resolve()),
         ):
             output_downloader = OutputDownloader(
@@ -1237,7 +1238,7 @@ class TestFullDownload:
         resolving the symlink target, the absolute path with ".." removed is stored.
         """
         with patch(
-            f"{deadline.__package__}.job_attachments.download._get_asset_root_from_s3",
+            f"{deadline.__package__}.job_attachments.download._get_asset_root_from_metadata",
             return_value=str(tmp_path.resolve()),
         ):
             output_downloader = OutputDownloader(
@@ -1274,7 +1275,7 @@ class TestFullDownload:
         Assert a ValueError is thrown when given a non-existent root path.
         """
         with patch(
-            f"{deadline.__package__}.job_attachments.download._get_asset_root_from_s3",
+            f"{deadline.__package__}.job_attachments.download._get_asset_root_from_metadata",
             return_value=str(tmp_path.resolve()),
         ):
             output_downloader = OutputDownloader(
@@ -1336,7 +1337,7 @@ class TestFullDownload:
             tmp_path / "test" / "test12.txt",
         ]
         with patch(
-            f"{deadline.__package__}.job_attachments.download._get_asset_root_from_s3",
+            f"{deadline.__package__}.job_attachments.download._get_asset_root_from_metadata",
             return_value=str(tmp_path.resolve()),
         ):
             output_downloader = OutputDownloader(
@@ -1428,7 +1429,7 @@ class TestFullDownload:
         expected_files_after_create_copy.extend(expected_files)
 
         with patch(
-            f"{deadline.__package__}.job_attachments.download._get_asset_root_from_s3",
+            f"{deadline.__package__}.job_attachments.download._get_asset_root_from_metadata",
             return_value=str(tmp_path.resolve()),
         ):
             output_downloader = OutputDownloader(
@@ -1457,7 +1458,7 @@ class TestFullDownload:
         self, farm_id, queue_id, tmp_path: Path
     ):
         with patch(
-            f"{deadline.__package__}.job_attachments.download._get_asset_root_from_s3",
+            f"{deadline.__package__}.job_attachments.download._get_asset_root_from_metadata",
             return_value=str(tmp_path.resolve()),
         ):
             output_downloader = OutputDownloader(
@@ -1496,7 +1497,7 @@ class TestFullDownload:
         ]
 
         with patch(
-            f"{deadline.__package__}.job_attachments.download._get_asset_root_from_s3",
+            f"{deadline.__package__}.job_attachments.download._get_asset_root_from_metadata",
             return_value="/test_root",
         ):
             output_downloader = OutputDownloader(
@@ -1652,57 +1653,56 @@ class TestFullDownload:
     ):
         self.create_output_downloaded_and_validate_path(farm_id, outputs_by_root, queue_id)
 
-    def test_get_asset_root_from_s3_error_message_on_not_found(self):
+    def test_get_asset_root_from_metadata_returns_none_if_not_found(self):
+        assert _get_asset_root_from_metadata(metadata={}) is None
+
+    def test_get_asset_root_and_manifest_from_s3_gets_large_manifests_in_multiple_chunks(self):
         """
         Test if the function raises the expected exception with a proper error message
-        when S3 client's head_object returns a Not Found (404) error.
+        when S3 client's download_fileobj returns an Access Denied (403) error.
         """
-        s3_client = boto3.client("s3")
-        stubber = Stubber(s3_client)
-        stubber.add_client_error(
-            "head_object",
-            service_error_code="NotFound",
-            service_message="Not Found",
-            http_status_code=404,
-        )
+        test_manifest = {
+            "manifestVersion": "2023-03-03",
+            "hashAlg": "xxh128",
+            "totalSize": 12345,
+            "paths": [
+                {
+                    "path": "relative/path/to/file1.txt",
+                    "hash": "abcdef1234567890",
+                    "size": 1024,
+                    "mtime": 1678012345000000,
+                },
+                {
+                    "path": "relative/path/to/file2.png",
+                    "hash": "0987654321fedcba",
+                    "size": 11321,
+                    "mtime": 1678012346000000,
+                },
+            ],
+        }
+        test_root = "/tmp"
 
-        with stubber, patch(
-            f"{deadline.__package__}.job_attachments.download.get_s3_client", return_value=s3_client
-        ):
-            with pytest.raises(JobAttachmentsS3ClientError) as err:
-                _get_asset_root_from_s3("not/existed/test.txt", "test-bucket")
-            assert isinstance(err.value.__cause__, ClientError)
-            assert (
-                err.value.__cause__.response["ResponseMetadata"]["HTTPStatusCode"] == 404
-                # type: ignore[attr-defined]
-            )
-            assert (
-                "Error checking if object exists in bucket 'test-bucket', Target key or prefix: 'not/existed/test.txt', "
-                "HTTP Status Code: 404, Not found. "
-            ) in str(err.value)
-
-    def test_get_asset_root_from_s3_error_message_on_timeout(self):
-        """
-        Test that the appropriate error is raised when a ReadTimeoutError occurs
-        during an S3 client's head_object call.
-        """
         mock_s3_client = MagicMock()
-        mock_s3_client.head_object.side_effect = ReadTimeoutError(endpoint_url="test_url")
+        mock_s3_client.get_object.return_value = {
+            "Metadata": {"asset-root": test_root},
+            "ContentLength": 9999999999,
+            "Body": MagicMock(),
+        }
+
+        def mock_download_fileobj(_1, _2, buffer, **kwargs):
+            buffer.write(json.dumps(test_manifest).encode("utf-8"))
+
+        mock_s3_client.download_fileobj = mock_download_fileobj
 
         with patch(
             f"{deadline.__package__}.job_attachments.download.get_s3_client",
             return_value=mock_s3_client,
         ):
-            with pytest.raises(AssetSyncError) as exc:
-                _get_asset_root_from_s3("test-key", "test-bucket")
-            assert isinstance(exc.value.__cause__, BotoCoreError)
-            assert (
-                "An issue occurred with AWS service request while checking for the existence of an object in the S3 bucket: "
-                'Read timeout on endpoint URL: "test_url"\n'
-                "This could be due to temporary issues with AWS, internet connection, or your AWS credentials. "
-                "Please verify your credentials and network connection. If the problem persists, try again later"
-                " or contact support for further assistance."
-            ) in str(exc.value)
+            asset_root, asset_manifest = get_asset_root_and_manifest_from_s3(
+                "test-key", "test-bucket"
+            )
+            assert asset_root == test_root
+            assert asset_manifest.hashAlg == test_manifest["hashAlg"]
 
     def test_get_manifest_from_s3_error_message_on_access_denied(self):
         """
@@ -1712,7 +1712,7 @@ class TestFullDownload:
         s3_client = boto3.client("s3")
         stubber = Stubber(s3_client)
         stubber.add_client_error(
-            "head_object",
+            "get_object",
             service_error_code="AccessDenied",
             service_message="Access Denied",
             http_status_code=403,
@@ -1739,7 +1739,7 @@ class TestFullDownload:
         during an S3 client's download_fileobj call.
         """
         mock_s3_client = MagicMock()
-        mock_s3_client.download_fileobj.side_effect = ReadTimeoutError(endpoint_url="test_url")
+        mock_s3_client.get_object.side_effect = ReadTimeoutError(endpoint_url="test_url")
 
         with patch(
             f"{deadline.__package__}.job_attachments.download.get_s3_client",

--- a/test/unit/deadline_job_attachments/test_download.py
+++ b/test/unit/deadline_job_attachments/test_download.py
@@ -39,7 +39,6 @@ from deadline.job_attachments.download import (
     download_file,
     download_files_from_manifests,
     download_files_in_directory,
-    get_asset_root_and_manifest_from_s3,
     get_job_input_output_paths_by_asset_root,
     get_job_input_paths_by_asset_root,
     get_job_output_paths_by_asset_root,
@@ -1655,54 +1654,6 @@ class TestFullDownload:
 
     def test_get_asset_root_from_metadata_returns_none_if_not_found(self):
         assert _get_asset_root_from_metadata(metadata={}) is None
-
-    def test_get_asset_root_and_manifest_from_s3_gets_large_manifests_in_multiple_chunks(self):
-        """
-        Test if the function raises the expected exception with a proper error message
-        when S3 client's download_fileobj returns an Access Denied (403) error.
-        """
-        test_manifest = {
-            "manifestVersion": "2023-03-03",
-            "hashAlg": "xxh128",
-            "totalSize": 12345,
-            "paths": [
-                {
-                    "path": "relative/path/to/file1.txt",
-                    "hash": "abcdef1234567890",
-                    "size": 1024,
-                    "mtime": 1678012345000000,
-                },
-                {
-                    "path": "relative/path/to/file2.png",
-                    "hash": "0987654321fedcba",
-                    "size": 11321,
-                    "mtime": 1678012346000000,
-                },
-            ],
-        }
-        test_root = "/tmp"
-
-        mock_s3_client = MagicMock()
-        mock_s3_client.get_object.return_value = {
-            "Metadata": {"asset-root": test_root},
-            "ContentLength": 9999999999,
-            "Body": MagicMock(),
-        }
-
-        def mock_download_fileobj(_1, _2, buffer, **kwargs):
-            buffer.write(json.dumps(test_manifest).encode("utf-8"))
-
-        mock_s3_client.download_fileobj = mock_download_fileobj
-
-        with patch(
-            f"{deadline.__package__}.job_attachments.download.get_s3_client",
-            return_value=mock_s3_client,
-        ):
-            asset_root, asset_manifest = get_asset_root_and_manifest_from_s3(
-                "test-key", "test-bucket"
-            )
-            assert asset_root == test_root
-            assert asset_manifest.hashAlg == test_manifest["hashAlg"]
 
     def test_get_manifest_from_s3_error_message_on_access_denied(self):
         """


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud/issues/646

### What was the problem/requirement? (What/Why)
Currently when downloading job attachments, we make 3 calls to S3:
1. HEAD request in our code to get the asset-root metadata
2. HEAD request by S3 transfer manager to determine the object size to see if multipart downloading is necessary
3. GetObject request to download the object.

Only the third is necessary since it includes the metadata and since nearly all manifests will be relatively small.

### What was the solution? (How)
Get everything we need in a single GetObject request. In the edge case where the manifest is very large and doesn't fit in one reasonable-sized request, fall back on the previous chunked downloader.

### What is the impact of this change?
Reduces S3 calls by 2/3 when getting output manifests.

### How was this change tested?
- Have you run the unit tests? Yes
- Have you run the integration tests? Yes
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass. Yes, all passing.

I did a manual performance test by downloading a job with 1000 tasks  that each had a small output file. Downloading the output was about twice as fast (5:11 -> 2:38):
```
$ time deadline job download-output --farm-id farm-ff07fe0f9ea043e1a3a53310a256b090 --queue-id queue-31f0feaec56940e88b57561a5c1b71a1 --job-id job-f66d811f5b8a4adc9c8b9c7ea1c9e837                                    
Downloading output from Job 'Download Performance Test'

Downloading Outputs  [####################################]  100%          
Download Summary:
    Downloaded 1000 files totaling 1.02 MB.
    Total download time of 35.51796 seconds at 28.83 KB/s.
    Download locations (total file counts):
        /.../output (1000 files)

deadline job download-output --farm-id farm-ff07fe0f9ea043e1a3a53310a256b090   27.06s user 7.80s system 11% cpu 5:11.73 total

$ time deadline job download-output --farm-id farm-ff07fe0f9ea043e1a3a53310a256b090 --queue-id queue-31f0feaec56940e88b57561a5c1b71a1 --job-id job-f66d811f5b8a4adc9c8b9c7ea1c9e837
Downloading output from Job 'Download Performance Test'

Downloading Outputs  [####################################]  100%          
Download Summary:
    Downloaded 1000 files totaling 1.02 MB.
    Total download time of 35.97593 seconds at 28.46 KB/s.
    Download locations (total file counts):
        /.../output (1000 files)

deadline job download-output --farm-id farm-ff07fe0f9ea043e1a3a53310a256b090   21.73s user 4.61s system 44% cpu 59.354 total
```

### Was this change documented?
n/a

### Does this PR introduce new dependencies?

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?
No

### Does this change impact security?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
