### PR TITLE
chore: add MacOS install builder archive mapping

### DIFF
--- a/scripts/find_installbuilder.py
+++ b/scripts/find_installbuilder.py
@@ -15,6 +15,7 @@ from common import UnsupportedOSError
 _INSTALL_BUILDER_ARCHIVE_FILENAME = {
     "Windows": "VMware-InstallBuilder-Professional-windows.tar.gz",
     "Linux": "VMware-InstallBuilder-Professional-linux.tar.gz",
+    "Darwin": "VMware-InstallBuilder-Professional-macos.tar.gz",
 }
 
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Dev run of building the installer was failing with:
```
common.UnsupportedOSError: Unsupported OS: Darwin
```
### What was the solution? (How)
Add the name of the installer archive for Mac to the list

### What is the impact of this change?
Build works

### How was this change tested?
In my own account

### Was this change documented?
No

### Does this PR introduce new dependencies?
No

### Is this a breaking change?
No
### Does this change impact security?

No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
