### PR TITLE
test: loosen assertion around click runner output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
 # limiting dependencies if they want/need to.
 dependencies = [
   "boto3 >= 1.36.8",
-  "click >= 8.1.7",
+  "click >= 8.1.7,<8.2.0",
   "pyyaml >= 6.0",
   # Job Attachments
   "typing_extensions >= 4.7,< 4.14; python_version == '3.7'",

--- a/test/integ/cli/test_cli_attachment.py
+++ b/test/integ/cli/test_cli_attachment.py
@@ -125,7 +125,6 @@ class TestAttachment:
         assert result.exit_code != 0, (
             f"Expecting cross-account s3 access to fail but not, CLI output {result.output}"
         )
-        assert "deadline.job_attachments.exceptions.JobAttachmentsS3ClientError" in result.output
         assert "HTTP Status Code: 403, Access denied." in result.output
 
         result = runner.invoke(
@@ -144,7 +143,6 @@ class TestAttachment:
         assert result.exit_code != 0, (
             f"Expecting cross-account s3 access to fail but not, CLI output {result.output}"
         )
-        assert "deadline.job_attachments.exceptions.JobAttachmentsS3ClientError" in result.output
         assert "HTTP Status Code: 403, Forbidden or Access denied." in result.output
 
     @pytest.mark.integ


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Integration tests started failing on Saturday and they were expecting to see a specific exception in the CLI output. 

```
FAILED test/integ/cli/test_cli_attachment.py::TestAttachment::test_attachment_s3_cross_account_access_denied - assert 'deadline.job_attachments.exceptions.JobAttachmentsS3ClientError' in "The AWS Deadline Cloud CLI encountered the following exception:\nError checking if object exists in bucket 'job-attachment-bucket-snipe-test', Target key or prefix: 'test/Data/19a71beb47d7cc2d654ac4637e680c88.xxh128', HTTP Status Code: 403, Access denied. Ensure that the bucket is in the account 938076848303, and your AWS IAM Role or User has the 's3:ListBucket' permission for this bucket.\n"
```

We have not merged anything since May 5th, so it points to a dependency regression. Looking at the logs, the last successful run used click 8.1.8 and the first failure used click 8.2.0. From the release notes I can see some changes around stdout handling - https://click.palletsprojects.com/en/stable/changes/#version-8-2-0

> Keep stdout and stderr streams independent in CliRunner. Always collect stderr output and never raise an exception. Add a new output stream to simulate what the user sees in its terminal. Removes the mix_stderr parameter in CliRunner. [#2522](https://github.com/pallets/click/issues/2522) [#2523](https://github.com/pallets/click/pull/2523)

Running the test locally, I can verify that the test succeeds with click 8.1.8 and fails with 8.2.0 and that the output in the terminal when manually running the commands is the same.

```
deadline attachment upload --manifests /Users/dev/.deadline/job_history/donkersdirectstudio-us-west-2/2025-04/2025-04-25-01-test-close-Explosion/manifests/a60904892799f43e7332a31049abf318_input  --root-dirs /Users/dev/Downloads/explosion  --profile default --s3-root-uri s3://job-attachment-bucket-snipe-test/test
The AWS Deadline Cloud CLI encountered the following exception:
Error checking if object exists in bucket 'job-attachment-bucket-snipe-test', Target key or prefix: 'test/Data/f8c423deb7b1d4d0422cfaa27d95e42e.xxh128', HTTP Status Code: 403, Access denied. Ensure that the bucket is in the account 000000000000, and your AWS IAM Role or User has the 's3:ListBucket' permission for this bucket.
Traceback (most recent call last):
  File "/Users/dev/github/deadline-cloud/src/deadline/job_attachments/upload.py", line 777, in file_already_uploaded
    self._s3.head_object(
  File "/Users/Library/Application Support/hatch/env/virtual/deadline/7XR_zEB6/deadline/lib/python3.12/site-packages/botocore/client.py", line 595, in _api_call
    return self._make_api_call(operation_name, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/Library/Application Support/hatch/env/virtual/deadline/7XR_zEB6/deadline/lib/python3.12/site-packages/botocore/context.py", line 123, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/Library/Application Support/hatch/env/virtual/deadline/7XR_zEB6/deadline/lib/python3.12/site-packages/botocore/client.py", line 1058, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (403) when calling the HeadObject operation: Forbidden

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/dev/github/deadline-cloud/src/deadline/client/cli/_common.py", line 55, in wraps
    func(*args, **kwargs)
  File "/Users/dev/github/deadline-cloud/src/deadline/client/cli/_groups/attachment_group.py", line 206, in attachment_upload
    attachment_api.attachment_upload(
  File "/Users/dev/github/deadline-cloud/src/deadline/job_attachments/api/attachment.py", line 168, in attachment_upload
    key, data = asset_uploader.upload_assets(
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dev/github/deadline-cloud/src/deadline/job_attachments/upload.py", line 222, in upload_assets
    self.upload_input_files(
  File "/Users/dev/github/deadline-cloud/src/deadline/job_attachments/upload.py", line 368, in upload_input_files
    (is_uploaded, file_size) = future.result()
                               ^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/concurrent/futures/_base.py", line 449, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/concurrent/futures/thread.py", line 59, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dev/github/deadline-cloud/src/deadline/job_attachments/upload.py", line 524, in upload_object_to_cas
    if self.file_already_uploaded(s3_bucket, s3_upload_key):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dev/github/deadline-cloud/src/deadline/job_attachments/upload.py", line 789, in file_already_uploaded
    raise JobAttachmentsS3ClientError(
deadline.job_attachments.exceptions.JobAttachmentsS3ClientError: Error checking if object exists in bucket 'job-attachment-bucket-snipe-test', Target key or prefix: 'test/Data/f8c423deb7b1d4d0422cfaa27d95e42e.xxh128', HTTP Status Code: 403, Access denied. Ensure that the bucket is in the account 000000000000, and your AWS IAM Role or User has the 's3:ListBucket' permission for this bucket.
```

The tests are using CLIRunner's Result.output which should combine the two streams and is what the user should see in the terminal, however when I inspect the result's stderr, nothing appears to be captured. So it seems that stderr is no longer properly being captured in the latest click release. The same exact output is available to the user in both versions of click, and when I run the command locally and pipe stdout/stderr to different files they are properly separated.

Will have to file an issue and a minimal reproduction case.

### What was the solution? (How)

Remove the over-specific assertion. I am also limiting click to an older version since there appears to be some more changes that breaking our tests around result codes

```
FAILED test/unit/deadline_client/cli/test_cli.py::test_cli_debug_logging_on - subprocess.CalledProcessError: Command '['/Users/morgane/Library/Application Support/hatch/env/virtual/deadline/7XR_zEB6/deadline/bin/python', '-m', 'deadline', '--log-level', 'DEBUG',...
FAILED test/unit/deadline_client/cli/test_cli.py::test_cli_group_without_command[config] - assert 2 == 0
FAILED test/unit/deadline_client/cli/test_cli.py::test_cli_group_without_command[farm] - assert 2 == 0
FAILED test/unit/deadline_client/cli/test_cli.py::test_cli_group_without_command[queue] - assert 2 == 0
FAILED test/unit/deadline_client/cli/test_cli.py::test_cli_group_without_command[bundle] - assert 2 == 0
```

### What is the impact of this change?

Working tests!

### How was this change tested?

Ran it locally.

Before the change
```
test/integ/cli/test_cli_attachment.py::TestAttachment::test_attachment_s3_cross_account_access_denied 
[gw0] [  1%] FAILED test/integ/cli/test_cli_attachment.py::TestAttachment::test_attachment_s3_cross_account_access_denied 
```

After the change
```
test/integ/cli/test_cli_attachment.py::TestAttachment::test_attachment_s3_cross_account_access_denied 
[gw0] [  1%] PASSED test/integ/cli/test_cli_attachment.py::TestAttachment::test_attachment_s3_cross_account_access_denied 
```

### Was this change documented?

N/A

### Does this PR introduce new dependencies?

N/A

### Is this a breaking change?

N/A

### Does this change impact security?
N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
