### PR TITLE
chore: Add new workflows for issue staleness and comment management.

### DIFF
--- a/.github/workflows/responded.yml
+++ b/.github/workflows/responded.yml
@@ -1,0 +1,9 @@
+name: Contributor Responded
+on:
+    issue_comment:
+        types: [created, edited]
+
+jobs:
+    label-new-prs:
+        uses: aws-deadline/.github/.github/workflows/reusable_responded.yml@mainline
+        secrets: inherit

--- a/.github/workflows/stale_prs_and_issues.yml
+++ b/.github/workflows/stale_prs_and_issues.yml
@@ -1,0 +1,10 @@
+name: 'Check stale issues/PRs.'
+on: 
+  schedule:
+    # Run every hour on the hour
+    - cron: '0 * * * *'
+
+jobs:
+    label-new-prs:
+        uses: aws-deadline/.github/.github/workflows/reusable_stale_prs_and_issues.yml@mainline
+        secrets: inherit


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Issues and PRs that are waiting on contributor should be closed as stale. If a contributor responds to feedback, the issue/pr should have a label notifying the maintainers.

### What was the solution? (How)

We've added 2 reusable workflows that do this. This PR enables their usage in this repo.
Similar to this Blender PR: https://github.com/aws-deadline/deadline-cloud-for-blender/pull/196 

### What is the impact of this change?

Issue management will be easier and cleaner that it previously has been.

### How was this change tested?

Same change was enabled in Deadline Cloud For Blender and has been running their for some time now.

### Was this change documented?

No

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?

No

### Does this change impact security?

No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
