### PR TITLE
fix: Queue drop down widget does not expand to full width of the row

### DIFF
--- a/src/deadline/client/ui/dialogs/deadline_config_dialog.py
+++ b/src/deadline/client/ui/dialogs/deadline_config_dialog.py
@@ -242,6 +242,8 @@ class DeadlineWorkstationConfigWidget(QWidget):
         layout.addRow(default_farm_box_label, self.default_farm_box)
 
     def _build_farm_settings_ui(self, group, layout):
+        layout.setFieldGrowthPolicy(QFormLayout.ExpandingFieldsGrow)
+
         self.default_queue_box = DeadlineQueueListComboBox(parent=group)
         default_queue_box_label = self.labels["defaults.queue_id"] = QLabel("Default queue")
         self.default_queue_box.box.currentIndexChanged.connect(self.default_queue_changed)
@@ -653,7 +655,8 @@ class _DeadlineResourceListComboBox(QWidget):
         self.box = QComboBox(parent=self)
         layout = QHBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
-        layout.addWidget(self.box)
+        layout.addWidget(self.box, stretch=1)
+
         self.refresh_button = QPushButton("")
         layout.addWidget(self.refresh_button)
         self.refresh_button.setIcon(QApplication.style().standardIcon(QStyle.SP_BrowserReload))


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-maya/issues/258

### What was the problem/requirement? (What/Why)
- Deadline's config gui has several drop downs for Queue and Storage profile selection.
- The rows for Queue and Storage profile do not make maximum use of the width of the widget and truncate queue names.
- This is a usability issue that users cannot see the full Queue or Storage profile name.

### What was the solution? (How)
- Tried a few different approaches like changing the box width of the combo box and combo box's layout. These do not work.
- Finally changed the parent layout's growth policy. The default policy is QFormLayout.FieldsStayAtSizeHint (Default), Fields remain at their size hint. 
- To fix this, I am using QFormLayout.ExpandingFieldsGrow, Fields with an expanding size policy will grow to fill available space

### What is the impact of this change?
- Better usability! See the screenshot below. 

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests?
<img width="672" alt="Screenshot 2025-05-13 at 6 47 24 PM" src="https://github.com/user-attachments/assets/afc97def-3b68-465f-9d09-18758e24a2c7" />

Yes

- Have you run the integration tests?
No, this is a gui fix.

- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass.
No.

### Was this change documented?
Not Applicable.

### Does this PR introduce new dependencies?

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [X] This PR does not add any new dependencies.

### Is this a breaking change?
No

### Does this change impact security?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
