### PR TITLE
feat(cli): Add queue role credential export functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,42 @@ and removing them by logging out:
 $ deadline auth logout
 ```
 
+## AWS Credentials Integration
+
+You can use the Deadline Cloud client to obtain temporary AWS credentials for a queue and use them with the AWS CLI or SDK. This enables you to create AWS profiles that have queue-specific permissions for use in programmatic workflows.
+
+To export credentials for a queue in a format compatible with the AWS SDK credentials_process interface:
+
+```sh
+$ deadline queue export-credentials --farm-id farm-1234567890abcdefg --queue-id q-12345abcdef --mode USER
+{
+  "Version": 1,
+  "AccessKeyId": "ASIA...",
+  "SecretAccessKey": "wJalr...",
+  "SessionToken": "AQoD...",
+  "Expiration": "2025-04-08T20:00:46Z"
+}
+```
+
+You can then reference this command in your AWS config file to create a profile that uses these credentials. Often this will be a profile from a Deadline Cloud monitor session:
+
+```
+[profile deadline-queue]
+credential_process = deadline queue export-credentials --farm-id farm-1234567890abcdefg --queue-id q-12345abcdef --mode USER --profile myfarm-us-west-2
+region = us-west-2
+```
+
+Then use this profile with AWS CLI commands:
+
+```sh
+$ aws s3 ls --profile deadline-queue
+```
+
+Available modes:
+- `USER`: Credentials with full queue-role permissions.
+- `READ`: Credentials with read-only permissions for queue logs
+
+
 ## Code of Conduct
 
 This project has adopted the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct).

--- a/src/deadline/client/api/__init__.py
+++ b/src/deadline/client/api/__init__.py
@@ -25,6 +25,8 @@ __all__ = [
     "get_storage_profile_for_queue",
     "record_success_fail_telemetry_event",
     "record_function_latency_telemetry_event",
+    "assume_queue_role_for_user",
+    "assume_queue_role_for_read",
 ]
 
 # The following import is needed to prevent the following sporadic failure:
@@ -63,6 +65,10 @@ from ._list_apis import (
     list_storage_profiles_for_queue,
 )
 from ._queue_parameters import get_queue_parameter_definitions
+from ._queue_credentials import (
+    assume_queue_role_for_user,
+    assume_queue_role_for_read,
+)
 from ._submit_job_bundle import (
     create_job_from_job_bundle,
     wait_for_create_job_to_complete,

--- a/src/deadline/client/api/_queue_credentials.py
+++ b/src/deadline/client/api/_queue_credentials.py
@@ -1,0 +1,78 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+API methods for queue role credentials.
+"""
+
+from configparser import ConfigParser
+from typing import Dict, Any, Optional
+
+from . import _session, _telemetry
+
+
+@_telemetry.record_function_latency_telemetry_event()
+def assume_queue_role_for_user(
+    farmId: str, queueId: str, *, config: Optional[ConfigParser] = None
+) -> Dict[str, Any]:
+    """
+    Assumes the user role for a queue and returns temporary credentials.
+
+    These credentials can be used to perform user-level operations on the queue,
+    such as submitting jobs and monitoring job status.
+
+    Args:
+        farmId: The ID of the farm containing the queue.
+        queueId: The ID of the queue to assume the role for.
+        config: Optional configuration to use. If not provided, the default configuration is used.
+
+    Returns:
+        A dictionary containing the temporary credentials in the following format:
+        {
+            "credentials": {
+                "accessKeyId": str,
+                "secretAccessKey": str,
+                "sessionToken": str,
+                "expiration": datetime
+            }
+        }
+
+    Raises:
+        ClientError: If there is an error assuming the role.
+    """
+    client = _session.get_boto3_client("deadline", config=config)
+    response = client.assume_queue_role_for_user(farmId=farmId, queueId=queueId)
+    return response
+
+
+@_telemetry.record_function_latency_telemetry_event()
+def assume_queue_role_for_read(
+    farmId: str, queueId: str, *, config: Optional[ConfigParser] = None
+) -> Dict[str, Any]:
+    """
+    Assumes the read role for a queue and returns temporary credentials.
+
+    These credentials can be used to perform read-only operations on the queue,
+    such as viewing job status and queue information.
+
+    Args:
+        farmId: The ID of the farm containing the queue.
+        queueId: The ID of the queue to assume the role for.
+        config: Optional configuration to use. If not provided, the default configuration is used.
+
+    Returns:
+        A dictionary containing the temporary credentials in the following format:
+        {
+            "credentials": {
+                "accessKeyId": str,
+                "secretAccessKey": str,
+                "sessionToken": str,
+                "expiration": datetime
+            }
+        }
+
+    Raises:
+        ClientError: If there is an error assuming the role.
+    """
+    client = _session.get_boto3_client("deadline", config=config)
+    response = client.assume_queue_role_for_read(farmId=farmId, queueId=queueId)
+    return response

--- a/src/deadline/client/cli/_groups/queue_group.py
+++ b/src/deadline/client/cli/_groups/queue_group.py
@@ -5,6 +5,8 @@ All the `deadline queue` commands.
 """
 
 import click
+import json
+import time
 from botocore.exceptions import ClientError  # type: ignore[import]
 
 from ... import api
@@ -55,6 +57,99 @@ def queue_list(**args):
     ]
 
     click.echo(_cli_object_repr(structured_queue_list))
+
+
+@cli_queue.command(name="export-credentials")
+@click.option("--queue-id", help="The queue ID to use.")
+@click.option("--farm-id", help="The farm ID to use.")
+@click.option(
+    "--mode",
+    type=click.Choice(["USER", "READ"], case_sensitive=False),
+    default="USER",
+    help="The type of queue role to assume (default: USER)",
+)
+@click.option(
+    "--output-format",
+    type=click.Choice(["credentials_process"], case_sensitive=False),
+    default="credentials_process",
+    help="Format of the output (default: credentials_process)",
+)
+@click.option("--profile", help="The AWS profile to use.")
+@_handle_error
+def queue_export_credentials(mode, output_format, **args):
+    """
+    Export queue credentials in a format compatible with AWS SDK credentials_process.
+    """
+    start_time = time.time()
+    is_success = True
+    error_type = None
+
+    # Get a temporary config object with the standard options handled
+    config = _apply_cli_options_to_config(required_options={"farm_id", "queue_id"}, **args)
+
+    queue_id: str = config_file.get_setting("defaults.queue_id", config=config)
+    farm_id: str = config_file.get_setting("defaults.farm_id", config=config)
+
+    try:
+        # Call the appropriate API based on mode
+        if mode.upper() == "USER":
+            response = api.assume_queue_role_for_user(
+                farmId=farm_id, queueId=queue_id, config=config
+            )
+        elif mode.upper() == "READ":
+            response = api.assume_queue_role_for_read(
+                farmId=farm_id, queueId=queue_id, config=config
+            )
+        else:
+            is_success = False
+            error_type = "InvalidMode"
+            raise DeadlineOperationError(f"Invalid mode: {mode}")
+
+        # Format the response according to the AWS SDK credentials_process format
+        if output_format.lower() == "credentials_process":
+            credentials = response["credentials"]
+            formatted_credentials = {
+                "Version": 1,
+                "AccessKeyId": credentials["accessKeyId"],
+                "SecretAccessKey": credentials["secretAccessKey"],
+                "SessionToken": credentials["sessionToken"],
+                "Expiration": credentials["expiration"].isoformat(),
+            }
+            click.echo(json.dumps(formatted_credentials, indent=2))
+        else:
+            is_success = False
+            error_type = "InvalidOutputFormat"
+            raise DeadlineOperationError(f"Invalid output format: {output_format}")
+
+    except ClientError as exc:
+        is_success = False
+        error_type = "ClientError"
+        if "AccessDenied" in str(exc):
+            raise DeadlineOperationError(
+                f"Insufficient permissions to assume the requested queue role: {exc}"
+            ) from exc
+        elif "UnrecognizedClientException" in str(exc):
+            raise DeadlineOperationError(
+                f"Authentication failed. Please run 'deadline auth login' or check your AWS credentials: {exc}"
+            ) from exc
+        else:
+            raise DeadlineOperationError(
+                f"Failed to get credentials from AWS Deadline Cloud:\n{exc}"
+            ) from exc
+    finally:
+        # Record telemetry
+        duration_ms = int((time.time() - start_time) * 1000)
+        api._telemetry.get_deadline_cloud_library_telemetry_client().record_event(
+            "com.amazon.rum.deadline.queue_export_credentials",
+            {
+                "mode": mode,
+                "queue_id": queue_id,
+                "output_format": output_format,
+                "is_success": is_success,
+                "error_type": error_type if not is_success else None,
+                "duration_ms": duration_ms,
+            },
+        )
 
 
 @cli_queue.command(name="paramdefs")

--- a/test/integ/cli/test_cli_queue.py
+++ b/test/integ/cli/test_cli_queue.py
@@ -2,8 +2,11 @@
 
 from .test_utils import DeadlineCliTest
 from deadline.client.cli import main
+import datetime
 
 from click.testing import CliRunner
+import json
+import boto3
 
 
 def test_queue_get(deadline_cli_test: DeadlineCliTest) -> None:
@@ -46,3 +49,47 @@ def test_queue_list(deadline_cli_test: DeadlineCliTest) -> None:
     # The following vary from queue to queue, so just make sure the general layout is there.
     # Unit tests are able to test the output more throughly. We'll only look for the required fields.
     assert "displayName:" in result.output
+
+
+def test_queue_export_credentials(deadline_cli_test: DeadlineCliTest) -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(
+        main,
+        [
+            "queue",
+            "export-credentials",
+            "--farm-id",
+            deadline_cli_test.farm_id,
+            "--queue-id",
+            deadline_cli_test.queue_id,
+        ],
+    )
+
+    try:
+        assert result.exit_code == 0
+
+        creds = json.loads(result.output)
+        # Transform credential_process output back into what boto expects
+
+        # We want to make sure the date is in an expected format, but we're not going to further validate this date
+        _ = datetime.datetime.fromisoformat(creds["Expiration"])
+        assert creds["Version"] == 1
+
+        session = boto3.Session(
+            aws_access_key_id=creds["AccessKeyId"],
+            aws_secret_access_key=creds["SecretAccessKey"],
+            aws_session_token=creds["SessionToken"],
+        )
+
+        # Use the session
+        sts = session.client("sts")
+
+        # If this works it means our creds are good, so we're happy
+        sts.get_caller_identity()
+    except json.JSONDecodeError:
+        # If JSON parsing fails, don't include the raw output in the error as this could print credentials
+        assert False, "Failed to parse JSON output from export-credentials"
+    except Exception as e:
+        # For any other exception, make sure we don't include credentials in the error, so we need to be careful with what we print.
+        assert False, f"Test failed: {type(e).__name__}"

--- a/test/unit/deadline_client/api/test_queue_credentials.py
+++ b/test/unit/deadline_client/api/test_queue_credentials.py
@@ -1,0 +1,95 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Tests for queue role credentials API methods.
+"""
+
+import datetime
+from unittest import mock
+import pytest
+
+from deadline.client.api import _queue_credentials as queue_credentials
+
+
+@pytest.fixture
+def mock_boto3_client():
+    """Mock the boto3 client."""
+    with mock.patch("deadline.client.api._session.get_boto3_client") as mock_get_client:
+        mock_client = mock.MagicMock()
+        mock_get_client.return_value = mock_client
+        yield mock_client
+
+
+def test_assume_queue_role_for_user(mock_boto3_client):
+    """Test assuming user role for a queue."""
+    # Setup
+    expiration = datetime.datetime(2025, 4, 8, 20, 0, 46)
+    mock_boto3_client.assume_queue_role_for_user.return_value = {
+        "Credentials": {
+            "AccessKeyId": "ASIAEXAMPLE",
+            "SecretAccessKey": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            "SessionToken": "AQoDYXdzEJr...<remainder of session token>",
+            "Expiration": expiration,
+        }
+    }
+
+    # Execute
+    result = queue_credentials.assume_queue_role_for_user(
+        farmId="farm-1234567890abcdefg", queueId="q-12345abcdef"
+    )
+
+    # Verify
+    mock_boto3_client.assume_queue_role_for_user.assert_called_once_with(
+        farmId="farm-1234567890abcdefg", queueId="q-12345abcdef"
+    )
+    assert result["Credentials"]["AccessKeyId"] == "ASIAEXAMPLE"
+    assert result["Credentials"]["SecretAccessKey"] == "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+    assert result["Credentials"]["SessionToken"] == "AQoDYXdzEJr...<remainder of session token>"
+    assert result["Credentials"]["Expiration"] == expiration
+
+
+def test_assume_queue_role_for_read(mock_boto3_client):
+    """Test assuming read role for a queue."""
+    # Setup
+    expiration = datetime.datetime(2025, 4, 8, 20, 0, 46)
+    mock_boto3_client.assume_queue_role_for_read.return_value = {
+        "Credentials": {
+            "AccessKeyId": "ASIAEXAMPLE",
+            "SecretAccessKey": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            "SessionToken": "AQoDYXdzEJr...<remainder of session token>",
+            "Expiration": expiration,
+        }
+    }
+
+    # Execute
+    result = queue_credentials.assume_queue_role_for_read(
+        farmId="farm-1234567890abcdefg", queueId="q-12345abcdef"
+    )
+
+    # Verify
+    mock_boto3_client.assume_queue_role_for_read.assert_called_once_with(
+        farmId="farm-1234567890abcdefg", queueId="q-12345abcdef"
+    )
+    assert result["Credentials"]["AccessKeyId"] == "ASIAEXAMPLE"
+    assert result["Credentials"]["SecretAccessKey"] == "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+    assert result["Credentials"]["SessionToken"] == "AQoDYXdzEJr...<remainder of session token>"
+    assert result["Credentials"]["Expiration"] == expiration
+
+
+def test_assume_queue_role_client_error(mock_boto3_client):
+    """Test error handling when assuming role fails."""
+    # Setup
+    from botocore.exceptions import ClientError
+
+    mock_boto3_client.assume_queue_role_for_user.side_effect = ClientError(
+        {"Error": {"Code": "AccessDenied", "Message": "Access denied"}},
+        "AssumeQueueRoleForUser",
+    )
+
+    # Execute and verify
+    with pytest.raises(ClientError) as excinfo:
+        queue_credentials.assume_queue_role_for_user(
+            farmId="farm-1234567890abcdefg", queueId="q-12345abcdef"
+        )
+
+    assert "AccessDenied" in str(excinfo.value)

--- a/test/unit/deadline_client/cli/test_queue_export_credentials.py
+++ b/test/unit/deadline_client/cli/test_queue_export_credentials.py
@@ -1,0 +1,189 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Tests for the queue export-credentials command.
+"""
+
+import json
+import datetime
+from unittest import mock
+import pytest
+from click.testing import CliRunner
+from botocore.exceptions import ClientError
+
+from deadline.client.config import config_file
+from deadline.client.cli._groups.queue_group import queue_export_credentials
+
+
+@pytest.fixture
+def mock_api():
+    """Mock the API module."""
+    with mock.patch("deadline.client.cli._groups.queue_group.api") as mock_api:
+        # Mock the telemetry client
+        mock_api._telemetry.get_deadline_cloud_library_telemetry_client.return_value = (
+            mock.MagicMock()
+        )
+        yield mock_api
+
+
+def test_queue_export_credentials_user_mode(mock_api, fresh_deadline_config):
+    """Test exporting credentials in USER mode."""
+    # Setup
+    expiration = datetime.datetime(2025, 4, 8, 20, 0, 46)
+    mock_api.assume_queue_role_for_user.return_value = {
+        "credentials": {
+            "accessKeyId": "ASIAEXAMPLE",
+            "secretAccessKey": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            "sessionToken": "AQoDYXdzEJr...<remainder of session token>",
+            "expiration": expiration,
+        }
+    }
+
+    # Execute
+    runner = CliRunner()
+    result = runner.invoke(
+        queue_export_credentials,
+        ["--farm-id", "f-abcdef12345", "--queue-id", "q-12345abcdef", "--mode", "USER"],
+    )
+
+    # Verify
+    assert result.exit_code == 0
+    output = json.loads(result.output)
+    assert output == {
+        "Version": 1,
+        "AccessKeyId": "ASIAEXAMPLE",
+        "SecretAccessKey": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+        "SessionToken": "AQoDYXdzEJr...<remainder of session token>",
+        "Expiration": expiration.isoformat(),
+    }
+    mock_api.assume_queue_role_for_user.assert_called_once_with(
+        farmId="f-abcdef12345", queueId="q-12345abcdef", config=mock.ANY
+    )
+
+    # Verify telemetry
+    telemetry_client = mock_api._telemetry.get_deadline_cloud_library_telemetry_client.return_value
+    telemetry_client.record_event.assert_called_once()
+    event_name, event_details = telemetry_client.record_event.call_args[0]
+    assert event_name == "com.amazon.rum.deadline.queue_export_credentials"
+    assert event_details["mode"] == "USER"
+    assert event_details["queue_id"] == "q-12345abcdef"
+    assert event_details["is_success"] is True
+    assert event_details["error_type"] is None
+
+
+def test_queue_export_credentials_read_mode(mock_api, fresh_deadline_config):
+    """Test exporting credentials in READ mode."""
+    # Setup
+    expiration = datetime.datetime(2025, 4, 8, 20, 0, 46)
+    mock_api.assume_queue_role_for_read.return_value = {
+        "credentials": {
+            "accessKeyId": "ASIAEXAMPLE",
+            "secretAccessKey": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            "sessionToken": "AQoDYXdzEJr...<remainder of session token>",
+            "expiration": expiration,
+        }
+    }
+
+    # Execute
+    runner = CliRunner()
+    result = runner.invoke(
+        queue_export_credentials,
+        ["--farm-id", "f-abcdef12345", "--queue-id", "q-12345abcdef", "--mode", "READ"],
+    )
+
+    # Verify
+    assert result.exit_code == 0
+    output = json.loads(result.output)
+    assert output == {
+        "Version": 1,
+        "AccessKeyId": "ASIAEXAMPLE",
+        "SecretAccessKey": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+        "SessionToken": "AQoDYXdzEJr...<remainder of session token>",
+        "Expiration": expiration.isoformat(),
+    }
+
+    mock_api.assume_queue_role_for_read.assert_called_once_with(
+        farmId="f-abcdef12345", queueId="q-12345abcdef", config=mock.ANY
+    )
+
+
+def test_queue_export_credentials_default_queue_id(mock_api, fresh_deadline_config):
+    """Test exporting credentials using default farm ID and queue ID from config."""
+    # Setup
+    expiration = datetime.datetime(2025, 4, 8, 20, 0, 46)
+    mock_api.assume_queue_role_for_user.return_value = {
+        "credentials": {
+            "accessKeyId": "ASIAEXAMPLE",
+            "secretAccessKey": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            "sessionToken": "AQoDYXdzEJr...<remainder of session token>",
+            "expiration": expiration,
+        }
+    }
+
+    config_file.set_setting("defaults.farm_id", "f-default")
+    config_file.set_setting("defaults.queue_id", "q-default")
+
+    # Execute
+    runner = CliRunner()
+    result = runner.invoke(queue_export_credentials, [])
+
+    # Verify
+    assert result.exit_code == 0, result.output
+    mock_api.assume_queue_role_for_user.assert_called_once_with(
+        farmId="f-default", queueId="q-default", config=mock.ANY
+    )
+
+
+def test_queue_export_credentials_client_error(mock_api, fresh_deadline_config):
+    """Test error handling when API call fails."""
+    # Setup
+
+    mock_api.assume_queue_role_for_user.side_effect = ClientError(
+        {"Error": {"Code": "AccessDeniedException", "Message": "Access denied"}},
+        "AssumeQueueRoleForUser",
+    )
+
+    # Execute
+    runner = CliRunner()
+    result = runner.invoke(
+        queue_export_credentials,
+        ["--farm-id", "f-abcdef12345", "--queue-id", "q-12345abcdef"],
+    )
+
+    # Verify
+    assert result.exit_code != 0
+    assert "Insufficient permissions" in result.output
+
+    # Verify telemetry
+    telemetry_client = mock_api._telemetry.get_deadline_cloud_library_telemetry_client.return_value
+    telemetry_client.record_event.assert_called_once()
+    event_name, event_details = telemetry_client.record_event.call_args[0]
+    assert event_name == "com.amazon.rum.deadline.queue_export_credentials"
+    assert event_details["is_success"] is False
+    assert event_details["error_type"] == "ClientError"
+
+
+def test_queue_export_credentials_auth_error(mock_api, fresh_deadline_config):
+    """Test error handling when authentication fails."""
+    # Setup
+
+    mock_api.assume_queue_role_for_user.side_effect = ClientError(
+        {
+            "Error": {
+                "Code": "UnrecognizedClientException",
+                "Message": "The security token included in the request is invalid",
+            }
+        },
+        "AssumeQueueRoleForUser",
+    )
+
+    # Execute
+    runner = CliRunner()
+    result = runner.invoke(
+        queue_export_credentials,
+        ["--farm-id", "f-abcdef12345", "--queue-id", "q-12345abcdef"],
+    )
+
+    # Verify
+    assert result.exit_code != 0
+    assert "Authentication failed" in result.output


### PR DESCRIPTION
Add API methods and CLI command to export queue credentials in a format compatible with AWS SDK credentials_process interface. This enables users to create AWS profiles that use queue-specific credentials.

- Add assume_queue_role_for_user and assume_queue_role_for_read API methods
- Add queue export-credentials CLI command with USER and READ modes
- Add unit tests for the new API methods

This feature allows users to integrate Deadline Cloud queue credentials with their AWS profiles, enabling queue-specific permissions with AWS CLI and SDK operations.


### What was the problem/requirement? (What/Why)
During a recent discussion with a user, they had some usecases where hooking up queue credentials to the AWS CLI would enable additional programmatic usecases

### What was the solution? (How)
The new subcommand 'export-credentials' has been added. This command prints credentials in a format useful by the AWS SDK credential_process interface

### What is the impact of this change?
Customers have additional tools to use Deadline Cloud's permission management system in their scripts and workflows outside what is immediately supported by the Deadline Cloud tools.

### How was this change tested?
Unit tests have been added
I created a local credential profile using this command and successfully made `aws sts get-caller-identity` API invokes.

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests? yes
- Have you run the integration tests? yes, and I have added a test.
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass. no

### Was this change documented?

- Are relevant docstrings in the code base updated? yes
- Has the README.md been updated? yes

### Does this PR introduce new dependencies? no

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x ] This PR does not add any new dependencies.

### Is this a breaking change? No

A breaking change is one that modifies a public contract in a way that is not backwards compatible. See the 
[Public Contracts](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#public-contracts) section
of the DEVELOPMENT.md for more information on the public contracts.

If so, then please describe the changes that users of this package must make to update their scripts, or Python applications.


### Does this change impact security? No. While this change might appear on the surface to impact security because of its nature of returning credentials, it is simply transforming credentials that the user must already have access to. It does not change any security posture. 

- Does the change need to be threat modeled? For example, does it create or modify files/directories that must only be readable by the process owner?
    - If so, then please label this pull request with the "security" label. We'll work with you to analyze the threats.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
