### PR TITLE
chore: allow the Deadline endpoint to be read from an AWS profile con…

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -179,8 +179,20 @@ Notes:
   3. `export INTEG_TEST_JA_CROSS_ACCOUNT_BUCKET=<your-bucket-name-in-the-second-account>`
   4. Run the integration tests.
 * AWS Developers note: If testing with a non-production deployment of AWS Deadline Cloud then you will have to
-define the `AWS_ENDPOINT_URL_DEADLINE` environment variable to the non-production endpoint URL. For example,
-production endpoints look like: `export AWS_ENDPOINT_URL_DEADLINE="https://deadline.$AWS_DEFAULT_REGION.amazonaws.com"`
+define the endpoint. There are two options:
+   * Set the `AWS_ENDPOINT_URL_DEADLINE` environment variable to the non-production endpoint URL. For example,
+production endpoints look like: `export AWS_ENDPOINT_URL_DEADLINE="https://deadline.$AWS_DEFAULT_REGION.amazonaws.com"`.
+   * Set the `deaadline_endpoint` property in your profile in `~/.aws/config`. For example, your profile might look like:
+      ```
+      [profile my-farm]
+      region=us-west-2
+      credential_process="/Applications/Deadline Cloud Monitor.app/Contents/MacOS/Deadline Cloud Monitor" get-credentials --profile my-farm
+      user_id=00000000-0000-0000-0000-000000000000
+      identity_store_id=d-0000000000
+      monitor_id=monitor-00000000000000000000000000000000
+      deadline_endpoint=https://deadline.us-west-2.amazonaws.com
+      ```
+
 
 ### Squish GUI Submitter Tests
 

--- a/src/deadline/client/api/_session.py
+++ b/src/deadline/client/api/_session.py
@@ -12,6 +12,7 @@ from configparser import ConfigParser
 from contextlib import contextmanager
 from enum import Enum
 from functools import lru_cache
+import os
 from typing import Optional
 
 import boto3  # type: ignore[import]
