### PR TITLE
chore: move uninstaller to DeadlineClient prefix

### DIFF
--- a/installer/DeadlineCloudClient.xml
+++ b/installer/DeadlineCloudClient.xml
@@ -11,6 +11,7 @@
         Reference: https://clients.bitrock.com/installbuilder/docs/installbuilder-userguide.html#built_in_variables
     -->
     <installerFilename>${product_shortname}-${platform_name}-installer.${platform_exec_suffix}</installerFilename>
+    <uninstallerDirectory>${installdir}/DeadlineClient</uninstallerDirectory>
     <enableRollback>1</enableRollback>
     <enableTimestamp>1</enableTimestamp>
 
@@ -437,10 +438,10 @@ ${_fnAddEnvironmentVariable_list}
         </writeFile>
         <writeFile>
             <progressText>Writing version file</progressText>
-            <path>${installdir}/installer_version.txt</path>
+            <path>${installdir}/DeadlineClient/installer_version.txt</path>
             <text>${project.version}</text>
         </writeFile>
-        <changePermissions permissions="0644" files="${installdir}/installer_version.txt"/>
+        <changePermissions permissions="0644" files="${installdir}/DeadlineClient/installer_version.txt"/>
         <addFilesToUninstaller>
           <files>${installdir}/DeadlineClient/</files>
         </addFilesToUninstaller>
@@ -458,7 +459,6 @@ ${_fnAddEnvironmentVariable_list}
                 <isFalse value="${installer_is_root_install}"/>
             </ruleList>
         </actionGroup>
-        <deleteFile path="${installdir}/installer_version.txt"/>
     </preUninstallationActionList>
 
     <postUninstallationActionList>

--- a/test/installer/test_installer.py
+++ b/test/installer/test_installer.py
@@ -84,8 +84,9 @@ def _validate_files(installation_path: Path) -> None:
     # THEN
     top_level_dir = [f.name for f in installation_path.iterdir()]
     assert "DeadlineClient" in top_level_dir
-    assert "installer_version.txt" in top_level_dir
-    assert uninstaller in top_level_dir
+    deadline_client_dir = [f.name for f in (Path(installation_path, "DeadlineClient")).iterdir()]
+    assert "installer_version.txt" in deadline_client_dir
+    assert uninstaller in deadline_client_dir
 
     # Check main CLI runs
     cli_path = installation_path / "DeadlineClient" / "deadline"
@@ -134,9 +135,11 @@ def per_test_system_installation(installer_path, tmp_path):
 
 @pytest.fixture(scope="function")
 def uninstaller_path():
-    uninstaller_path = Path("uninstall")
+    uninstaller_path = Path("DeadlineClient", "uninstall")
     if platform.system() == "Darwin":
-        uninstaller_path = Path("uninstall.app", "Contents", "MacOS", "installbuilder.sh")
+        uninstaller_path = Path(
+            "DeadlineClient", "uninstall.app", "Contents", "MacOS", "installbuilder.sh"
+        )
     elif platform.system() == "Windows":
         uninstaller_path = uninstaller_path.with_suffix(".exe")
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The individual installer for the Deadline Cloud client places its uninstaller and installer_version.txt under the root prefix not within the DeadlineClient prefix that is automatically created within.

### What was the solution? (How)
Move the uninstaller and installer_version.txt within the DeadlineClient prefix within the installation directory

### What is the impact of this change?
Future changes are unblocked.

### How was this change tested?

Built dev installers for all 3 OSes and verified that the uninstaller worked on each of them and removed the entire installation.

### Was this change documented?

No

### Does this PR introduce new dependencies?

No

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
