### PR TITLE
fix: manifest snapshot include and exclude paths handled incorrectly in glob

### DIFF
--- a/src/deadline/client/cli/_groups/manifest_group.py
+++ b/src/deadline/client/cli/_groups/manifest_group.py
@@ -74,6 +74,7 @@ def cli_manifest():
     "--include",
     default=None,
     help="Glob syntax of files and directories to include in the manifest. Can be provided multiple times.",
+    multiple=True,
 )
 @click.option(
     "-e",

--- a/src/deadline/job_attachments/_glob.py
+++ b/src/deadline/job_attachments/_glob.py
@@ -43,6 +43,33 @@ def _process_glob_inputs(glob_arg_input: str) -> GlobConfig:
     return glob_config
 
 
+def _match_files_with_pattern(base_path: str, patterns: List[str]) -> set:
+    """
+    Helper function to match files based on glob patterns.
+
+    Args:
+        base_path: Root path to glob from
+        patterns: List of glob patterns to match
+
+    Returns:
+        Set of normalized file paths that match the patterns
+    """
+    matched_files = set()
+    for pattern in patterns:
+        # Make pattern relative to base path
+        full_pattern = os.path.join(base_path, pattern)
+
+        # Use recursive glob for directory matching
+        for matched_path in glob.glob(full_pattern, recursive=True):
+            # Only add files, not directories
+            if os.path.isfile(matched_path):
+                # Convert to proper path format
+                normalized_path = os.path.normpath(matched_path)
+                matched_files.add(normalized_path)
+
+    return matched_files
+
+
 def _glob_paths(
     path: str, include: List[str] = ["**/*"], exclude: Optional[List[str]] = None
 ) -> List[str]:
@@ -57,35 +84,12 @@ def _glob_paths(
     # Convert path to absolute path
     base_path = os.path.abspath(path)
 
-    # Initialize result set
-    matched_files = set()
-
     # Process include patterns
-    for pattern in include:
-        # Make pattern relative to base path
-        full_pattern = os.path.join(base_path, pattern)
-
-        # Use recursive glob for directory matching
-        for matched_path in glob.glob(full_pattern, recursive=True):
-            # Only add files, not directories
-            if os.path.isfile(matched_path):
-                # Convert to proper path format
-                normalized_path = os.path.normpath(matched_path)
-                matched_files.add(normalized_path)
+    matched_files = _match_files_with_pattern(base_path, include)
 
     # Process exclude patterns
     if exclude:
-        files_to_exclude = set()
-        for pattern in exclude:
-            # Make pattern relative to base path
-            full_pattern = os.path.join(base_path, pattern)
-
-            # Find files to exclude
-            for matched_path in glob.glob(full_pattern, recursive=True):
-                if os.path.isfile(matched_path):
-                    normalized_path = os.path.normpath(matched_path)
-                    files_to_exclude.add(normalized_path)
-
+        files_to_exclude = _match_files_with_pattern(base_path, exclude)
         # Remove excluded files from result
         matched_files -= files_to_exclude
 

--- a/src/deadline/job_attachments/_glob.py
+++ b/src/deadline/job_attachments/_glob.py
@@ -1,5 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
+import os
+import glob
 import json
 from pathlib import Path
 from typing import List, Optional
@@ -52,21 +54,39 @@ def _glob_paths(
     exclude: Optional, pattern syntax for files to exclude.
     return: List of files found based on supplied glob patterns.
     """
-    include_files: List[Optional[str]] = []
-    for input_glob in include:
-        include_files.extend(
-            [str(path) if path.is_file() else None for path in Path(path).glob(input_glob)]
-        )
-    include_files = list(filter(None, include_files))
+    # Convert path to absolute path
+    base_path = os.path.abspath(path)
 
+    # Initialize result set
+    matched_files = set()
+
+    # Process include patterns
+    for pattern in include:
+        # Make pattern relative to base path
+        full_pattern = os.path.join(base_path, pattern)
+
+        # Use recursive glob for directory matching
+        for matched_path in glob.glob(full_pattern, recursive=True):
+            # Only add files, not directories
+            if os.path.isfile(matched_path):
+                # Convert to proper path format
+                normalized_path = os.path.normpath(matched_path)
+                matched_files.add(normalized_path)
+
+    # Process exclude patterns
     if exclude:
-        exclude_files = []
-        for exclude_glob in exclude:
-            exclude_files.extend(
-                [str(path) if path.is_file() else None for path in Path(path).glob(exclude_glob)]
-            )
+        files_to_exclude = set()
+        for pattern in exclude:
+            # Make pattern relative to base path
+            full_pattern = os.path.join(base_path, pattern)
 
-        # use sets to remove duplicates and remove all excluded file.
-        exclude_files = list(filter(None, exclude_files))
-        include_files = list(set(include_files) - set(exclude_files))
-    return include_files  # type: ignore[return-value]
+            # Find files to exclude
+            for matched_path in glob.glob(full_pattern, recursive=True):
+                if os.path.isfile(matched_path):
+                    normalized_path = os.path.normpath(matched_path)
+                    files_to_exclude.add(normalized_path)
+
+        # Remove excluded files from result
+        matched_files -= files_to_exclude
+
+    return list(matched_files)

--- a/src/deadline/job_attachments/asset_sync.py
+++ b/src/deadline/job_attachments/asset_sync.py
@@ -583,6 +583,25 @@ class AssetSync:
 
         return self.manifest_model.AssetManifest(**asset_manifest_args)  # type: ignore[call-arg]
 
+    @staticmethod
+    def _get_output_dirs(
+        manifest_properties: ManifestProperties,
+    ) -> List[str]:
+        output_dirs: List[str] = []
+        source_path_format = manifest_properties.rootPathFormat
+        current_path_format = PathFormat.get_host_path_format()
+
+        for output_dir in manifest_properties.outputRelativeDirectories or []:
+            if source_path_format != current_path_format:
+                if source_path_format == PathFormat.WINDOWS:
+                    output_dir = output_dir.replace("\\", "/")
+                elif source_path_format == PathFormat.POSIX:
+                    output_dir = output_dir.replace("/", "\\")
+
+            output_dirs.append(output_dir)
+
+        return output_dirs
+
     def _get_output_files(
         self,
         manifest_properties: ManifestProperties,

--- a/src/deadline/job_attachments/asset_sync.py
+++ b/src/deadline/job_attachments/asset_sync.py
@@ -583,25 +583,6 @@ class AssetSync:
 
         return self.manifest_model.AssetManifest(**asset_manifest_args)  # type: ignore[call-arg]
 
-    @staticmethod
-    def _get_output_dirs(
-        manifest_properties: ManifestProperties,
-    ) -> List[str]:
-        output_dirs: List[str] = []
-        source_path_format = manifest_properties.rootPathFormat
-        current_path_format = PathFormat.get_host_path_format()
-
-        for output_dir in manifest_properties.outputRelativeDirectories or []:
-            if source_path_format != current_path_format:
-                if source_path_format == PathFormat.WINDOWS:
-                    output_dir = output_dir.replace("\\", "/")
-                elif source_path_format == PathFormat.POSIX:
-                    output_dir = output_dir.replace("/", "\\")
-
-            output_dirs.append(output_dir)
-
-        return output_dirs
-
     def _get_output_files(
         self,
         manifest_properties: ManifestProperties,

--- a/test/integ/cli/test_cli_manifest_snapshot.py
+++ b/test/integ/cli/test_cli_manifest_snapshot.py
@@ -129,6 +129,8 @@ class TestManifestSnapshot:
         # Lets add another file.
         new_file = "subdir1/file3.txt"
         Path(os.path.join(root_dir, new_file)).touch()
+        new_nested_file = "subdir1/nested/file4.txt"
+        Path(os.path.join(root_dir, new_nested_file)).touch()
 
         # When
         runner = CliRunner()
@@ -163,8 +165,8 @@ class TestManifestSnapshot:
         for file_entry in manifest_data.get("paths", []):
             actual_files.add(file_entry.get("path"))
 
-        assert actual_files == {"subdir1/file3.txt"}, (
-            f"Expected manifest to contain only 'subdir1/file1.txt' and 'subdir1/file3.txt', "
+        assert actual_files == {new_file, new_nested_file}, (
+            f"Expected manifest to contain only 'subdir1/file3.txt' and 'subdir1/nested/file4.txt', "
             f"but got {actual_files}"
         )
 

--- a/test/integ/cli/test_cli_manifest_snapshot.py
+++ b/test/integ/cli/test_cli_manifest_snapshot.py
@@ -25,6 +25,13 @@ class TestManifestSnapshot:
         with tempfile.TemporaryDirectory() as tmpdir_path:
             yield tmpdir_path
 
+    @pytest.fixture
+    def manifest_dir(self, temp_dir):
+        manifest_dir = os.path.join(temp_dir, "manifest_dir")
+        os.makedirs(manifest_dir)
+
+        yield manifest_dir
+
     def _create_test_manifest(self, tmp_path: str, root_dir: str) -> str:
         """
         Create some test files in the temp dir, snapshot it and return the manifest file.
@@ -105,6 +112,61 @@ class TestManifestSnapshot:
             diff = json.loads(result.output)
             assert len(diff["new"]) == 1
             assert new_file in diff["new"]
+
+    def test_manifest_snapshot_and_diff_with_include(self, tmp_path: str, manifest_dir: str):
+        """
+        Tests creating a snapshot of the whole root directory and then running a diff with an include filter.
+        This verifies that:
+        1. The initial snapshot contains all files
+        2. The diff correctly identifies changes only in the included subdirectory
+        """
+        TEST_ROOT_DIR = "root_dir"
+
+        # Given a created manifest file...
+        root_dir = os.path.join(tmp_path, TEST_ROOT_DIR)
+        manifest = self._create_test_manifest(tmp_path, root_dir)
+
+        # Lets add another file.
+        new_file = "subdir1/file3.txt"
+        Path(os.path.join(root_dir, new_file)).touch()
+
+        # When
+        runner = CliRunner()
+        args = [
+            "manifest",
+            "snapshot",
+            "--root",
+            root_dir,
+            "--diff",
+            manifest,
+            "--include",
+            "subdir1/**",
+            "--destination",
+            manifest_dir,
+        ]
+
+        result = runner.invoke(main, args)
+        assert result.exit_code == 0, result.output
+
+        # Find the manifest file
+        manifest_files = os.listdir(manifest_dir)
+        assert len(manifest_files) == 1, (
+            f"Expected exactly one manifest file, but got {len(manifest_files)}"
+        )
+        manifest_path = os.path.join(manifest_dir, manifest_files[0])
+
+        # Read the manifest file and verify its contents
+        with open(manifest_path, "r") as f:
+            manifest_data = json.load(f)
+
+        actual_files = set()
+        for file_entry in manifest_data.get("paths", []):
+            actual_files.add(file_entry.get("path"))
+
+        assert actual_files == {"subdir1/file3.txt"}, (
+            f"Expected manifest to contain only 'subdir1/file1.txt' and 'subdir1/file3.txt', "
+            f"but got {actual_files}"
+        )
 
     @pytest.mark.integ
     @pytest.mark.skipif(

--- a/test/unit/deadline_job_attachments/api/test_snapshot.py
+++ b/test/unit/deadline_job_attachments/api/test_snapshot.py
@@ -4,7 +4,7 @@ import json
 import os
 from pathlib import Path
 import tempfile
-from typing import List, Optional
+from typing import List, Optional, Set
 from deadline.job_attachments.api.manifest import _manifest_snapshot
 from deadline.job_attachments.exceptions import ManifestCreationException
 from deadline.job_attachments.models import ManifestSnapshot
@@ -17,6 +17,12 @@ class TestSnapshotAPI:
     def temp_dir(self):
         with tempfile.TemporaryDirectory() as tmpdir_path:
             yield tmpdir_path
+
+    def get_manifest_files(self, manifest_path) -> Set[str]:
+        """Helper method to extract file paths from a manifest"""
+        with open(manifest_path, "r") as manifest_file:
+            manifest_payload = json.load(manifest_file)
+            return {item["path"] for item in manifest_payload["paths"]}
 
     def test_snapshot_empty_folder(self, temp_dir):
         """
@@ -102,6 +108,9 @@ class TestSnapshotAPI:
         [
             pytest.param(
                 ["test_file", "**/nested_file"], None, ["test_file", "nested/nested_file"]
+            ),
+            pytest.param(
+                ["nested/**"], None, ["nested/excluded_nested_file", "nested/nested_file"]
             ),
             pytest.param(
                 None,
@@ -384,3 +393,103 @@ class TestSnapshotAPI:
         )
         # Then. We should find no new manifest, there were no files to snapshot
         assert diffed_manifest is None
+
+    @pytest.mark.parametrize(
+        "test_case,initial_include,initial_exclude,diff_include,diff_exclude,modified_files,new_files,expected_diff_files",
+        [
+            # Test case 1: Include filter with same filter in diff
+            (
+                "include_filter",
+                None,  # initial include
+                None,  # initial exclude
+                ["subdir1/**"],  # diff include
+                None,  # diff exclude
+                ["subdir1/file1.txt"],  # files to modify
+                [
+                    ("subdir1/file2.txt", "new txt"),
+                    ("subdir1/file1.txt", "new dat"),
+                ],  # new files to add
+                {"subdir1/file1.txt", "subdir1/file2.txt"},  # expected files in diff
+            ),
+            # Test case 2: Exclude filter with same filter in diff
+            (
+                "exclude_filter",
+                None,  # initial include
+                ["*.dat"],  # initial exclude
+                None,  # diff include
+                ["*.dat"],  # diff exclude
+                ["file1.txt", "file1.dat"],  # files to modify
+                [],  # no new files
+                {"file1.txt"},  # expected files in diff (dat file excluded)
+            ),
+        ],
+    )
+    def test_diff_with_includes_excludes(
+        self,
+        temp_dir,
+        test_case,
+        initial_include,
+        initial_exclude,
+        diff_include,
+        diff_exclude,
+        modified_files,
+        new_files,
+        expected_diff_files,
+    ):
+        """
+        Parametrized test for different filter scenarios with diff:
+        1. Create initial snapshot with specified include/exclude filters
+        2. Modify specified files and add new files
+        3. Create diff snapshot with specified include/exclude filters
+        4. Verify the diff contains the expected files
+        """
+        # Setup test directory
+        root_dir = os.path.join(temp_dir, "snapshot")
+        os.makedirs(root_dir, exist_ok=True)
+
+        # Create initial files
+        subdir1 = os.path.join(root_dir, "subdir1")
+        subdir2 = os.path.join(root_dir, "subdir2")
+        os.makedirs(subdir1)
+        os.makedirs(subdir2)
+        Path(os.path.join(subdir1, "file1.txt")).touch()
+        Path(os.path.join(subdir2, "file2.txt")).touch()
+
+        # Create initial snapshot with specified filters
+        initial_manifest = _manifest_snapshot(
+            root=root_dir,
+            destination=temp_dir,
+            name=f"initial_{test_case}",
+            include=initial_include,
+            exclude=initial_exclude,
+        )
+
+        assert initial_manifest is not None
+        initial_paths = self.get_manifest_files(initial_manifest.manifest)
+        assert len(initial_paths) == 2
+
+        # Modify specified files
+        for filename in modified_files:
+            with open(os.path.join(root_dir, filename), "w") as f:
+                f.write(f"modified {filename}")
+
+        # Add new files
+        for filename, content in new_files:
+            with open(os.path.join(root_dir, filename), "w") as f:
+                f.write(content)
+
+        # Create diff snapshot with specified filters
+        diff_manifest = _manifest_snapshot(
+            root=root_dir,
+            destination=temp_dir,
+            name=f"diff_{test_case}",
+            include=diff_include,
+            exclude=diff_exclude,
+            diff=initial_manifest.manifest,
+        )
+
+        assert diff_manifest is not None
+        diff_files = self.get_manifest_files(diff_manifest.manifest)
+
+        # Verify diff manifest contains expected files
+        assert diff_files == expected_diff_files

--- a/test/unit/deadline_job_attachments/test_glob.py
+++ b/test/unit/deadline_job_attachments/test_glob.py
@@ -77,3 +77,47 @@ def test_glob_path_exclude(test_glob_folder: str):
     assert len(globbed_files) == 2
     assert os.path.join(os.sep, test_glob_folder, "include.txt") in globbed_files
     assert os.path.join(os.sep, test_glob_folder, "nested", "nested_include.txt") in globbed_files
+
+
+def test_glob_path_include_subdir(test_glob_folder: str):
+    """
+    Test case to glob files only from the include sub directory.
+    """
+    globbed_files: List[str] = _glob_paths(path=test_glob_folder, include=["nested/**"])
+
+    # There are 2 files
+    assert len(globbed_files) == 2
+    assert os.path.join(os.sep, test_glob_folder, "nested", "nested_include.txt") in globbed_files
+    assert os.path.join(os.sep, test_glob_folder, "nested", "nested_exclude.txt") in globbed_files
+
+
+def test_glob_path_include_nonexistent(test_glob_folder: str):
+    """
+    Test case to glob files only from the include sub directory which does not exist.
+    """
+    globbed_files: List[str] = _glob_paths(path=test_glob_folder, include=["nonexistent/**"])
+
+    # There are 0 files
+    assert len(globbed_files) == 0
+
+
+def test_glob_path_exclude_subdir(test_glob_folder: str):
+    """
+    Test case to glob files and exclude sub directory.
+    """
+    globbed_files: List[str] = _glob_paths(path=test_glob_folder, exclude=["nested/**"])
+
+    # There are 2 files
+    assert len(globbed_files) == 2
+    assert os.path.join(os.sep, test_glob_folder, "include.txt") in globbed_files
+    assert os.path.join(os.sep, test_glob_folder, "exclude.txt") in globbed_files
+
+
+def test_glob_path_exclude_nonexistent(test_glob_folder: str):
+    """
+    Test case to glob files only exclude sub directory which does not exist.
+    """
+    globbed_files: List[str] = _glob_paths(path=test_glob_folder, exclude=["nonexistent/**"])
+
+    # There are 2 files
+    assert len(globbed_files) == 4


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
This PR fixes 2 issues for `deadline manifest snapshot`

#### snapshot doesn't handle `--include` correctly during glob
```
deadline manifest snapshot --root /tmp/test/ --destination /tmp/manifest --name snap --include "manifest/include/*"
The AWS Deadline Cloud CLI encountered the following exception:
Non-relative patterns are unsupported
Traceback (most recent call last):
  File "/Users/.local/share/mise/installs/python/3.11/lib/python3.11/site-packages/deadline/client/cli/_common.py", line 55, in wraps
    func(*args, **kwargs)
  File "/Users/.local/share/mise/installs/python/3.11/lib/python3.11/site-packages/deadline/client/cli/_groups/manifest_group.py", line 126, in manifest_snapshot
    manifest_out = _manifest_snapshot(
                   ^^^^^^^^^^^^^^^^^^^
  File "/Users/.local/share/mise/installs/python/3.11/lib/python3.11/site-packages/deadline/job_attachments/api/manifest.py", line 109, in _manifest_snapshot
    current_files = _glob_paths(
                    ^^^^^^^^^^^^
  File "/Users/.local/share/mise/installs/python/3.11/lib/python3.11/site-packages/deadline/job_attachments/_glob.py", line 58, in _glob_paths
    [str(path) if path.is_file() else None for path in Path(path).glob(input_glob)]
  File "/Users/.local/share/mise/installs/python/3.11/lib/python3.11/site-packages/deadline/job_attachments/_glob.py", line 58, in <listcomp>
    [str(path) if path.is_file() else None for path in Path(path).glob(input_glob)]
  File "/Users/.local/share/mise/installs/python/3.11/lib/python3.11/pathlib.py", line 949, in glob
    raise NotImplementedError("Non-relative patterns are unsupported")
NotImplementedError: Non-relative patterns are unsupported
```

#### snapshot doesn't handle relative path for include/exclude correctly during glob, leading to incorrect result
```
deadline manifest snapshot --root /tmp/test/ --destination /tmp/manifest --name snap --exclude "exclude/**"
Hashing Attachments  [####################################]  100%
Hashing Summary:
    Processed 0 files totaling 0.0 B.
    Skipped re-processing 3 files totaling 878.0 B.
    Total processing time of 0.00893 seconds at 0.0 B/s.

Manifest generated at /tmp/manifest/snap-3f1ef35a0f70aa555fcaee015582c797-2025-04-30T11-37-33.manifest
> cat /tmp/manifest/snap-3f1ef35a0f70aa555fcaee015582c797-2025-04-30T11-37-33.manifest
{"hashAlg":"xxh128","manifestVersion":"2023-03-03","paths":[{"hash":"cd0b746aedf46b92ccd520dcb0de67c1","mtime":1745883777682931,"path":"a.json","size":862},{"hash":"00d3908e6f5d42058cd46cb20b215405","mtime":1745883939757176,"path":"exclude/1.json","size":8},{"hash":"2b39693d18bea38b5ae9aba1859ea67f","mtime":1745883928172160,"path":"include/1.json","size":8}],"totalSize":878}
```

### What was the solution? (How)
1. Makes sure a `--include` is passed in as a list
2. Handle include and exclude path in glob w.r.t. root

### What is the impact of this change?
`manifest snapshot` would work as it's intended to with `--include` and `--exclude`

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- [x] Have you run the unit tests?
- [x] Have you run the integration tests?
- [N/A] Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass.

### Was this change documented?

- [N/A] Are relevant docstrings in the code base updated?
- [N/A] Has the README.md been updated? If you modified CLI arguments, for instance.

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?
No
### Does this change impact security?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