@@ -129,6 +130,18 @@ def get_boto3_client(service_name: str, config: Optional[ConfigParser] = None) -
     """
 
     session = get_boto3_session(config=config)
+
+    # If the deadline_endpoint is set as a property of the AWS profile, use it by setting
+    # the AWS_ENDPOINT_URL_DEADLINE env variable. Useful for setting a non-standard endpoint
+    # in use cases where it's not easy to set an environment variable like using a submitter.
+    if service_name == "deadline":
+        profile_config = session._session.get_scoped_config()
+        if (
+            "deadline_endpoint" in profile_config
+            and os.environ.get("AWS_ENDPOINT_URL_DEADLINE") is None
+        ):
+            os.environ["AWS_ENDPOINT_URL_DEADLINE"] = profile_config["deadline_endpoint"]
+
     return session.client(service_name, config=get_default_client_config())
 
 

--- a/test/unit/deadline_client/api/test_session.py
+++ b/test/unit/deadline_client/api/test_session.py
@@ -1,0 +1,138 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import os
+from unittest import TestCase, mock
+
+from botocore.session import Session as BotocoreSession
+from botocore.config import Config
+
+from deadline.client.api._session import get_boto3_client
+
+
+class TestSession(TestCase):
+    """Tests for the _session.py module."""
+
+    @mock.patch.dict(os.environ, {}, clear=True)
+    @mock.patch("deadline.client.api._session.get_boto3_session")
+    def test_get_boto3_client_sets_deadline_endpoint_from_profile(self, mock_get_session):
+        """Test that get_boto3_client sets AWS_ENDPOINT_URL_DEADLINE from profile config."""
+        # Setup mock session with a profile that has deadline_endpoint
+        mock_session = mock.MagicMock()
+        mock_get_session.return_value = mock_session
+
+        mock_botocore_session = mock.MagicMock(spec=BotocoreSession)
+        mock_session._session = mock_botocore_session
+
+        # Mock the profile config with a deadline_endpoint
+        mock_botocore_session.get_scoped_config.return_value = {
+            "deadline_endpoint": "https://deadline.custom-region.amazonaws.com"
+        }
+
+        # Mock get_default_client_config
+        mock_config = mock.MagicMock(spec=Config)
+        with mock.patch(
+            "deadline.client.api._session.get_default_client_config", return_value=mock_config
+        ):
+            # Call the function with deadline service
+            get_boto3_client("deadline")
+
+            # Verify that AWS_ENDPOINT_URL_DEADLINE was set correctly
+            self.assertEqual(
+                os.environ.get("AWS_ENDPOINT_URL_DEADLINE"),
+                "https://deadline.custom-region.amazonaws.com",
+            )
+
+            # Verify that the client was created with the correct service name
+            mock_session.client.assert_called_once_with("deadline", config=mock_config)
+
+    @mock.patch.dict(os.environ, {}, clear=True)
+    @mock.patch("deadline.client.api._session.get_boto3_session")
+    def test_get_boto3_client_without_deadline_endpoint(self, mock_get_session):
+        """Test that get_boto3_client doesn't set AWS_ENDPOINT_URL_DEADLINE when not in profile."""
+        # Setup mock session with a profile that doesn't have deadline_endpoint
+        mock_session = mock.MagicMock()
+        mock_get_session.return_value = mock_session
+
+        mock_botocore_session = mock.MagicMock(spec=BotocoreSession)
+        mock_session._session = mock_botocore_session
+
+        # Mock the profile config without a deadline_endpoint
+        mock_botocore_session.get_scoped_config.return_value = {"region": "us-west-2"}
+
+        # Mock get_default_client_config
+        mock_config = mock.MagicMock(spec=Config)
+        with mock.patch(
+            "deadline.client.api._session.get_default_client_config", return_value=mock_config
+        ):
+            # Call the function with deadline service
+            get_boto3_client("deadline")
+
+            # Verify that AWS_ENDPOINT_URL_DEADLINE was not set
+            self.assertNotIn("AWS_ENDPOINT_URL_DEADLINE", os.environ)
+
+            # Verify that the client was created with the correct service name
+            mock_session.client.assert_called_once_with("deadline", config=mock_config)
+
+    @mock.patch.dict(os.environ, {}, clear=True)
+    @mock.patch("deadline.client.api._session.get_boto3_session")
+    def test_get_boto3_client_non_deadline_service(self, mock_get_session):
+        """Test that get_boto3_client doesn't check for deadline_endpoint for non-deadline services."""
+        # Setup mock session
+        mock_session = mock.MagicMock()
+        mock_get_session.return_value = mock_session
+
+        mock_botocore_session = mock.MagicMock(spec=BotocoreSession)
+        mock_session._session = mock_botocore_session
+
+        # Mock the profile config with a deadline_endpoint
+        mock_botocore_session.get_scoped_config.return_value = {
+            "deadline_endpoint": "https://deadline.custom-region.amazonaws.com"
+        }
+
+        # Mock get_default_client_config
+        mock_config = mock.MagicMock(spec=Config)
+        with mock.patch(
+            "deadline.client.api._session.get_default_client_config", return_value=mock_config
+        ):
+            # Call the function with a non-deadline service
+            get_boto3_client("s3")
+
+            # Verify that AWS_ENDPOINT_URL_DEADLINE was not set
+            self.assertNotIn("AWS_ENDPOINT_URL_DEADLINE", os.environ)
+
+            # Verify that the client was created with the correct service name
+            mock_session.client.assert_called_once_with("s3", config=mock_config)
+
+    @mock.patch.dict(
+        os.environ,
+        {"AWS_ENDPOINT_URL_DEADLINE": "https://existing-endpoint.amazonaws.com"},
+        clear=True,
+    )
+    @mock.patch("deadline.client.api._session.get_boto3_session")
+    def test_get_boto3_client_does_not_override_existing_env_var(self, mock_get_session):
+        """Test that get_boto3_client does not override an existing AWS_ENDPOINT_URL_DEADLINE env var."""
+        # Setup mock session with a profile that has deadline_endpoint
+        mock_session = mock.MagicMock()
+        mock_get_session.return_value = mock_session
+
+        mock_botocore_session = mock.MagicMock(spec=BotocoreSession)
+        mock_session._session = mock_botocore_session
+
+        # Mock the profile config with a deadline_endpoint
+        mock_botocore_session.get_scoped_config.return_value = {
+            "deadline_endpoint": "https://deadline.new-endpoint.amazonaws.com"
+        }
+
+        # Mock get_default_client_config
+        mock_config = mock.MagicMock(spec=Config)
+        with mock.patch(
+            "deadline.client.api._session.get_default_client_config", return_value=mock_config
+        ):
+            # Call the function with deadline service
+            get_boto3_client("deadline")
+
+            # Verify that AWS_ENDPOINT_URL_DEADLINE was not overridden
+            self.assertEqual(
+                os.environ.get("AWS_ENDPOINT_URL_DEADLINE"),
+                "https://existing-endpoint.amazonaws.com",
+            )


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
For using non-standard endpoints, we can set the `AWS_ENDPOINT_URL_DEADLINE` env var. But in some cases like using a submitter in a DCC, it's not easy to set env vars. Also it can be annoying to have to set the env var every time it's used.

### What was the solution? (How)
Allow the Deadline endpoint to be set as a property of the AWS profile.

### What is the impact of this change?
Easier to use non-standard endpoints when using submitters.

### How was this change tested?
Manual testing and unit tests.

### Was this change documented?
Yes

### Does this PR introduce new dependencies?
*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?
No

### Does this change impact security?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
