### PR TITLE
chore: use pip3 in pipeline script

### DIFF
--- a/pipeline/build_pyinstaller_artifact.sh
+++ b/pipeline/build_pyinstaller_artifact.sh
@@ -3,8 +3,8 @@
 # Set the -e option
 set -e
 
-pip install --upgrade pip
-pip install --upgrade hatch
+pip3 install --upgrade pip
+pip3 install --upgrade hatch
 
 hatch run installer:build
 hatch run installer:make_exe


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

unused pyenv pip was overriding the intended python env. 

### What was the solution? (How)
Swapping to pip3 avoids this, though maybe a little obtuse.

### What is the impact of this change?
MacOS Installer builds using the right python.

### How was this change tested?
Ran installer workflows for macos which now uses the right pip. Ran linux and confirmed everything still worked as expected

### Was this change documented?
N/A

### Does this PR introduce new dependencies?
N/A

### Is this a breaking change?

N/A

### Does this change impact security?

N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
