### PR TITLE
fix!: Implement improved job attachments containment warning

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -22,9 +22,9 @@ To develop the Python code in this repository you will need:
 
 1. Python 3.8 or higher. We recommend [mise](https://github.com/jdx/mise) if you would like to run more than one version
    of Python on the same system. When running unit tests against all supported Python versions, for instance.
-2. The [hatch](https://github.com/pypa/hatch) package installed (`pip install --upgrade hatch`) into your Python environment. 
+2. The [hatch](https://github.com/pypa/hatch) package installed (`pip install --upgrade hatch`) into your Python environment.
 
-You can develop on a Linux, MacOs, or Windows workstation, but you may find that some of the support scripting is specific to
+You can develop on a Linux, MacOS, or Windows workstation, but you may find that some of the support scripting is specific to
 Linux/MacOS workstations.
 
 If you are making changes to the Job Attachments files, then you will also need the following to be able to run the integration
@@ -50,14 +50,14 @@ from any directory of this repository:
 * `hatch run fmt` - To automatically reformat all code to adhere to our formatting standards.
 * `hatch shell` - Enter a shell environment where you can run the `deadline` command-line directly as it is implemented in your
   checked-out local git repository.
-* `hatch env prune` - Delete all of your isolated workspace [environments](https://hatch.pypa.io/1.12/environment/) 
+* `hatch env prune` - Delete all of your isolated workspace [environments](https://hatch.pypa.io/1.12/environment/)
    for this package.
 
 If you are not sure about how to approach development for this package, then we suggest a development
 process along the lines of the following as a starting point:
 
 1. Make your functional changes and make sure that they work.
-2. Add unit tests for your changes and ensure that all unit tests pass. 
+2. Add unit tests for your changes and ensure that all unit tests pass.
    Iteratively improve your implementation until all unit tests pass. (See [Unit tests](#unit-tests))
 3. Add integration tests for your changes if applicable. Ensure that all integration tests pass.
    Iteratively improve your implementation until all integration and unit tests pass. (See [Integration tests](#integration-tests))
@@ -88,7 +88,7 @@ The tests for this package have three forms:
    without requiring an AWS account.
 2. Integration tests - Tests that ensure that the implementation behaves as expected when run in a real environment.
    Ensuring that code properly interacts as expected with a real Amazon S3 bucket, for instance.
-3. Squish GUI Submitter tests - Tests that verify the Deadline GUI using Squish automated framework. Squish tests require a license. 
+3. Squish GUI Submitter tests - Tests that verify the Deadline GUI using Squish automated framework. Squish tests require a license.
 
 ### Writing Tests
 
@@ -117,7 +117,7 @@ You can run unit tests by running:
 * `hatch run test` - To run the unit tests with your default Python runtime.
 * `hatch run all:test` - To run the unit tests with all of the supported Python runtime versions that you have installed.
 
-Notes: 
+Notes:
 * If you are running unit tests on Linux, you may encounter errors such as `INTERNALERROR> ImportError: libEGL.so.1: cannot open shared object file: No such file or directory`. This is because some Qt dependencies are missed on Linux. Please install these [Qt dependencies](https://github.com/aws-deadline/.github/blob/mainline/.github/workflows/reusable_python_build.yml#L46-L49) to resolve this issue.
 
 #### Running Docker-based Unit Tests
@@ -157,7 +157,7 @@ export JOB_ATTACHMENTS_BUCKET=$(
 )
 export JA_TEST_ROOT_PREFIX=$(
    aws deadline get-queue --farm-id $FARM_ID --queue-id $QUEUE_ID \
-    --query 'jobAttachmentSettings.rootPrefix' | tr -d '"' 
+    --query 'jobAttachmentSettings.rootPrefix' | tr -d '"'
 )
 ```
 
@@ -167,7 +167,7 @@ Then you can run the integration tests with:
 hatch run integ:test
 ```
 
-Notes: 
+Notes:
 * If you are not one of the AWS Deadline Cloud developers then you may see test failures in tests marked with
   `pytest.mark.cross_account`. That's okay, just ignore them; they'll be tested with the required setup in our CI.
 * If you are adding/changing code related to the Job Attachments' file-upload interactions with S3, then if you have a second
@@ -184,11 +184,11 @@ production endpoints look like: `export AWS_ENDPOINT_URL_DEADLINE="https://deadl
 
 ### Squish GUI Submitter Tests
 
-Squish GUI tests are located under the `test/squish` directory of this repository. New tests can be added for the Deadline GUI when necessary (ie: new functionality is introduced and a test can be added for coverage, or existing functionality is modified). When changes are made, Squish automated tests should be run to ensure changes are not breaking Deadline CLI and GUI functionality. 
+Squish GUI tests are located under the `test/squish` directory of this repository. New tests can be added for the Deadline GUI when necessary (ie: new functionality is introduced and a test can be added for coverage, or existing functionality is modified). When changes are made, Squish automated tests should be run to ensure changes are not breaking Deadline CLI and GUI functionality.
 
 #### Running Squish GUI Submitter Tests
 
-A separate ReadMe for developing/running Squish GUI tests is located in the `test/squish` directory. Please refer to [test/squish/SQUISH_README.md](./test/squish/SQUISH_README.md) on full instructions to use the automated tests. Note that a Squish license is required in order to run the tests. Currently, you may either have your own Squish license or you may file a [pull request](https://help.github.com/articles/creating-a-pull-request/) to the Deadline Cloud team to run or add any tests against any changes to be committed. Please perform any necessary manual tests prior to submitting any changes, in addition to making sure at least a minimal render job test passes. 
+A separate ReadMe for developing/running Squish GUI tests is located in the `test/squish` directory. Please refer to [test/squish/SQUISH_README.md](./test/squish/SQUISH_README.md) on full instructions to use the automated tests. Note that a Squish license is required in order to run the tests. Currently, you may either have your own Squish license or you may file a [pull request](https://help.github.com/articles/creating-a-pull-request/) to the Deadline Cloud team to run or add any tests against any changes to be committed. Please perform any necessary manual tests prior to submitting any changes, in addition to making sure at least a minimal render job test passes.
 
 ## Things to Know
 
@@ -208,7 +208,7 @@ For the command-line interface:
 
 For the Python library interface:
 * We follow the [PEP 8](https://peps.python.org/pep-0008/#descriptive-naming-styles) weak internal use indicator convention
-  and name all functions and modules that are internal/private with a leading underscore character. 
+  and name all functions and modules that are internal/private with a leading underscore character.
 * All functions and modules whose name does not begin with an underscore are part of the public contract for this package.
 * Things like adding a non-required keyword argument to a function, or adding a new public function are not breaking changes.
 * Things like renaming a keyword argument, or adding/removing a positional argument in a public function is a breaking change.
@@ -222,9 +222,9 @@ Library dependencies are Python packages required to build and run the Deadline 
 
 The Deadline Cloud library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of each new dependency.
 
-We try to minimize the number of dependencies required to build and run Deadline Cloud. When contributing changes, please consider the following. 
+We try to minimize the number of dependencies required to build and run Deadline Cloud. When contributing changes, please consider the following.
 
-#### Why is a new dependency needed? 
+#### Why is a new dependency needed?
 
 * Is the dependency library functionality required small enough to have a minimal version added to the Deadline Cloud code base?
 
@@ -234,12 +234,12 @@ We try to minimize the number of dependencies required to build and run Deadline
     - PyPI download stats
     - GitHub stars
     - GitHub dependency graph showing downstream consumers
-* Is it well-maintained? 
+* Is it well-maintained?
 * Is the library released regularly or recently?
 
 #### Version Pinning
 
-* How should we pin the version of this new dependency? 
+* How should we pin the version of this new dependency?
     - Please consider changes over time such as API or CLI command evolution and breakage.
 * Does the library follow a versioning scheme such as semver?
 
@@ -287,17 +287,14 @@ class MyCustomWidget(QWidget):
       self.__refresh_thread = None
       self.__refresh_id = 0
 
-      # Set this to True when exiting
-      self.canceled = False
+      # Use the CancelationFlag object to decouple the cancelation value
+      # from the window lifetime.
+      self.canceled = CancelationFlag()
+      self.destroyed.connect(self.canceled.set_canceled)
 
       # Connect the Signals to handler functions that run on the main thread
       self.update.connect(self.handle_update)
       self.background_exception.connect(self.handle_background_exception)
-
-    def closeEvent(self, event):
-      # Tell background threads when the widget closes
-      self.canceled = True
-      event.accept()
 
    def handle_background_exception(self, e: BaseException):
       # Handle the error

--- a/src/deadline/client/api/_job_attachment.py
+++ b/src/deadline/client/api/_job_attachment.py
@@ -1,14 +1,15 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
-from deadline.client import api
-from deadline.client.config import config_file
-from deadline.job_attachments.models import AssetRootGroup, AssetRootManifest
-from deadline.job_attachments.upload import S3AssetManager, SummaryStatistics
+from .. import api
+from ..config import config_file
+from ...job_attachments.models import AssetRootGroup, AssetRootManifest
+from ...job_attachments.upload import S3AssetManager, SummaryStatistics
+from ...job_attachments.progress_tracker import ProgressReportMetadata, ProgressStatus
 
 
 import textwrap
 from configparser import ConfigParser
-from typing import Callable, Dict, List, Optional, Tuple
+from typing import Callable, List, Optional, Tuple
 
 
 def _hash_attachments(
@@ -25,7 +26,7 @@ def _hash_attachments(
     callback. Returns a list of the asset manifests of the hashed files.
     """
 
-    def _default_update_hash_progress(hashing_metadata: Dict[str, str]) -> bool:
+    def _default_update_hash_progress(hashing_metadata: ProgressReportMetadata) -> bool:
         return True
 
     if not hashing_progress_callback:
@@ -41,7 +42,18 @@ def _hash_attachments(
     api.get_deadline_cloud_library_telemetry_client(config=config).record_hashing_summary(
         hashing_summary
     )
-    print_function_callback("Hashing Summary:")
-    print_function_callback(textwrap.indent(str(hashing_summary), "    "))
+    if hashing_summary.total_files > 0:
+        print_function_callback("Hashing Summary:")
+        print_function_callback(textwrap.indent(str(hashing_summary), "    "))
+    else:
+        # Ensure to call the callback once if no files were processed
+        hashing_progress_callback(
+            ProgressReportMetadata(
+                status=ProgressStatus.PREPARING_IN_PROGRESS,
+                progress=100,
+                transferRate=0,
+                progressMessage="No files to hash",
+            )
+        )
 
     return hashing_summary, manifests

--- a/src/deadline/client/api/_submit_job_bundle.py
+++ b/src/deadline/client/api/_submit_job_bundle.py
@@ -10,16 +10,22 @@ import json
 import logging
 import time
 import os
+import re
 import textwrap
 from configparser import ConfigParser
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Iterable
+from collections.abc import Collection
+from pathlib import Path
 
 from botocore.client import BaseClient
 
-from deadline.client.api._job_attachment import _hash_attachments  # type: ignore[import]
-
 from .. import api
-from ..exceptions import DeadlineOperationError, CreateJobWaiterCanceled
+from ..exceptions import (
+    DeadlineOperationError,
+    CreateJobWaiterCanceled,
+    DeadlineOperationCanceled,
+    UserInitiatedCancel,
+)
 from ..config import get_setting, set_setting, config_file
 from ..job_bundle import deadline_yaml_dump
 from ..job_bundle.loader import (
@@ -41,12 +47,190 @@ from ...job_attachments.models import (
     AssetRootManifest,
     AssetUploadGroup,
     JobAttachmentS3Settings,
+    StorageProfile,
+    FileSystemLocationType,
 )
-from ...job_attachments.progress_tracker import ProgressReportMetadata
+from ...job_attachments.progress_tracker import ProgressReportMetadata, ProgressStatus
 from ...job_attachments.upload import S3AssetManager
 from ._session import session_context
+from ._job_attachment import _hash_attachments  # type: ignore[import]
+from ...job_attachments._path_summarization import human_readable_file_size, summarize_path_list
 
 logger = logging.getLogger(__name__)
+
+
+def _summarize_asset_paths(
+    input_paths: Collection[Path | str], output_paths: Collection[Path | str], name: str
+) -> list[str]:
+    result = []
+    if input_paths:
+        result.append(f"{name} for upload:\n")
+        result.append(textwrap.indent(summarize_path_list(input_paths), "  "))
+    if output_paths:
+        result.append(f"{name} to collect job outputs for download:\n")
+        # We expect the list of output paths to be small, but truncate it to an arbitrary limit just in case for the summary
+        summary_entry_count = 4
+        if len(output_paths) == summary_entry_count + 1:
+            summary_entry_count += 1
+        result.extend(f"  {path}\n" for path in sorted(output_paths)[:summary_entry_count])
+        if len(output_paths) > summary_entry_count:
+            result.append(f"\n  ... and {len(output_paths) - summary_entry_count} more\n")
+    return result
+
+
+def _generate_message_for_asset_paths(
+    upload_group: AssetUploadGroup,
+    storage_profile: Optional[StorageProfile],
+    known_asset_paths: Iterable[str],
+) -> tuple[str, bool]:
+    """Generate a message about asset uploads and along with a flag indicating if there are warnings."""
+    # Collect all the input and output paths
+    all_input_paths: set[Path | str] = set()
+    all_output_paths: set[Path | str] = set()
+    for group in upload_group.asset_groups:
+        all_input_paths.update(path for path in group.inputs)
+        all_output_paths.update(path for path in group.outputs)
+
+    # Filter to get the unknown paths
+    if known_asset_paths:
+        known_path_regex = re.compile(
+            f"{'|'.join(re.escape(path) for path in known_asset_paths)}.*"
+        )
+        unknown_input_paths = {
+            path for path in all_input_paths if not known_path_regex.match(str(path))
+        }
+        unknown_output_paths = {
+            path for path in all_output_paths if not known_path_regex.match(str(path))
+        }
+    else:
+        unknown_input_paths = all_input_paths
+        unknown_output_paths = all_output_paths
+
+    unknown_path_warnings = _summarize_asset_paths(
+        unknown_input_paths, unknown_output_paths, "Unknown locations"
+    )
+
+    warning_messages = []
+    default_prompt_response = not unknown_path_warnings
+    if unknown_path_warnings:
+        warning_messages.append("\nWARNING: Files were specified outside of known asset paths.\n\n")
+
+    warning_messages.extend(
+        [
+            f"Job submission contains {upload_group.total_input_files} input files "
+            f"totaling {human_readable_file_size(upload_group.total_input_bytes)}. "
+            "All input files will be uploaded to S3 if they are not already present in the job attachments bucket.\n\n"
+        ]
+    )
+    warning_messages.extend(_summarize_asset_paths(all_input_paths, all_output_paths, "Locations"))
+
+    if unknown_path_warnings:
+        warning_messages.append("\n---\n\n")
+        warning_messages.append("The list of known asset prefixes for this submission are:\n")
+        if known_asset_paths:
+            warning_messages.extend(f"  {path}\n" for path in sorted(set(known_asset_paths)))
+        else:
+            warning_messages.append("  (empty list)\n")
+        warning_messages.append("\n")
+        warning_messages.extend(unknown_path_warnings)
+        warning_messages.append(
+            "\nTo enable submission without user input, add directory locations containing the unknown paths to either "
+            + "1. The list of known asset paths in the local Deadline Cloud configuration. "
+        )
+        if storage_profile:
+            warning_messages.append(
+                f"2. The Storage Profile '{storage_profile.displayName}' as LOCAL file system locations, from the AWS Deadline Cloud management console.\n"
+            )
+        else:
+            warning_messages.append(
+                "2. In a Storage Profile as LOCAL file system locations created from the AWS Deadline Cloud management console, and then configured on your workstation.\n"
+            )
+
+    return "".join(warning_messages), default_prompt_response
+
+
+@api.record_success_fail_telemetry_event(metric_name="asset_upload")  # type: ignore
+def _upload_attachments(
+    asset_manager: S3AssetManager,
+    manifests: List[AssetRootManifest],
+    print_function_callback: Callable,
+    upload_progress_callback: Optional[Callable],
+    config: Optional[ConfigParser] = None,
+    from_gui: bool = False,
+) -> Dict[str, Any]:
+    """
+    Starts the job attachments upload and handles the progress reporting callback.
+    Returns the attachment settings from the upload.
+    """
+
+    def _default_update_upload_progress(upload_metadata: ProgressReportMetadata) -> bool:
+        return True
+
+    if not upload_progress_callback:
+        upload_progress_callback = _default_update_upload_progress
+
+    upload_summary, attachment_settings = asset_manager.upload_assets(
+        manifests=manifests,
+        on_uploading_assets=upload_progress_callback,
+        s3_check_cache_dir=config_file.get_cache_directory(),
+    )
+    api.get_deadline_cloud_library_telemetry_client(config=config).record_upload_summary(
+        upload_summary,
+        from_gui=from_gui,
+    )
+
+    if upload_summary.total_files > 0:
+        print_function_callback("Upload Summary:")
+        print_function_callback(textwrap.indent(str(upload_summary), "    "))
+    else:
+        # Ensure to call the callback once if no files were processed
+        upload_progress_callback(
+            ProgressReportMetadata(
+                status=ProgressStatus.UPLOAD_IN_PROGRESS,
+                progress=100,
+                transferRate=0,
+                progressMessage="No files to upload",
+            )
+        )
+
+    return attachment_settings.to_dict()
+
+
+def _filter_redundant_known_paths(known_asset_paths: Iterable[str]) -> list[str]:
+    """
+    Filters out redundant paths from the known asset paths list.
+
+    This algorithm identifies any paths that have a different path as a prefix,
+    and removes them from the list. Pseudo-code is:
+
+        1. Sort the paths from shortest to longest, so any prefix of a path has
+           to happen before that path.
+        2. For each path, split it into parts (i.e. '/mnt/prod/project' becomes
+           ['/', 'mnt', 'prod', 'project']), and then insert it part by part into
+           a nested dict called dir_tree organized as a TRIE. The value True in the
+           TRIE indicates that a path with that as its final part is in the list.
+        3. While inserting a path into the TRIE, detect whether another path already
+           had a prefix of the parts, and filter out the path when that occurs.
+    """
+    # This directory tree gets filled with the known asset paths, with
+    # a True value as a marker for the last part of already seen paths.
+    dir_tree: dict[str, Any] = {}
+    filtered_paths: list[str] = []
+    # Process the paths from shortest to longest, so that prefixes are always seen first
+    for path in sorted(known_asset_paths, key=len):
+        parts = Path(path).parts
+        current: Optional[dict[str, Any]] = dir_tree
+        for part in parts[:-1]:
+            # If we see a True value, another path is a prefix so we can skip it.
+            if current.get(part) is True:  # type: ignore
+                current = None
+                break
+            current = current.setdefault(part, {})  # type: ignore
+        # If we didn't find a prefix or equal path, add this one and mark it in dir_tree
+        if current is not None and current.get(parts[-1]) is not True:
+            filtered_paths.append(path)
+            current[parts[-1]] = True
+    return filtered_paths
 
 
 @api.record_function_latency_telemetry_event()
@@ -62,16 +246,16 @@ def create_job_from_job_bundle(
     max_failed_tasks_count: Optional[int] = None,
     max_retries_per_task: Optional[int] = None,
     max_worker_count: Optional[int] = None,
-    print_function_callback: Callable[[str], None] = lambda msg: None,
-    decide_cancel_submission_callback: Callable[
-        [AssetUploadGroup], bool
-    ] = lambda upload_group: False,
+    require_paths_exist: bool = False,
+    submitter_name: Optional[str] = None,
+    known_asset_paths: Collection[str] = [],
+    from_gui: bool = False,
+    print_function_callback: Callable[[str], None] = print,
+    interactive_confirmation_callback: Optional[Callable[[str, bool], bool]] = None,
     hashing_progress_callback: Optional[Callable[[ProgressReportMetadata], bool]] = None,
     upload_progress_callback: Optional[Callable[[ProgressReportMetadata], bool]] = None,
     create_job_result_callback: Optional[Callable[[], bool]] = None,
-    require_paths_exist: bool = False,
-    submitter_name: Optional[str] = None,
-) -> Union[str, None]:
+) -> str:
     """
     Creates a job in the farm/queue configured as default for the
     workstation from the job bundle in the provided directory.
@@ -124,15 +308,18 @@ def create_job_from_job_bundle(
         config (ConfigParser, optional): The AWS Deadline Cloud configuration
                 object to use instead of the config file.
         priority (int, optional): explicit value for the priority of the job.
-        max_worker_count (int, optional): explicit value for the max worker count of the job.
         max_failed_tasks_count (int, optional): explicit value for the maximum allowed failed tasks.
         max_retries_per_task (int, optional): explicit value for the maximum retries per task.
+        max_worker_count (int, optional): explicit value for the max worker count of the job.
+        require_paths_exist (bool, optional): Whether to require that all input paths exist.
+        submitter_name (str, optional): Name of the application submitting the bundle.
+        known_asset_paths (list[str], optional): A list of paths that should not generate
+                warnings when outside storage profile locations. Defaults to an empty list.
         print_function_callback (Callable str -> None, optional): Callback to print messages produced in this function.
-                Used in the CLI to print to stdout using click.echo. By default ignores messages.
-        decide_cancel_submission_callback (Callable dict[str, int], int, int -> bool): If the job has job
-                attachments, decide whether or not to cancel the submission given what assets will
-                or will not be uploaded. If returns true, the submission is canceled. If False,
-                the submission continues. By default the submission always continues.
+                By default calls print(), Can be replaced by click.echo or a logging function of choice.
+        interactive_confirmation_callback (Callable [str, bool] -> bool): Callback arguments are (confirmation_message, default_response).
+                This function should present the provided prompt, using default_response as the default value to respond with if the user
+                does not make an explicit choice, and return True if the user wants to continue, False to cancel.
         hashing_progress_callback / upload_progress_callback / create_job_result_callback (Callable -> bool):
                 Callbacks periodically called while hashing / uploading / waiting for job creation. If returns false,
                 the operation will be cancelled. If return true, the operation continues. Default behavior for each
@@ -141,7 +328,7 @@ def create_job_from_job_bundle(
     """
 
     if not submitter_name:
-        submitter_name = "CLI"
+        submitter_name = "Custom"
 
     session_context["submitter-name"] = submitter_name
 
@@ -175,7 +362,7 @@ def create_job_from_job_bundle(
         farmId=farm_id,
         queueId=queue_id,
     )
-    print_function_callback(f"Submitting to Queue: {queue['displayName']}")
+    print_function_callback(f"Submitting to Queue: {queue['displayName']}\n")
 
     create_job_args: Dict[str, Any] = {
         "farmId": farm_id,
@@ -222,7 +409,56 @@ def create_job_from_job_bundle(
         parameters, job_bundle_dir
     )
 
+    # Extend known_asset_paths with all paths that are treated as known. These are
+    # paths provided explicitly by the call to submit the job bundle:
+    #   * Paths in the known_asset_paths parameter to this function call
+    #   * Paths contained inside the job bundle.
+    #   * Paths configured in the locally configured storage profile as LOCAL (not SHARED).
+    #   * Paths configured in the local config file settings.known_asset_paths
+    #   * Paths provided within the job_parameters parameter to this function call
+    # Paths that are treated as unknown (unless in one of the above categories). These can be
+    # absolute paths referencing anywhere in the file system, not explicitly provided by the call,
+    # so require that they be marked as known in the local configuration file or the associated
+    # Storage Profile in the AWS account:
+    #   * Paths provided in the job bundle via the parameter_values.json/.yaml file
+    #   * Paths provided in the job bundle via the asset_references.json/.yaml files
+    known_asset_paths = list(known_asset_paths) + [os.path.abspath(job_bundle_dir)]
+    # Add the configured storage profile paths
+    if storage_profile:
+        known_asset_paths.extend(
+            [
+                fsl.path
+                for fsl in storage_profile.fileSystemLocations
+                if fsl.type == FileSystemLocationType.LOCAL
+            ]
+        )
+    # Add the configured known asset paths
+    configured_known_asset_paths = config_file.get_setting(
+        "settings.known_asset_paths", config=config
+    ).strip()
+    if configured_known_asset_paths:
+        known_asset_paths.extend(configured_known_asset_paths.split(os.pathsep))
+    # Use the parameter names from job_parameters, but the values from parameters. If a value was provided
+    # in job_parameters, it has been applied into parameters and normalized as necessary.
+    known_parameter_names = {job_param.get("name") for job_param in job_parameters}
+    for job_param in parameters:
+        if job_param.get("type") == "PATH" and job_param.get("name") in known_parameter_names:
+            job_param_value = job_param.get("value")
+            if job_param_value:
+                if job_param.get("objectType") == "FILE":
+                    # If the job parameter is a file, use its directory as the known path. When collecting
+                    # outputs for upload, only that directory is used, not the file path.
+                    known_asset_paths.append(os.path.dirname(job_param_value))
+                else:
+                    known_asset_paths.append(job_param_value)
+
+    # Filter known_asset_paths to remove any paths that have another one as a prefix. This can
+    # reduce the amount of processing needed later, and produces a shorter warning message when presenting
+    # to users.
+    known_asset_paths = _filter_redundant_known_paths(known_asset_paths)
+
     # Hash and upload job attachments if there are any
+    files_processed = False
     if asset_references and "jobAttachmentSettings" in queue:
         # Extend input_filenames with all the files in the input_directories
         missing_directories: set[str] = set()
@@ -245,7 +481,8 @@ def create_job_from_job_bundle(
                 asset_references.input_filenames.update(
                     os.path.normpath(os.path.join(root, file)) for file in files
                 )
-            # Empty directories just become references since there's nothing to upload
+            # Empty directories just become references since the current asset manifest spec
+            # version cannot represent them.
             if is_dir_empty:
                 logger.info(f"Input directory '{directory}' is empty. Adding to referenced paths.")
                 asset_references.referenced_paths.add(directory)
@@ -283,10 +520,44 @@ def create_job_from_job_bundle(
             storage_profile=storage_profile,
             require_paths_exist=require_paths_exist,
         )
+
         if upload_group.asset_groups:
-            if decide_cancel_submission_callback(upload_group):
-                print_function_callback("Job submission canceled.")
-                return None
+            # Generate warning message if needed
+            asset_path_message, default_prompt_response = _generate_message_for_asset_paths(
+                upload_group, storage_profile, known_asset_paths
+            )
+
+            if interactive_confirmation_callback is None:
+                # In this case, no user prompt can be presented. The result of the function must
+                # be the default that would be presented to the interactive prompt.
+                print_function_callback(asset_path_message)
+                if not default_prompt_response:
+                    print_function_callback("\nJob submission canceled (user input not enabled).")
+                    raise DeadlineOperationCanceled()
+            elif config_file.str2bool(get_setting("settings.auto_accept", config=config)):
+                if not default_prompt_response:
+                    if from_gui:
+                        # In the from_gui case, we present a prompt even though settings.auto_accept is enabled.
+                        if not interactive_confirmation_callback(
+                            asset_path_message + "Do you wish to proceed?", default_prompt_response
+                        ):
+                            print_function_callback("Job submission canceled (user input).")
+                            raise UserInitiatedCancel()
+                    else:
+                        # In this case, no user prompt should be presented. The result of the function must
+                        # be the default that would be presented to the interactive prompt.
+                        print_function_callback(
+                            f"{asset_path_message}\nJob submission canceled (settings.auto_accept enabled and there were unknown paths)."
+                        )
+                        raise DeadlineOperationCanceled()
+                else:
+                    print_function_callback(asset_path_message)
+            else:
+                if not interactive_confirmation_callback(
+                    asset_path_message + "\nDo you wish to proceed?", default_prompt_response
+                ):
+                    print_function_callback("Job submission canceled (user input).")
+                    raise UserInitiatedCancel()
 
             _, asset_manifests = _hash_attachments(
                 asset_manager=asset_manager,
@@ -298,12 +569,39 @@ def create_job_from_job_bundle(
             )
 
             attachment_settings = _upload_attachments(  # type: ignore
-                asset_manager, asset_manifests, print_function_callback, upload_progress_callback
+                asset_manager,
+                asset_manifests,
+                print_function_callback,
+                upload_progress_callback,
+                from_gui=from_gui,
             )
             attachment_settings["fileSystem"] = JobAttachmentsFileSystem(
                 job_attachments_file_system
             )
             create_job_args["attachments"] = attachment_settings
+
+            files_processed = True
+
+    if not files_processed:
+        # Call each callback once indicating nothing to do.
+        if hashing_progress_callback is not None:
+            hashing_progress_callback(
+                ProgressReportMetadata(
+                    status=ProgressStatus.PREPARING_IN_PROGRESS,
+                    progress=0,
+                    transferRate=0,
+                    progressMessage="No files to hash",
+                )
+            )
+        if upload_progress_callback is not None:
+            upload_progress_callback(
+                ProgressReportMetadata(
+                    status=ProgressStatus.UPLOAD_IN_PROGRESS,
+                    progress=0,
+                    transferRate=0,
+                    progressMessage="No files to upload",
+                )
+            )
 
     create_job_args.update(app_parameters_formatted)
 
@@ -325,10 +623,11 @@ def create_job_from_job_bundle(
     api.get_deadline_cloud_library_telemetry_client().record_event(
         event_type="com.amazon.rum.deadline.submission",
         event_details={"submitter_name": submitter_name},
+        from_gui=from_gui,
     )
 
     create_job_response = deadline.create_job(**create_job_args)
-    logger.debug(f"CreateJob Response {create_job_response}")
+    logger.debug("CreateJob Response %r", create_job_response)
 
     if create_job_response and "jobId" in create_job_response:
         job_id = create_job_response["jobId"]
@@ -354,7 +653,9 @@ def create_job_from_job_bundle(
         )
 
         api.get_deadline_cloud_library_telemetry_client().record_event(
-            event_type="com.amazon.rum.deadline.create_job", event_details={"is_success": success}
+            event_type="com.amazon.rum.deadline.create_job",
+            event_details={"is_success": success},
+            from_gui=from_gui,
         )
 
         if not success:
@@ -362,7 +663,7 @@ def create_job_from_job_bundle(
 
         print_function_callback("Submitted job bundle:")
         print_function_callback(f"   {job_bundle_dir}")
-        print_function_callback(status_message + f"\n{job_id}\n")
+        print_function_callback(status_message + f"\n{job_id}")
 
         return job_id
     else:
@@ -393,7 +694,7 @@ def wait_for_create_job_to_complete(
         )
 
         if not continue_callback():
-            raise CreateJobWaiterCanceled
+            raise CreateJobWaiterCanceled()
 
         job = deadline_client.get_job(jobId=job_id, queueId=queue_id, farmId=farm_id)
 
@@ -408,37 +709,3 @@ def wait_for_create_job_to_complete(
     raise TimeoutError(
         f"Timed out after {delay_sec * max_attempts} seconds while waiting for Job to be created: {job_id}"
     )
-
-
-@api.record_success_fail_telemetry_event(metric_name="cli_asset_upload")  # type: ignore
-def _upload_attachments(
-    asset_manager: S3AssetManager,
-    manifests: List[AssetRootManifest],
-    print_function_callback: Callable = lambda msg: None,
-    upload_progress_callback: Optional[Callable] = None,
-    config: Optional[ConfigParser] = None,
-) -> Dict[str, Any]:
-    """
-    Starts the job attachments upload and handles the progress reporting callback.
-    Returns the attachment settings from the upload.
-    """
-
-    def _default_update_upload_progress(upload_metadata: Dict[str, str]) -> bool:
-        return True
-
-    if not upload_progress_callback:
-        upload_progress_callback = _default_update_upload_progress
-
-    upload_summary, attachment_settings = asset_manager.upload_assets(
-        manifests=manifests,
-        on_uploading_assets=upload_progress_callback,
-        s3_check_cache_dir=config_file.get_cache_directory(),
-    )
-    api.get_deadline_cloud_library_telemetry_client(config=config).record_upload_summary(
-        upload_summary
-    )
-
-    print_function_callback("Upload Summary:")
-    print_function_callback(textwrap.indent(str(upload_summary), "    "))
-
-    return attachment_settings.to_dict()

--- a/src/deadline/client/api/_telemetry.py
+++ b/src/deadline/client/api/_telemetry.py
@@ -374,12 +374,11 @@ def record_success_fail_telemetry_event(**decorator_kwargs: Dict[str, Any]) -> C
             :param * Python variable argument. See https://docs.python.org/3/glossary.html#term-parameter
             :param ** Python variable argument. See https://docs.python.org/3/glossary.html#term-parameter
             """
-            success: bool = True
+            success: bool = False
             try:
-                return function(*args, **kwargs)
-            except Exception as e:
-                success = False
-                raise e
+                result = function(*args, **kwargs)
+                success = True
+                return result
             finally:
                 event_name = decorator_kwargs.get("metric_name", function.__name__)
                 get_deadline_cloud_library_telemetry_client().record_event(

--- a/src/deadline/client/cli/_common.py
+++ b/src/deadline/client/cli/_common.py
@@ -17,6 +17,7 @@ import sys
 from configparser import ConfigParser
 from typing import Any, Callable, Optional, Set
 import logging
+import traceback
 
 import click
 from contextlib import ExitStack
@@ -65,13 +66,11 @@ def _handle_error(func: Callable) -> Callable:
         except click.ClickException:
             # Let click exceptions fall through
             raise
-        except Exception as e:
+        except Exception:
             # Log and print out unfamiliar exceptions with additional
             # messaging.
-            click.echo(f"The AWS Deadline Cloud CLI encountered the following exception:\n{e}")
-
-            if logging.DEBUG >= logger.getEffectiveLevel():
-                logger.exception("Exception details:")
+            click.echo("The AWS Deadline Cloud CLI encountered the following exception:")
+            click.echo(traceback.format_exc())
             _prompt_at_completion(ctx)
             sys.exit(1)
 

--- a/src/deadline/client/cli/_groups/bundle_group.py
+++ b/src/deadline/client/cli/_groups/bundle_group.py
@@ -6,9 +6,9 @@ All the `deadline bundle` commands.
 
 from __future__ import annotations
 
-import textwrap
 import json
 import logging
+import sys
 import re
 from typing import Any, Optional
 
@@ -16,17 +16,20 @@ import click
 from botocore.exceptions import ClientError
 
 from ... import api
-from ...config import config_file, get_setting, set_setting
+from ...config import config_file
 from ....job_attachments.exceptions import (
     AssetSyncError,
     AssetSyncCancelledError,
     MisconfiguredInputsError,
 )
-from ....job_attachments.models import AssetUploadGroup, JobAttachmentsFileSystem
-from ....job_attachments._path_summarization import human_readable_file_size, summarize_path_list
+from ....job_attachments.models import JobAttachmentsFileSystem
 
 from ...exceptions import DeadlineOperationError, CreateJobWaiterCanceled
-from .._common import _apply_cli_options_to_config, _handle_error, _ProgressBarCallbackManager
+from .._common import (
+    _apply_cli_options_to_config,
+    _handle_error,
+    _ProgressBarCallbackManager,
+)
 from ._sigint_handler import SigIntHandler
 
 logger = logging.getLogger(__name__)
@@ -69,6 +72,20 @@ def validate_parameters(ctx, param, value):
         parameters_split.append({"name": regex_match[1], "value": regex_match[2]})
 
     return parameters_split
+
+
+def _interactive_confirmation_prompt(message: str, default_response: bool) -> bool:
+    """
+    Callback to decide if submission should continue or be canceled. Returns True to continue, False to cancel.
+
+    Args:
+        warning_message (str): The warning message to display.
+        default_response (bool): The default to present as the response (True to continue, False to cancel).
+    """
+    return click.confirm(
+        message,
+        default=default_response,
+    )
 
 
 @cli_bundle.command(name="submit")
@@ -128,13 +145,19 @@ def validate_parameters(ctx, param, value):
     type=click.STRING,
     help="Name of the application submitting the bundle.",
 )
+@click.option(
+    "--known-asset-path",
+    multiple=True,
+    help="Path that should not generate warnings when outside storage profile locations. "
+    "Can be specified multiple times for different paths.",
+)
 @click.argument("job_bundle_dir")
 @_handle_error
 def bundle_submit(
     job_bundle_dir,
     job_attachments_file_system,
     parameter,
-    yes,
+    known_asset_path,
     name,
     priority,
     max_failed_tasks_count,
@@ -156,60 +179,6 @@ def bundle_submit(
     def _check_create_job_wait_canceled() -> bool:
         return sigint_handler.continue_operation
 
-    def _decide_cancel_submission(upload_group: AssetUploadGroup) -> bool:
-        """
-        Callback to decide if submission should be cancelled or not. Return 'True' to cancel.
-        Prints a warning that requires confirmation if paths are found outside of configured storage profile locations.
-        """
-        warning_message = ""
-        warning_input_paths = set()
-        warning_output_paths = set()
-        for group in upload_group.asset_groups:
-            if not group.file_system_location_name:
-                warning_input_paths.update(group.inputs)
-                warning_output_paths.update(group.outputs)
-
-        if len(warning_input_paths) > 0:
-            warning_message += "Locations for upload:\n"
-            warning_message += textwrap.indent(summarize_path_list(warning_input_paths), "  ")
-        if len(warning_output_paths) > 0:
-            warning_message += "Locations to collect job outputs for download:\n"
-            # We expect the list of output paths to be small, but truncate it to an arbitrary limit just in case for the summary
-            warning_entry_count = 4
-            if len(warning_output_paths) == warning_entry_count + 1:
-                warning_entry_count += 1
-            for path in sorted(warning_output_paths)[:warning_entry_count]:
-                warning_message += f"  {path}\n"
-            if len(warning_output_paths) > warning_entry_count:
-                warning_message += (
-                    f"\n  ... and {len(warning_output_paths) - warning_entry_count} more\n"
-                )
-
-        # Exit early if there are no warnings and we've either set auto accept or there's no files to confirm
-        if not warning_message and (
-            yes
-            or config_file.str2bool(get_setting("settings.auto_accept", config=config))
-            or upload_group.total_input_files == 0
-        ):
-            return False
-
-        message_text = (
-            f"Job submission contains {upload_group.total_input_files} input files totaling {human_readable_file_size(upload_group.total_input_bytes)}. "
-            " All input files will be uploaded to S3 if they are not already present in the job attachments bucket."
-        )
-        if warning_message:
-            message_text += (
-                f"\n\nFiles were specified outside of the configured storage profile location(s). "
-                " Please confirm that you intend to submit a job that uses files from the following directories:\n"
-                f"{warning_message}\n"
-                "To permanently remove this warning you must only use files located within a storage profile location."
-            )
-        message_text += "\n\nDo you wish to proceed?"
-        return not click.confirm(
-            message_text,
-            default=not warning_message,
-        )
-
     try:
         job_id = api.create_job_from_job_bundle(
             job_bundle_dir=job_bundle_dir,
@@ -225,29 +194,29 @@ def bundle_submit(
             upload_progress_callback=upload_callback_manager.callback,
             create_job_result_callback=_check_create_job_wait_canceled,
             print_function_callback=click.echo,
-            decide_cancel_submission_callback=_decide_cancel_submission,
+            interactive_confirmation_callback=_interactive_confirmation_prompt,
             require_paths_exist=require_paths_exist,
-            submitter_name=submitter_name,
+            submitter_name=submitter_name or "CLI",
+            known_asset_paths=known_asset_path,
         )
 
         # Check Whether the CLI options are modifying any of the default settings that affect
         # the job id. If not, we'll save the job id submitted as the default job id.
         # If the submission is canceled by the user job_id will be None, so ignore this case as well.
         if (
-            job_id is not None
-            and args.get("profile") is None
+            args.get("profile") is None
             and args.get("farm_id") is None
             and args.get("queue_id") is None
             and args.get("storage_profile_id") is None
         ):
-            set_setting("defaults.job_id", job_id)
+            config_file.set_setting("defaults.job_id", job_id)
 
     except AssetSyncCancelledError as exc:
         if sigint_handler.continue_operation:
             raise DeadlineOperationError(f"Job submission unexpectedly canceled:\n{exc}") from exc
         else:
             click.echo("Job submission canceled.")
-            return
+            sys.exit(1)
     except AssetSyncError as exc:
         raise DeadlineOperationError(f"Failed to upload job attachments:\n{exc}") from exc
     except CreateJobWaiterCanceled as exc:
@@ -257,7 +226,7 @@ def bundle_submit(
             ) from exc
         else:
             click.echo("Canceled waiting for final status of CreateJob.")
-            return
+            sys.exit(1)
     except ClientError as exc:
         raise DeadlineOperationError(
             f"Failed to submit the job bundle to AWS Deadline Cloud:\n{exc}"
@@ -265,7 +234,7 @@ def bundle_submit(
     except MisconfiguredInputsError as exc:
         click.echo(str(exc))
         click.echo("Job submission canceled.")
-        return
+        sys.exit(1)
     except Exception as exc:
         api.get_deadline_cloud_library_telemetry_client().record_error(
             event_details={"exception_scope": "on_submit"},
@@ -303,8 +272,16 @@ def bundle_submit(
     "JSON: Displays messages in JSON line format, so that the info can be easily "
     "parsed/consumed by custom scripts.",
 )
+@click.option(
+    "--known-asset-path",
+    multiple=True,
+    help="Path that should not generate warnings when outside storage profile locations. "
+    "Can be specified multiple times for different paths.",
+)
 @_handle_error
-def bundle_gui_submit(job_bundle_dir, browse, output, install_gui, submitter_name, **args):
+def bundle_gui_submit(
+    job_bundle_dir, browse, output, install_gui, submitter_name, known_asset_path, **args
+):
     """
     Opens a GUI to submit an Open Job Description job bundle.
     """
@@ -320,7 +297,10 @@ def bundle_gui_submit(job_bundle_dir, browse, output, install_gui, submitter_nam
         output = output.lower()
 
         submitter = show_job_bundle_submitter(
-            input_job_bundle_dir=job_bundle_dir, browse=browse, submitter_name=submitter_name
+            input_job_bundle_dir=job_bundle_dir,
+            browse=browse,
+            submitter_name=submitter_name,
+            known_asset_paths=known_asset_path,
         )
 
         if not submitter:

--- a/src/deadline/client/cli/_groups/job_group.py
+++ b/src/deadline/client/cli/_groups/job_group.py
@@ -701,7 +701,6 @@ def job_download_output(step_id, task_id, output, **args):
             click.echo(_get_json_line(JSON_MSG_TYPE_ERROR, error_one_liner))
             sys.exit(1)
         else:
-            logger.exception("Exception details:")
             if logging.DEBUG >= logger.getEffectiveLevel():
                 logger.exception("Exception details:")
             raise DeadlineOperationError(f"Failed to download output:\n{e}") from e

--- a/src/deadline/client/config/config_file.py
+++ b/src/deadline/client/config/config_file.py
@@ -33,7 +33,8 @@ CONFIG_FILE_PATH_ENV_VAR = "DEADLINE_CONFIG_FILE_PATH"
 # The default AWS Deadline Cloud endpoint URL
 # Environment variable that, if set, overrides the value of DEFAULT_DEADLINE_ENDPOINT_URL
 DEFAULT_DEADLINE_ENDPOINT_URL = os.getenv(
-    "AWS_ENDPOINT_URL_DEADLINE", f"https://deadline.{boto3.Session().region_name}.amazonaws.com"
+    "AWS_ENDPOINT_URL_DEADLINE",
+    f"https://deadline.{boto3.Session().region_name}.amazonaws.com",
 )
 
 # The default directory within which to save the history of created jobs.
@@ -96,6 +97,7 @@ SETTINGS: Dict[str, Dict[str, Any]] = {
     },
     "settings.auto_accept": {
         "default": "false",
+        "description": "Automatically accept the default choice for any interactive prompts.",
     },
     "settings.conflict_resolution": {
         "default": FileConflictResolution.NOT_SELECTED.name,
@@ -105,9 +107,19 @@ SETTINGS: Dict[str, Dict[str, Any]] = {
         "default": "WARNING",
         "description": "The logging level to use in the CLI and GUIs.",
     },
-    "telemetry.opt_out": {"default": "false"},
-    "telemetry.identifier": {"default": ""},
-    "defaults.job_attachments_file_system": {"default": "COPIED", "depend": "defaults.farm_id"},
+    "telemetry.opt_out": {
+        "default": "false",
+        "description": "If set to 'true', don't record any telemetry events.",
+    },
+    "telemetry.identifier": {
+        "default": "",
+        "description": "A randomly generated identifier used to record telemetry events for this configuration.",
+    },
+    "defaults.job_attachments_file_system": {
+        "default": "COPIED",
+        "depend": "defaults.farm_id",
+        "description": "The file system mode to use for job attachments when running jobs. COPIED means to download a copy of the attachment data, VIRTUAL means to use a virtual file system for lazy loading.",
+    },
     "settings.s3_max_pool_connections": {
         "default": "50",
         "description": (
@@ -122,6 +134,10 @@ SETTINGS: Dict[str, Dict[str, Any]] = {
             "When uploading job attachments, the file size threshold is set to separate 'large' files from 'small' files so that 'large' files can be processed serially. "
             "This multiplier is used to calculate the size threshold. (Small files are defined as those smaller than or equal to the chunk size multiplied by this factor.)"
         ),
+    },
+    "settings.known_asset_paths": {
+        "default": "",  # OS-specific path separator delimited list
+        "description": "A list of paths that should not generate warnings when outside storage profile locations, separated by the OS path list separator (semicolon on Windows, colon on Linux/macOS).",
     },
 }
 

--- a/src/deadline/client/exceptions.py
+++ b/src/deadline/client/exceptions.py
@@ -9,12 +9,25 @@ class DeadlineOperationError(Exception):
     """Error whose message gets printed verbatim by the cli handler"""
 
 
-class CreateJobWaiterCanceled(Exception):
-    """Error for when the waiter on CreateJob is interrupted"""
+class DeadlineOperationCanceled(DeadlineOperationError):
+    """DeadlineOperationError for when an operation was canceled"""
+
+    def __init__(self, message: str = "Operation canceled"):
+        super().__init__(message)
 
 
-class UserInitiatedCancel(Exception):
+class CreateJobWaiterCanceled(DeadlineOperationCanceled):
+    """Error for when the waiter after CreateJob is interrupted"""
+
+    def __init__(self, message: str = "Operation canceled while waiting for CreateJob to finish"):
+        super().__init__(message)
+
+
+class UserInitiatedCancel(DeadlineOperationCanceled):
     """Error for when the user requests cancelation"""
+
+    def __init__(self, message: str = "Operation canceled by user"):
+        super().__init__(message)
 
 
 class NonValidInputError(Exception):

--- a/src/deadline/client/ui/cli_job_submitter.py
+++ b/src/deadline/client/ui/cli_job_submitter.py
@@ -15,6 +15,7 @@ from qtpy.QtWidgets import (  # pylint: disable=import-error; type: ignore
 )
 
 from ..job_bundle import deadline_yaml_dump
+from ..job_bundle.parameters import JobParameter
 from .dataclasses import CliJobSettings
 from .dialogs.submit_job_to_deadline_dialog import (
     SubmitJobToDeadlineDialog,
@@ -49,11 +50,11 @@ def show_cli_job_submitter(parent=None, f=Qt.WindowFlags()) -> None:
         widget: SubmitJobToDeadlineDialog,
         job_bundle_dir: str,
         settings: CliJobSettings,
-        queue_parameters: list[dict[str, Any]],
+        queue_parameters: list[JobParameter],
         asset_references: AssetReferences,
         host_requirements: Optional[Dict[str, Any]] = None,
         purpose: JobBundlePurpose = JobBundlePurpose.SUBMISSION,
-    ) -> None:
+    ) -> dict[str, Any]:
         """
         Perform a submission when the submit button is pressed
 
@@ -72,19 +73,17 @@ def show_cli_job_submitter(parent=None, f=Qt.WindowFlags()) -> None:
         job_template: Dict[str, Any] = {
             "specificationVersion": "jobtemplate-2023-09",
             "name": settings.name,
-            "description": settings.description,
-            "parameterDefinitions": [
-                {
-                    "name": "DataDir",
-                    "type": "PATH",
-                    "objectType": "DIRECTORY",
-                    "dataFlow": "INOUT",
-                    "default": settings.data_dir,
-                }
-            ],
         }
-        if not settings.description:
-            del job_template["description"]
+        if settings.description:
+            job_template["description"] = settings.description
+        job_template["parameterDefinitions"] = [
+            {
+                "name": "DataDir",
+                "type": "PATH",
+                "objectType": "DIRECTORY",
+                "dataFlow": "INOUT",
+            }
+        ]
         step = {
             "name": "CliScript",
             "script": {
@@ -164,6 +163,11 @@ def show_cli_job_submitter(parent=None, f=Qt.WindowFlags()) -> None:
                     deadline_yaml_dump(asset_references.to_dict(), f)
                 elif settings.file_format == "JSON":
                     json.dump(asset_references.to_dict(), f, indent=1)
+
+        return {
+            "known_asset_paths": [settings.data_dir],
+            "job_parameters": [{"name": "DataDir", "value": settings.data_dir}],
+        }
 
     __submitter_dialog = SubmitJobToDeadlineDialog(
         job_setup_widget_type=CliJobSettingsWidget,

--- a/src/deadline/client/ui/dialogs/deadline_config_dialog.py
+++ b/src/deadline/client/ui/dialogs/deadline_config_dialog.py
@@ -26,10 +26,12 @@ from qtpy.QtWidgets import (  # pylint: disable=import-error; type: ignore
     QComboBox,
     QDialog,
     QDialogButtonBox,
+    QFileDialog,
     QFormLayout,
     QGroupBox,
     QHBoxLayout,
     QLabel,
+    QListWidget,
     QMessageBox,
     QPushButton,
     QSizePolicy,
@@ -38,6 +40,8 @@ from qtpy.QtWidgets import (  # pylint: disable=import-error; type: ignore
     QVBoxLayout,
     QWidget,
 )
+
+import os
 
 from ... import api
 from ..deadline_authentication_status import DeadlineAuthenticationStatus
@@ -307,6 +311,60 @@ class DeadlineWorkstationConfigWidget(QWidget):
             "Current logging level",
             self._log_levels,
         )
+
+        # Known asset paths section
+        known_paths_label = QLabel("Known asset paths")
+        known_paths_label.setToolTip(
+            "Paths that should not generate warnings when outside storage profile locations"
+        )
+        self.labels["settings.known_asset_paths"] = known_paths_label
+
+        known_paths_widget = QWidget(parent=group)
+        known_paths_layout = QVBoxLayout(known_paths_widget)
+        known_paths_layout.setContentsMargins(0, 0, 0, 0)
+
+        # Add buttons and status label
+        button_layout = QHBoxLayout()
+        self.add_known_path_button = QPushButton("Add...")
+        self.add_known_path_button.clicked.connect(self._on_add_known_path)
+        self.edit_known_path_button = QPushButton("Edit...")
+        self.edit_known_path_button.clicked.connect(self._on_edit_known_path)
+        self.remove_known_path_button = QPushButton("Remove Selected")
+        self.remove_known_path_button.clicked.connect(self._on_remove_known_path)
+        self.known_paths_status = QLabel()
+        button_layout.addWidget(self.add_known_path_button)
+        button_layout.addWidget(self.edit_known_path_button)
+        button_layout.addWidget(self.remove_known_path_button)
+        button_layout.addStretch()
+        button_layout.addWidget(self.known_paths_status)
+        known_paths_layout.addLayout(button_layout)
+
+        # Add path list
+        self.known_paths_list = QListWidget(parent=known_paths_widget)
+        self.known_paths_list.setAlternatingRowColors(True)
+        known_paths_layout.addWidget(self.known_paths_list)
+
+        layout.addRow(known_paths_label, known_paths_widget)
+
+        # Add refresh callback for known paths
+        def refresh_known_paths():
+            with block_signals(self.known_paths_list):
+                self.known_paths_list.clear()
+                paths_str = config_file.get_setting(
+                    "settings.known_asset_paths", config=self.config
+                )
+                if paths_str:
+                    paths = paths_str.split(os.pathsep)
+                    self.known_paths_list.addItems(paths)
+
+            # Update status label
+            count = self.known_paths_list.count()
+            self.known_paths_status.setText(f"{count} paths")
+
+            self._update_known_paths_buttons()
+
+        self._refresh_callbacks.append(refresh_known_paths)
+        self.known_paths_list.itemSelectionChanged.connect(self._update_known_paths_buttons)
 
     def _init_checkbox_setting(
         self, group: QWidget, layout: QFormLayout, setting_name: str, label_text: str
@@ -578,8 +636,10 @@ class DeadlineWorkstationConfigWidget(QWidget):
 
         self.changes.clear()
 
-        # The file watcher will see the file modification and call refresh() for us
         config_file.write_config(self.config)
+
+        # Refresh the GUI (writing the config file should cause this, but do this redundantly to make sure)
+        self.refresh()
 
         return True
 
@@ -615,6 +675,78 @@ class DeadlineWorkstationConfigWidget(QWidget):
             index
         )
         self.refresh()
+
+    def _on_add_known_path(self):
+        """Handle adding a new known path"""
+        path = QFileDialog.getExistingDirectory(
+            self, "Select a directory to add to known asset paths", os.path.expanduser("~")
+        )
+        if path:
+            # Normalize path
+            path = os.path.normpath(path)
+
+            # Get current paths
+            current_paths = []
+            for i in range(self.known_paths_list.count()):
+                current_paths.append(self.known_paths_list.item(i).text())
+
+            # Only add if not already in list
+            if path not in current_paths:
+                self.known_paths_list.addItem(path)
+
+                # Update config
+                current_paths.append(path)
+                self.changes["settings.known_asset_paths"] = os.pathsep.join(current_paths)
+                self.refresh()
+
+    def _on_remove_known_path(self):
+        """Handle removing the selected known path"""
+        current_row = self.known_paths_list.currentRow()
+        if current_row >= 0:
+            self.known_paths_list.takeItem(current_row)
+
+            # Update config
+            current_paths = []
+            for i in range(self.known_paths_list.count()):
+                current_paths.append(self.known_paths_list.item(i).text())
+            self.changes["settings.known_asset_paths"] = os.pathsep.join(current_paths)
+            self.refresh()
+
+    def _update_known_paths_buttons(self):
+        """Enable/disable edit and remove buttons based on selection"""
+        has_selection = self.known_paths_list.currentRow() >= 0
+        self.edit_known_path_button.setEnabled(has_selection)
+        self.remove_known_path_button.setEnabled(has_selection)
+
+    def _on_edit_known_path(self):
+        """Handle editing the selected known path"""
+        current_row = self.known_paths_list.currentRow()
+        if current_row >= 0:
+            current_path = self.known_paths_list.item(current_row).text()
+            path = QFileDialog.getExistingDirectory(
+                self,
+                "Select a directory to replace the selected path",
+                current_path if os.path.exists(current_path) else os.path.expanduser("~"),
+            )
+            if path:
+                # Normalize path
+                path = os.path.normpath(path)
+
+                # Only update if path changed
+                if path != current_path:
+                    # Get current paths
+                    current_paths = []
+                    for i in range(self.known_paths_list.count()):
+                        if i != current_row:  # Skip the path being edited
+                            current_paths.append(self.known_paths_list.item(i).text())
+
+                    # Only add if not already in list
+                    if path not in current_paths:
+                        self.known_paths_list.item(current_row).setText(path)
+                        current_paths.insert(current_row, path)
+
+                    self.changes["settings.known_asset_paths"] = os.pathsep.join(current_paths)
+                    self.refresh()
 
 
 class _DeadlineResourceListComboBox(QWidget):

--- a/src/deadline/client/ui/dialogs/submit_job_progress_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_progress_dialog.py
@@ -6,14 +6,12 @@ AWS Deadline Cloud
 
 from __future__ import annotations
 
-import json
 import logging
-import os
 import threading
-import textwrap
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, Optional
+from functools import partial
+import time
 
-from botocore.client import BaseClient  # type: ignore[import]
 from qtpy.QtCore import Qt, Signal
 from qtpy.QtGui import QCloseEvent
 from qtpy.QtWidgets import (  # pylint: disable=import-error; type: ignore
@@ -31,45 +29,81 @@ from qtpy.QtWidgets import (  # pylint: disable=import-error; type: ignore
     QWidget,
 )
 
-from deadline.client import api
-from deadline.client.exceptions import (
-    CreateJobWaiterCanceled,
-    DeadlineOperationError,
-    UserInitiatedCancel,
-)
-from deadline.client.config import set_setting, config_file
-from deadline.client.job_bundle.loader import (
-    read_yaml_or_json,
-    read_yaml_or_json_object,
-    validate_directory_symlink_containment,
-)
-from deadline.client.job_bundle.parameters import (
-    JobParameter,
-    apply_job_parameters,
-    merge_queue_job_parameters,
-    read_job_bundle_parameters,
-)
-from deadline.client.job_bundle.submission import (
-    AssetReferences,
-    split_parameter_args,
-)
-from deadline.job_attachments.exceptions import AssetSyncCancelledError, MisconfiguredInputsError
-from deadline.job_attachments.models import (
-    AssetRootGroup,
-    AssetRootManifest,
-    AssetUploadGroup,
-    StorageProfile,
-)
-from deadline.job_attachments.progress_tracker import ProgressReportMetadata, SummaryStatistics
-from deadline.job_attachments.upload import S3AssetManager
-from deadline.job_attachments._path_summarization import (
-    human_readable_file_size,
-    summarize_path_list,
-)
+from .. import CancelationFlag
+from ... import api
+from ...config import set_setting
+from ....job_attachments.progress_tracker import ProgressReportMetadata
 
 __all__ = ["SubmitJobProgressDialog"]
 
 logger = logging.getLogger(__name__)
+
+
+def _print_function_callback(
+    cancelation_flag: CancelationFlag, dialog: SubmitJobProgressDialog, message: str
+):
+    """Callback for when api.create_job_from_job_bundle prints a message."""
+    if not cancelation_flag:
+        dialog.submission_thread_print.emit(message)
+
+
+def _interactive_confirmation_callback(
+    cancelation_flag: CancelationFlag,
+    dialog: SubmitJobProgressDialog,
+    message: str,
+    default_response: bool,
+) -> bool:
+    """Callback for when api.create_job_from_job_bundle presents a warning to users."""
+    if not cancelation_flag.canceled:
+        # The handler for the submission_thread_request_warning_dialog signal will show
+        # the warning dialog in the main GUI thread, then will set the _warning_dialog_completed
+        # property to True when it is done.
+        dialog._warning_dialog_completed = False
+        dialog.submission_thread_request_warning_dialog.emit(message, default_response)
+    while not cancelation_flag.canceled and not dialog._warning_dialog_completed:
+        time.sleep(0.1)
+    return not cancelation_flag.canceled and not dialog._warning_dialog_canceled
+
+
+def _hashing_progress_callback(
+    cancelation_flag: CancelationFlag,
+    dialog: SubmitJobProgressDialog,
+    progress_report_metadata: ProgressReportMetadata,
+):
+    """Callback for when api.create_job_from_job_bundle provides a hashing progress update."""
+    if not cancelation_flag.canceled:
+        dialog.submission_thread_hashing_progress.emit(progress_report_metadata)
+    return not cancelation_flag.canceled
+
+
+def _upload_progress_callback(
+    cancelation_flag: CancelationFlag,
+    dialog: SubmitJobProgressDialog,
+    progress_report_metadata: ProgressReportMetadata,
+):
+    """Callback for when api.create_job_from_job_bundle provides an upload progress update."""
+    if not cancelation_flag.canceled:
+        dialog.submission_thread_upload_progress.emit(progress_report_metadata)
+    return not cancelation_flag.canceled
+
+
+def _create_job_result_callback(cancelation_flag: CancelationFlag):
+    """Callback for when api.create_job_from_job_bundle checks whether to cancel."""
+    return not cancelation_flag.canceled
+
+
+def _submission_thread_runner(
+    cancelation_flag: CancelationFlag, dialog: SubmitJobProgressDialog, kwargs
+):
+    """Function to run api.create_job_from_job_bundle in a background thread."""
+    try:
+        job_id = api.create_job_from_job_bundle(**kwargs)
+        if not cancelation_flag.canceled:
+            dialog.job_id = job_id
+            dialog.submission_thread_succeeded.emit(job_id)
+    except Exception as e:
+        if not cancelation_flag.canceled:
+            dialog.submission_thread_exception.emit(e)
 
 
 class SubmitJobProgressDialog(QDialog):
@@ -78,82 +112,95 @@ class SubmitJobProgressDialog(QDialog):
     to AWS Deadline Cloud.
     """
 
-    # These signals are sent when the background threads raise an exception.
-    hashing_thread_exception = Signal(BaseException)
-    upload_thread_exception = Signal(BaseException)
-    create_job_thread_exception = Signal(BaseException)
+    job_id: Optional[str] = None
+    cancelation_flag: CancelationFlag
 
-    # These signals are sent when the background threads succeed.
-    hashing_thread_succeeded = Signal(SummaryStatistics, list)
-    upload_thread_succeeded = Signal(SummaryStatistics, dict)
-    create_job_thread_succeeded = Signal(bool, str)
+    # This signal is sent when the background thread raises an exception.
+    submission_thread_exception = Signal(BaseException)
 
-    # These signals are sent when the progress reporting callbacks are called
-    # from job attachments during hashing/uploading.
-    hashing_thread_progress_report = Signal(ProgressReportMetadata)
-    upload_thread_progress_report = Signal(ProgressReportMetadata)
+    # These signals are sent from the background thread
+    submission_thread_print = Signal(str)
+    submission_thread_hashing_progress = Signal(ProgressReportMetadata)
+    submission_thread_upload_progress = Signal(ProgressReportMetadata)
+    submission_thread_request_warning_dialog = Signal(str, bool)
+
+    # This signal is sent when the background thread succeeds.
+    submission_thread_succeeded = Signal(str)
 
     def __init__(self, parent: QWidget) -> None:
         super().__init__(parent=parent)
-        self._continue_submission = True
+
+        # Use the CancelationFlag object to decouple the cancelation value
+        # from the window lifetime.
+        self.cancelation_flag = CancelationFlag()
+        self.destroyed.connect(self.cancelation_flag.set_canceled)
+        self._warning_dialog_canceled = False
+
         self._submission_complete = False
-        self._create_job_args: Dict[str, Any] = {}
-        self._create_job_response: Dict[str, Any] = {}
-        self.__hashing_thread: Optional[threading.Thread] = None
-        self.__upload_thread: Optional[threading.Thread] = None
-        self.__create_job_thread: Optional[threading.Thread] = None
+        self.__submission_thread: Optional[threading.Thread] = None
+        self.submission_thread_print.connect(self.handle_print)
+        self.submission_thread_hashing_progress.connect(self.handle_hashing_thread_progress_report)
+        self.submission_thread_upload_progress.connect(self.handle_upload_thread_progress_report)
+        self.submission_thread_succeeded.connect(self.handle_create_job_thread_succeeded)
+        self.submission_thread_request_warning_dialog.connect(self.handle_request_warning_dialog)
+        self.submission_thread_exception.connect(self.handle_thread_exception)
 
         self._build_ui()
 
-    def start_submission(
+    def start_job_submission(
         self,
-        farm_id: str,
-        queue_id: str,
-        storage_profile: Optional[StorageProfile],
         job_bundle_dir: str,
-        queue_parameters: list[JobParameter],
-        asset_manager: Optional[S3AssetManager],
-        deadline_client: BaseClient,
-        auto_accept: bool = False,
-        require_paths_exist: bool = False,
-    ) -> Optional[Dict[str, Any]]:
+        job_parameters: list[dict[str, Any]] = [],
+        **kwargs,
+    ):
         """
-        Starts a submission. Returns the response from calling create job. If an error occurs
-        or the submission is canceled then None is returned.
+        Starts a job submission background thread and returns immediately. It wires up
+        appropriate callbacks and then forwards all arguments.
 
-        Args:
-            farm_id (str): Id of the farm to submit to
-            queue_id (str): Id of the queue to submit to
-            storage_profile (StorageProfile): the storage profile to associate
-                with the job.
-            job_bundle_dir (str): Path to the folder containing the job bundle to
-                submit.
-            asset_manager (S3AssetManager): A job attachments S3AssetManager
-                configured for the farm/queue to submit to
-            deadline_client (BaseClient): A boto client for AWS Deadline Cloud
-            auto_accept (bool, default False): Flag for whether any confirmation
-                prompts should automatically be accepted.
+        See the documentation for deadline.client.api.create_job_from_job_bundle for
+        more details.
         """
-        self._farm_id = farm_id
-        self._queue_id = queue_id
-        self._storage_profile = storage_profile
-        self._job_bundle_dir = job_bundle_dir
-        self._queue_parameters = queue_parameters
-        self._asset_manager = asset_manager
-        self._deadline_client = deadline_client
-        self._auto_accept = auto_accept
-        self._require_paths_exist = require_paths_exist
 
-        self._start_submission()
-        return self.exec_()
+        kwargs["job_bundle_dir"] = job_bundle_dir
+        kwargs["job_parameters"] = job_parameters
+        kwargs["from_gui"] = True
+        kwargs["submitter_name"] = kwargs.get("submitter_name", "CustomGUI")
+
+        # The CancelationFlag object has a lifetime decoupled from the dialog. Each callback
+        # always checks for cancelation before calling a method or accessing a property of the dialog,
+        # and the Qt object's destroyed event is connected to set its canceled flag.
+        kwargs["print_function_callback"] = partial(
+            _print_function_callback, self.cancelation_flag, self
+        )
+        kwargs["interactive_confirmation_callback"] = partial(
+            _interactive_confirmation_callback, self.cancelation_flag, self
+        )
+        kwargs["hashing_progress_callback"] = partial(
+            _hashing_progress_callback, self.cancelation_flag, self
+        )
+        kwargs["upload_progress_callback"] = partial(
+            _upload_progress_callback, self.cancelation_flag, self
+        )
+        kwargs["create_job_result_callback"] = partial(
+            _create_job_result_callback, self.cancelation_flag
+        )
+
+        self.__submission_thread = threading.Thread(
+            target=partial(_submission_thread_runner, self.cancelation_flag, self, kwargs),
+            name="AWS Deadline Cloud Job Submission",
+        )
+        self.__submission_thread.start()
 
     def _build_ui(self):
-        """Builds up the Dialog UI"""
+        """Builds job submission progress UI"""
         # Remove help button from title bar
-        self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)
+        self.setWindowFlags(
+            (self.windowFlags() & ~Qt.WindowContextHelpButtonHint) | Qt.WindowCloseButtonHint
+        )
         self.lyt = QVBoxLayout(self)
         self.lyt.setContentsMargins(5, 10, 5, 5)
-        self.setMinimumWidth(450)
+        self.setMinimumWidth(600)
+        self.setMinimumHeight(700)
 
         self.status_label = QLabel("Preparing files...")
         self.status_label.setMargin(5)
@@ -163,9 +210,8 @@ class SubmitJobProgressDialog(QDialog):
         self.upload_progress = JobAttachmentsProgressWidget(
             initial_message="Preparing for upload...", title="Upload progress", parent=self
         )
-        self.summary_edit = QTextEdit()
-        self.summary_edit.setVisible(False)
-        self.summary_edit.setReadOnly(True)
+        self.submission_log = QTextEdit()
+        self.submission_log.setReadOnly(True)
         self.button_box = QDialogButtonBox(Qt.Horizontal)
         self.button_box.setStandardButtons(QDialogButtonBox.Cancel)
 
@@ -173,332 +219,51 @@ class SubmitJobProgressDialog(QDialog):
         self.lyt.addWidget(self.status_label)
         self.lyt.addWidget(self.hashing_progress)
         self.lyt.addWidget(self.upload_progress)
-        self.lyt.addWidget(self.summary_edit)
+        self.lyt.addWidget(self.submission_log)
         self.lyt.addWidget(self.button_box)
 
         self.setWindowTitle("AWS Deadline Cloud submission")
 
-        self.hashing_thread_progress_report.connect(self.handle_hashing_thread_progress_report)
-        self.hashing_thread_succeeded.connect(self.handle_hashing_thread_succeeded)
-        self.hashing_thread_exception.connect(self.handle_thread_exception)
-
-        self.upload_thread_progress_report.connect(self.handle_upload_thread_progress_report)
-        self.upload_thread_succeeded.connect(self.handle_upload_thread_succeeded)
-        self.upload_thread_exception.connect(self.handle_thread_exception)
-
-        self.create_job_thread_succeeded.connect(self.handle_create_job_thread_succeeded)
-        self.create_job_thread_exception.connect(self.handle_thread_exception)
-
         self.button_box.accepted.connect(self.accept)
         self.button_box.rejected.connect(self.close)
 
-    def _start_submission(self):
+    def handle_request_warning_dialog(self, message: str, default_response: bool):
+        # Build the UI for user confirmation
+        message_box = QMessageBox(self)
+        if not default_response:
+            message_box.setIcon(QMessageBox.Warning)
+
+        self.submission_log.append(f"{message}\n")
+        message_box.setText(message)
+        message_box.setStandardButtons(QMessageBox.Ok | QMessageBox.Cancel)
+        message_box.setDefaultButton(QMessageBox.Ok if default_response else QMessageBox.Cancel)
+
+        if default_response:
+            # If the default response is to continue, add the "Do not ask again" button
+            dont_ask_button = QPushButton("Do not ask again", self)
+            dont_ask_button.clicked.connect(lambda: set_setting("settings.auto_accept", "true"))
+            message_box.addButton(dont_ask_button, QMessageBox.ActionRole)
+
+        message_box.setWindowTitle("Job attachments file upload confirmation")
+        selection = message_box.exec()
+
+        if selection == QMessageBox.Cancel:
+            self._warning_dialog_canceled = True
+
+        self._warning_dialog_completed = True
+
+    def handle_print(self, message: str) -> None:
         """
-        Starts building up the arguments to pass to create job. If there are any
-        job attachments the hashing process will be started. If there are no job
-        attachments then create job will be called without calling job attachments.
+        Handles the signal sent from the background thread to print messages
+        to the log.
         """
-
-        # Ensure the job bundle doesn't contain files that resolve outside of the bundle directory
-        validate_directory_symlink_containment(self._job_bundle_dir)
-
-        # Read in the job template
-        file_contents, file_type = read_yaml_or_json(
-            self._job_bundle_dir, "template", required=True
-        )
-
-        self._create_job_args["farmId"] = self._farm_id
-        self._create_job_args["queueId"] = self._queue_id
-        self._create_job_args["template"] = file_contents
-        self._create_job_args["templateType"] = file_type
-
-        if self._storage_profile:
-            self._create_job_args["storageProfileId"] = self._storage_profile.storageProfileId
-
-        # The job parameters
-        job_bundle_parameters = read_job_bundle_parameters(self._job_bundle_dir)
-
-        asset_references_obj = read_yaml_or_json_object(
-            self._job_bundle_dir, "asset_references", required=False
-        )
-        self.asset_references = AssetReferences.from_dict(asset_references_obj)
-
-        parameter_definitions = merge_queue_job_parameters(
-            queue_id=self._queue_id,
-            job_parameters=job_bundle_parameters,
-            queue_parameters=self._queue_parameters,
-        )
-
-        apply_job_parameters(
-            [],
-            self._job_bundle_dir,
-            parameter_definitions,
-            self.asset_references,
-        )
-
-        app_parameters_formatted, job_parameters_formatted = split_parameter_args(
-            parameter_definitions, self._job_bundle_dir
-        )
-
-        self._create_job_args.update(app_parameters_formatted)
-
-        if job_parameters_formatted:
-            self._create_job_args["parameters"] = job_parameters_formatted
-
-        if self._asset_manager and (
-            self.asset_references.input_filenames
-            or self.asset_references.input_directories
-            or self.asset_references.output_directories
-        ):
-            # Extend input_filenames with all the files in the input_directories
-            missing_directories: set[str] = set()
-            for directory in self.asset_references.input_directories:
-                if not os.path.isdir(directory):
-                    if self._require_paths_exist:
-                        missing_directories.add(directory)
-                    else:
-                        logging.warning(
-                            f"Input directory '{directory}' does not exist. Adding to referenced paths."
-                        )
-                        self.asset_references.referenced_paths.add(directory)
-                    continue
-
-                is_dir_empty = True
-                for root, _, files in os.walk(directory):
-                    if not files:
-                        continue
-                    is_dir_empty = False
-                    self.asset_references.input_filenames.update(
-                        os.path.normpath(os.path.join(root, file)) for file in files
-                    )
-                # Empty directories just become references since there's nothing to upload
-                if is_dir_empty:
-                    logging.info(
-                        f"Input directory '{directory}' is empty. Adding to referenced paths."
-                    )
-                    self.asset_references.referenced_paths.add(directory)
-            self.asset_references.input_directories.clear()
-
-            if missing_directories:
-                sample_size = 3
-                misconfigured_directories_msg = (
-                    "Job submission contains misconfigured input directories and cannot be submitted."
-                    " All input directories must exist."
-                )
-
-                missing_directory_list = sorted(list(missing_directories))
-                sample_of_missing_directories = "\n\t".join(missing_directory_list[:sample_size])
-                sample_of_misconfigured_inputs = (
-                    f"\nNon-existent directories:\n\t{sample_of_missing_directories}\n"
-                )
-                all_missing_directories = "\n\t".join(missing_directory_list)
-                all_misconfigured_inputs = (
-                    f"\nNon-existent directories:\n\t{all_missing_directories}"
-                )
-
-                logging.error(misconfigured_directories_msg + all_misconfigured_inputs)
-                if len(missing_directories) > sample_size:
-                    misconfigured_directories_msg += (
-                        " Check logs for all occurrences, here's a sample:\n"
-                    )
-                misconfigured_directories_msg += f"{sample_of_misconfigured_inputs}"
-
-                raise MisconfiguredInputsError(misconfigured_directories_msg)
-
-            upload_group = self._asset_manager.prepare_paths_for_upload(
-                input_paths=sorted(self.asset_references.input_filenames),
-                output_paths=sorted(self.asset_references.output_directories),
-                referenced_paths=sorted(self.asset_references.referenced_paths),
-                storage_profile=self._storage_profile,
-                require_paths_exist=self._require_paths_exist,
-            )
-            # If we find any Job Attachments, start a background thread
-            if upload_group.asset_groups:
-                if not self._confirm_asset_references_outside_storage_profile(upload_group):
-                    raise UserInitiatedCancel("Submission canceled.")
-
-                self._start_hashing(
-                    upload_group.asset_groups,
-                    upload_group.total_input_files,
-                    upload_group.total_input_bytes,
-                )
-                return
-
-        self.hashing_progress.setVisible(False)
-        self.upload_progress.setVisible(False)
-        self._start_create_job()
-
-    def _hashing_background_thread(
-        self,
-        asset_groups: list[AssetRootGroup],
-        total_input_files: int,
-        total_input_bytes: int,
-    ) -> None:
-        """
-        This function gets started in a background thread to start the hashing
-        of any job attachments.
-        """
-        try:
-
-            def _update_hash_progress(hashing_metadata: ProgressReportMetadata) -> bool:
-                self.hashing_thread_progress_report.emit(hashing_metadata)
-                return self._continue_submission
-
-            logger.info("Hashing job attachments files...")
-
-            # This thread is only started if self._asset_manager is set.
-            hashing_summary, manifests = cast(
-                S3AssetManager, self._asset_manager
-            ).hash_assets_and_create_manifest(
-                asset_groups=asset_groups,
-                total_input_files=total_input_files,
-                total_input_bytes=total_input_bytes,
-                hash_cache_dir=config_file.get_cache_directory(),
-                on_preparing_to_submit=_update_hash_progress,
-            )
-
-            logger.info("Finished hashing job attachments files.")
-
-            self.hashing_thread_succeeded.emit(hashing_summary, manifests)
-        except AssetSyncCancelledError as e:
-            # If it wasn't canceled, send the exception to the dialog
-            if self._continue_submission:
-                self.hashing_thread_exception.emit(e)
-            else:
-                logger.info("Job attachments hashing canceled.")
-        except Exception as e:
-            # Send the exception to the dialog
-            self.hashing_thread_exception.emit(e)
-
-    @api.record_success_fail_telemetry_event(metric_name="gui_asset_upload")  # type: ignore
-    def _upload_background_thread(self, manifests: List[AssetRootManifest]) -> None:
-        """
-        This function gets started in a background thread to start the upload
-        of any job attachments.
-        """
-        try:
-
-            def _update_upload_progress(upload_metadata: ProgressReportMetadata) -> bool:
-                self.upload_thread_progress_report.emit(upload_metadata)
-                return self._continue_submission
-
-            logger.info("Uploading job attachments files...")
-
-            # This thread is only started if self._asset_manager is set.
-            upload_summary, attachment_settings = cast(
-                S3AssetManager, self._asset_manager
-            ).upload_assets(
-                manifests=manifests,
-                on_uploading_assets=_update_upload_progress,
-                s3_check_cache_dir=config_file.get_cache_directory(),
-                manifest_write_dir=self._job_bundle_dir,
-            )
-
-            logger.info("Finished uploading job attachments files.")
-
-            self.upload_thread_succeeded.emit(upload_summary, attachment_settings.to_dict())
-        except AssetSyncCancelledError as e:
-            # If it wasn't canceled, send the exception to the dialog
-            if self._continue_submission:
-                self.hashing_thread_exception.emit(e)
-            else:
-                logger.info("Job attachments upload canceled.")
-        except Exception as e:
-            # Send the exception to the dialog
-            self.hashing_thread_exception.emit(e)
-
-    def _create_job_background_thread(self) -> None:
-        """
-        This function gets started in a background thread to call CreateJob.
-        """
-        try:
-
-            def _continue_create_job_wait() -> bool:
-                return self._continue_submission
-
-            logger.info("Waiting for job to be created...")
-
-            success = False
-
-            logger.debug(json.dumps(self._create_job_args, indent=1))
-            self._create_job_response = self._deadline_client.create_job(**self._create_job_args)
-            logger.debug(f"CreateJob Response {self._create_job_response}")
-
-            if self._create_job_response and "jobId" in self._create_job_response:
-                job_id = self._create_job_response["jobId"]
-
-                # Set the default job id so it holds the most-recently submitted job.
-                set_setting("defaults.job_id", job_id)
-
-                success, message = api.wait_for_create_job_to_complete(
-                    self._farm_id,
-                    self._queue_id,
-                    job_id,
-                    self._deadline_client,
-                    _continue_create_job_wait,
-                )
-                message += f"\n{job_id}\n"
-            else:
-                message = "CreateJob response was empty, or did not contain a job ID."
-            if success:
-                self.create_job_thread_succeeded.emit(success, message)
-            else:
-                self.create_job_thread_exception.emit(DeadlineOperationError(message))
-        except CreateJobWaiterCanceled as e:
-            # If it wasn't canceled, send the exception to the dialog
-            if self._continue_submission:
-                self.create_job_thread_exception.emit(e)
-            else:
-                logger.info("Wait for CreateJob result canceled.")
-        except Exception as e:
-            # Send the exception to the dialog
-            self.create_job_thread_exception.emit(e)
-
-    def _start_hashing(
-        self,
-        asset_groups: list[AssetRootGroup],
-        total_input_files: int,
-        total_input_bytes: int,
-    ) -> None:
-        """
-        Starts the background hashing thread.
-        """
-        self.status_label.setText("Hashing job attachments...")
-        self.__hashing_thread = threading.Thread(
-            target=self._hashing_background_thread,
-            name="AWS Deadline Cloud hashing background thread",
-            args=(asset_groups, total_input_files, total_input_bytes),
-        )
-        self.__hashing_thread.start()
-
-    def _start_upload(self, asset_manifests: List[AssetRootManifest]) -> None:
-        """
-        Starts the background upload thread.
-        """
-        self.status_label.setText("Uploading job attachments...")
-        self.__upload_thread = threading.Thread(
-            target=self._upload_background_thread,
-            name="AWS Deadline Cloud upload background thread",
-            args=(asset_manifests,),
-        )
-        self.__upload_thread.start()
-
-    def _start_create_job(self) -> None:
-        """
-        Starts the background thread to call CreateJob.
-        """
-        self.status_label.setText("Waiting for job to be created...")
-        self.__create_job_thread = threading.Thread(
-            target=self._create_job_background_thread,
-            name="AWS Deadline Cloud CreateJob background thread",
-        )
-        self.__create_job_thread.start()
+        self.submission_log.append(f"{message}\n")
 
     def handle_hashing_thread_progress_report(
         self, progress_metadata: ProgressReportMetadata
     ) -> None:
         """
-        Handles the signal sent from the background threads when reporting
+        Handles the signal sent from the background thread when reporting
         hashing progress. Sets the progress bar in the dialog based on
         the callback progress data from job attachments.
         """
@@ -509,163 +274,39 @@ class SubmitJobProgressDialog(QDialog):
         self, progress_metadata: ProgressReportMetadata
     ) -> None:
         """
-        Handles the signal sent from the background threads when reporting
+        Handles the signal sent from the background thread when reporting
         upload progress. Sets the progress bar in the dialog based on
         the callback progress data from job attachments.
         """
         self.upload_progress.progress_bar.setValue(int(progress_metadata.progress))
         self.upload_progress.progress_message.setText(progress_metadata.progressMessage)
 
-    def handle_hashing_thread_succeeded(
-        self,
-        hashing_summary: SummaryStatistics,
-        asset_manifests: List[AssetRootManifest],
-    ) -> None:
-        """
-        Handles the signal sent from the background hashing thread when the
-        hashing process has completed.
-        """
-        api.get_deadline_cloud_library_telemetry_client().record_hashing_summary(
-            hashing_summary, from_gui=True
-        )
-        self.summary_edit.setText(
-            f"\nHashing summary:\n{textwrap.indent(str(hashing_summary), '    ')}"
-        )
-        self._start_upload(asset_manifests)
-
-    def handle_upload_thread_succeeded(
-        self, upload_summary: SummaryStatistics, attachment_settings: Any
-    ) -> None:
-        """
-        Handles the signal sent from the background upload thread when the upload
-        has finished.
-        """
-        if attachment_settings:
-            self._create_job_args["attachments"] = attachment_settings
-            self._create_job_args["attachments"]["fileSystem"] = config_file.get_setting(
-                "defaults.job_attachments_file_system"
-            )
-
-        api.get_deadline_cloud_library_telemetry_client().record_upload_summary(
-            upload_summary, from_gui=True
-        )
-        self.summary_edit.setText(
-            f"{self.summary_edit.toPlainText()}"
-            + f"\nUpload summary:\n{textwrap.indent(str(upload_summary), '    ')}"
-        )
-
-        self._start_create_job()
-
-    def handle_create_job_thread_succeeded(self, success: bool, status_message: str) -> None:
+    def handle_create_job_thread_succeeded(self, job_id: str) -> None:
         """
         Handles the signal sent from the background CreateJob thread when the
         job creation has finished.
         """
-        api.get_deadline_cloud_library_telemetry_client().record_event(
-            event_type="com.amazon.rum.deadline.create_job",
-            event_details={"is_success": success},
-            from_gui=True,
-        )
-
-        if success:
+        if job_id:
             self._submission_complete = True
             self.status_label.setText("Submission complete")
             self.button_box.setStandardButtons(QDialogButtonBox.Ok)
             self.button_box.button(QDialogButtonBox.Ok).setDefault(True)
         else:
-            self.status_label.setText("Submission error")
+            if self.cancelation_flag or self._warning_dialog_canceled:
+                self.status_label.setText("Submission canceled")
+            else:
+                self.status_label.setText("Submission error")
             self.button_box.setStandardButtons(QDialogButtonBox.Close)
             self.button_box.button(QDialogButtonBox.Close).setDefault(True)
-
-        self.summary_edit.setText(f"{status_message} {self.summary_edit.toPlainText()}")
-        self.summary_edit.setVisible(True)
-        self.adjustSize()
 
     def handle_thread_exception(self, e: BaseException) -> None:
         """
         Handles the signal sent from the background threads when an exception is
         thrown.
         """
-        self.hashing_progress.setVisible(False)
-        self.upload_progress.setVisible(False)
-        self.status_label.setVisible(False)
         self.button_box.setStandardButtons(QDialogButtonBox.Close)
-        self.summary_edit.setText(f"Error occurred: {str(e)}")
-        self.summary_edit.setVisible(True)
-        self.adjustSize()
+        self.submission_log.append(f"Error occurred: {str(e)}\n")
         logger.exception(e, exc_info=(type(e), e, e.__traceback__))
-
-    def _confirm_asset_references_outside_storage_profile(
-        self, upload_group: AssetUploadGroup
-    ) -> bool:
-        """
-        Creates a dialog to prompt the user to confirm that they want to proceed
-        with uploading when files were found outside of the configured storage profile locations.
-        """
-        message_text = (
-            f"Job submission contains {upload_group.total_input_files} input files totaling {human_readable_file_size(upload_group.total_input_bytes)}. "
-            " All input files will be uploaded to S3 if they are not already present in the job attachments bucket."
-        )
-        warning_message = ""
-        warning_input_paths = set()
-        warning_output_paths = set()
-        for group in upload_group.asset_groups:
-            if not group.file_system_location_name:
-                warning_input_paths.update(group.inputs)
-                warning_output_paths.update(group.outputs)
-
-        if len(warning_input_paths) > 0:
-            warning_message += "Locations for upload:\n"
-            warning_message += textwrap.indent(summarize_path_list(warning_input_paths), "  ")
-        if len(warning_output_paths) > 0:
-            warning_message += "Locations to collect job outputs for download:\n"
-            # We expect the list of output paths to be small, but truncate it to an arbitrary limit just in case for the summary
-            warning_entry_count = 4
-            if len(warning_output_paths) == warning_entry_count + 1:
-                warning_entry_count += 1
-            for path in sorted(warning_output_paths)[:warning_entry_count]:
-                warning_message += f"  {path}\n"
-            if len(warning_output_paths) > warning_entry_count:
-                warning_message += (
-                    f"\n  ... and {len(warning_output_paths) - warning_entry_count} more\n"
-                )
-
-        # Exit early if we've set auto accept and there are no warnings
-        if not warning_message and self._auto_accept:
-            return True
-
-        # Build the UI
-        message_box = QMessageBox(self)
-        if warning_message:
-            if self._storage_profile:
-                fs_locations_text = "\n\t".join(
-                    [fs_location.path for fs_location in self._storage_profile.fileSystemLocations]
-                )
-                message_text += f"\n\nFiles were specified outside of the configured storage profile location(s):\n{fs_locations_text}\n"
-            else:
-                message_text += "\n\nNo storage profile locations are configured for this queue."
-            message_text += (
-                "\nPlease confirm that you intend to submit a job that uses files from the following directories:\n"
-                f"{warning_message}\n"
-                "To permanently remove this warning you must only use files located within a storage profile location."
-            )
-            message_box.setIcon(QMessageBox.Warning)
-
-        message_box.setText(message_text)
-        message_box.setStandardButtons(QMessageBox.Ok | QMessageBox.Cancel)
-        message_box.setDefaultButton(QMessageBox.Ok)
-
-        if not warning_message:
-            # If we don't have any warnings, add the "Do not ask again" button that acts like 'OK' but sets the config
-            # setting to always auto-accept similar prompts in the future.
-            dont_ask_button = QPushButton("Do not ask again", self)
-            dont_ask_button.clicked.connect(lambda: set_setting("settings.auto_accept", "true"))
-            message_box.addButton(dont_ask_button, QMessageBox.ActionRole)
-
-        message_box.setWindowTitle("Job attachments valid files confirmation")
-        selection = message_box.exec()
-
-        return selection != QMessageBox.Cancel
 
     def closeEvent(self, event: QCloseEvent) -> None:
         """
@@ -676,32 +317,21 @@ class SubmitJobProgressDialog(QDialog):
         if self._submission_complete:
             self.accept()
         else:
+            self.cancelation_flag.set_canceled()
             logger.info("Canceling submission...")
             self.status_label.setText("Canceling submission...")
-            self.hashing_progress.setVisible(False)
-            self.upload_progress.setVisible(False)
-            self.adjustSize()
-            self._continue_submission = False
-            self._shutdown_threads()
+            if self.__submission_thread is not None:
+                while self.__submission_thread.is_alive():
+                    QApplication.instance().processEvents()  # type: ignore[union-attr]
             super().closeEvent(event)
 
-    def _shutdown_threads(self) -> None:
-        """Closes any threads. Used before canceling/closing"""
-
-        threads = (self.__hashing_thread, self.__upload_thread, self.__create_job_thread)
-
-        for thread in threads:
-            if thread:
-                while thread.is_alive():
-                    QApplication.instance().processEvents()  # type: ignore[union-attr]
-
-    def exec_(self) -> Optional[Dict[str, Any]]:  # type: ignore[override]
+    def exec_(self) -> Optional[str]:  # type: ignore[override]
         """
-        Runs the modal job progress dialog, returns the response from calling
-        create job if the dialog was accepted. Otherwise returns None
+        Runs the modal job progress dialog, returns the submitted job ID if it
+        was successful, otherwise None.
         """
         if super().exec_() == QDialog.Accepted:
-            return self._create_job_response
+            return self.job_id
         return None
 
 

--- a/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
@@ -7,7 +7,9 @@ from __future__ import annotations
 import logging
 import os
 import sys
-from typing import Any, Dict, Optional
+import json
+from typing import Any, Dict, Optional, Protocol
+import yaml
 
 from qtpy.QtCore import QSize, Qt  # pylint: disable=import-error
 from qtpy.QtGui import QKeyEvent  # pylint: disable=import-error
@@ -24,18 +26,16 @@ from qtpy.QtWidgets import (  # pylint: disable=import-error; type: ignore
     QWidget,
 )
 
-from deadline.client.ui.dialogs.submit_job_progress_dialog import SubmitJobProgressDialog
-from deadline.job_attachments.models import JobAttachmentS3Settings
-from deadline.job_attachments.upload import S3AssetManager
+from .submit_job_progress_dialog import SubmitJobProgressDialog
 
 from ..dataclasses import HostRequirements
 from ... import api
 from ..deadline_authentication_status import DeadlineAuthenticationStatus
 from .. import block_signals
-from ...config import get_setting
-from ...config.config_file import str2bool
+from ...config import get_setting, set_setting, config_file
 from ...exceptions import UserInitiatedCancel, NonValidInputError
 from ...job_bundle import create_job_history_bundle_dir
+from ...job_bundle.parameters import JobParameter
 from ...job_bundle.submission import AssetReferences
 from ..widgets.deadline_authentication_status_widget import DeadlineAuthenticationStatusWidget
 from ..widgets.job_attachments_tab import JobAttachmentsWidget
@@ -48,6 +48,22 @@ logger = logging.getLogger(__name__)
 
 # initialize early so once the UI opens, things are already initialized
 DeadlineAuthenticationStatus.getInstance()
+
+
+class OnCreateJobBundleCallback(Protocol):
+    """This protocol defines the callback for creating a job bundle in the SubmitJobToDeadlineDialog."""
+
+    def __call__(
+        self,
+        widget: SubmitJobToDeadlineDialog,
+        job_bundle_dir: str,
+        settings: Any,
+        queue_parameters: list[JobParameter],
+        asset_references: AssetReferences,
+        host_requirements: Optional[Dict[str, Any]] = None,
+        *,
+        purpose: JobBundlePurpose,
+    ) -> dict[str, Any]: ...
 
 
 class SubmitJobToDeadlineDialog(QDialog):
@@ -64,11 +80,19 @@ class SubmitJobToDeadlineDialog(QDialog):
             to override default queue parameter values from the queue. For example,
             a Rez queue environment may have a default "" for the RezPackages parameter, but a Maya
             submitter would override that default with "maya-2023" or similar.
-        auto_detected_attachments (FlatAssetReferences): The job attachments that were automatically detected
+        auto_detected_attachments (AssetReferences): The job attachments that were automatically detected
             from the input document/scene file or starting job bundle.
-        attachments: (FlatAssetReferences): The job attachments that have been added to the job by the user.
-        on_create_job_bundle_callback: A function to call when the dialog needs to create a Job Bundle. It
-            is called with arguments (widget, job_bundle_dir, settings, queue_parameters, asset_references)
+        attachments (AssetReferences): The job attachments that have been added to the job by the user.
+        on_create_job_bundle_callback (OnCreateJobBundleCallback): A function to call when the dialog
+            needs to create a Job Bundle. It is called with arguments:
+            (widget, job_bundle_dir, settings, queue_parameters, asset_references, host_requirements, purpose).
+            It can return either None or a dict with parameters about the submission. Currently,
+            the additional parameters supported are:
+            {
+                # See documentation for deadline.client.api.create_job_from_job_bundle about these parameters
+                "job_parameters": [{"name": "ParameterName", "value": "Parameter Value", ...}],
+                "known_asset_paths": ["/path/1", ...],
+            }
         parent: parent of the widget
         f: Qt Window Flags
         show_host_requirements_tab: Display the host requirements tab in dialog if set to True. Default
@@ -84,12 +108,13 @@ class SubmitJobToDeadlineDialog(QDialog):
         initial_shared_parameter_values: dict[str, Any],
         auto_detected_attachments: AssetReferences,
         attachments: AssetReferences,
-        on_create_job_bundle_callback,
+        on_create_job_bundle_callback: OnCreateJobBundleCallback,
         parent=None,
         f=Qt.WindowFlags(),
         show_host_requirements_tab=False,
         host_requirements: Optional[HostRequirements] = None,
         submitter_name: Optional[str] = None,
+        known_asset_paths: Optional[list[str]] = None,
     ):
         # The Qt.Tool flag makes sure our widget stays in front of the main application window
         super().__init__(parent=parent, f=f)
@@ -103,6 +128,7 @@ class SubmitJobToDeadlineDialog(QDialog):
         self.job_history_bundle_dir: Optional[str] = None
         self.deadline_authentication_status = DeadlineAuthenticationStatus.getInstance()
         self.show_host_requirements_tab = show_host_requirements_tab
+        self.known_asset_paths = known_asset_paths or []
 
         self._build_ui(
             job_setup_widget_type,
@@ -356,19 +382,19 @@ class SubmitJobToDeadlineDialog(QDialog):
             )
 
             if self.show_host_requirements_tab:
-                requirements = self.host_requirements.get_requirements()
-                self.on_create_job_bundle_callback(
+                host_requirements = self.host_requirements.get_requirements()
+                parameters_from_callback = self.on_create_job_bundle_callback(
                     self,
                     self.job_history_bundle_dir,
                     settings,
                     queue_parameters,
                     asset_references,
-                    requirements,
+                    host_requirements,
                     purpose=JobBundlePurpose.EXPORT,
                 )
             else:
                 # Maintaining backward compatibility for submitters that do not support host_requirements yet
-                self.on_create_job_bundle_callback(
+                parameters_from_callback = self.on_create_job_bundle_callback(
                     self,
                     self.job_history_bundle_dir,
                     settings,
@@ -376,6 +402,14 @@ class SubmitJobToDeadlineDialog(QDialog):
                     asset_references,
                     purpose=JobBundlePurpose.EXPORT,
                 )
+            if parameters_from_callback is None:
+                parameters_from_callback = {}
+
+            # If the callback returned job parameters, update them in the job bundle as well so that
+            # submission from the job history dir is equivalent.
+            job_parameters = parameters_from_callback.get("job_parameters", [])
+            if job_parameters:
+                self.save_job_parameters_to_job_bundle(self.job_history_bundle_dir, job_parameters)
 
             logger.info(f"Saved the submission as a job bundle: {self.job_history_bundle_dir}")
             if sys.platform == "win32":
@@ -396,6 +430,36 @@ class SubmitJobToDeadlineDialog(QDialog):
             logger.exception("Error saving bundle")
             message = str(exc)
             QMessageBox.critical(self, f"{self.submitter_name} job submission", message)  # type: ignore[call-arg]
+
+    def save_job_parameters_to_job_bundle(
+        self, job_bundle_dir: str, job_parameters: list[JobParameter]
+    ):
+        """
+        Saves the job parameters to the job bundle. If the job bundle already has a parameter_values file,
+        it updates it. Otherwise it creates it.
+        """
+        job_parameters_dict = {param["name"]: param for param in job_parameters}
+
+        job_parameters_file = os.path.join(job_bundle_dir, "parameter_values.yaml")
+        if os.path.exists(job_parameters_file):
+            with open(job_parameters_file, "r", encoding="utf8") as f:
+                existing_job_parameters = yaml.safe_load(f).get("parameterValues", [])
+        else:
+            job_parameters_file = os.path.join(job_bundle_dir, "parameter_values.json")
+            if os.path.exists(job_parameters_file):
+                with open(job_parameters_file, "r", encoding="utf8") as f:
+                    existing_job_parameters = json.load(f).get("parameterValues", [])
+            else:
+                existing_job_parameters = []
+
+        # Overwrite any existing values, and add new values at the end
+        combined_job_parameters = []
+        for param in existing_job_parameters:
+            combined_job_parameters.append(job_parameters_dict.pop(param["name"], param))
+        combined_job_parameters.extend(job_parameters_dict.values())
+
+        with open(job_parameters_file, "w", encoding="utf8") as f:
+            json.dump({"parameterValues": combined_job_parameters}, f, indent=1)
 
     def on_submit(self):
         """
@@ -419,15 +483,13 @@ class SubmitJobToDeadlineDialog(QDialog):
 
         # Submit the job
         try:
-            deadline = api.get_boto3_client("deadline")
-
             self.job_history_bundle_dir = create_job_history_bundle_dir(
                 self.submitter_name, settings.name
             )
 
             if self.show_host_requirements_tab:
                 requirements = self.host_requirements.get_requirements()
-                self.on_create_job_bundle_callback(
+                parameters_from_callback = self.on_create_job_bundle_callback(
                     self,
                     self.job_history_bundle_dir,
                     settings,
@@ -438,7 +500,7 @@ class SubmitJobToDeadlineDialog(QDialog):
                 )
             else:
                 # Maintaining backward compatibility for submitters that do not support host_requirements yet
-                self.on_create_job_bundle_callback(
+                parameters_from_callback = self.on_create_job_bundle_callback(
                     self,
                     self.job_history_bundle_dir,
                     settings,
@@ -446,56 +508,27 @@ class SubmitJobToDeadlineDialog(QDialog):
                     asset_references,
                     purpose=JobBundlePurpose.SUBMISSION,
                 )
+            if parameters_from_callback is None:
+                parameters_from_callback = {}
 
-            farm_id = get_setting("defaults.farm_id")
-            queue_id = get_setting("defaults.queue_id")
-            storage_profile_id = get_setting("settings.storage_profile_id")
+            # If the callback returned job parameters, update them in the job bundle as well so that
+            # submission from the job history dir is equivalent.
+            job_parameters = parameters_from_callback.get("job_parameters", [])
+            if job_parameters:
+                self.save_job_parameters_to_job_bundle(self.job_history_bundle_dir, job_parameters)
 
-            storage_profile = None
-            if storage_profile_id:
-                storage_profile = api.get_storage_profile_for_queue(
-                    farm_id, queue_id, storage_profile_id, deadline
-                )
-
-            queue = deadline.get_queue(farmId=farm_id, queueId=queue_id)
-
-            queue_role_session = api.get_queue_user_boto3_session(
-                deadline=deadline,
-                farm_id=farm_id,
-                queue_id=queue_id,
-                queue_display_name=queue["displayName"],
-            )
-
-            asset_manager: Optional[S3AssetManager] = None
-            if "jobAttachmentSettings" in queue:
-                asset_manager = S3AssetManager(
-                    farm_id=farm_id,
-                    queue_id=queue_id,
-                    job_attachment_settings=JobAttachmentS3Settings(
-                        **queue["jobAttachmentSettings"]
-                    ),
-                    session=queue_role_session,
-                )
-
-            api.get_deadline_cloud_library_telemetry_client().record_event(
-                event_type="com.amazon.rum.deadline.submission",
-                event_details={
-                    "submitter_name": self.submitter_name,
-                },
-                from_gui=True,
-            )
-
-            self.create_job_response = job_progress_dialog.start_submission(
-                farm_id,
-                queue_id,
-                storage_profile,
-                self.job_history_bundle_dir,
-                queue_parameters,
-                asset_manager,
-                deadline,
-                auto_accept=str2bool(get_setting("settings.auto_accept")),
+            job_id = job_progress_dialog.start_job_submission(
+                job_bundle_dir=self.job_history_bundle_dir,
+                submitter_name=self.submitter_name,
+                config=config_file.read_config(),
                 require_paths_exist=self.job_attachments.get_require_paths_exist(),
+                job_parameters=job_parameters,
+                known_asset_paths=self.known_asset_paths
+                + parameters_from_callback.get("known_asset_paths", []),
             )
+            if job_id:
+                set_setting("defaults.job_id", job_id)
+
         except UserInitiatedCancel as uic:
             logger.info("Canceling submission.")
             QMessageBox.information(self, f"{self.submitter_name} job submission", str(uic))

--- a/src/deadline/client/ui/job_bundle_submitter.py
+++ b/src/deadline/client/ui/job_bundle_submitter.py
@@ -45,6 +45,7 @@ def show_job_bundle_submitter(
     parent=None,
     f=Qt.WindowFlags(),
     submitter_name: Optional[str] = None,
+    known_asset_paths: Optional[list[str]] = None,
 ) -> Optional[SubmitJobToDeadlineDialog]:
     """
     Opens an AWS Deadline Cloud job submission dialog for the provided job bundle.
@@ -84,7 +85,7 @@ def show_job_bundle_submitter(
         asset_references: AssetReferences,
         host_requirements: Optional[Dict[str, Any]] = None,
         purpose: JobBundlePurpose = JobBundlePurpose.SUBMISSION,
-    ) -> None:
+    ) -> dict[str, Any]:
         """
         Perform a submission when the submit button is pressed
 
@@ -120,12 +121,12 @@ def show_job_bundle_submitter(
         # First filter the queue parameters to exclude any from the job template,
         # then extend it with the job template parameters.
         job_parameter_names = {param["name"] for param in settings.parameters}
-        parameters_values: list[dict[str, Any]] = [
+        parameter_values: list[dict[str, Any]] = [
             {"name": param["name"], "value": param["value"]}
             for param in queue_parameters
             if param["name"] not in job_parameter_names
         ]
-        parameters_values.extend(
+        parameter_values.extend(
             {"name": param["name"], "value": param["value"]} for param in settings.parameters
         )
 
@@ -135,7 +136,7 @@ def show_job_bundle_submitter(
         )
 
         apply_job_parameters(
-            parameters_values,
+            parameter_values,
             job_bundle_dir,
             parameters,
             AssetReferences(),
@@ -150,12 +151,11 @@ def show_job_bundle_submitter(
             file_type=file_type,
             data=asset_references.to_dict(),
         )
-        save_yaml_or_json_to_file(
-            bundle_dir=job_bundle_dir,
-            filename="parameter_values",
-            file_type=file_type,
-            data={"parameterValues": parameters_values},
-        )
+
+        return {
+            "known_asset_paths": [os.path.abspath(settings.input_job_bundle_dir)],
+            "job_parameters": parameter_values,
+        }
 
     # Ensure the job bundle doesn't contain files that resolve outside of the bundle directory
     validate_directory_symlink_containment(input_job_bundle_dir)
@@ -197,6 +197,7 @@ def show_job_bundle_submitter(
         parent=parent,
         f=f,
         submitter_name=submitter_name,
+        known_asset_paths=known_asset_paths,
     )
     submitter_dialog.show()
     return submitter_dialog

--- a/src/deadline/client/ui/widgets/cli_job_settings_tab.py
+++ b/src/deadline/client/ui/widgets/cli_job_settings_tab.py
@@ -107,5 +107,6 @@ class CliJobSettingsWidget(QWidget):
         settings.file_format = self.file_format_box.currentText()
 
     def use_array_parameter_changed(self, state: int):
-        self.array_parameter_name.setEnabled(state == Qt.Checked)
-        self._set_enabled_with_label("array_parameter_values", state == Qt.Checked)
+        enabled = Qt.CheckState(state) == Qt.Checked
+        self.array_parameter_name.setEnabled(enabled)
+        self._set_enabled_with_label("array_parameter_values", enabled)

--- a/src/deadline/client/ui/widgets/shared_job_settings_tab.py
+++ b/src/deadline/client/ui/widgets/shared_job_settings_tab.py
@@ -303,7 +303,7 @@ class SharedJobPropertiesWidget(QGroupBox):  # pylint: disable=too-few-public-me
         self.limited_max_worker_count.toggled.connect(
             self.limited_max_worker_count_radio_button_toggled
         )
-        self.max_worker_count_layout = QVBoxLayout(self)
+        self.max_worker_count_layout = QVBoxLayout()
         self.max_worker_count_layout.addWidget(self.unlimited_max_worker_count)
         self.max_worker_count_layout.addWidget(self.limited_max_worker_count)
         self.max_worker_count_layout.addWidget(self.max_worker_count_box)

--- a/src/deadline/job_attachments/caches/cache_db.py
+++ b/src/deadline/job_attachments/caches/cache_db.py
@@ -41,7 +41,7 @@ class CacheDB(ABC):
 
             self.enabled = True
         except ImportError:
-            logger.warn(f"SQLite was not found, {cache_name} will not be used.")
+            logger.warning(f"SQLite was not found, {cache_name} will not be used.")
             self.enabled = False
             return
 

--- a/src/deadline/job_attachments/models.py
+++ b/src/deadline/job_attachments/models.py
@@ -61,6 +61,8 @@ class AssetUploadGroup:
     """Represents all of the information needed to prepare to upload assets"""
 
     asset_groups: List[AssetRootGroup] = field(default_factory=list)
+    known_asset_paths: List[Path] = field(default_factory=list)
+    """List of paths that should not generate warnings"""
     total_input_files: int = 0
     total_input_bytes: int = 0
 

--- a/src/deadline/job_attachments/upload.py
+++ b/src/deadline/job_attachments/upload.py
@@ -1117,7 +1117,7 @@ class S3AssetManager:
                 common_path = common_path.parent
             asset_group.root_path = str(common_path)
 
-        return list(groupings.values())
+        return sorted(groupings.values(), key=lambda v: (v.root_path, v.file_system_location_name))
 
     def _get_matched_group(
         self, root_path: str, groupings: dict[str, AssetRootGroup]
@@ -1230,8 +1230,8 @@ class S3AssetManager:
         input_paths: list[str],
         output_paths: list[str],
         referenced_paths: list[str],
-        storage_profile: Optional[StorageProfile] = None,
-        require_paths_exist: bool = False,
+        storage_profile: Optional[StorageProfile],
+        require_paths_exist: bool,
     ) -> list[AssetRootGroup]:
         """
         Resolves all of the paths that will be uploaded, sorting by storage profile location.

--- a/src/deadline/job_attachments/vfs.py
+++ b/src/deadline/job_attachments/vfs.py
@@ -115,7 +115,7 @@ class VFSProcessManager(object):
         """
         fusermount3_path = os.path.join(cls.find_vfs_link_dir(), "fusermount3")
         if not os.path.exists(fusermount3_path):
-            log.warn(f"fusermount3 not found at {cls.find_vfs_link_dir()}")
+            log.warning(f"fusermount3 not found at {cls.find_vfs_link_dir()}")
             return None
         return ["sudo", "-u", os_user, fusermount3_path, "-u", mount_path]
 
@@ -133,7 +133,7 @@ class VFSProcessManager(object):
         try:
             run_result = subprocess.run(shutdown_args, check=True)
         except subprocess.CalledProcessError as e:
-            log.warn(f"Shutdown failed with error {e}")
+            log.warning(f"Shutdown failed with error {e}")
             # Don't reraise, check if mount is gone
         log.info(f"Shutdown returns {run_result.returncode}")
         return cls.wait_for_mount(mount_path, session_dir, expected=False)
@@ -195,7 +195,7 @@ class VFSProcessManager(object):
                         if os.path.exists(manifest_path):
                             return Path(manifest_path)
                         else:
-                            log.warn(f"Expected VFS input manifest at {manifest_path}")
+                            log.warning(f"Expected VFS input manifest at {manifest_path}")
                             return None
         except FileNotFoundError:
             log.warning(f"VFS pid file not found at {pid_file_path}")

--- a/test/unit/deadline_client/api/test_api_telemetry.py
+++ b/test/unit/deadline_client/api/test_api_telemetry.py
@@ -128,7 +128,7 @@ def test_initialize_failure_then_success(fresh_deadline_config):
         assert client._system_metadata["monitor_id"] == "monitor-id"
 
 
-def test_get_telemetry_identifier(mock_telemetry_client):
+def test_get_telemetry_identifier(fresh_deadline_config, mock_telemetry_client):
     """Ensures that getting the local-user-id handles empty/malformed strings"""
     # Confirm that we generate a new UUID if the setting doesn't exist, and write to config
     uuid.UUID(mock_telemetry_client.telemetry_id, version=4)  # Should not raise ValueError
@@ -146,7 +146,7 @@ def test_get_telemetry_identifier(mock_telemetry_client):
 
 
 @pytest.mark.timeout(5)  # Timeout in case we don't exit the while loop
-def test_process_event_queue_thread(mock_telemetry_client):
+def test_process_event_queue_thread(fresh_deadline_config, mock_telemetry_client):
     """Test that the queue processing thread function exits cleanly after getting None"""
     # GIVEN
     queue_mock = MagicMock()
@@ -170,7 +170,7 @@ def test_process_event_queue_thread(mock_telemetry_client):
 )
 @pytest.mark.timeout(5)  # Timeout in case we don't exit the while loop
 def test_process_event_queue_thread_retries_and_exits(
-    mock_telemetry_client, http_code, attempt_count
+    fresh_deadline_config, mock_telemetry_client, http_code, attempt_count
 ):
     """Test that the thread exits cleanly after getting an unexpected exception"""
     # GIVEN
@@ -190,7 +190,9 @@ def test_process_event_queue_thread_retries_and_exits(
 
 
 @pytest.mark.timeout(5)  # Timeout in case we don't exit the while loop
-def test_process_event_queue_thread_handles_unexpected_error(mock_telemetry_client):
+def test_process_event_queue_thread_handles_unexpected_error(
+    fresh_deadline_config, mock_telemetry_client
+):
     """Test that the thread exits cleanly after getting an unexpected exception"""
     # GIVEN
     queue_mock = MagicMock()
@@ -204,7 +206,7 @@ def test_process_event_queue_thread_handles_unexpected_error(mock_telemetry_clie
     assert queue_mock.get.call_count == 1
 
 
-def test_record_hashing_summary(mock_telemetry_client):
+def test_record_hashing_summary(fresh_deadline_config, mock_telemetry_client):
     """Tests that recording a hashing summary sends the expected TelemetryEvent to the thread queue"""
     # GIVEN
     queue_mock = MagicMock()
@@ -224,7 +226,7 @@ def test_record_hashing_summary(mock_telemetry_client):
     queue_mock.put_nowait.assert_called_once_with(expected_event)
 
 
-def test_record_upload_summary(mock_telemetry_client):
+def test_record_upload_summary(fresh_deadline_config, mock_telemetry_client):
     """Tests that recording an upload summary sends the expected TelemetryEvent to the thread queue"""
     # GIVEN
     queue_mock = MagicMock()
@@ -244,7 +246,7 @@ def test_record_upload_summary(mock_telemetry_client):
     queue_mock.put_nowait.assert_called_once_with(expected_event)
 
 
-def test_record_error(mock_telemetry_client):
+def test_record_error(fresh_deadline_config, mock_telemetry_client):
     """Test that recording an error sends the expected TelemetryEvent to the thread queue"""
     # GIVEN
     queue_mock = MagicMock()
@@ -291,13 +293,17 @@ def test_record_error(mock_telemetry_client):
     ],
 )
 def test_get_prefixed_endpoint(
-    mock_telemetry_client: TelemetryClient, endpoint: str, prefix: str, expected_result: str
+    fresh_deadline_config,
+    mock_telemetry_client: TelemetryClient,
+    endpoint: str,
+    prefix: str,
+    expected_result: str,
 ):
     """Test that the _get_prefixed_endpoint function returns the expected prefixed endpoint"""
     assert mock_telemetry_client._get_prefixed_endpoint(endpoint, prefix) == expected_result
 
 
-def test_record_decorator_success():
+def test_record_decorator_success(fresh_deadline_config):
     """Tests that recording a decorator successful metric"""
     with patch.object(
         api._telemetry, "get_deadline_endpoint_url", side_effect=["https://fake-endpoint-url"]
@@ -325,7 +331,7 @@ def test_record_decorator_success():
         queue_mock.put_nowait.assert_called_once_with(expected_event)
 
 
-def test_record_decorator_fails():
+def test_record_decorator_fails(fresh_deadline_config):
     """Tests that recording a decorator failed metric"""
     with patch.object(
         api._telemetry, "get_deadline_endpoint_url", side_effect=["https://fake-endpoint-url"]
@@ -354,7 +360,7 @@ def test_record_decorator_fails():
         queue_mock.put_nowait.assert_called_once_with(expected_event)
 
 
-def test_latency_decorator():
+def test_latency_decorator(fresh_deadline_config):
     """Tests that the latency recording decorator works"""
     with patch.object(
         api._telemetry, "get_deadline_endpoint_url", side_effect=["https://fake-endpoint-url"]

--- a/test/unit/deadline_client/api/test_job_bundle_submission.py
+++ b/test/unit/deadline_client/api/test_job_bundle_submission.py
@@ -9,35 +9,35 @@ import os
 from logging import INFO
 from pathlib import Path
 from typing import Any, Dict, Tuple
-from unittest.mock import ANY, patch, Mock
+from unittest.mock import ANY, patch, Mock, call
 from deadline.client import exceptions
 
 import pytest
 import time
 
 from deadline.client import api, config
-from deadline.client.api import _submit_job_bundle
 from deadline.job_attachments.exceptions import MisconfiguredInputsError
 from deadline.job_attachments.models import (
     AssetRootGroup,
     AssetUploadGroup,
-    Attachments,
     FileSystemLocation,
     FileSystemLocationType,
     JobAttachmentsFileSystem,
-    ManifestProperties,
     PathFormat,
     StorageProfile,
     StorageProfileOperatingSystemFamily,
 )
 from deadline.job_attachments.upload import S3AssetManager
-from deadline.job_attachments.progress_tracker import SummaryStatistics, ProgressReportMetadata
+from deadline.job_attachments.progress_tracker import ProgressReportMetadata
 
+from ..testing_utilities import patch_calls_for_create_job_from_job_bundle, write_test_asset_files
 from ..shared_constants import (
     MOCK_BUCKET_NAME,
     MOCK_FARM_ID,
     MOCK_STORAGE_PROFILE_ID,
     MOCK_QUEUE_ID,
+    MOCK_JOB_ID,
+    MOCK_STATUS_MESSAGE,
 )
 
 MOCK_GET_QUEUE_RESPONSE = {
@@ -57,14 +57,6 @@ MOCK_GET_QUEUE_RESPONSE = {
     "updatedAt": "2022-11-22T22:26:57+00:00",
     "updatedBy": "0123abcdf-abcd-0123-fa82-0123456abcd1",
 }
-
-MOCK_JOB_ID = "job-0123456789abcdefghijklmnopqrstuv"
-
-MOCK_CREATE_JOB_RESPONSE = {"jobId": MOCK_JOB_ID}
-
-MOCK_STATUS_MESSAGE = "Testing123"
-
-MOCK_GET_JOB_RESPONSE = {"state": "READY", "lifecycleStatusMessage": MOCK_STATUS_MESSAGE}
 
 MOCK_GET_STORAGE_PROFILE_FOR_QUEUE_RESPONSE = {
     "storageProfileId": MOCK_STORAGE_PROFILE_ID,
@@ -305,20 +297,18 @@ def test_create_job_from_job_bundle(
     """
     Test a matrix of different job template and parameters file cases.
     """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("settings.storage_profile_id", MOCK_STORAGE_PROFILE_ID)
+
     job_template_type, job_template = MOCK_JOB_TEMPLATE_CASES[job_template_case]
     parameters_type, parameters, expected_create_job_parameters = MOCK_PARAMETERS_CASES[
         parameters_case
     ]
-    with patch.object(api._session, "get_boto3_session") as session_mock:
-        session_mock().client("deadline").create_job.side_effect = [MOCK_CREATE_JOB_RESPONSE]
-        session_mock().client("deadline").get_job.return_value = MOCK_GET_JOB_RESPONSE
-        session_mock().client(
-            "deadline"
-        ).get_storage_profile_for_queue.return_value = MOCK_GET_STORAGE_PROFILE_FOR_QUEUE_RESPONSE
-
-        config.set_setting("defaults.farm_id", MOCK_FARM_ID)
-        config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
-        config.set_setting("settings.storage_profile_id", MOCK_STORAGE_PROFILE_ID)
+    with patch_calls_for_create_job_from_job_bundle() as mock:
+        mock.get_boto3_client().get_storage_profile_for_queue.return_value = (
+            MOCK_GET_STORAGE_PROFILE_FOR_QUEUE_RESPONSE
+        )
 
         # Write the template to the job bundle
         with open(
@@ -349,7 +339,7 @@ def test_create_job_from_job_bundle(
     expected_create_job_parameters_dict["priority"] = expected_create_job_parameters_dict.get(
         "priority", 50
     )
-    session_mock().client("deadline").create_job.assert_called_once_with(
+    mock.get_boto3_client().create_job.assert_called_once_with(
         farmId=MOCK_FARM_ID,
         queueId=MOCK_QUEUE_ID,
         template=job_template,
@@ -365,14 +355,10 @@ def test_create_job_from_job_bundle_error_missing_template(
     """
     Test a job bundle with missing template.
     """
-    with patch.object(api._session, "get_boto3_session") as session_mock, patch.object(
-        _submit_job_bundle.api, "get_deadline_cloud_library_telemetry_client"
-    ):
-        session_mock().client("deadline").create_job.side_effect = [MOCK_CREATE_JOB_RESPONSE]
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
 
-        config.set_setting("defaults.farm_id", MOCK_FARM_ID)
-        config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
-
+    with patch_calls_for_create_job_from_job_bundle():
         # Don't write a template file
 
         # Write the parameters to the job bundle, if the test case parameter includes them
@@ -395,14 +381,10 @@ def test_create_job_from_job_bundle_error_duplicate_template(
     """
     Test a job bundle with both a JSON and YAML template.
     """
-    with patch.object(api._session, "get_boto3_session") as session_mock, patch.object(
-        _submit_job_bundle.api, "get_deadline_cloud_library_telemetry_client"
-    ):
-        session_mock().client("deadline").create_job.side_effect = [MOCK_CREATE_JOB_RESPONSE]
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
 
-        config.set_setting("defaults.farm_id", MOCK_FARM_ID)
-        config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
-
+    with patch_calls_for_create_job_from_job_bundle():
         # Write both a JSON and YAML template file
         with open(os.path.join(temp_job_bundle_dir, "template.json"), "w", encoding="utf8") as f:
             f.write(MOCK_JOB_TEMPLATE_CASES["MINIMAL_JSON"][1])
@@ -429,14 +411,10 @@ def test_create_job_from_job_bundle_error_duplicate_parameters(
     """
     Test a job bundle with an incorrect AWS Deadline Cloud parameter
     """
-    with patch.object(api._session, "get_boto3_session") as session_mock, patch.object(
-        _submit_job_bundle.api, "get_deadline_cloud_library_telemetry_client"
-    ):
-        session_mock().client("deadline").create_job.side_effect = [MOCK_CREATE_JOB_RESPONSE]
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
 
-        config.set_setting("defaults.farm_id", MOCK_FARM_ID)
-        config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
-
+    with patch_calls_for_create_job_from_job_bundle():
         # Write a JSON template
         with open(os.path.join(temp_job_bundle_dir, "template.json"), "w", encoding="utf8") as f:
             f.write(MOCK_JOB_TEMPLATE_CASES["MINIMAL_JSON"][1])
@@ -455,63 +433,16 @@ def test_create_job_from_job_bundle_error_duplicate_parameters(
             )
 
 
-def _write_asset_files(assets_dir: str, asset_contents: Dict[str, str]):
-    """
-    Write a set of asset contents files to the provided assets directory.
-    Each key of asset_contents is a relative path from assets_dir, and
-    each value is what to write to the file.
-    """
-    for rel_path, contents in asset_contents.items():
-        path = os.path.join(assets_dir, rel_path)
-        if not os.path.isdir(os.path.dirname(path)):
-            os.makedirs(os.path.dirname(path))
-        if isinstance(contents, str):
-            with open(path, "w", encoding="utf8") as f:
-                f.write(contents)
-        elif isinstance(contents, bytes):
-            with open(path, "wb") as f:
-                f.write(contents)
-        else:
-            raise ValueError("The contents provided in asset_contents must be either str or bytes.")
-
-
 def test_create_job_from_job_bundle_job_attachments(
     fresh_deadline_config, temp_job_bundle_dir, temp_assets_dir
 ):
     """
     Test a job bundle with asset references.
     """
-    # Use a temporary directory for the job bundle
-    with patch.object(_submit_job_bundle.api, "get_boto3_session"), patch.object(
-        _submit_job_bundle.api, "get_boto3_client"
-    ) as client_mock, patch.object(
-        _submit_job_bundle.api, "get_queue_user_boto3_session"
-    ), patch.object(
-        _submit_job_bundle, "_hash_attachments", return_value=(None, None)
-    ) as mock_hash_attachments, patch.object(
-        S3AssetManager,
-        "prepare_paths_for_upload",
-    ) as mock_prepare_paths, patch.object(
-        S3AssetManager, "upload_assets"
-    ) as mock_upload_assets, patch.object(
-        _submit_job_bundle.api, "get_deadline_cloud_library_telemetry_client"
-    ) as mock_telemetry, patch.object(
-        api._telemetry, "get_deadline_endpoint_url", side_effect=["https://fake-endpoint-url"]
-    ):
-        client_mock().get_queue.side_effect = [MOCK_GET_QUEUE_RESPONSE]
-        client_mock().create_job.side_effect = [MOCK_CREATE_JOB_RESPONSE]
-        client_mock().get_job.side_effect = [MOCK_GET_JOB_RESPONSE]
-        client_mock().get_storage_profile_for_queue.side_effect = [
+    with patch_calls_for_create_job_from_job_bundle() as mock:
+        mock.get_boto3_client().get_storage_profile_for_queue.return_value = (
             MOCK_GET_STORAGE_PROFILE_FOR_QUEUE_RESPONSE
-        ]
-        expected_upload_group = AssetUploadGroup(
-            total_input_files=3, total_input_bytes=256, asset_groups=[AssetRootGroup()]
         )
-        mock_prepare_paths.return_value = expected_upload_group
-        mock_upload_assets.return_value = [
-            SummaryStatistics(),
-            Attachments([]),
-        ]
 
         config.set_setting("defaults.farm_id", MOCK_FARM_ID)
         config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
@@ -527,7 +458,7 @@ def test_create_job_from_job_bundle_job_attachments(
             "somedir/asset-2.txt": "Asset 2",
             "somedir/asset-3.bat": "@echo asset 3",
         }
-        _write_asset_files(temp_assets_dir, asset_contents)
+        write_test_asset_files(temp_assets_dir, asset_contents)
 
         # Write the asset_references file
         asset_references = {
@@ -548,52 +479,54 @@ def test_create_job_from_job_bundle_job_attachments(
         def fake_upload_callback(metadata: ProgressReportMetadata) -> bool:
             return True
 
-        def fake_print_callback(msg: str) -> None:
-            pass
-
         # This is the function we're testing
         api.create_job_from_job_bundle(
             temp_job_bundle_dir,
-            print_function_callback=fake_print_callback,
+            print_function_callback=print,
             hashing_progress_callback=fake_hashing_callback,
             upload_progress_callback=fake_upload_callback,
             queue_parameter_definitions=[],
+            known_asset_paths=[temp_assets_dir],
         )
 
-        mock_prepare_paths.assert_called_once_with(
-            input_paths=sorted(
-                [
-                    os.path.join(temp_assets_dir, "asset-1.txt"),
-                    os.path.join(temp_assets_dir, os.path.normpath("somedir/asset-2.txt")),
-                    os.path.join(temp_assets_dir, os.path.normpath("somedir/asset-3.bat")),
-                ]
-            ),
-            output_paths=[os.path.join(temp_assets_dir, "somedir")],
-            referenced_paths=[],
-            storage_profile=MOCK_STORAGE_PROFILE,
-            require_paths_exist=False,
-        )
-        mock_hash_attachments.assert_called_once_with(
+        mock.hash_attachments.assert_called_once_with(
             asset_manager=ANY,
-            asset_groups=[AssetRootGroup()],
+            asset_groups=[
+                AssetRootGroup(
+                    root_path=temp_assets_dir,
+                    inputs={Path(temp_assets_dir) / p for p in asset_contents.keys()},
+                    outputs={Path(temp_assets_dir) / "somedir"},
+                )
+            ],
             total_input_files=3,
-            total_input_bytes=256,
-            print_function_callback=fake_print_callback,
+            total_input_bytes=35,
+            print_function_callback=print,
             hashing_progress_callback=fake_hashing_callback,
         )
-        client_mock().create_job.assert_called_once_with(
+        mock.get_boto3_client().create_job.assert_called_once_with(
             farmId=MOCK_FARM_ID,
             queueId=MOCK_QUEUE_ID,
             template=ANY,
-            templateType=ANY,
+            templateType="JSON",
             priority=50,
             storageProfileId=MOCK_STORAGE_PROFILE_ID,
-            attachments={
-                "manifests": [],
-                "fileSystem": JobAttachmentsFileSystem.COPIED,
-            },
+            attachments=ANY,
         )
-        assert mock_telemetry.call_count == 3
+        mock_telemetry_client = mock.get_deadline_cloud_library_telemetry_client()
+        assert mock_telemetry_client.record_hashing_summary.call_count == 1
+        assert mock_telemetry_client.record_upload_summary.call_count == 1
+        assert mock_telemetry_client.record_event.mock_calls == [
+            call(
+                event_type="com.amazon.rum.deadline.submission",
+                event_details={"submitter_name": "Custom"},
+                from_gui=False,
+            ),
+            call(
+                event_type="com.amazon.rum.deadline.create_job",
+                event_details={"is_success": True},
+                from_gui=False,
+            ),
+        ]
 
 
 def test_create_job_from_job_bundle_empty_job_attachments(
@@ -604,37 +537,20 @@ def test_create_job_from_job_bundle_empty_job_attachments(
     (for example, if under a SHARED Storage Profile Filesystem Location), no Job
     Attachments calls are made.
     """
-    # Use a temporary directory for the job bundle
-    with patch.object(_submit_job_bundle.api, "get_boto3_session"), patch.object(
-        _submit_job_bundle.api, "get_boto3_client"
-    ) as client_mock, patch.object(
-        _submit_job_bundle.api, "get_queue_user_boto3_session"
-    ), patch.object(
-        _submit_job_bundle, "_hash_attachments", return_value=(None, None)
-    ) as mock_hash_attachments, patch.object(
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("settings.storage_profile_id", MOCK_STORAGE_PROFILE_ID)
+
+    with patch_calls_for_create_job_from_job_bundle() as mock, patch.object(
         S3AssetManager,
         "prepare_paths_for_upload",
-    ) as mock_prepare_paths, patch.object(
-        S3AssetManager, "upload_assets"
-    ) as mock_upload_assets, patch.object(
-        _submit_job_bundle.api, "get_deadline_cloud_library_telemetry_client"
-    ), patch.object(
-        api._telemetry, "get_deadline_endpoint_url", side_effect=["https://fake-endpoint-url"]
-    ):
-        client_mock().get_queue.side_effect = [MOCK_GET_QUEUE_RESPONSE]
-        client_mock().create_job.side_effect = [MOCK_CREATE_JOB_RESPONSE]
-        client_mock().get_job.side_effect = [MOCK_GET_JOB_RESPONSE]
-        client_mock().get_storage_profile_for_queue.side_effect = [
+    ) as mock_prepare_paths:
+        mock.get_boto3_client().get_storage_profile_for_queue.return_value = (
             MOCK_GET_STORAGE_PROFILE_FOR_QUEUE_RESPONSE
-        ]
-
+        )
         # When this function returns an empty object, we skip Job Attachments calls
         expected_upload_group = AssetUploadGroup()
         mock_prepare_paths.return_value = expected_upload_group
-
-        config.set_setting("defaults.farm_id", MOCK_FARM_ID)
-        config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
-        config.set_setting("settings.storage_profile_id", MOCK_STORAGE_PROFILE_ID)
 
         # Write a JSON template
         with open(os.path.join(temp_job_bundle_dir, "template.json"), "w", encoding="utf8") as f:
@@ -646,7 +562,7 @@ def test_create_job_from_job_bundle_empty_job_attachments(
             "somedir/asset-2.txt": "Asset 2",
             "somedir/asset-3.bat": "@echo asset 3",
         }
-        _write_asset_files(temp_assets_dir, asset_contents)
+        write_test_asset_files(temp_assets_dir, asset_contents)
 
         # Write the asset_references file
         asset_references = {
@@ -667,13 +583,10 @@ def test_create_job_from_job_bundle_empty_job_attachments(
         def fake_upload_callback(metadata: ProgressReportMetadata) -> bool:
             return True
 
-        def fake_print_callback(msg: str) -> None:
-            pass
-
         # This is the function we're testing
         api.create_job_from_job_bundle(
             temp_job_bundle_dir,
-            print_function_callback=fake_print_callback,
+            print_function_callback=print,
             hashing_progress_callback=fake_hashing_callback,
             upload_progress_callback=fake_upload_callback,
             queue_parameter_definitions=[],
@@ -692,10 +605,10 @@ def test_create_job_from_job_bundle_empty_job_attachments(
             storage_profile=MOCK_STORAGE_PROFILE,
             require_paths_exist=False,
         )
-        mock_hash_attachments.assert_not_called()
-        mock_upload_assets.assert_not_called()
+        mock.hash_attachments.assert_not_called()
+        mock.upload_assets.assert_not_called()
         # Should not be called with Job Attachments
-        client_mock().create_job.assert_called_once_with(
+        mock.get_boto3_client().create_job.assert_called_once_with(
             farmId=MOCK_FARM_ID,
             queueId=MOCK_QUEUE_ID,
             template=ANY,
@@ -711,17 +624,15 @@ def test_create_job_from_job_bundle_with_empty_asset_references(
     """
     Test a job bundle with an asset_references file but no referenced files.
     """
-    job_template_type, job_template = MOCK_JOB_TEMPLATE_CASES["MINIMAL_JSON"]
-    with patch.object(api._session, "get_boto3_session") as session_mock:
-        session_mock().client("deadline").create_job.side_effect = [MOCK_CREATE_JOB_RESPONSE]
-        session_mock().client("deadline").get_job.side_effect = [MOCK_GET_JOB_RESPONSE]
-        session_mock().client("deadline").get_storage_profile_for_queue.side_effect = [
-            MOCK_GET_STORAGE_PROFILE_FOR_QUEUE_RESPONSE
-        ]
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("settings.storage_profile_id", MOCK_STORAGE_PROFILE_ID)
 
-        config.set_setting("defaults.farm_id", MOCK_FARM_ID)
-        config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
-        config.set_setting("settings.storage_profile_id", MOCK_STORAGE_PROFILE_ID)
+    job_template_type, job_template = MOCK_JOB_TEMPLATE_CASES["MINIMAL_JSON"]
+    with patch_calls_for_create_job_from_job_bundle() as mock:
+        mock.get_boto3_client().get_storage_profile_for_queue.return_value = (
+            MOCK_GET_STORAGE_PROFILE_FOR_QUEUE_RESPONSE
+        )
 
         # Write the template to the job bundle
         with open(
@@ -749,7 +660,7 @@ def test_create_job_from_job_bundle_with_empty_asset_references(
 
         assert response == MOCK_JOB_ID
         # There should be no job attachments section in the result
-        session_mock().client("deadline").create_job.assert_called_once_with(
+        mock.get_boto3_client().create_job.assert_called_once_with(
             farmId=MOCK_FARM_ID,
             queueId=MOCK_QUEUE_ID,
             template=job_template,
@@ -766,6 +677,9 @@ def test_create_job_from_job_bundle_partially_empty_directories(
     Test a job bundle with an input directory that contains both empty directories and input files
     does not throw a MisconfiguredInputsError and successfully submits
     """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+
     job_template_type, job_template = MOCK_JOB_TEMPLATE_CASES["MINIMAL_JSON"]
     temp_bundle_dir_as_path = Path(temp_job_bundle_dir)
     assets_directory: str = str(temp_bundle_dir_as_path / "assets")
@@ -773,14 +687,7 @@ def test_create_job_from_job_bundle_partially_empty_directories(
     Path(empty_directory).mkdir(parents=True)
     (temp_bundle_dir_as_path / "assets" / "input_file").touch()
 
-    with patch.object(_submit_job_bundle.api, "get_boto3_client") as client_mock, patch.object(
-        _submit_job_bundle.api, "get_queue_user_boto3_session"
-    ):
-        client_mock().create_job.side_effect = [MOCK_CREATE_JOB_RESPONSE]
-        client_mock().get_queue.side_effect = [MOCK_GET_QUEUE_RESPONSE]
-        config.set_setting("defaults.farm_id", MOCK_FARM_ID)
-        config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
-
+    with patch_calls_for_create_job_from_job_bundle():
         # Write the template to the job bundle
         with open(
             os.path.join(temp_job_bundle_dir, f"template.{job_template_type.lower()}"),
@@ -818,19 +725,17 @@ def test_create_job_from_job_bundle_misconfigured_directories(
     with a job bundle with input directories that do not exist throws an error.
     Also confirms that empty directories as logged and added to referenced paths.
     """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+
     job_template_type, job_template = MOCK_JOB_TEMPLATE_CASES["MINIMAL_JSON"]
     temp_bundle_dir_as_path = Path(temp_job_bundle_dir)
     missing_directory = str(temp_bundle_dir_as_path / "does" / "not" / "exist" / "bad_path")
     empty_directory = str(temp_bundle_dir_as_path / "empty_dir")
     Path(empty_directory).mkdir()
 
-    with patch.object(_submit_job_bundle.api, "get_boto3_session"), patch.object(
-        _submit_job_bundle.api, "get_boto3_client"
-    ) as client_mock, patch.object(_submit_job_bundle.api, "get_queue_user_boto3_session"):
+    with patch_calls_for_create_job_from_job_bundle():
         caplog.set_level(INFO)
-        client_mock().get_queue.side_effect = [MOCK_GET_QUEUE_RESPONSE]
-        config.set_setting("defaults.farm_id", MOCK_FARM_ID)
-        config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
 
         # Write the template to the job bundle
         with open(
@@ -872,19 +777,17 @@ def test_create_job_from_job_bundle_misconfigured_input_files(
     directories in the warning message, but DOES incldue misconfigured directories that
     were specified as files, which should result in an error.
     """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+
     job_template_type, job_template = MOCK_JOB_TEMPLATE_CASES["MINIMAL_JSON"]
     temp_bundle_dir_as_path = Path(temp_job_bundle_dir)
     missing_file = str(temp_bundle_dir_as_path / "does" / "not" / "exist.png")
     directory_pretending_to_be_file = str(temp_bundle_dir_as_path / "sneaky_bad_not_file")
     Path(directory_pretending_to_be_file).mkdir()
 
-    with patch.object(api._session, "get_boto3_session"), patch.object(
-        _submit_job_bundle.api, "get_boto3_client"
-    ) as client_mock, patch.object(_submit_job_bundle.api, "get_queue_user_boto3_session"):
+    with patch_calls_for_create_job_from_job_bundle():
         caplog.set_level(INFO)
-        client_mock().get_queue.side_effect = [MOCK_GET_QUEUE_RESPONSE]
-        config.set_setting("defaults.farm_id", MOCK_FARM_ID)
-        config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
 
         # Write the template to the job bundle
         with open(
@@ -925,52 +828,15 @@ def test_create_job_from_job_bundle_with_single_asset_file(
     """
     Test a job bundle with a single input file reference and no output directories.
     """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("settings.storage_profile_id", MOCK_STORAGE_PROFILE_ID)
 
     # Use a temporary directory for the job bundle
-    with patch.object(_submit_job_bundle.api, "get_boto3_session"), patch.object(
-        _submit_job_bundle.api, "get_boto3_client"
-    ) as client_mock, patch.object(
-        _submit_job_bundle.api, "get_queue_user_boto3_session"
-    ), patch.object(
-        _submit_job_bundle, "_hash_attachments", return_value=(None, None)
-    ) as mock_hash_attachments, patch.object(
-        S3AssetManager,
-        "prepare_paths_for_upload",
-    ) as mock_prepare_paths, patch.object(
-        S3AssetManager, "upload_assets"
-    ) as mock_upload_assets, patch.object(
-        _submit_job_bundle.api, "get_deadline_cloud_library_telemetry_client"
-    ), patch.object(
-        api._telemetry, "get_deadline_endpoint_url", side_effect=["https://fake-endpoint-url"]
-    ):
-        client_mock().create_job.side_effect = [MOCK_CREATE_JOB_RESPONSE]
-        client_mock().get_queue.side_effect = [MOCK_GET_QUEUE_RESPONSE]
-        client_mock().get_job.side_effect = [MOCK_GET_JOB_RESPONSE]
-        client_mock().get_storage_profile_for_queue.side_effect = [
+    with patch_calls_for_create_job_from_job_bundle() as mock:
+        mock.get_boto3_client().get_storage_profile_for_queue.side_effect = [
             MOCK_GET_STORAGE_PROFILE_FOR_QUEUE_RESPONSE
         ]
-        expected_upload_group = AssetUploadGroup(
-            total_input_files=1, total_input_bytes=1, asset_groups=[AssetRootGroup()]
-        )
-        mock_prepare_paths.return_value = expected_upload_group
-        mock_upload_assets.return_value = [
-            SummaryStatistics(),
-            Attachments(
-                [
-                    ManifestProperties(
-                        rootPath="/mnt/root/path1",
-                        rootPathFormat=PathFormat.POSIX,
-                        inputManifestPath="mock-manifest",
-                        inputManifestHash="mock-manifest-hash",
-                        outputRelativeDirectories=["."],
-                    ),
-                ],
-            ),
-        ]
-
-        config.set_setting("defaults.farm_id", MOCK_FARM_ID)
-        config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
-        config.set_setting("settings.storage_profile_id", MOCK_STORAGE_PROFILE_ID)
 
         # Write a JSON template
         with open(os.path.join(temp_job_bundle_dir, "template.json"), "w", encoding="utf8") as f:
@@ -980,7 +846,7 @@ def test_create_job_from_job_bundle_with_single_asset_file(
         asset_contents = {
             "asset-1.txt": "This is asset 1",
         }
-        _write_asset_files(temp_assets_dir, asset_contents)
+        write_test_asset_files(temp_assets_dir, asset_contents)
 
         # Write the asset_references file
         asset_references = {
@@ -999,54 +865,51 @@ def test_create_job_from_job_bundle_with_single_asset_file(
         def fake_upload_callback(metadata: ProgressReportMetadata) -> bool:
             return True
 
-        def fake_print_callback(msg: str) -> None:
-            pass
-
         # This is the function we're testing
         api.create_job_from_job_bundle(
             temp_job_bundle_dir,
-            print_function_callback=fake_print_callback,
+            print_function_callback=print,
             hashing_progress_callback=fake_hashing_callback,
             upload_progress_callback=fake_upload_callback,
             queue_parameter_definitions=[],
+            known_asset_paths=[temp_assets_dir],
         )
 
-        mock_prepare_paths.assert_called_once_with(
-            input_paths=[os.path.join(temp_assets_dir, "asset-1.txt")],
-            output_paths=[],
-            referenced_paths=[],
-            storage_profile=MOCK_STORAGE_PROFILE,
-            require_paths_exist=False,
-        )
-        mock_hash_attachments.assert_called_once_with(
+        mock.hash_attachments.assert_called_once_with(
             asset_manager=ANY,
-            asset_groups=[AssetRootGroup()],
+            asset_groups=[
+                AssetRootGroup(
+                    root_path=temp_assets_dir, inputs={Path(temp_assets_dir) / "asset-1.txt"}
+                )
+            ],
             total_input_files=1,
-            total_input_bytes=1,
-            print_function_callback=fake_print_callback,
+            total_input_bytes=15,
+            print_function_callback=print,
             hashing_progress_callback=fake_hashing_callback,
         )
 
-        client_mock().create_job.assert_called_once_with(
-            farmId=MOCK_FARM_ID,
-            queueId=MOCK_QUEUE_ID,
-            template=ANY,
-            templateType=ANY,
-            priority=50,
-            storageProfileId=MOCK_STORAGE_PROFILE_ID,
-            attachments={
-                "manifests": [
-                    {
-                        "rootPath": "/mnt/root/path1",
-                        "rootPathFormat": PathFormat.POSIX,
-                        "inputManifestPath": "mock-manifest",
-                        "inputManifestHash": "mock-manifest-hash",
-                        "outputRelativeDirectories": ["."],
-                    },
-                ],
-                "fileSystem": JobAttachmentsFileSystem.COPIED,
-            },
-        )
+        assert mock.get_boto3_client().create_job.mock_calls == [
+            call(
+                farmId=MOCK_FARM_ID,
+                queueId=MOCK_QUEUE_ID,
+                template=ANY,
+                templateType=ANY,
+                priority=50,
+                storageProfileId=MOCK_STORAGE_PROFILE_ID,
+                attachments={
+                    "manifests": [
+                        {
+                            "rootPath": "/mnt/root/path1",
+                            "rootPathFormat": PathFormat.POSIX,
+                            "inputManifestPath": "mock-manifest",
+                            "inputManifestHash": "mock-manifest-hash",
+                            "outputRelativeDirectories": ["."],
+                        },
+                    ],
+                    "fileSystem": JobAttachmentsFileSystem.COPIED,
+                },
+            )
+        ]
 
 
 get_job_responses = [

--- a/test/unit/deadline_client/api/test_job_bundle_submission_asset_refs.py
+++ b/test/unit/deadline_client/api/test_job_bundle_submission_asset_refs.py
@@ -8,6 +8,7 @@ where there are PATH parameters that carry assetReference IN/OUT metadata.
 import os
 import pytest
 from unittest.mock import ANY, patch
+from pathlib import Path
 
 from deadline.client import api, config
 from deadline.client.api import _submit_job_bundle
@@ -15,7 +16,6 @@ from deadline.client.exceptions import DeadlineOperationError
 from deadline.job_attachments.models import (
     Attachments,
     AssetRootGroup,
-    AssetUploadGroup,
     JobAttachmentsFileSystem,
     AssetRootManifest,
     ManifestProperties,
@@ -24,13 +24,14 @@ from deadline.job_attachments.models import (
 from deadline.job_attachments.upload import S3AssetManager
 from deadline.job_attachments.progress_tracker import SummaryStatistics
 
-from ..shared_constants import MOCK_FARM_ID, MOCK_QUEUE_ID
-from .test_job_bundle_submission import (
-    MOCK_CREATE_JOB_RESPONSE,
+from ..shared_constants import (
+    MOCK_FARM_ID,
+    MOCK_QUEUE_ID,
     MOCK_GET_JOB_RESPONSE,
+    MOCK_CREATE_JOB_RESPONSE,
     MOCK_GET_QUEUE_RESPONSE,
-    _write_asset_files,
 )
+from ..testing_utilities import write_test_asset_files
 
 # A YAML job template that contains every type of (file, directory) * (none, in, out, inout) asset references
 JOB_BUNDLE_RELATIVE_FILE_PATH = "./file/inside/job_bundle.txt"
@@ -241,7 +242,7 @@ def test_create_job_from_job_bundle_with_not_valid_directory_path(
 
 
 def test_create_job_from_job_bundle_with_all_asset_ref_variants(
-    fresh_deadline_config, temp_job_bundle_dir, temp_assets_dir
+    fresh_deadline_config, temp_job_bundle_dir, temp_assets_dir, temp_cwd
 ):
     """
     Test a job bundle with template from JOB_TEMPLATE_ALL_ASSET_REF_VARIANTS.
@@ -251,7 +252,7 @@ def test_create_job_from_job_bundle_with_all_asset_ref_variants(
         _submit_job_bundle.api, "get_boto3_client"
     ) as client_mock, patch.object(
         _submit_job_bundle.api, "get_queue_user_boto3_session"
-    ), patch.object(S3AssetManager, "prepare_paths_for_upload") as mock_prepare_paths, patch.object(
+    ), patch.object(
         S3AssetManager, "hash_assets_and_create_manifest"
     ) as mock_hash_assets, patch.object(
         S3AssetManager, "upload_assets"
@@ -261,7 +262,6 @@ def test_create_job_from_job_bundle_with_all_asset_ref_variants(
         client_mock().create_job.side_effect = [MOCK_CREATE_JOB_RESPONSE]
         client_mock().get_queue.side_effect = [MOCK_GET_QUEUE_RESPONSE]
         client_mock().get_job.side_effect = [MOCK_GET_JOB_RESPONSE]
-        mock_prepare_paths.return_value = AssetUploadGroup(asset_groups=[AssetRootGroup()])
         mock_hash_assets.return_value = [SummaryStatistics(), AssetRootManifest()]
         mock_upload_assets.return_value = [
             SummaryStatistics(),
@@ -317,7 +317,7 @@ def test_create_job_from_job_bundle_with_all_asset_ref_variants(
         ]
 
         # Write file contents to the job bundle dir
-        _write_asset_files(
+        write_test_asset_files(
             temp_job_bundle_dir,
             {
                 JOB_BUNDLE_RELATIVE_FILE_PATH: "file in",
@@ -326,7 +326,7 @@ def test_create_job_from_job_bundle_with_all_asset_ref_variants(
             },
         )
         # Write file contents to the temporary assets dir
-        _write_asset_files(
+        write_test_asset_files(
             temp_assets_dir,
             {
                 "file/inside/asset-dir-fileinout.txt": "file inout",
@@ -337,53 +337,64 @@ def test_create_job_from_job_bundle_with_all_asset_ref_variants(
 
         # This is the function we're testing
         api.create_job_from_job_bundle(
-            temp_job_bundle_dir, job_parameters=job_parameters, queue_parameter_definitions=[]
+            temp_job_bundle_dir,
+            job_parameters=job_parameters,
+            queue_parameter_definitions=[],
+            known_asset_paths=[
+                temp_assets_dir,
+                os.path.join(os.getcwd(), "dir", "inside"),
+                os.path.join(os.getcwd(), "file", "inside"),
+            ],
         )
 
         # The values of input_paths and output_paths are the first
         # thing this test needs to verify, confirming that the
         # bundle dir is used for default parameter values, and the
         # current working directory is used for job parameters.
-        input_paths = sorted(
-            os.path.normpath(p)
-            for p in [
-                temp_assets_dir + "/./dir/inside/asset-dir-dirinout/file_x.txt",
-                temp_assets_dir + "/./dir/inside/asset-dir-dirinout/subdir/file_y.txt",
-                temp_assets_dir + "/file/inside/asset-dir-fileinout.txt",
-                temp_job_bundle_dir + "/dir/inside/job_bundle/file1.txt",
-                temp_job_bundle_dir + "/dir/inside/job_bundle/subdir/file1.txt",
-                temp_job_bundle_dir + "/file/inside/job_bundle.txt",
-            ]
-        )
-        output_paths = sorted(
-            os.path.normpath(os.path.abspath(p))
-            for p in [
-                temp_assets_dir + "/./dir/inside/asset-dir-dirinout",
-                temp_assets_dir + "/file/inside",
-                "./dir/inside/cwd-dirout",
-                "./file/inside",
-            ]
-        )
-        referenced_paths = sorted(
-            os.path.normpath(os.path.abspath(p))
-            for p in [
-                os.path.join(temp_assets_dir, "./dir/inside/asset-dir-dirnone"),
-                os.path.join(temp_assets_dir, "./dir/inside/asset-dir-dirnonedefault"),
-                os.path.join(temp_assets_dir, "file/inside/asset-dir-filenonedefault.txt"),
-                os.path.join(temp_assets_dir, "file/inside/asset-dir-filenone.txt"),
-            ]
-        )
-        mock_prepare_paths.assert_called_once_with(
-            input_paths=input_paths,
-            output_paths=output_paths,
-            referenced_paths=referenced_paths,
-            storage_profile=None,
-            require_paths_exist=False,
-        )
         mock_hash_assets.assert_called_once_with(
-            asset_groups=[AssetRootGroup()],
-            total_input_files=0,
-            total_input_bytes=0,
+            asset_groups=[
+                AssetRootGroup(
+                    root_path=os.path.commonpath(
+                        [os.getcwd(), temp_job_bundle_dir, temp_assets_dir]
+                    ),
+                    inputs={
+                        Path(temp_job_bundle_dir) / "dir" / "inside" / "job_bundle" / "file1.txt",
+                        Path(temp_job_bundle_dir)
+                        / "dir"
+                        / "inside"
+                        / "job_bundle"
+                        / "subdir"
+                        / "file1.txt",
+                        Path(temp_job_bundle_dir) / "file" / "inside" / "job_bundle.txt",
+                        Path(temp_assets_dir)
+                        / "dir"
+                        / "inside"
+                        / "asset-dir-dirinout"
+                        / "subdir"
+                        / "file_y.txt",
+                        Path(temp_assets_dir)
+                        / "dir"
+                        / "inside"
+                        / "asset-dir-dirinout"
+                        / "file_x.txt",
+                        Path(temp_assets_dir) / "file" / "inside" / "asset-dir-fileinout.txt",
+                    },
+                    outputs={
+                        Path(os.path.join(os.getcwd(), "dir", "inside", "cwd-dirout")),
+                        Path(os.path.join(os.getcwd(), "file", "inside")),
+                        Path(temp_assets_dir) / "file" / "inside",
+                        Path(temp_assets_dir) / "dir" / "inside" / "asset-dir-dirinout",
+                    },
+                    references={
+                        Path(temp_assets_dir) / "file" / "inside" / "asset-dir-filenone.txt",
+                        Path(temp_assets_dir) / "file" / "inside" / "asset-dir-filenonedefault.txt",
+                        Path(temp_assets_dir) / "dir" / "inside" / "asset-dir-dirnone",
+                        Path(temp_assets_dir) / "dir" / "inside" / "asset-dir-dirnonedefault",
+                    },
+                ),
+            ],
+            total_input_files=6,
+            total_input_bytes=59,
             hash_cache_dir=os.path.expanduser(os.path.join("~", ".deadline", "cache")),
             on_preparing_to_submit=ANY,
         )

--- a/test/unit/deadline_client/cli/test_cli_bundle.py
+++ b/test/unit/deadline_client/cli/test_cli_bundle.py
@@ -8,26 +8,18 @@ import os
 import sys
 import tempfile
 import json
-from unittest.mock import ANY, patch, Mock
+from unittest.mock import ANY, patch, Mock, call
 
 import boto3  # type: ignore[import]
 from click.testing import CliRunner
 import pytest
 
 from deadline.client import config
-from deadline.client.api import _queue_parameters
 import deadline.client.api as api_module
 from deadline.client.cli import main
-from deadline.client.cli._groups import bundle_group
-from deadline.client.api import _submit_job_bundle
-from deadline.client.config.config_file import set_setting
-from deadline.job_attachments.upload import S3AssetManager
 from deadline.job_attachments.models import JobAttachmentsFileSystem
-from deadline.job_attachments.progress_tracker import SummaryStatistics
 
 from ..api.test_job_bundle_submission import (
-    MOCK_CREATE_JOB_RESPONSE,
-    MOCK_GET_JOB_RESPONSE,
     MOCK_FARM_ID,
     MOCK_JOB_TEMPLATE_CASES,
     MOCK_PARAMETERS_CASES,
@@ -35,64 +27,12 @@ from ..api.test_job_bundle_submission import (
     get_minimal_json_job_template,
 )
 
-MOCK_LIST_QUEUE_ENVIRONMENTS_RESPONSE = {
-    "environments": [
-        {"queueEnvironmentId": "queueenv-123", "name": "First Env", "priority": 2},
-        {"queueEnvironmentId": "queueenv-234", "name": "Second Env", "priority": 1},
-    ]
-}
+from ..testing_utilities import (
+    patch_calls_for_create_job_from_job_bundle,
+    MOCK_CREATE_JOB_RESPONSE,
+    MOCK_GET_JOB_RESPONSE,
+)
 
-MOCK_QUEUE_ENV_TEMPLATE_1 = """
-specificationVersion: 'jobtemplate-2023-09'
-parameterDefinitions:
-- name: RezPackages
-  type: STRING
-  description: Choose which rez packages to install for the render.
-  default: ""
-  userInterface:
-    control: LINE_EDIT
-    label: Rez Packages
-environment:
-  name: Rez Non-Final
-  script:
-    actions:
-      onEnter:
-        command: "say-hello"
-"""
-
-MOCK_QUEUE_ENV_TEMPLATE_2 = """
-specificationVersion: 'jobtemplate-2023-09'
-parameterDefinitions:
-- name: IntParam
-  type: INT
-  default: ""
-  userInterface:
-    control: SPIN_BOX
-    label: Int Param
-environment:
-  name: Int Param Env
-  script:
-    actions:
-      onEnter:
-        command: "say-hello"
-"""
-
-MOCK_GET_QUEUE_ENVIRONMENTS_RESPONSES = [
-    {
-        "queueEnvironmentId": "queueenv-123",
-        "name": "Rez Non-Final",
-        "priority": 1,
-        "templateType": "YAML",
-        "template": MOCK_QUEUE_ENV_TEMPLATE_1,
-    },
-    {
-        "queueEnvironmentId": "queueenv-234",
-        "name": "Int Param Env",
-        "priority": 1,
-        "templateType": "YAML",
-        "template": MOCK_QUEUE_ENV_TEMPLATE_1,
-    },
-]
 os.environ["AWS_ENDPOINT_URL_DEADLINE"] = "https://fake-endpoint"
 
 
@@ -116,28 +56,11 @@ def test_cli_bundle_submit(fresh_deadline_config, temp_job_bundle_dir):
     ) as f:
         f.write(MOCK_PARAMETERS_CASES["TEMPLATE_ONLY_JSON"][1])
 
-    with patch.object(
-        _submit_job_bundle.api, "get_boto3_client"
-    ) as get_boto3_client_mock, patch.object(
-        _queue_parameters, "get_boto3_client"
-    ) as qp_boto3_client_mock, patch.object(
-        _submit_job_bundle, "_hash_attachments", return_value=[]
-    ), patch.object(_submit_job_bundle.api, "get_queue_user_boto3_session"), patch.object(
-        _submit_job_bundle, "_upload_attachments"
-    ), patch.object(bundle_group.api, "get_deadline_cloud_library_telemetry_client"):
-        get_boto3_client_mock().create_job.return_value = MOCK_CREATE_JOB_RESPONSE
-        get_boto3_client_mock().get_job.return_value = MOCK_GET_JOB_RESPONSE
-        qp_boto3_client_mock().list_queue_environments.return_value = (
-            MOCK_LIST_QUEUE_ENVIRONMENTS_RESPONSE
-        )
-        qp_boto3_client_mock().get_queue_environment.side_effect = (
-            MOCK_GET_QUEUE_ENVIRONMENTS_RESPONSES
-        )
-
+    with patch_calls_for_create_job_from_job_bundle() as mock:
         runner = CliRunner()
         result = runner.invoke(main, ["bundle", "submit", temp_job_bundle_dir])
 
-        get_boto3_client_mock().create_job.assert_called_with(
+        mock.get_boto3_client().create_job.assert_called_with(
             farmId=MOCK_FARM_ID,
             queueId=MOCK_QUEUE_ID,
             parameters=MOCK_PARAMETERS_CASES["TEMPLATE_ONLY_JSON"][2]["parameters"],  # type: ignore
@@ -145,10 +68,10 @@ def test_cli_bundle_submit(fresh_deadline_config, temp_job_bundle_dir):
             templateType="JSON",
             priority=50,
         )
-        assert temp_job_bundle_dir in result.output
-        assert MOCK_CREATE_JOB_RESPONSE["jobId"] in result.output
-        assert MOCK_GET_JOB_RESPONSE["lifecycleStatusMessage"] in result.output
-        assert result.exit_code == 0
+        assert temp_job_bundle_dir in result.output, result.output
+        assert MOCK_CREATE_JOB_RESPONSE["jobId"] in result.output, result.output
+        assert MOCK_GET_JOB_RESPONSE["lifecycleStatusMessage"] in result.output, result.output
+        assert result.exit_code == 0, result.output
 
 
 def test_cli_bundle_explicit_parameters(fresh_deadline_config):
@@ -347,6 +270,7 @@ def test_cli_bundle_asset_load_method(fresh_deadline_config, temp_job_bundle_dir
 
     config.set_setting("defaults.farm_id", MOCK_FARM_ID)
     config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("settings.auto_accept", "true")
 
     # Write a JSON template
     with open(os.path.join(temp_job_bundle_dir, "template.json"), "w", encoding="utf8") as f:
@@ -377,37 +301,11 @@ def test_cli_bundle_asset_load_method(fresh_deadline_config, temp_job_bundle_dir
         }
         json.dump(data, f)
 
-    upload_group_mock = Mock()
-    upload_group_mock.asset_groups = [Mock()]
-    upload_group_mock.total_input_files = 0
     attachment_mock = Mock()
     attachment_mock.total_bytes = 0
     attachment_mock.total_files.return_value = 0
 
-    with patch.object(
-        _submit_job_bundle.api, "get_boto3_client"
-    ) as bundle_boto3_client_mock, patch.object(
-        _queue_parameters, "get_boto3_client"
-    ) as qp_boto3_client_mock, patch.object(
-        _submit_job_bundle, "_hash_attachments", return_value=(attachment_mock, {})
-    ), patch.object(_submit_job_bundle, "_upload_attachments", return_value={}), patch.object(
-        _submit_job_bundle.api, "get_boto3_session"
-    ), patch.object(_submit_job_bundle.api, "get_queue_user_boto3_session"), patch.object(
-        bundle_group.api, "get_deadline_cloud_library_telemetry_client"
-    ), patch.object(S3AssetManager, "prepare_paths_for_upload", return_value=upload_group_mock):
-        bundle_boto3_client_mock().create_job.return_value = MOCK_CREATE_JOB_RESPONSE
-        bundle_boto3_client_mock().get_job.return_value = MOCK_GET_JOB_RESPONSE
-        bundle_boto3_client_mock().get_queue.return_value = {
-            "displayName": "Test Queue",
-            "jobAttachmentSettings": {"s3BucketName": "mock", "rootPrefix": "root"},
-        }
-        qp_boto3_client_mock().list_queue_environments.return_value = (
-            MOCK_LIST_QUEUE_ENVIRONMENTS_RESPONSE
-        )
-        qp_boto3_client_mock().get_queue_environment.side_effect = (
-            MOCK_GET_QUEUE_ENVIRONMENTS_RESPONSES
-        )
-
+    with patch_calls_for_create_job_from_job_bundle() as mock:
         params = ["bundle", "submit", temp_job_bundle_dir]
 
         # None case represents not setting the parameter
@@ -423,19 +321,32 @@ def test_cli_bundle_asset_load_method(fresh_deadline_config, temp_job_bundle_dir
             else config.get_setting("defaults.job_attachments_file_system")
         )
 
-        assert temp_job_bundle_dir in result.output
-        bundle_boto3_client_mock().create_job.assert_called_with(
-            farmId=MOCK_FARM_ID,
-            queueId=MOCK_QUEUE_ID,
-            parameters=MOCK_PARAMETERS_CASES["TEMPLATE_ONLY_JSON"][2]["parameters"],  # type: ignore
-            template=MOCK_JOB_TEMPLATE_CASES["MINIMAL_JSON"][1],
-            templateType="JSON",
-            attachments={"fileSystem": expected_loading_method},
-            priority=50,
-        )
-        assert MOCK_CREATE_JOB_RESPONSE["jobId"] in result.output
-        assert MOCK_GET_JOB_RESPONSE["lifecycleStatusMessage"] in result.output
-        assert result.exit_code == 0
+        assert temp_job_bundle_dir in result.output, result.output
+        assert mock.get_boto3_client().create_job.mock_calls == [
+            call(
+                farmId=MOCK_FARM_ID,
+                queueId=MOCK_QUEUE_ID,
+                parameters=MOCK_PARAMETERS_CASES["TEMPLATE_ONLY_JSON"][2]["parameters"],  # type: ignore
+                template=MOCK_JOB_TEMPLATE_CASES["MINIMAL_JSON"][1],
+                templateType="JSON",
+                attachments={
+                    "fileSystem": expected_loading_method,
+                    "manifests": [
+                        {
+                            "rootPath": "/mnt/root/path1",
+                            "rootPathFormat": "posix",
+                            "inputManifestPath": "mock-manifest",
+                            "inputManifestHash": "mock-manifest-hash",
+                            "outputRelativeDirectories": ["."],
+                        }
+                    ],
+                },
+                priority=50,
+            )
+        ], result.output
+        assert MOCK_CREATE_JOB_RESPONSE["jobId"] in result.output, result.output
+        assert MOCK_GET_JOB_RESPONSE["lifecycleStatusMessage"] in result.output, result.output
+        assert result.exit_code == 0, result.output
 
 
 def test_cli_bundle_job_parameter_from_cli(fresh_deadline_config):
@@ -443,15 +354,7 @@ def test_cli_bundle_job_parameter_from_cli(fresh_deadline_config):
     Verify that job parameters specified at the CLI are passed to the CreateJob call
     """
     # Use a temporary directory for the job bundle
-    with tempfile.TemporaryDirectory() as tmpdir, patch.object(
-        boto3, "Session"
-    ) as session_mock, patch.object(
-        bundle_group.api, "get_deadline_cloud_library_telemetry_client"
-    ) as telemetry_mock:
-        session_mock().client("deadline").create_job.return_value = MOCK_CREATE_JOB_RESPONSE
-        session_mock().client("deadline").get_job.return_value = MOCK_GET_JOB_RESPONSE
-        session_mock.reset_mock()
-
+    with tempfile.TemporaryDirectory() as tmpdir, patch_calls_for_create_job_from_job_bundle() as mock:
         # Write a JSON template
         with open(os.path.join(tmpdir, "template.json"), "w", encoding="utf8") as f:
             f.write(MOCK_JOB_TEMPLATE_CASES["MINIMAL_JSON"][1])
@@ -478,7 +381,7 @@ def test_cli_bundle_job_parameter_from_cli(fresh_deadline_config):
             ],
         )
 
-        session_mock().client().create_job.assert_called_once_with(
+        mock.get_boto3_client().create_job.assert_called_once_with(
             farmId=MOCK_FARM_ID,
             queueId=MOCK_QUEUE_ID,
             template=ANY,
@@ -490,9 +393,10 @@ def test_cli_bundle_job_parameter_from_cli(fresh_deadline_config):
             priority=45,
         )
 
-        telemetry_mock.return_value.record_event.assert_any_call(
+        mock.get_deadline_cloud_library_telemetry_client.return_value.record_event.assert_any_call(
             event_type="com.amazon.rum.deadline.submission",
             event_details={"submitter_name": "MyDCC"},
+            from_gui=False,
         )
 
         assert result.exit_code == 0
@@ -503,11 +407,7 @@ def test_cli_bundle_empty_job_parameter_from_cli(fresh_deadline_config):
     Verify that an empty job parameter specified at the CLI are passed to the CreateJob call
     """
     # Use a temporary directory for the job bundle
-    with tempfile.TemporaryDirectory() as tmpdir, patch.object(boto3, "Session") as session_mock:
-        session_mock().client("deadline").create_job.return_value = MOCK_CREATE_JOB_RESPONSE
-        session_mock().client("deadline").get_job.return_value = MOCK_GET_JOB_RESPONSE
-        session_mock.reset_mock()
-
+    with tempfile.TemporaryDirectory() as tmpdir, patch_calls_for_create_job_from_job_bundle() as mock:
         # Write a JSON template
         with open(os.path.join(tmpdir, "template.json"), "w", encoding="utf8") as f:
             f.write(MOCK_JOB_TEMPLATE_CASES["MINIMAL_JSON"][1])
@@ -528,18 +428,20 @@ def test_cli_bundle_empty_job_parameter_from_cli(fresh_deadline_config):
             ],
         )
 
-        session_mock().client().create_job.assert_called_once_with(
-            farmId=MOCK_FARM_ID,
-            queueId=MOCK_QUEUE_ID,
-            template=ANY,
-            templateType="JSON",
-            parameters={
-                "sceneFile": {"string": ""},
-            },
-            priority=50,
-        )
+        assert mock.get_boto3_client().create_job.mock_calls == [
+            call(
+                farmId=MOCK_FARM_ID,
+                queueId=MOCK_QUEUE_ID,
+                template=ANY,
+                templateType="JSON",
+                parameters={
+                    "sceneFile": {"string": ""},
+                },
+                priority=50,
+            )
+        ], result.output
 
-        assert result.exit_code == 0
+        assert result.exit_code == 0, result.output
 
 
 def test_cli_bundle_job_parameter_with_equals_from_cli(fresh_deadline_config):
@@ -547,11 +449,7 @@ def test_cli_bundle_job_parameter_with_equals_from_cli(fresh_deadline_config):
     Verify that a job parameter value with an '=' in it is passed correctly to the CreateJob call
     """
     # Use a temporary directory for the job bundle
-    with tempfile.TemporaryDirectory() as tmpdir, patch.object(boto3, "Session") as session_mock:
-        session_mock().client("deadline").create_job.return_value = MOCK_CREATE_JOB_RESPONSE
-        session_mock().client("deadline").get_job.return_value = MOCK_GET_JOB_RESPONSE
-        session_mock.reset_mock()
-
+    with tempfile.TemporaryDirectory() as tmpdir, patch_calls_for_create_job_from_job_bundle() as mock:
         # Write a JSON template
         with open(os.path.join(tmpdir, "template.json"), "w", encoding="utf8") as f:
             f.write(MOCK_JOB_TEMPLATE_CASES["MINIMAL_JSON"][1])
@@ -572,8 +470,7 @@ def test_cli_bundle_job_parameter_with_equals_from_cli(fresh_deadline_config):
             ],
         )
 
-        print(result.output)
-        session_mock().client().create_job.assert_called_once_with(
+        mock.get_boto3_client().create_job.assert_called_once_with(
             farmId=MOCK_FARM_ID,
             queueId=MOCK_QUEUE_ID,
             template=ANY,
@@ -584,19 +481,15 @@ def test_cli_bundle_job_parameter_with_equals_from_cli(fresh_deadline_config):
             priority=50,
         )
 
-        assert result.exit_code == 0
+        assert result.exit_code == 0, result.output
 
 
-def test_cli_bundle_invalid_job_paramter(fresh_deadline_config):
+def test_cli_bundle_invalid_job_parameter(fresh_deadline_config):
     """
     Verify that a badly formatted parameter value (without "Key=Value") throws an error
     """
     # Use a temporary directory for the job bundle
-    with tempfile.TemporaryDirectory() as tmpdir, patch.object(boto3, "Session") as session_mock:
-        session_mock().client("deadline").create_job.return_value = MOCK_CREATE_JOB_RESPONSE
-        session_mock().client("deadline").get_job.return_value = MOCK_GET_JOB_RESPONSE
-        session_mock.reset_mock()
-
+    with tempfile.TemporaryDirectory() as tmpdir, patch_calls_for_create_job_from_job_bundle():
         # Write a JSON template
         with open(os.path.join(tmpdir, "template.json"), "w", encoding="utf8") as f:
             f.write(MOCK_JOB_TEMPLATE_CASES["MINIMAL_JSON"][1])
@@ -621,16 +514,12 @@ def test_cli_bundle_invalid_job_paramter(fresh_deadline_config):
         assert result.exit_code == 2
 
 
-def test_cli_bundle_invalid_job_paramter_name(fresh_deadline_config):
+def test_cli_bundle_invalid_job_parameter_name(fresh_deadline_config):
     """
     Verify that a non-identifier parameter name raises an error.
     """
     # Use a temporary directory for the job bundle
-    with tempfile.TemporaryDirectory() as tmpdir, patch.object(boto3, "Session") as session_mock:
-        session_mock().client("deadline").create_job.return_value = MOCK_CREATE_JOB_RESPONSE
-        session_mock().client("deadline").get_job.return_value = MOCK_GET_JOB_RESPONSE
-        session_mock.reset_mock()
-
+    with tempfile.TemporaryDirectory() as tmpdir, patch_calls_for_create_job_from_job_bundle():
         # Write a JSON template
         with open(os.path.join(tmpdir, "template.json"), "w", encoding="utf8") as f:
             f.write(MOCK_JOB_TEMPLATE_CASES["MINIMAL_JSON"][1])
@@ -666,6 +555,7 @@ def test_cli_bundle_accept_upload_confirmation(fresh_deadline_config, temp_job_b
 
     config.set_setting("defaults.farm_id", MOCK_FARM_ID)
     config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("settings.auto_accept", "false")
 
     # Write a JSON template
     with open(os.path.join(temp_job_bundle_dir, "template.json"), "w", encoding="utf8") as f:
@@ -685,25 +575,7 @@ def test_cli_bundle_accept_upload_confirmation(fresh_deadline_config, temp_job_b
         }
         json.dump(data, f)
 
-    with patch.object(
-        _submit_job_bundle.api, "get_boto3_client"
-    ) as get_boto3_client_mock, patch.object(
-        _submit_job_bundle, "_hash_attachments", return_value=[SummaryStatistics(), "test"]
-    ), patch.object(_submit_job_bundle, "_upload_attachments"), patch.object(
-        _submit_job_bundle.api, "get_boto3_session"
-    ), patch.object(
-        _submit_job_bundle.api, "get_queue_parameter_definitions", return_value=[]
-    ), patch.object(_submit_job_bundle.api, "get_queue_user_boto3_session"), patch.object(
-        bundle_group.api, "get_deadline_cloud_library_telemetry_client"
-    ):
-        get_boto3_client_mock().create_job.return_value = MOCK_CREATE_JOB_RESPONSE
-        get_boto3_client_mock().get_job.return_value = MOCK_GET_JOB_RESPONSE
-        get_boto3_client_mock().get_queue.return_value = {
-            "displayName": "Test Queue",
-            "jobAttachmentSettings": {"s3BucketName": "mock", "rootPrefix": "root"},
-        }
-
-        set_setting("settings.auto_accept", "false")
+    with patch_calls_for_create_job_from_job_bundle() as mock:
         runner = CliRunner()
         result = runner.invoke(
             main,
@@ -719,7 +591,7 @@ def test_cli_bundle_accept_upload_confirmation(fresh_deadline_config, temp_job_b
             input="y",
         )
 
-        get_boto3_client_mock().create_job.assert_called_with(
+        mock.get_boto3_client().create_job.assert_called_with(
             farmId=MOCK_FARM_ID,
             queueId=MOCK_QUEUE_ID,
             template=MOCK_JOB_TEMPLATE_CASES["MINIMAL_JSON"][1],
@@ -727,17 +599,18 @@ def test_cli_bundle_accept_upload_confirmation(fresh_deadline_config, temp_job_b
             attachments=ANY,
             priority=50,
         )
-        assert result.exit_code == 0
+        assert result.exit_code == 0, result.output
 
 
 def test_cli_bundle_reject_upload_confirmation(fresh_deadline_config, temp_job_bundle_dir):
     """
     Verify that when the user rejects the job attachments upload confirmation
-    that no further action is taken after that point.
+    that no further action is taken after that point, and that a failure CLI exit code results.
     """
 
     config.set_setting("defaults.farm_id", MOCK_FARM_ID)
     config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("settings.auto_accept", "false")
 
     # Write a JSON template
     with open(os.path.join(temp_job_bundle_dir, "template.json"), "w", encoding="utf8") as f:
@@ -757,31 +630,7 @@ def test_cli_bundle_reject_upload_confirmation(fresh_deadline_config, temp_job_b
         }
         json.dump(data, f)
 
-    with patch.object(
-        _submit_job_bundle.api, "get_boto3_client"
-    ) as get_boto3_client_mock, patch.object(
-        _queue_parameters, "get_boto3_client"
-    ) as qp_boto3_client_mock, patch.object(
-        _submit_job_bundle, "_hash_attachments", return_value=[SummaryStatistics(), "test"]
-    ), patch.object(
-        _submit_job_bundle, "_upload_attachments"
-    ) as upload_attachments_mock, patch.object(
-        _submit_job_bundle.api, "get_boto3_session"
-    ), patch.object(_submit_job_bundle.api, "get_queue_user_boto3_session"), patch.object(
-        bundle_group.api, "get_deadline_cloud_library_telemetry_client"
-    ):
-        get_boto3_client_mock().get_queue.return_value = {
-            "displayName": "Test Queue",
-            "jobAttachmentSettings": {"s3BucketName": "mock", "rootPrefix": "root"},
-        }
-        qp_boto3_client_mock().list_queue_environments.return_value = (
-            MOCK_LIST_QUEUE_ENVIRONMENTS_RESPONSE
-        )
-        qp_boto3_client_mock().get_queue_environment.side_effect = (
-            MOCK_GET_QUEUE_ENVIRONMENTS_RESPONSES
-        )
-
-        set_setting("settings.auto_accept", "false")
+    with patch_calls_for_create_job_from_job_bundle() as mock:
         runner = CliRunner()
         result = runner.invoke(
             main,
@@ -797,8 +646,8 @@ def test_cli_bundle_reject_upload_confirmation(fresh_deadline_config, temp_job_b
             input="n",
         )
 
-        upload_attachments_mock.assert_not_called()
-        assert result.exit_code == 0
+        mock.upload_assets.assert_not_called()
+        assert result.exit_code == 1
 
 
 @patch("deadline.client.ui.gui_context_for_cli")

--- a/test/unit/deadline_client/cli/test_cli_bundle_known_paths.py
+++ b/test/unit/deadline_client/cli/test_cli_bundle_known_paths.py
@@ -1,0 +1,360 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Tests for the known asset paths functionality in the bundle_submit CLI command.
+"""
+
+import os
+import json
+import tempfile
+from unittest.mock import patch, ANY, call
+
+import click
+from click.testing import CliRunner
+import pytest
+
+from deadline.client import config
+from deadline.client.cli import main
+from deadline.client.api._submit_job_bundle import _filter_redundant_known_paths
+
+from ..api.test_job_bundle_submission import (
+    MOCK_FARM_ID,
+    MOCK_QUEUE_ID,
+    MOCK_JOB_TEMPLATE_CASES,
+)
+from ..testing_utilities import patch_calls_for_create_job_from_job_bundle
+
+
+@pytest.mark.parametrize(
+    "input, expected",
+    [
+        ([], []),
+        (["/a", "/a", "/a"], ["/a"]),
+        (["/a/b", "/a/b/c", "/a/", "/a"], ["/a"]),
+        (["/a", "/"], ["/"]),
+        (["/a", "/b", "/a"], ["/a", "/b"]),
+        (["/a", "/b", "/c"], ["/a", "/b", "/c"]),
+        (["/a", "/b", "/a", "/c", "/b", "/a"], ["/a", "/b", "/c"]),
+    ],
+)
+def test_filter_redundant_known_paths(input, expected):
+    assert sorted(_filter_redundant_known_paths(input)) == expected
+    if os.name == "nt":
+        assert sorted(_filter_redundant_known_paths(path.replace("/", "\\") for path in input)) == [
+            path.replace("/", "\\") for path in expected
+        ]
+        assert sorted(
+            _filter_redundant_known_paths("C:" + path.replace("/", "\\") for path in input)
+        ) == ["C:" + path.replace("/", "\\") for path in expected]
+
+
+def test_cli_bundle_known_paths_combine(fresh_deadline_config, temp_job_bundle_dir):
+    """
+    Test that the CLI combines known upload paths from both the CLI parameter
+    and the configuration setting.
+    """
+    # Set up configuration
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("settings.auto_accept", "true")
+
+    # Set known paths in config using OS-specific path separator
+    config_path1 = "/path/from/config/1" if os.name != "nt" else "C:\\path\\from\\config\\1"
+    config_path2 = "/path/from/config/2" if os.name != "nt" else "C:\\path\\from\\config\\2"
+    config.set_setting("settings.known_asset_paths", os.pathsep.join([config_path1, config_path2]))
+
+    # Write a JSON template
+    with open(os.path.join(temp_job_bundle_dir, "template.json"), "w", encoding="utf8") as f:
+        f.write(MOCK_JOB_TEMPLATE_CASES["MINIMAL_JSON"][1])
+
+    # Create a file outside the job bundle directory
+    with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+        temp_file.write(b"test content")
+        external_file_path = temp_file.name
+
+    try:
+        # Create asset references pointing to the external file
+        with open(
+            os.path.join(temp_job_bundle_dir, "asset_references.json"), "w", encoding="utf8"
+        ) as f:
+            json.dump(
+                {
+                    "assetReferences": {
+                        "inputs": {
+                            "filenames": [external_file_path],
+                            "directories": [],
+                        },
+                        "outputs": {"directories": []},
+                    }
+                },
+                f,
+            )
+
+        with patch_calls_for_create_job_from_job_bundle() as mock:
+            # Create OS-specific CLI paths
+            cli_path1 = "/path/from/cli/1" if os.name != "nt" else "C:\\path\\from\\cli\\1"
+            cli_path2 = os.path.dirname(external_file_path)
+
+            # Run the CLI command with known upload paths
+            runner = CliRunner()
+            result = runner.invoke(
+                main,
+                [
+                    "bundle",
+                    "submit",
+                    "--yes",
+                    temp_job_bundle_dir,
+                    "--known-asset-path",
+                    cli_path1,
+                    "--known-asset-path",
+                    cli_path2,
+                ],
+            )
+
+            # Verify the command succeeded
+            assert result.exit_code == 0, result.output
+
+            # Verify create_job_from_job_bundle was called with combined paths
+            mock.create_job_from_job_bundle.assert_called_once()
+            _, kwargs = mock.create_job_from_job_bundle.call_args
+            assert "known_asset_paths" in kwargs
+            known_paths = kwargs["known_asset_paths"]
+            assert cli_path1 in known_paths, result.output
+            assert cli_path2 in known_paths, result.output
+            assert config_path1 not in known_paths, result.output
+            assert config_path2 not in known_paths, result.output
+
+            # Check that both the CLI and config paths are provided to generate_message_for_asset_paths
+            mock.generate_message_for_asset_paths.assert_called_once()
+            (_, _, known_paths), _ = mock.generate_message_for_asset_paths.call_args
+            assert cli_path1 in known_paths, result.output
+            assert cli_path2 in known_paths, result.output
+            assert config_path1 in known_paths, result.output
+            assert config_path2 in known_paths, result.output
+    finally:
+        # Clean up the temporary file
+        os.unlink(external_file_path)
+
+
+def test_cli_bundle_storage_profile_known_paths(fresh_deadline_config, temp_job_bundle_dir):
+    """
+    Test that known paths from a storage profile are included when submitting a job bundle.
+    """
+    # Set up configuration
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("settings.auto_accept", "true")
+
+    # Set a storage profile ID in the config
+    storage_profile_id = "mock-storage-profile-id"
+    config.set_setting("settings.storage_profile_id", storage_profile_id)
+
+    # Write a JSON template
+    with open(os.path.join(temp_job_bundle_dir, "template.json"), "w", encoding="utf8") as f:
+        f.write(MOCK_JOB_TEMPLATE_CASES["MINIMAL_JSON"][1])
+
+    # Create a file outside the job bundle directory
+    with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+        temp_file.write(b"test content")
+        external_file_path = temp_file.name
+
+    try:
+        # Create asset references pointing to the external file
+        with open(
+            os.path.join(temp_job_bundle_dir, "asset_references.json"), "w", encoding="utf8"
+        ) as f:
+            json.dump(
+                {
+                    "assetReferences": {
+                        "inputs": {
+                            "filenames": [external_file_path],
+                            "directories": [],
+                        },
+                        "outputs": {"directories": []},
+                    }
+                },
+                f,
+            )
+
+        # Create a mock storage profile with file system locations
+        local_storage_profile_path = os.path.dirname(external_file_path)
+        shared_storage_profile_path = (
+            "/shared/path/from/storage/profile"
+            if os.name != "nt"
+            else "C:\\shared\\path\\from\\storage\\profile"
+        )
+
+        # Create the StorageProfile object directly
+        os_family = "WINDOWS" if os.name == "nt" else "LINUX"
+        storage_profile_response = {
+            "storageProfileId": storage_profile_id,
+            "displayName": "Mock Storage Profile",
+            "osFamily": os_family,
+            "fileSystemLocations": [
+                {
+                    "name": "mock-local-location",
+                    "path": local_storage_profile_path,
+                    "type": "LOCAL",
+                },
+                {
+                    "name": "mock-shared-location",
+                    "path": shared_storage_profile_path,
+                    "type": "SHARED",
+                },
+            ],
+        }
+
+        with patch_calls_for_create_job_from_job_bundle() as mock:
+            mock.get_boto3_client().get_storage_profile_for_queue.return_value = (
+                storage_profile_response
+            )
+
+            # Run the CLI command with known upload paths
+            runner = CliRunner()
+            result = runner.invoke(
+                main,
+                [
+                    "bundle",
+                    "submit",
+                    "--yes",
+                    temp_job_bundle_dir,
+                ],
+            )
+
+            # Verify the command succeeded
+            assert result.exit_code == 0, result.output
+
+            # Verify get_storage_profile_for_queue was called with correct parameters
+            assert mock.get_boto3_client().get_storage_profile_for_queue.mock_calls == [
+                call(
+                    farmId=MOCK_FARM_ID, queueId=MOCK_QUEUE_ID, storageProfileId=storage_profile_id
+                )
+            ], result.output
+
+            # Verify create_job_from_job_bundle was called
+            mock.create_job_from_job_bundle.assert_called_once()
+            _, kwargs = mock.create_job_from_job_bundle.call_args
+            assert "known_asset_paths" in kwargs
+            known_paths = kwargs["known_asset_paths"]
+
+            # Verify the storage profile path is not in the known paths passed to create_job_in_job_bundle
+            assert local_storage_profile_path not in known_paths, result.output
+            assert shared_storage_profile_path not in known_paths, result.output
+
+            # Check that the LOCAL storage profile paths are provided to generate_message_for_asset_paths
+            mock.generate_message_for_asset_paths.assert_called_once()
+            (_, _, known_paths), _ = mock.generate_message_for_asset_paths.call_args
+            assert local_storage_profile_path in known_paths, result.output
+            # The SHARED storage location should not be in the known paths list
+            assert shared_storage_profile_path not in known_paths, result.output
+    finally:
+        # Clean up the temporary file
+        os.unlink(external_file_path)
+
+
+def test_cli_bundle_warning_suppression(fresh_deadline_config, temp_job_bundle_dir):
+    """
+    Test that warnings are suppressed for paths in known_asset_paths.
+    """
+    # Set up configuration
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("settings.auto_accept", "false")
+
+    # Write a JSON template
+    with open(os.path.join(temp_job_bundle_dir, "template.json"), "w", encoding="utf8") as f:
+        f.write(MOCK_JOB_TEMPLATE_CASES["MINIMAL_JSON"][1])
+
+    # Create a file in the job bundle directory
+    job_bundle_file_path = os.path.join(temp_job_bundle_dir, "test_file.txt")
+    with open(job_bundle_file_path, "wb") as f:
+        f.write(b"test content")
+
+    # Create a file outside the job bundle directory
+    with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+        temp_file.write(b"test content")
+        external_file_path = temp_file.name
+
+    try:
+        # Create asset references pointing to the external file
+        with open(
+            os.path.join(temp_job_bundle_dir, "asset_references.json"), "w", encoding="utf8"
+        ) as f:
+            json.dump(
+                {
+                    "assetReferences": {
+                        "inputs": {
+                            "filenames": [external_file_path, job_bundle_file_path],
+                            "directories": [],
+                        },
+                        "outputs": {"directories": []},
+                    }
+                },
+                f,
+            )
+
+        with patch_calls_for_create_job_from_job_bundle():
+            # First test: without known_asset_path - should show warning and succeed when user confirms
+            with patch.object(click, "confirm", return_value=True) as mock_confirm:
+                runner = CliRunner()
+                result = runner.invoke(
+                    main,
+                    [
+                        "bundle",
+                        "submit",
+                        temp_job_bundle_dir,
+                    ],
+                )
+
+                # Verify warning was shown
+                assert result.exit_code == 0, result.output
+                mock_confirm.assert_called_once_with(ANY, default=False)
+                # The warning message should say there are two input files, but only one has an issue
+                warning_message = mock_confirm.call_args[0][0]
+                assert "Job submission contains 2 input files" in warning_message, warning_message
+                assert (
+                    f"Unknown locations for upload:\n  {external_file_path}" in warning_message
+                ), warning_message
+
+            # Second test: without known_asset_path - should show warning and fail when user cancels
+            with patch.object(click, "confirm", return_value=False) as mock_confirm:
+                runner = CliRunner()
+                result = runner.invoke(
+                    main,
+                    [
+                        "bundle",
+                        "submit",
+                        temp_job_bundle_dir,
+                    ],
+                )
+
+                # Verify warning was shown
+                assert result.exit_code == 1, result.output
+                mock_confirm.assert_called_once_with(ANY, default=False)
+                # The warning message should say there are two input files, but only one has an issue
+                warning_message = mock_confirm.call_args[0][0]
+                assert "Job submission contains 2 input files" in warning_message, warning_message
+                assert (
+                    f"Unknown locations for upload:\n  {external_file_path}" in warning_message
+                ), warning_message
+
+            # Third test: with known_asset_path - should not show warning
+            with patch.object(click, "confirm", return_value=True) as mock_confirm:
+                runner = CliRunner()
+                result = runner.invoke(
+                    main,
+                    [
+                        "bundle",
+                        "submit",
+                        temp_job_bundle_dir,
+                        "--known-asset-path",
+                        os.path.dirname(external_file_path),
+                    ],
+                )
+
+                # Verify warning was not shown
+                assert result.exit_code == 0, result.output
+                mock_confirm.assert_called_once_with(ANY, default=True)
+    finally:
+        # Clean up the temporary file
+        os.unlink(external_file_path)

--- a/test/unit/deadline_client/cli/test_cli_config.py
+++ b/test/unit/deadline_client/cli/test_cli_config.py
@@ -36,7 +36,7 @@ def test_cli_config_show_defaults(fresh_deadline_config):
     assert fresh_deadline_config in result.output
 
     # Assert the expected number of settings
-    assert len(settings.keys()) == 15
+    assert len(settings.keys()) == 16
 
     for setting_name in settings.keys():
         assert setting_name in result.output
@@ -105,13 +105,12 @@ def test_cli_config_show_modified_config(fresh_deadline_config):
     config.set_setting("telemetry.identifier", "user-id-123abc-456def")
     config.set_setting("settings.s3_max_pool_connections", "100")
     config.set_setting("settings.small_file_threshold_multiplier", "15")
+    config.set_setting("settings.known_asset_paths", "/known/asset/path")
 
     runner = CliRunner()
     result = runner.invoke(main, ["config", "show"])
 
-    print(result.output)
-
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result.output
 
     # We should see all the overridden values in the output
     assert "EnvVarOverrideProfile" in result.output
@@ -124,6 +123,7 @@ def test_cli_config_show_modified_config(fresh_deadline_config):
     assert "CREATE_COPY" in result.output
     assert "DEBUG" in result.output
     assert "user-id-123abc-456def" in result.output
+    assert "/known/asset/path" in result.output
     # It shouldn't say anywhere that there is a default setting
     assert "(default)" not in result.output
 

--- a/test/unit/deadline_client/conftest.py
+++ b/test/unit/deadline_client/conftest.py
@@ -5,6 +5,8 @@ Common fixtures for Deadline Client Library tests.
 """
 
 import tempfile
+import os
+
 import pytest
 
 
@@ -26,3 +28,20 @@ def temp_assets_dir():
 
     with tempfile.TemporaryDirectory() as assets_dir:
         yield assets_dir
+
+
+@pytest.fixture(scope="function")
+def temp_cwd():
+    """
+    Fixture to provide a temporary current working directory.
+    """
+
+    with tempfile.TemporaryDirectory() as cwd:
+        # Change the current working directory to the temporary directory
+        original_cwd = os.getcwd()
+        try:
+            os.chdir(cwd)
+            yield cwd
+        finally:
+            # Restore the original current working directory
+            os.chdir(original_cwd)

--- a/test/unit/deadline_client/shared_constants.py
+++ b/test/unit/deadline_client/shared_constants.py
@@ -39,3 +39,68 @@ MOCK_GET_QUEUE_RESPONSE = {
     "updatedAt": "2022-11-22T22:26:57+00:00",
     "updatedBy": "0123abcdf-abcd-0123-fa82-0123456abcd1",
 }
+
+MOCK_LIST_QUEUE_ENVIRONMENTS_RESPONSE = {
+    "environments": [
+        {"queueEnvironmentId": "queueenv-123", "name": "First Env", "priority": 2},
+        {"queueEnvironmentId": "queueenv-234", "name": "Second Env", "priority": 1},
+    ]
+}
+
+MOCK_QUEUE_ENV_TEMPLATE_1 = """
+specificationVersion: 'jobtemplate-2023-09'
+parameterDefinitions:
+- name: RezPackages
+  type: STRING
+  description: Choose which rez packages to install for the render.
+  default: ""
+  userInterface:
+    control: LINE_EDIT
+    label: Rez Packages
+environment:
+  name: Rez Non-Final
+  script:
+    actions:
+      onEnter:
+        command: "say-hello"
+"""
+
+MOCK_QUEUE_ENV_TEMPLATE_2 = """
+specificationVersion: 'jobtemplate-2023-09'
+parameterDefinitions:
+- name: IntParam
+  type: INT
+  default: ""
+  userInterface:
+    control: SPIN_BOX
+    label: Int Param
+environment:
+  name: Int Param Env
+  script:
+    actions:
+      onEnter:
+        command: "say-hello"
+"""
+
+MOCK_GET_QUEUE_ENVIRONMENT_RESPONSES = [
+    {
+        "queueEnvironmentId": "queueenv-123",
+        "name": "Rez Non-Final",
+        "priority": 1,
+        "templateType": "YAML",
+        "template": MOCK_QUEUE_ENV_TEMPLATE_1,
+    },
+    {
+        "queueEnvironmentId": "queueenv-234",
+        "name": "Int Param Env",
+        "priority": 1,
+        "templateType": "YAML",
+        "template": MOCK_QUEUE_ENV_TEMPLATE_1,
+    },
+]
+
+MOCK_CREATE_JOB_RESPONSE = {"jobId": MOCK_JOB_ID}
+
+MOCK_STATUS_MESSAGE = "Testing123"
+
+MOCK_GET_JOB_RESPONSE = {"state": "READY", "lifecycleStatusMessage": MOCK_STATUS_MESSAGE}

--- a/test/unit/deadline_client/testing_utilities.py
+++ b/test/unit/deadline_client/testing_utilities.py
@@ -8,6 +8,24 @@ import contextlib
 import os
 import tempfile
 from typing import Dict, Optional, Tuple
+from unittest.mock import patch, Mock
+import boto3
+
+from deadline.client.api import _submit_job_bundle
+from deadline.job_attachments.models import (
+    Attachments,
+    ManifestProperties,
+    PathFormat,
+)
+from deadline.job_attachments.upload import S3AssetManager
+from deadline.job_attachments.progress_tracker import SummaryStatistics
+
+from .shared_constants import (
+    MOCK_CREATE_JOB_RESPONSE,
+    MOCK_GET_JOB_RESPONSE,
+    MOCK_GET_QUEUE_ENVIRONMENT_RESPONSES,
+    MOCK_LIST_QUEUE_ENVIRONMENTS_RESPONSE,
+)
 
 if os.name == "nt":
 
@@ -126,3 +144,100 @@ def program_that_prints_output(
         yield temp.name
     finally:
         os.remove(temp.name)
+
+
+def write_test_asset_files(assets_dir: str, asset_contents: Dict[str, str]):
+    """
+    Write a set of asset contents files to the provided assets directory.
+    Each key of asset_contents is a relative path from assets_dir, and
+    each value is what to write to the file.
+    """
+    for rel_path, contents in asset_contents.items():
+        path = os.path.join(assets_dir, rel_path)
+        if not os.path.isdir(os.path.dirname(path)):
+            os.makedirs(os.path.dirname(path))
+        if isinstance(contents, str):
+            with open(path, "w", encoding="utf8") as f:
+                f.write(contents)
+        elif isinstance(contents, bytes):
+            with open(path, "wb") as f:
+                f.write(contents)
+        else:
+            raise ValueError("The contents provided in asset_contents must be either str or bytes.")
+
+
+@contextlib.contextmanager
+def patch_calls_for_create_job_from_job_bundle(
+    *,
+    create_job_return=MOCK_CREATE_JOB_RESPONSE,
+    get_job_return=MOCK_GET_JOB_RESPONSE,
+    get_queue_return={
+        "displayName": "Test Queue",
+        "jobAttachmentSettings": {"s3BucketName": "mock", "rootPrefix": "root"},
+    },
+    queue_paramdefs=[],
+    upload_assets_return=[
+        SummaryStatistics(),
+        Attachments(
+            [
+                ManifestProperties(
+                    rootPath="/mnt/root/path1",
+                    rootPathFormat=PathFormat.POSIX,
+                    inputManifestPath="mock-manifest",
+                    inputManifestHash="mock-manifest-hash",
+                    outputRelativeDirectories=["."],
+                ),
+            ],
+        ),
+    ],
+):
+    """This is a context manager to help test deadline.client.api.create_job_from_job_bundle.
+
+    It patches a bunch of functions that might call to the internet, or need to be wrapped to test JA effectively.
+    See the assignments in this function implementation to access the mocked values."""
+    with patch.object(
+        _submit_job_bundle.api, "get_deadline_cloud_library_telemetry_client"
+    ) as mock_get_deadline_cloud_library_telemetry_client, patch.object(
+        _submit_job_bundle.api, "get_queue_parameter_definitions", return_value=queue_paramdefs
+    ) as mock_get_queue_parameter_definitions, patch.object(
+        _submit_job_bundle.api,
+        "create_job_from_job_bundle",
+        wraps=_submit_job_bundle.create_job_from_job_bundle,
+    ) as mock_create_job_from_job_bundle, patch.object(
+        _submit_job_bundle,
+        "_generate_message_for_asset_paths",
+        wraps=_submit_job_bundle._generate_message_for_asset_paths,
+    ) as mock_generate_message_for_asset_paths, patch.object(
+        _submit_job_bundle, "_hash_attachments", wraps=_submit_job_bundle._hash_attachments
+    ) as mock_hash_attachments, patch(
+        "deadline.job_attachments.upload.S3AssetUploader"
+    ), patch.object(
+        S3AssetManager, "upload_assets", return_value=upload_assets_return
+    ) as mock_upload_assets, patch.object(
+        _submit_job_bundle.api, "get_queue_user_boto3_session"
+    ) as mock_get_queue_user_boto3_session, patch.object(boto3, "Session") as boto3_session_mock:
+        mock = Mock()
+        # Read these assignments to see what to access
+        mock.get_boto3_client = boto3_session_mock().client
+        mock.get_deadline_cloud_library_telemetry_client = (
+            mock_get_deadline_cloud_library_telemetry_client
+        )
+        mock.create_job_from_job_bundle = mock_create_job_from_job_bundle
+        mock.get_queue_parameter_definitions = mock_get_queue_parameter_definitions
+        mock.generate_message_for_asset_paths = mock_generate_message_for_asset_paths
+        mock.hash_attachments = mock_hash_attachments
+        mock.upload_assets = mock_upload_assets
+        mock.get_queue_user_boto3_session = mock_get_queue_user_boto3_session
+        mock.Session = boto3_session_mock
+
+        mock.get_boto3_client().create_job.return_value = create_job_return
+        mock.get_boto3_client().get_job.return_value = get_job_return
+        mock.get_boto3_client().get_queue.return_value = get_queue_return
+        mock.get_boto3_client().list_queue_environments.return_value = (
+            MOCK_LIST_QUEUE_ENVIRONMENTS_RESPONSE
+        )
+        mock.get_boto3_client().get_queue_environment.side_effect = (
+            MOCK_GET_QUEUE_ENVIRONMENT_RESPONSES
+        )
+
+        yield mock


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud/issues/407

### What was the problem/requirement? (What/Why)

The intent of Deadline Cloud's job submission is to warn when submitting files from directories that the user hasn't explicitly specified. The current implementation doesn't follow this rule.

### What was the solution? (How)

* Refactor create_job_from_job_bundle to support calls from both the CLI
  and from the GUI.
    * Modify the behavior for auto_accept as follows: If is_gui is true,
      it calls the confirmation function anyway whatn the default is to
      cancel, because GUI is always an interactive context. If is_gui is
      false, it automatically accepts the default. If there are unknown
      path warnings, the default is to cancel, and it cancels with a
      message describing what it did. If there are no unknown path
      warnings, the default is to proceed, and it does so.
    * Modify the return type from Union[str, None] to str. Before, it
      sometimes would raise an exception and other times return None.
      Now, if it returns a value, that value is a job id.
    * Add a new parameter known_asset_paths. This is a list of
      directories that are ok for uploading or downloading data to S3
      for running jobs. The values in this list are added to the known
      asset paths from the local configuration and any PATH parameter
      values that are passed in to the function's job_parameters
      parameter.
    * Modify the decide_cancel_submission_callback type from
      Callable[[AssetUploadGroup], bool] to Callable[[str, bool], bool],
      and move all the business logic about when to ask for user input
      about canceling into create_job_from_job_bundle so that it's
      shared between all usages (e.g. including the CLI and GUI code).
      Previously, the CLI and GUI implemented the same logic with
      duplicated code. The callback now should always present the
      requested prompt to the user, and the boolean parameter indicates
      whether the default should be to cancel or to proceed.
    * Add a printout summarizing the job attachments files to
      upload/collect outputs for download. Even in non-interactive
      contexts, it is useful to see this information.
* Add a new setting known_asset_paths to the config file. It's a list of
  paths that should not generate warnings when outside storage profile
  locations.
    * Update the configuration GUI to include editing of this list.
* Add descriptions to all the config file properties that didn't have
  descriptions. In particular, the 'auto_accept' setting is now defined
  to automatically accept the default.
* Fix the DEVELOPMENT.md sample showing cancelation to use
  CancelationFlag that decouples the value from the window lifetime.
* Change usage of deprecated log.warn into log.warning.
* Add missing `fresh_deadline_config` fixture to failing telemetry
  tests.

### What is the impact of this change?

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests?
- Have you run the integration tests?
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass.

### Was this change documented?

- Are relevant docstrings in the code base updated?
- Has the README.md been updated? If you modified CLI arguments, for instance.

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [ ] This PR does not add any new dependencies.

### Is this a breaking change?

BREAKING CHANGE: The behavior for the auto_accept configuration option
    has changed to automatically accept the default option that would be
    presented interactively. One exception is in a GUI context, when
    automatically accepting would cancel the operation.

BREAKING CHANGE: The parameter decide_cancel_submission_callback is
    removed from api.create_job_from_job_bundle, and a new paramete
    interactive_confirmation_callback replaces it. The previous callback
    included business logic that is now in the create job function, and
    the callback's purpose is now solely to present an interactive
    confirmation prompt.

### Does this change impact security?

- Does the change need to be threat modeled? For example, does it create or modify files/directories that must only be readable by the process owner?
    - If so, then please label this pull request with the "security" label. We'll work with you to analyze the threats.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
