### PR TITLE
chore: remove unused quality check

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -11,7 +11,6 @@ typing = "mypy {args:src test} --always-false=PYQT5 --always-false=PYSIDE2 --alw
 style = ["ruff check {args:.}", "ruff format --check --diff {args:.}"]
 fmt = ["ruff format {args:.}", "style"]
 lint = ["style", "typing"]
-quality = ["style", "typing"]
 
 [[envs.all.matrix]]
 python = ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]

--- a/hatch.toml
+++ b/hatch.toml
@@ -11,7 +11,7 @@ typing = "mypy {args:src test} --always-false=PYQT5 --always-false=PYSIDE2 --alw
 style = ["ruff check {args:.}", "ruff format --check --diff {args:.}"]
 fmt = ["ruff format {args:.}", "style"]
 lint = ["style", "typing"]
-quality = ["ruff format {args:.}", "typing", "style"]
+quality = ["style", "typing"]
 
 [[envs.all.matrix]]
 python = ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Our code quality checks were formatting files instead of checking formatting, so it's possible for someone to check in unformatted files.

### What was the solution? (How)
Fix the style check so that it checks the formatting instead of doing the formatting.

### What is the impact of this change?
Enforces code formatting.

### How was this change tested?
I ran `hatch run quality` with the ruff command update and incorrectly formatted code, and it failed as expected. Then I fixed the formatting nad it passed.

### Was this change documented?
n/a

### Does this PR introduce new dependencies?

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?

No
### Does this change impact security?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
