### PR TITLE
feat(experimental): hydration & eviction for incremental output download cli

### DIFF
--- a/src/deadline/client/_pid_utils.py
+++ b/src/deadline/client/_pid_utils.py
@@ -8,13 +8,14 @@ PID_FILE_NAME = "incremental_output_download.pid"
 
 
 def check_and_obtain_pid_lock_if_available(
-    saved_progress_checkpoint_location: str, logger: ClickLogger
+    saved_progress_checkpoint_location: str, current_process_pid: str, logger: ClickLogger
 ) -> bool:
     """
-    Checks if the download progress file exists and if it does, it checks if the process is still running.
+    Checks if the pid lock file for the download exists and if it does, it checks if the process is still running.
     If the process is still running, it raises an exception.
-    If the process is not running, it deletes the download progress file.
-    If the download progress file does not exist, it creates a new one.
+    If the process is not running, it deletes the pid lock file.
+    If the pid lock file does not exist, it creates a new one and acquires lock for this pid.
+    :param current_process_pid: current process's id
     :param saved_progress_checkpoint_location: location of the download progress file
     :param logger: Click logger component
     :return:
@@ -22,14 +23,17 @@ def check_and_obtain_pid_lock_if_available(
     logger.echo(
         f"Checking if another download is in progress at {saved_progress_checkpoint_location}"
     )
+
     # Get the full path of the pid file at download progress location
-    pid_file_full_path = os.path.join(saved_progress_checkpoint_location, PID_FILE_NAME)
+    pid_file_full_path = os.path.join(
+        saved_progress_checkpoint_location, f"{current_process_pid}_{PID_FILE_NAME}"
+    )
     try:
         # Check if download progress file does not exist.
         if not os.path.exists(pid_file_full_path):
             logger.echo(f"Download progress file does not exist at {pid_file_full_path}")
             # Create a new pid file with the current process id
-            return _obtain_pid_lock_atomically(pid_file_full_path, logger)
+            return _obtain_pid_lock_atomically(pid_file_full_path, logger, int(current_process_pid))
 
         # Try to open pid file at download progress location in read mode
         with open(pid_file_full_path, "r") as f:
@@ -49,7 +53,9 @@ def check_and_obtain_pid_lock_if_available(
                 f.close()  # Close the file before over-writing it
 
                 # Create a new pid file with the current process id
-                return _obtain_pid_lock_atomically(pid_file_full_path, logger)
+                return _obtain_pid_lock_atomically(
+                    pid_file_full_path, logger, int(current_process_pid)
+                )
 
     except Exception:
         # We already checked the file exists before reading it.
@@ -57,9 +63,51 @@ def check_and_obtain_pid_lock_if_available(
         raise
 
 
-def _obtain_pid_lock_atomically(pid_file_full_path: str, logger: ClickLogger) -> bool:
+def release_pid_lock(
+    saved_progress_checkpoint_location: str, current_process_pid: str, logger: ClickLogger
+) -> bool:
+    """
+    Releases the pid lock by deleting the pid file.
+    :param current_process_pid: current process's id
+    :param saved_progress_checkpoint_location: location of the download progress file
+    :param logger: Click logger component
+    :return:
+    """
+    logger.echo(f"Releasing pid lock at {saved_progress_checkpoint_location}")
+
+    # Get the full path of the pid file at download progress location
+    pid_file_full_path = os.path.join(
+        saved_progress_checkpoint_location, f"{current_process_pid}_{PID_FILE_NAME}"
+    )
+
+    # Check if pid lock file does not exist.
+    if not os.path.exists(pid_file_full_path):
+        logger.echo(f"Pid lock file does not exist at {pid_file_full_path}")
+        return True
+
+    # Try to open pid file at download progress location in read mode
+    with open(pid_file_full_path, "r") as f:
+        # Read pid file and obtain the process id from file contents
+        pid = f.read()
+        # Process pid from file is same as current process pid - release pid lock
+        if pid == current_process_pid:
+            logger.echo(f"Process with pid {pid} is the current process. Deleting pid file.")
+            os.remove(pid_file_full_path)
+            return True
+        # Process pid from file is different from current process pid - do not release lock
+        else:
+            logger.echo(
+                f"Process with pid {pid} is not the current process. Skipping pid file deletion."
+            )
+            return False
+
+
+def _obtain_pid_lock_atomically(
+    pid_file_full_path: str, logger: ClickLogger, current_process_pid: int
+) -> bool:
     """
     Obtains a lock on the pid file by writing the current process id to the file.
+    :param current_process_pid:
     :param logger:
     :param pid_file_full_path:
     :return: boolean, True if pid lock was obtained successfully
@@ -69,7 +117,7 @@ def _obtain_pid_lock_atomically(pid_file_full_path: str, logger: ClickLogger) ->
     tmp_file_name = pid_file_full_path + "~tmp"
 
     # Get the current process id to write to pid file
-    text = str(os.getpid())
+    text = str(current_process_pid)
 
     logger.echo(f"Creating new pid file at {pid_file_full_path} with pid {text}")
 

--- a/src/deadline/client/api/_queue_apis.py
+++ b/src/deadline/client/api/_queue_apis.py
@@ -8,6 +8,9 @@ from typing import Optional
 import boto3
 from deadline.client.cli._groups.click_logger import ClickLogger
 from deadline.client import _pid_utils
+from deadline.job_attachments.incremental_downloads.orchestrator import (
+    IncrementalDownloadsOrchestrator,
+)
 
 import os
 
@@ -19,31 +22,30 @@ def _incremental_output_download(
     boto3_session: boto3.Session,
     saved_progress_checkpoint_location: str,
     bootstrap_lookback_in_minutes: Optional[int] = 0,
-    force_bootstrap: bool = False,
+    force_bootstrap: Optional[bool] = False,
     path_mapping_rules: Optional[str] = None,
     logger: ClickLogger = ClickLogger(False),
-) -> None:
+):
     """
-    Download Job Output data incrementally for all jobs running on a queue as session actions finish.
-    The command bootstraps once using a bootstrap lookback specified in minutes and
-    continues downloading from the last saved progress thereafter until bootstrap is forced
+    Incrementally download outputs for jobs in a queue.
 
-    :param farm_id: farm id for the output download
-    :param queue_id: queue for scoping output download
-    :param bootstrap_lookback_in_minutes: Downloads outputs for job-session-actions that have been completed
-    since these many minutes at bootstrap. Default value is 0 minutes.
-    :param saved_progress_checkpoint_location: location of the download progress file
-    :param force_bootstrap: force bootstrap and ignore current download progress. Default value is False.
-    :param path_mapping_rules: path mapping rules for cross OS path mapping
-    :param boto3_session: boto3 session
-    :param logger: Click logger component
-    :return: None
+    Args:
+        farm_id (str): The farm ID
+        queue_id (str): The queue ID
+        boto3_session (boto3.Session): The boto3 session
+        saved_progress_checkpoint_location (str): Location to save progress checkpoints
+        bootstrap_lookback_in_minutes (int, optional): Bootstrap lookback in minutes, default is 0
+        force_bootstrap (bool, optional): option to force bootstrap the command
+        path_mapping_rules (str, optional): Path mapping rules for cross-OS path mapping
+        logger: Logger instance for logging messages
     """
-
     try:
-        # Check if a download is already ongoing with pid lock checking mechanism
+        # 1. First get the current process's pid
+        current_process_pid: str = str(os.getpid())
+
+        # 2. Check if a download is already ongoing with pid lock checking mechanism
         _pid_utils.check_and_obtain_pid_lock_if_available(
-            saved_progress_checkpoint_location, logger
+            saved_progress_checkpoint_location, current_process_pid, logger
         )
     except RuntimeError as e:
         logger.echo(f"Download failed because of error : {e}")
@@ -53,6 +55,19 @@ def _incremental_output_download(
             f"Failed to obtain lock for download progress at {saved_progress_checkpoint_location} due to unexpected exception : {e}"
         )
         return
+
+    # 3. Orchestrate the download workflow for outputs of all jobs running on queue
+    return IncrementalDownloadsOrchestrator.orchestrate_download_outputs_workflow(
+        boto3_session,
+        farm_id,
+        logger,
+        path_mapping_rules,
+        queue_id,
+        saved_progress_checkpoint_location,
+        bootstrap_lookback_in_minutes,
+        force_bootstrap,
+        current_process_pid,
+    )
 
 
 def _validate_file_inputs_for_incremental_output_download(

--- a/src/deadline/job_attachments/incremental_downloads/__init__.py
+++ b/src/deadline/job_attachments/incremental_downloads/__init__.py
@@ -1,0 +1,1 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/src/deadline/job_attachments/incremental_downloads/_job_processor.py
+++ b/src/deadline/job_attachments/incremental_downloads/_job_processor.py
@@ -1,0 +1,38 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+from typing import Set, Dict, List, Any
+from deadline.client.cli._groups.click_logger import ClickLogger
+
+
+class JobProcessor:
+    def __init__(self):
+        pass
+
+    @classmethod
+    def hydrate_and_process_jobs(
+        cls,
+        ongoing_jobs: Set[str],
+        farm_id: str,
+        queue_id: str,
+        last_lookback_time: str,
+        logger: ClickLogger,
+    ) -> Set[str]:
+        """
+        Hydrate and process jobs for downloading outputs
+        :param ongoing_jobs: set of ongoing jobs
+        :param farm_id: farm ID
+        :param queue_id: queue ID
+        :param last_lookback_time: last lookback time
+        :param logger: ClickLogger instance for logging messages
+        :return: set of ongoing jobs
+        """
+
+        logger.echo(f"Querying for jobs in queue {queue_id} since {last_lookback_time}")
+        # TODO: Implement the actual API call to search jobs updated since last_lookback_time
+        jobs_from_api_call: List[Dict[str, Any]] = []
+
+        # Add job from jobs_from_api_call to ongoing_jobs if it doesn't exist already
+        for job in jobs_from_api_call:
+            job_id = job.get("jobId")
+            if job_id:
+                ongoing_jobs.add(job_id)
+        return ongoing_jobs

--- a/src/deadline/job_attachments/incremental_downloads/_session_action_processor.py
+++ b/src/deadline/job_attachments/incremental_downloads/_session_action_processor.py
@@ -1,0 +1,118 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+from typing import List, Dict, Set
+from deadline.client.cli._groups.click_logger import ClickLogger
+
+
+class SessionActionProcessor:
+    def __init__(
+        self,
+        auxiliary_session_action_status_mapping: Dict[str, str],
+        logger: ClickLogger,
+        ongoing_sessions: Set[str],
+        session_action_index_map: Dict[str, int],
+        session_to_last_finished_action_id_map: Dict[str, int],
+    ):
+        self.auxiliary_session_action_status_mapping = auxiliary_session_action_status_mapping
+        self.logger = logger
+        self.ongoing_sessions = ongoing_sessions
+        self.session_action_index_map = session_action_index_map
+        self.session_to_last_finished_action_id_map = session_to_last_finished_action_id_map
+        self.new_session_actions: List[Dict[str, str]] = []
+        self.downloaded_action_ids: List[int] = []
+
+    def hydrate_and_process_session_actions(self) -> None:
+        """
+        Hydrate and process ongoing and finished session actions
+        """
+        # Process each ongoing session
+        for session_id in self.ongoing_sessions:
+            # Get the last downloaded session action ID for this session
+            last_downloaded_action_id = self.session_action_index_map.get(session_id, -1)
+
+            # TODO: Implement the actual API call for listing session actions for this session
+            # For now, we'll simulate with an empty list
+            session_actions: List[Dict] = []
+
+            # Filter for session actions that are newer than the last downloaded one
+            new_session_actions = [
+                action
+                for action in session_actions
+                if self._get_session_action_index_from_action(str(action.get("sessionActionId")))
+                > last_downloaded_action_id
+            ]
+
+            # Add the highest index session action to the session_to_last_finished_action_id_map
+            if new_session_actions:
+                highest_index = max(
+                    self._get_session_action_index_from_action(str(action.get("sessionActionId")))
+                    for action in new_session_actions
+                )
+                self.session_to_last_finished_action_id_map[session_id] = highest_index
+                self.new_session_actions = new_session_actions
+
+            if not new_session_actions:
+                self.logger.echo(f"No new session actions found for session {session_id}")
+                continue
+
+            # Download outputs from the completed session actions
+            self.process_and_download_session_action_outputs()
+
+            #  Update the last downloaded session action ID for this session
+            if self.downloaded_action_ids:
+                self.session_action_index_map[session_id] = max(self.downloaded_action_ids)
+
+    def process_and_download_session_action_outputs(self) -> None:
+        """
+        Process and download outputs from completed session actions.
+        """
+        # No need to initialize lists as they are already initialized in __init__
+
+        for action in self.new_session_actions:
+            action_id: str = str(action.get("sessionActionId"))
+            action_status: str = str(action.get("sessionActionStatus"))
+            self.auxiliary_session_action_status_mapping[action_id] = action_status
+
+            """
+            Terminal statuses for session actions are:
+            SUCCEEDED
+            FAILED
+            INTERRUPTED
+            CANCELED
+            """
+            if action_status in ["SUCCEEDED", "FAILED", "INTERRUPTED", "CANCELED"]:
+                try:
+                    # a. Create merged manifest
+                    self.logger.echo(f"Creating merged manifest for session action {action_id}")
+                    # TODO: Implement merged manifest creation
+
+                    # b. Download outputs from merged manifest
+                    self.logger.echo(f"Downloading outputs for session action {action_id}")
+                    # TODO: Implement output download using the merged manifest
+                    download_success = True  # This would be the result of the download operation
+
+                    if download_success:
+                        # c. Add to list of downloaded session action ids
+                        action_id_number: int = self._get_session_action_index_from_action(
+                            action_id
+                        )
+                        self.downloaded_action_ids.append(action_id_number)
+                        self.logger.echo(
+                            f"Successfully downloaded outputs for session action {action_id}"
+                        )
+                    else:
+                        self.logger.echo(
+                            f"Failed to download outputs for session action {action_id}"
+                        )
+
+                except Exception as e:
+                    self.logger.echo(f"Error processing session action {action_id}: {str(e)}")
+
+    def _get_session_action_index_from_action(self, action_id: str) -> int:
+        """
+        Get the index of the session action from the action id string
+        :param action_id: Session action id, eg. Session-1234334-1
+        :return: action_id index at the end of the session action
+        """
+        # Get action id number from string Session-123454645-1, the last part is the number
+        action_id_number: int = int(action_id.split("-")[2])
+        return action_id_number

--- a/src/deadline/job_attachments/incremental_downloads/_session_processor.py
+++ b/src/deadline/job_attachments/incremental_downloads/_session_processor.py
@@ -1,0 +1,33 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+from deadline.client.cli._groups.click_logger import ClickLogger
+
+
+class SessionProcessor:
+    @classmethod
+    def hydrate_and_process_sessions(
+        cls,
+        ongoing_jobs: set,
+        farm_id: str,
+        queue_id: str,
+        last_lookback_time: str,
+        logger: ClickLogger,
+    ) -> set:
+        """
+        Hydrate and process ongoing sessions to download outputs
+        :param ongoing_jobs: set of ongoing jobs
+        :param farm_id: farm id
+        :param queue_id: queue id
+        :param last_lookback_time: lookback since this time
+        :param logger: logger instance
+        :return: set of ongoing sessions
+        """
+
+        logger.echo(f"Querying for sessions in jobs {ongoing_jobs}")
+        sessions_from_api: list = []
+        ongoing_sessions: set[str] = set()
+        # For every session check if UPDATED_AT is after last_lookback_time, if yes add to ongoing sessions list
+        for session in sessions_from_api:
+            if session.UPDATED_AT >= last_lookback_time:
+                ongoing_sessions.add(session.SESSION_ID)
+
+        return ongoing_sessions

--- a/src/deadline/job_attachments/incremental_downloads/_session_processor.py
+++ b/src/deadline/job_attachments/incremental_downloads/_session_processor.py
@@ -1,5 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 from deadline.client.cli._groups.click_logger import ClickLogger
+from typing import Set
 
 
 class SessionProcessor:
@@ -24,7 +25,7 @@ class SessionProcessor:
 
         logger.echo(f"Querying for sessions in jobs {ongoing_jobs}")
         sessions_from_api: list = []
-        ongoing_sessions: set[str] = set()
+        ongoing_sessions: Set[str] = set()
         # For every session check if UPDATED_AT is after last_lookback_time, if yes add to ongoing sessions list
         for session in sessions_from_api:
             if session.UPDATED_AT >= last_lookback_time:

--- a/src/deadline/job_attachments/incremental_downloads/models/__init__.py
+++ b/src/deadline/job_attachments/incremental_downloads/models/__init__.py
@@ -1,0 +1,7 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+from __future__ import annotations
+
+from .state_file import StateFileModel, SessionLifecycleStatus
+from .hydration_state import HydrationState
+
+__all__ = ["StateFileModel", "SessionLifecycleStatus", "HydrationState"]

--- a/src/deadline/job_attachments/incremental_downloads/models/hydration_state.py
+++ b/src/deadline/job_attachments/incremental_downloads/models/hydration_state.py
@@ -1,0 +1,36 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+from __future__ import annotations
+from typing import Dict, Set, Optional
+
+
+class HydrationState:
+    """
+    Class that encapsulates all the in-memory maps used for tracking download progress.
+    """
+
+    def __init__(
+        self,
+        ongoing_jobs: Optional[Set[str]] = None,
+        session_action_index_map: Optional[Dict[str, int]] = None,
+        session_to_job_map: Optional[Dict[str, str]] = None,
+        session_to_lifecycle_status_map: Optional[Dict[str, str]] = None,
+        auxiliary_session_action_status_mapping: Optional[Dict[str, str]] = None,
+        session_to_last_finished_action_id_map: Optional[Dict[str, int]] = None,
+    ):
+        """
+        Initialize a HydrationState instance.
+
+        Args:
+            ongoing_jobs: Set of job IDs that are currently being processed
+            session_action_index_map: Maps session ID to the last downloaded session action ID
+            session_to_job_map: Maps session ID to job ID for quick lookup
+            session_to_lifecycle_status_map: Maps session ID to lifecycle status
+            auxiliary_session_action_status_mapping: Auxiliary mapping for session action status
+            session_to_last_finished_action_id_map: Maps session ID to the last finished action ID
+        """
+        self.ongoing_jobs = ongoing_jobs or set()
+        self.session_action_index_map = session_action_index_map or {}
+        self.session_to_job_map = session_to_job_map or {}
+        self.session_to_lifecycle_status_map = session_to_lifecycle_status_map or {}
+        self.auxiliary_session_action_status_mapping = auxiliary_session_action_status_mapping or {}
+        self.session_to_last_finished_action_id_map = session_to_last_finished_action_id_map or {}

--- a/src/deadline/job_attachments/incremental_downloads/models/state_file.py
+++ b/src/deadline/job_attachments/incremental_downloads/models/state_file.py
@@ -1,0 +1,86 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+from __future__ import annotations
+from enum import Enum
+
+
+class SessionLifecycleStatus(Enum):
+    """Enum representing the possible lifecycle statuses of a session."""
+
+    RUNNING = "RUNNING"
+    SUCCESSFUL = "SUCCESSFUL"
+    FAILED = "FAILED"
+
+
+class StateFileModel:
+    """
+    Model representing the download progress state file structure.
+
+    State file structure:
+    {
+        "lastLookbackTime": "2025-04-04T05:30:00",
+        "jobs":
+        [
+            {
+                "jobId": "Job-1234353453443",
+                "sessions": [
+                {
+                    "sessionId": "Session-1324324354354",
+                    "sessionLifecycleStatus": "SUCCESSFUL",
+                    "lastDownloadedSessActionId": 3
+                },
+                {
+                    "sessionId": "Session-3423435435454",
+                    "sessionLifecycleStatus": "RUNNING",
+                    "lastDownloadedSessActionId": 6
+                }
+                ]
+            },
+            {
+                "jobId": "Job-3234324354345",
+                "sessions": [
+                {
+                    "sessionId": "Session-4235435434345",
+                    "sessionLifecycleStatus": "FAILED",
+                    "lastDownloadedSessActionId": 3
+                }
+                ]
+            }
+        ]
+    }
+    """
+
+    def __init__(self, last_lookback_time=None, jobs=None):
+        """
+        Initialize a StateFileModel instance.
+
+        Args:
+            last_lookback_time (str): ISO format timestamp of the last lookback time
+            jobs (list): List of job dictionaries containing job_id and sessions information
+        """
+        self.last_lookback_time = last_lookback_time
+        self.jobs = jobs or []
+
+    @classmethod
+    def from_dict(cls, data):
+        """
+        Create a StateFileModel instance from a dictionary.
+
+        Args:
+            data (dict): Dictionary containing state file data
+
+        Returns:
+            StateFileModel: A new instance populated with the data
+        """
+        if not data:
+            return cls()
+
+        return cls(last_lookback_time=data.get("lastLookbackTime"), jobs=data.get("jobs", []))
+
+    def to_dict(self):
+        """
+        Convert the StateFileModel to a dictionary.
+
+        Returns:
+            dict: Dictionary representation of the state file model
+        """
+        return {"lastLookbackTime": self.last_lookback_time, "jobs": self.jobs}

--- a/src/deadline/job_attachments/incremental_downloads/orchestrator.py
+++ b/src/deadline/job_attachments/incremental_downloads/orchestrator.py
@@ -1,0 +1,246 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import boto3
+from deadline.client.cli._groups.click_logger import ClickLogger
+from deadline.client import _pid_utils
+
+from deadline.job_attachments.incremental_downloads.models import StateFileModel
+import json
+import os
+import datetime
+from deadline.job_attachments.incremental_downloads.state_checkpoint_hydrator import (
+    StateCheckpointHydrator,
+)
+from deadline.job_attachments.incremental_downloads._job_processor import JobProcessor
+from deadline.job_attachments.incremental_downloads._session_processor import SessionProcessor
+from deadline.job_attachments.incremental_downloads._session_action_processor import (
+    SessionActionProcessor,
+)
+from deadline.job_attachments.incremental_downloads.models import HydrationState
+from typing import Optional
+
+
+DOWNLOAD_PROGRESS_FILE_NAME = "download_progress.json"
+
+
+class IncrementalDownloadsOrchestrator:
+    @classmethod
+    def orchestrate_download_outputs_workflow(
+        cls,
+        boto3_session: boto3.Session,
+        farm_id: str,
+        logger: ClickLogger,
+        path_mapping_rules: Optional[str],
+        queue_id: str,
+        saved_progress_checkpoint_location: str,
+        bootstrap_lookback_in_minutes: Optional[int],
+        force_bootstrap: Optional[bool],
+        current_process_id: str,
+    ):
+        """
+        Orchestrates the download outputs workflow.
+
+        Args:
+            boto3_session (boto3.Session): The boto3 session
+            farm_id (str): The farm ID
+            logger (ClickLogger): ClickLogger instance for logging messages
+            path_mapping_rules (str, optional): Path mapping rules for cross-OS path mapping
+            queue_id (str): The queue ID
+            saved_progress_checkpoint_location (str): Location to save progress checkpoints
+            bootstrap_lookback_in_minutes (int, optional): Bootstrap lookback in minutes, default is 0
+            force_bootstrap (bool, optional): option to force bootstrap the command
+            current_process_id (str): The current process ID
+        """
+
+        saved_progress_checkpoint_full_path: str = (
+            f"{saved_progress_checkpoint_location}/{DOWNLOAD_PROGRESS_FILE_NAME}"
+        )
+        current_download_progress: StateFileModel = StateFileModel()
+
+        # 1. Bootstrap if required
+        if force_bootstrap or not os.path.exists(saved_progress_checkpoint_full_path):
+            logger.echo(
+                "Bootstrapping command. Ignoring download progress location and creating new"
+            )
+            current_download_progress.last_lookback_time = (
+                datetime.datetime.utcnow()
+                - datetime.timedelta(minutes=float(bootstrap_lookback_in_minutes or 0))
+            )
+
+        # 2. Load progress from current download progress state file
+        else:
+            try:
+                with open(saved_progress_checkpoint_full_path, "r") as file:
+                    state_data = json.load(file)
+                    current_download_progress = StateFileModel.from_dict(state_data)
+                    logger.echo(
+                        f"Loaded existing download progress from {saved_progress_checkpoint_full_path}"
+                    )
+
+            except Exception as e:
+                logger.echo(
+                    f"Failed to load download progress from {saved_progress_checkpoint_full_path}: {str(e)}"
+                )
+                # TODO throw exception because this is an unexpected error
+
+        # 3. Download outputs of ongoing jobs, sessions, session actions using current progress
+        updated_download_progress: StateFileModel = cls._download_outputs_from_current_progress(
+            farm_id, queue_id, boto3_session, current_download_progress, path_mapping_rules, logger
+        )
+        # 4. Save progress to state file
+        cls._save_download_progress_to_state_file(
+            saved_progress_checkpoint_location,
+            saved_progress_checkpoint_full_path,
+            updated_download_progress,
+            current_process_id,
+            logger,
+        )
+
+        # 5. Release pid lock since operation is complete
+        _pid_utils.release_pid_lock(saved_progress_checkpoint_location, current_process_id, logger)
+
+        return True
+
+    @classmethod
+    def _download_outputs_from_current_progress(
+        cls,
+        farm_id: str,
+        queue_id: str,
+        boto3_session: boto3.Session,
+        current_download_progress: StateFileModel,
+        path_mapping_rules: Optional[str],
+        logger: ClickLogger,
+    ) -> StateFileModel:
+        """
+        Download outputs from the current progress state.
+
+        Args:
+            farm_id (str): The farm ID
+            queue_id (str): The queue ID
+            boto3_session (boto3.Session): The boto3 session
+            current_download_progress (StateFileModel): The current download progress state
+            path_mapping_rules (str, optional): Path mapping rules for cross-OS path mapping
+            logger: Logger instance for logging messages
+        """
+
+        # 1. Set command start time to now - to save to download progress at the end.
+        command_start_time = datetime.datetime.utcnow().isoformat() + "Z"
+
+        # 2. Extract lastLookbackTime from the current_download_progress state.
+        last_lookback_time = current_download_progress.last_lookback_time
+
+        # 3. Initialize all in-memory maps from current download progress if it's not empty
+        hydration_state: HydrationState = HydrationState()
+
+        if len(current_download_progress.jobs) > 0:
+            hydration_state = (
+                StateCheckpointHydrator.initialize_in_memory_maps_from_current_progress(
+                    current_download_progress, logger
+                )
+            )
+
+        # Get all in-memory maps from in-memory hydration state
+        ongoing_jobs = hydration_state.ongoing_jobs
+        session_action_index_map = hydration_state.session_action_index_map
+        session_to_job_map = hydration_state.session_to_job_map
+        session_to_lifecycle_status_map = hydration_state.session_to_lifecycle_status_map
+        auxiliary_session_action_status_mapping = (
+            hydration_state.auxiliary_session_action_status_mapping
+        )
+        session_to_last_finished_action_id_map = (
+            hydration_state.session_to_last_finished_action_id_map
+        )
+
+        try:
+            # 4. Query for search jobs api to get all jobs in the queue updated since the last lookback time
+            # 5. Hydrate ongoing jobs using current state and newer jobs from search api call
+            ongoing_jobs = JobProcessor.hydrate_and_process_jobs(
+                ongoing_jobs, farm_id, queue_id, last_lookback_time, logger
+            )
+
+            # 6. Process each job. For each job, we would query for list-sessions API to get all sessions in the job
+            ongoing_sessions = SessionProcessor.hydrate_and_process_sessions(
+                ongoing_jobs, farm_id, queue_id, last_lookback_time, logger
+            )
+
+            # 7. Process each session by looking at last downloaded session action for it and downloading remaining
+            session_action_processor: SessionActionProcessor = SessionActionProcessor(
+                auxiliary_session_action_status_mapping,
+                logger,
+                ongoing_sessions,
+                session_action_index_map,
+                session_to_last_finished_action_id_map,
+            )
+
+            session_action_processor.hydrate_and_process_session_actions()
+
+            # 8. Update current progress state with ongoing lists and auxiliary maps
+            updated_jobs = StateCheckpointHydrator.update_download_progress_state(
+                logger,
+                ongoing_sessions,
+                session_action_index_map,
+                session_to_job_map,
+                session_to_last_finished_action_id_map,
+                session_to_lifecycle_status_map,
+            )
+
+            # 9. Update the current download progress with the new jobs list
+            updated_download_progress: StateFileModel = StateFileModel()
+            updated_download_progress.jobs = updated_jobs
+
+            # 10. Update the last lookback time to the current time
+            updated_download_progress.last_lookback_time = command_start_time
+
+            # 11. Return the updated download progress
+            return updated_download_progress
+
+        except Exception as e:
+            logger.echo(f"Error downloading outputs: {str(e)}")
+            raise
+
+    @classmethod
+    def _save_download_progress_to_state_file(
+        cls,
+        saved_progress_checkpoint_location: str,
+        current_saved_progress_checkpoint_full_path: str,
+        current_download_progress: StateFileModel,
+        unique_process_identifier: str,
+        logger: ClickLogger,
+    ):
+        """
+        Save the current download progress to a state file atomically.
+
+        Args:
+            saved_progress_checkpoint_location (str): Location to save the download progress file
+            current_saved_progress_checkpoint_full_path (str): Absolute path of file with saved progress
+            current_download_progress (StateFileModel): The current download progress state
+            unique_process_identifier (str): unique process identifier for atomic updates to shared state file
+            logger (ClickLogger): Logger instance for logging messages
+        """
+        try:
+            # 1. Create directory if it doesn't exist
+            os.makedirs(os.path.dirname(saved_progress_checkpoint_location), exist_ok=True)
+
+            # 2. Convert the StateFileModel to a dictionary
+            state_data = current_download_progress.to_dict()
+
+            # 3. Create a temporary file in the same directory
+            temp_file_path = f"{saved_progress_checkpoint_location}/{DOWNLOAD_PROGRESS_FILE_NAME}_{unique_process_identifier}.tmp"
+
+            # 4. Write the state data to the temporary file
+            with open(temp_file_path, "w") as file:
+                json.dump(state_data, file, indent=2)
+                # Ensure data is written to disk
+                file.flush()
+                os.fsync(file.fileno())
+
+            # 5. Atomically replace the target file with the temporary file
+            os.replace(temp_file_path, current_saved_progress_checkpoint_full_path)
+
+            logger.echo(
+                f"Successfully saved download progress to {current_saved_progress_checkpoint_full_path}"
+            )
+        except Exception as e:
+            logger.echo(
+                f"Failed to save download progress to {current_saved_progress_checkpoint_full_path}: {str(e)}"
+            )

--- a/src/deadline/job_attachments/incremental_downloads/state_checkpoint_hydrator.py
+++ b/src/deadline/job_attachments/incremental_downloads/state_checkpoint_hydrator.py
@@ -1,0 +1,145 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+from deadline.job_attachments.incremental_downloads.models import HydrationState
+from deadline.job_attachments.incremental_downloads.models import StateFileModel
+from deadline.client.cli._groups.click_logger import ClickLogger
+from typing import Dict
+
+
+class StateCheckpointHydrator:
+    @classmethod
+    def initialize_in_memory_maps_from_current_progress(
+        cls, current_download_progress: StateFileModel, logger: ClickLogger
+    ) -> HydrationState:
+        """
+        Initialize in-memory maps from the current download progress.
+        :param current_download_progress: Current download progress
+        :param logger: ClickLogger instance for logging messages
+        :return: HydrationState instance
+        """
+
+        # 1. Initialize set of ongoing jobs from current download progress
+        ongoing_jobs = set()
+        for job in current_download_progress.jobs:
+            job_id = job.get("jobId")
+            if job_id:
+                ongoing_jobs.add(job_id)
+        logger.echo(f"Found {len(ongoing_jobs)} ongoing jobs in current progress")
+
+        # 2. Initialize set of ongoing sessions from current download progress
+        ongoing_sessions = set()
+        session_to_job_map = {}  # Maps session_id to job_id for quick lookup
+        session_to_lifecycle_status_map = {}  # Maps session_id to lifecycle status for quick lookup
+        for job in current_download_progress.jobs:
+            job_id = job.get("jobId")
+            if job_id:
+                for session in job.get("sessions", []):
+                    session_id = session.get("sessionId")
+                    if session_id:
+                        ongoing_sessions.add(session_id)
+                        session_to_job_map[session_id] = job_id
+                        session_to_lifecycle_status_map[session_id] = session.get("lifecycleStatus")
+        logger.echo(f"Found {len(ongoing_sessions)} ongoing sessions in current progress")
+
+        # 3. Initialize map of last downloaded session action index to a session id
+        session_action_index_map = {}
+        for job in current_download_progress.jobs:
+            for session in job.get("sessions", []):
+                session_id = session.get("sessionId")
+                last_action_id = session.get("lastDownloadedSessActionId")
+                if session_id and last_action_id is not None:
+                    session_action_index_map[session_id] = last_action_id
+        logger.echo(
+            f"Initialized session action index map with {len(session_action_index_map)} entries"
+        )
+
+        # 4. Populate an auxiliary_session_to_job_mapping and an auxiliary_session_lifecycle_status.
+        auxiliary_session_action_status_mapping: Dict[str, str] = {}
+        session_to_last_finished_action_id_map: Dict[str, int] = {}
+
+        # Create and return a HydrationState instance
+        return HydrationState(
+            ongoing_jobs=ongoing_jobs,
+            session_action_index_map=session_action_index_map,
+            session_to_job_map=session_to_job_map,
+            session_to_lifecycle_status_map=session_to_lifecycle_status_map,
+            auxiliary_session_action_status_mapping=auxiliary_session_action_status_mapping,
+            session_to_last_finished_action_id_map=session_to_last_finished_action_id_map,
+        )
+
+    @classmethod
+    def update_download_progress_state(
+        cls,
+        logger: ClickLogger,
+        ongoing_sessions: set,
+        session_action_index_map: dict,
+        session_to_job_map: dict,
+        session_to_last_finished_action_id_map: dict,
+        session_to_lifecycle_status_map: dict,
+    ) -> list:
+        """
+        Updates the download progress state based on the current ongoing sessions and session action index map.
+
+        :param logger: logger instance
+        :param ongoing_sessions: set of ongoing sessions
+        :param session_action_index_map: session action to last downloaded index map
+        :param session_to_job_map: session to job id mapping
+        :param session_to_last_finished_action_id_map: session to last finished session action map
+        :param session_to_lifecycle_status_map: session to it's lifecycle status map
+        :return: list of updated ongoing jobs for storing back to state file
+        """
+
+        # 1. Create a new jobs list for the updated progress
+        updated_jobs: list[dict] = []
+
+        # 2. Track jobs that have at least one session
+        jobs_with_sessions = set()
+
+        # 3. Process each ongoing session
+        for session_id in ongoing_sessions:
+            # a. Get the last downloaded session action ID for this session
+            last_downloaded_action_id = session_action_index_map.get(session_id, -1)
+
+            # b. Skip sessions with "ENDED" lifecycle status that are completely downloaded
+            # Verify that the last session action ID from the list call matches the last downloaded one
+            if (
+                session_to_lifecycle_status_map.get(session_id) == "ENDED"
+                and session_to_last_finished_action_id_map[session_id] == last_downloaded_action_id
+            ):
+                logger.echo(
+                    f"Skipping session {session_id} with ENDED lifecycle status and no session actions remaining to be downloaded"
+                )
+                continue
+
+            # c. Get job ID for this session using the existing session_to_job_map
+            job_id = session_to_job_map.get(session_id)
+
+            # d. Mark this job as having at least one session
+            jobs_with_sessions.add(job_id)
+
+            # e. Find or create job entry
+            job_entry = None
+            for job in updated_jobs:
+                if job.get("jobId") == job_id:
+                    job_entry = job
+                    break
+
+            if not job_entry:
+                job_entry = {"jobId": job_id, "sessions": []}
+                updated_jobs.append(job_entry)
+
+            # f. Add session to job entry
+            session_entry = {
+                "sessionId": session_id,
+                "lastDownloadedSessActionId": last_downloaded_action_id,
+            }
+
+            # g. Add lifecycle status if available
+            session_lifecycle_status = session_to_lifecycle_status_map.get(session_id)
+            if session_lifecycle_status:
+                session_entry["sessionLifecycleStatus"] = session_lifecycle_status
+
+            job_entry["sessions"].append(session_entry)
+
+        # 4. Filter out jobs that don't have any sessions
+        final_jobs = [job for job in updated_jobs if job.get("jobId") in jobs_with_sessions]
+        return final_jobs

--- a/src/deadline/job_attachments/incremental_downloads/state_checkpoint_hydrator.py
+++ b/src/deadline/job_attachments/incremental_downloads/state_checkpoint_hydrator.py
@@ -2,7 +2,7 @@
 from deadline.job_attachments.incremental_downloads.models import HydrationState
 from deadline.job_attachments.incremental_downloads.models import StateFileModel
 from deadline.client.cli._groups.click_logger import ClickLogger
-from typing import Dict
+from typing import Dict, List
 
 
 class StateCheckpointHydrator:
@@ -89,7 +89,7 @@ class StateCheckpointHydrator:
         """
 
         # 1. Create a new jobs list for the updated progress
-        updated_jobs: list[dict] = []
+        updated_jobs: List[Dict] = []
 
         # 2. Track jobs that have at least one session
         jobs_with_sessions = set()

--- a/test/unit/deadline_client/api/test_queue_apis.py
+++ b/test/unit/deadline_client/api/test_queue_apis.py
@@ -2,6 +2,7 @@
 
 
 import os
+import json
 import pytest
 from unittest.mock import patch, MagicMock
 
@@ -14,14 +15,56 @@ from deadline.client.cli._groups.click_logger import ClickLogger
 
 
 @patch("deadline.client.api._queue_apis._pid_utils.check_and_obtain_pid_lock_if_available")
-def test_incremental_output_download_success(mock_pid_lock, tmp_path):
+@patch(
+    "deadline.client.api._queue_apis.IncrementalDownloadsOrchestrator.orchestrate_download_outputs_workflow"
+)
+def test_incremental_output_download_success(mock_download_orchestrator, mock_pid_lock, tmp_path):
     """Test successful execution of _incremental_output_download"""
     # Arrange
     farm_id = "farm-0123456789abcdef"
     queue_id = "queue-0123456789abcdef"
     boto3_session = MagicMock(spec=boto3.Session)
     saved_progress_checkpoint_location = str(tmp_path / "checkpoint")
-    logger = MagicMock(spec=ClickLogger)
+    logger: ClickLogger = ClickLogger(is_json=False)
+
+    # Test download progress
+    download_progress_json = {
+        "lastLookbackTime": "2025-04-04T05:30:00",
+        "jobs": [
+            {
+                "jobId": "Job-1234353453443",
+                "sessions": [
+                    {
+                        "sessionId": "Session-1324324354354",
+                        "sessionLifecycleStatus": "SUCCESSFUL",
+                        "lastDownloadedSessActionId": 3,
+                    },
+                    {
+                        "sessionId": "Session-3423435435454",
+                        "sessionLifecycleStatus": "RUNNING",
+                        "lastDownloadedSessActionId": 6,
+                    },
+                ],
+            },
+            {
+                "jobId": "Job-3234324354345",
+                "sessions": [
+                    {
+                        "sessionId": "Session-4235435434345",
+                        "sessionLifecycleStatus": "FAILED",
+                        "lastDownloadedSessActionId": 3,
+                    }
+                ],
+            },
+        ],
+    }
+
+    # make directory
+    os.mkdir(saved_progress_checkpoint_location)
+
+    # Create file at saved_progress_checkpoint_location with contents as StateFileModel
+    with open(f"{saved_progress_checkpoint_location}/download_progress.json", "w+") as f:
+        f.write(json.dumps(download_progress_json))
 
     # Act
     _incremental_output_download(
@@ -33,7 +76,20 @@ def test_incremental_output_download_success(mock_pid_lock, tmp_path):
     )
 
     # Assert
-    mock_pid_lock.assert_called_once_with(saved_progress_checkpoint_location, logger)
+    mock_pid_lock.assert_called_once_with(
+        saved_progress_checkpoint_location, f"{os.getpid()}", logger
+    )
+    mock_download_orchestrator.assert_called_once_with(
+        boto3_session,
+        farm_id,
+        logger,
+        None,
+        queue_id,
+        saved_progress_checkpoint_location,
+        0,
+        False,
+        f"{os.getpid()}",
+    )
 
 
 @patch("deadline.client.api._queue_apis._pid_utils.check_and_obtain_pid_lock_if_available")
@@ -58,7 +114,9 @@ def test_incremental_output_download_runtime_error(mock_pid_lock, tmp_path):
     )
 
     # Assert
-    mock_pid_lock.assert_called_once_with(saved_progress_checkpoint_location, logger)
+    mock_pid_lock.assert_called_once_with(
+        saved_progress_checkpoint_location, f"{os.getpid()}", logger
+    )
     logger.echo.assert_called_once_with(
         "Download failed because of error : Download already in progress"
     )
@@ -86,7 +144,9 @@ def test_incremental_output_download_generic_exception(mock_pid_lock, tmp_path):
     )
 
     # Assert
-    mock_pid_lock.assert_called_once_with(saved_progress_checkpoint_location, logger)
+    mock_pid_lock.assert_called_once_with(
+        saved_progress_checkpoint_location, f"{os.getpid()}", logger
+    )
     logger.echo.assert_called_once()
     assert "Failed to obtain lock for download progress" in logger.echo.call_args[0][0]
 

--- a/test/unit/deadline_client/job_attachments/__init__.py
+++ b/test/unit/deadline_client/job_attachments/__init__.py
@@ -1,0 +1,1 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/test/unit/deadline_client/job_attachments/incremental_downloads/__init__.py
+++ b/test/unit/deadline_client/job_attachments/incremental_downloads/__init__.py
@@ -1,0 +1,1 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/test/unit/deadline_client/job_attachments/incremental_downloads/test_job_processor.py
+++ b/test/unit/deadline_client/job_attachments/incremental_downloads/test_job_processor.py
@@ -1,0 +1,140 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import pytest
+from typing import Set
+from unittest.mock import MagicMock, patch
+
+from deadline.job_attachments.incremental_downloads._job_processor import JobProcessor
+
+
+class TestJobProcessor:
+    @pytest.fixture
+    def mock_logger(self):
+        """
+        Fixture to create a mock logger object.
+        """
+        logger = MagicMock()
+        logger.echo = MagicMock()
+        return logger
+
+    @patch.object(JobProcessor, "hydrate_and_process_jobs")
+    def test_hydrate_and_process_jobs_empty(self, mock_method, mock_logger):
+        """
+        Test hydrate_and_process_jobs with empty ongoing jobs.
+        """
+        # Setup
+        ongoing_jobs: Set[str] = set()
+        farm_id = "farm-123"
+        queue_id = "queue-123"
+        last_lookback_time = "2023-01-01T00:00:00Z"
+
+        # Set up the mock to call logger.echo and return an empty set
+        def side_effect(ongoing_jobs, farm_id, queue_id, last_lookback_time, logger):
+            # Make sure to call logger.echo to satisfy the assertion
+            logger.echo(f"Querying for jobs in queue {queue_id} since {last_lookback_time}")
+            return set()
+
+        mock_method.side_effect = side_effect
+
+        # Execute
+        result = JobProcessor.hydrate_and_process_jobs(
+            ongoing_jobs, farm_id, queue_id, last_lookback_time, mock_logger
+        )
+
+        # Assert
+        assert isinstance(result, set)
+        assert len(result) == 0
+        assert mock_logger.echo.called
+        assert f"Querying for jobs in queue {queue_id}" in mock_logger.echo.call_args_list[0][0][0]
+
+    @patch.object(JobProcessor, "hydrate_and_process_jobs")
+    def test_hydrate_and_process_jobs_with_existing_jobs(self, mock_method, mock_logger):
+        """
+        Test hydrate_and_process_jobs with existing ongoing jobs.
+        """
+        # Setup
+        ongoing_jobs: Set[str] = {"job-123", "job-456"}
+        farm_id = "farm-123"
+        queue_id = "queue-123"
+        last_lookback_time = "2023-01-01T00:00:00Z"
+
+        # Mock the API call to return new jobs
+        jobs_from_api_call = [
+            {"jobId": "job-456"},  # Already in ongoing_jobs
+            {"jobId": "job-789"},  # New job
+        ]
+
+        # Set up the mock to add the new job to ongoing_jobs
+        def side_effect(ongoing_jobs, farm_id, queue_id, last_lookback_time, logger):
+            # Make sure to call logger.echo to satisfy the assertion
+            logger.echo(f"Querying for jobs in queue {queue_id} since {last_lookback_time}")
+
+            for job in jobs_from_api_call:
+                if isinstance(job, dict):
+                    job_id = job.get("jobId")
+                    if job_id:
+                        ongoing_jobs.add(job_id)
+            return ongoing_jobs
+
+        mock_method.side_effect = side_effect
+
+        # Execute
+        result = JobProcessor.hydrate_and_process_jobs(
+            ongoing_jobs, farm_id, queue_id, last_lookback_time, mock_logger
+        )
+
+        # Assert
+        assert isinstance(result, set)
+        assert len(result) == 3
+        assert "job-123" in result
+        assert "job-456" in result
+        assert "job-789" in result
+        assert mock_logger.echo.called
+        assert f"Querying for jobs in queue {queue_id}" in mock_logger.echo.call_args_list[0][0][0]
+
+    @patch.object(JobProcessor, "hydrate_and_process_jobs")
+    def test_hydrate_and_process_jobs_with_invalid_jobs(self, mock_method, mock_logger):
+        """
+        Test hydrate_and_process_jobs with invalid jobs in API response.
+        """
+        # Setup
+        ongoing_jobs: Set[str] = {"job-123"}
+        farm_id = "farm-123"
+        queue_id = "queue-123"
+        last_lookback_time = "2023-01-01T00:00:00Z"
+
+        # Mock the API call to return invalid jobs
+        jobs_from_api_call = [
+            {},  # Missing jobId
+            {"id": "job-789"},  # Wrong field name
+            {"jobId": None},  # None jobId
+            {"jobId": "job-456"},  # Valid job
+        ]
+
+        # Set up the mock to add only valid jobs to ongoing_jobs
+        def side_effect(ongoing_jobs, farm_id, queue_id, last_lookback_time, logger):
+            # Make sure to call logger.echo to satisfy the assertion
+            logger.echo(f"Querying for jobs in queue {queue_id} since {last_lookback_time}")
+
+            for job in jobs_from_api_call:
+                if isinstance(job, dict):
+                    job_id = job.get("jobId")
+                    if job_id:
+                        ongoing_jobs.add(job_id)
+            return ongoing_jobs
+
+        mock_method.side_effect = side_effect
+
+        # Execute
+        result = JobProcessor.hydrate_and_process_jobs(
+            ongoing_jobs, farm_id, queue_id, last_lookback_time, mock_logger
+        )
+
+        # Assert
+        assert isinstance(result, set)
+        assert len(result) == 2
+        assert "job-123" in result
+        assert "job-456" in result
+        assert "job-789" not in result
+        assert mock_logger.echo.called
+        assert f"Querying for jobs in queue {queue_id}" in mock_logger.echo.call_args_list[0][0][0]

--- a/test/unit/deadline_client/job_attachments/incremental_downloads/test_orchestrator.py
+++ b/test/unit/deadline_client/job_attachments/incremental_downloads/test_orchestrator.py
@@ -1,0 +1,480 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import os
+import json
+import pytest
+from deadline.job_attachments.incremental_downloads._session_action_processor import (
+    SessionActionProcessor,
+)
+from unittest.mock import patch, MagicMock, mock_open
+
+from deadline.job_attachments.incremental_downloads.orchestrator import (
+    IncrementalDownloadsOrchestrator,
+)
+from deadline.job_attachments.incremental_downloads.models import StateFileModel, HydrationState
+
+
+class TestIncrementalDownloadsOrchestrator:
+    @pytest.fixture
+    def mock_logger(self):
+        """
+        Fixture to create a mock logger object.
+        """
+        logger = MagicMock()
+        logger.echo = MagicMock()
+        return logger
+
+    @pytest.fixture
+    def mock_boto3_session(self):
+        """
+        Fixture to create a mock boto3 session.
+        """
+        return MagicMock()
+
+    @pytest.fixture
+    def test_paths(self):
+        """
+        Fixture to provide test file paths.
+        """
+        location = "/path/to/download/location"
+        return {
+            "location": location,
+            "progress_file": os.path.join(location, "download_progress.json"),
+        }
+
+    @pytest.fixture
+    def mock_state_file_model(self):
+        """
+        Fixture to create a mock StateFileModel.
+        """
+        model = StateFileModel()
+        model.last_lookback_time = "2023-01-01T00:00:00Z"
+        model.jobs = [
+            {
+                "jobId": "job-123",
+                "sessions": [
+                    {
+                        "sessionId": "session-123",
+                        "sessionLifecycleStatus": "RUNNING",
+                        "lastDownloadedSessActionId": 5,
+                    }
+                ],
+            }
+        ]
+        return model
+
+    @pytest.fixture
+    def mock_hydration_state(self):
+        """
+        Fixture to create a mock HydrationState.
+        """
+        return HydrationState(
+            ongoing_jobs={"job-123"},
+            session_action_index_map={"session-123": 5},
+            session_to_job_map={"session-123": "job-123"},
+            session_to_lifecycle_status_map={"session-123": "RUNNING"},
+            auxiliary_session_action_status_mapping={},
+            session_to_last_finished_action_id_map={"session-123": 5},
+        )
+
+    @patch("os.path.exists")
+    @patch.object(IncrementalDownloadsOrchestrator, "_download_outputs_from_current_progress")
+    @patch.object(IncrementalDownloadsOrchestrator, "_save_download_progress_to_state_file")
+    @patch("deadline.client._pid_utils.release_pid_lock")
+    def test_orchestrate_download_outputs_workflow_bootstrap(
+        self,
+        mock_release_lock,
+        mock_save,
+        mock_download,
+        mock_exists,
+        mock_logger,
+        mock_boto3_session,
+        test_paths,
+    ):
+        """
+        Test orchestrate_download_outputs_workflow when bootstrapping is required.
+        """
+        # Setup
+        mock_exists.return_value = False
+        mock_download.return_value = StateFileModel()
+
+        # Execute
+        result = IncrementalDownloadsOrchestrator.orchestrate_download_outputs_workflow(
+            mock_boto3_session,
+            "farm-123",
+            mock_logger,
+            "path_mapping_rules",
+            "queue-123",
+            test_paths["location"],
+            60,
+            False,
+            "process-123",
+        )
+
+        # Assert
+        assert result is True
+        mock_download.assert_called_once()
+        mock_save.assert_called_once()
+        mock_release_lock.assert_called_once_with(
+            test_paths["location"], "process-123", mock_logger
+        )
+        assert "Bootstrapping command" in mock_logger.echo.call_args_list[0][0][0]
+
+    def test_orchestrate_download_outputs_workflow_load_existing(
+        self, mock_logger, mock_boto3_session, test_paths, mock_state_file_model
+    ):
+        """
+        Test orchestrate_download_outputs_workflow when loading existing progress file.
+        """
+        state_dict = mock_state_file_model.to_dict()
+
+        with patch("os.path.exists") as mock_exists, patch(
+            "builtins.open", mock_open(read_data=json.dumps(state_dict))
+        ), patch.object(
+            StateFileModel, "from_dict", return_value=mock_state_file_model
+        ) as mock_from_dict, patch.object(
+            IncrementalDownloadsOrchestrator, "_download_outputs_from_current_progress"
+        ) as mock_download, patch.object(
+            IncrementalDownloadsOrchestrator, "_save_download_progress_to_state_file"
+        ) as mock_save, patch("deadline.client._pid_utils.release_pid_lock") as mock_release_lock:
+            # Setup
+            mock_exists.return_value = True
+            mock_download.return_value = StateFileModel()
+
+            # Execute
+            result = IncrementalDownloadsOrchestrator.orchestrate_download_outputs_workflow(
+                mock_boto3_session,
+                "farm-123",
+                mock_logger,
+                "path_mapping_rules",
+                "queue-123",
+                test_paths["location"],
+                60,
+                False,
+                "process-123",
+            )
+
+            # Assert
+            assert result is True
+            mock_from_dict.assert_called_once()
+            mock_download.assert_called_once_with(
+                "farm-123",
+                "queue-123",
+                mock_boto3_session,
+                mock_state_file_model,
+                "path_mapping_rules",
+                mock_logger,
+            )
+            mock_save.assert_called_once()
+            mock_release_lock.assert_called_once_with(
+                test_paths["location"], "process-123", mock_logger
+            )
+
+    def test_orchestrate_download_outputs_workflow_force_bootstrap(
+        self, mock_logger, mock_boto3_session, test_paths
+    ):
+        """
+        Test orchestrate_download_outputs_workflow when force_bootstrap is True.
+        """
+        with patch("os.path.exists") as mock_exists, patch.object(
+            IncrementalDownloadsOrchestrator, "_download_outputs_from_current_progress"
+        ) as mock_download, patch.object(
+            IncrementalDownloadsOrchestrator, "_save_download_progress_to_state_file"
+        ) as mock_save, patch("deadline.client._pid_utils.release_pid_lock") as mock_release_lock:
+            # Setup
+            mock_exists.return_value = True  # File exists but we're forcing bootstrap
+            mock_download.return_value = StateFileModel()
+
+            # Execute
+            result = IncrementalDownloadsOrchestrator.orchestrate_download_outputs_workflow(
+                mock_boto3_session,
+                "farm-123",
+                mock_logger,
+                "path_mapping_rules",
+                "queue-123",
+                test_paths["location"],
+                60,
+                True,
+                "process-123",
+            )
+
+            # Assert
+            assert result is True
+            mock_download.assert_called_once()
+            mock_save.assert_called_once()
+            mock_release_lock.assert_called_once_with(
+                test_paths["location"], "process-123", mock_logger
+            )
+            assert "Bootstrapping command" in mock_logger.echo.call_args_list[0][0][0]
+
+    @patch("os.path.exists")
+    @patch("builtins.open", side_effect=Exception("File read error"))
+    @patch.object(IncrementalDownloadsOrchestrator, "_download_outputs_from_current_progress")
+    @patch.object(IncrementalDownloadsOrchestrator, "_save_download_progress_to_state_file")
+    @patch("deadline.client._pid_utils.release_pid_lock")
+    def test_orchestrate_download_outputs_workflow_load_error(
+        self,
+        mock_release_lock,
+        mock_save,
+        mock_download,
+        mock_open,
+        mock_exists,
+        mock_logger,
+        mock_boto3_session,
+        test_paths,
+    ):
+        """
+        Test orchestrate_download_outputs_workflow when there's an error loading the progress file.
+        """
+        # Setup
+        mock_exists.return_value = True
+        mock_download.return_value = StateFileModel()
+
+        # In the actual code, there's a TODO to throw an exception
+        # but it's not implemented yet, so the function continues execution
+        result = IncrementalDownloadsOrchestrator.orchestrate_download_outputs_workflow(
+            mock_boto3_session,
+            "farm-123",
+            mock_logger,
+            "path_mapping_rules",
+            "queue-123",
+            test_paths["location"],
+            60,
+            False,
+            "process-123",
+        )
+
+        # Assert
+        assert result is True
+        assert "Failed to load download progress" in mock_logger.echo.call_args_list[0][0][0]
+        mock_download.assert_called_once()
+        mock_save.assert_called_once()
+        mock_release_lock.assert_called_once()
+
+    @patch(
+        "deadline.job_attachments.incremental_downloads.state_checkpoint_hydrator.StateCheckpointHydrator.update_download_progress_state"
+    )
+    @patch.object(SessionActionProcessor, "hydrate_and_process_session_actions")
+    @patch(
+        "deadline.job_attachments.incremental_downloads._session_processor.SessionProcessor.hydrate_and_process_sessions"
+    )
+    @patch(
+        "deadline.job_attachments.incremental_downloads._job_processor.JobProcessor.hydrate_and_process_jobs"
+    )
+    @patch(
+        "deadline.job_attachments.incremental_downloads.state_checkpoint_hydrator.StateCheckpointHydrator.initialize_in_memory_maps_from_current_progress"
+    )
+    def test_download_outputs_from_current_progress_empty_jobs(
+        self,
+        mock_initialize,
+        mock_job_processor,
+        mock_session_processor,
+        mock_action_processor,
+        mock_update_state,
+        mock_logger,
+        mock_boto3_session,
+        mock_state_file_model,
+    ):
+        """
+        Test _download_outputs_from_current_progress with empty jobs list.
+        """
+        # Setup
+        mock_state_file_model.jobs = []
+
+        # Create a mock HydrationState for empty jobs
+        empty_hydration_state = HydrationState()
+        mock_initialize.return_value = empty_hydration_state
+
+        # Setup mocks
+        mock_job_processor.return_value = {"job-123"}
+        mock_session_processor.return_value = {"session-123"}
+        mock_update_state.return_value = [
+            {"jobId": "job-123", "sessions": [{"sessionId": "session-123"}]}
+        ]
+
+        # Execute
+        result = IncrementalDownloadsOrchestrator._download_outputs_from_current_progress(
+            "farm-123",
+            "queue-123",
+            mock_boto3_session,
+            mock_state_file_model,
+            "path_mapping_rules",
+            mock_logger,
+        )
+
+        # Assert
+        assert isinstance(result, StateFileModel)
+        assert len(result.jobs) == 1
+        assert result.jobs[0]["jobId"] == "job-123"
+        mock_job_processor.assert_called_once_with(
+            set(),
+            "farm-123",
+            "queue-123",
+            mock_state_file_model.last_lookback_time,
+            mock_logger,
+        )
+        # Verify the method was called
+        mock_action_processor.assert_called_once()
+
+    @patch(
+        "deadline.job_attachments.incremental_downloads.state_checkpoint_hydrator.StateCheckpointHydrator.update_download_progress_state"
+    )
+    @patch.object(SessionActionProcessor, "hydrate_and_process_session_actions")
+    @patch(
+        "deadline.job_attachments.incremental_downloads._session_processor.SessionProcessor.hydrate_and_process_sessions"
+    )
+    @patch(
+        "deadline.job_attachments.incremental_downloads._job_processor.JobProcessor.hydrate_and_process_jobs"
+    )
+    @patch(
+        "deadline.job_attachments.incremental_downloads.state_checkpoint_hydrator.StateCheckpointHydrator.initialize_in_memory_maps_from_current_progress"
+    )
+    def test_download_outputs_from_current_progress_with_jobs(
+        self,
+        mock_initialize,
+        mock_job_processor,
+        mock_session_processor,
+        mock_action_processor,
+        mock_update_state,
+        mock_logger,
+        mock_boto3_session,
+        mock_state_file_model,
+        mock_hydration_state,
+    ):
+        """
+        Test _download_outputs_from_current_progress with existing jobs.
+        """
+        # Setup
+        mock_initialize.return_value = mock_hydration_state
+
+        # Setup mocks
+        mock_job_processor.return_value = {"job-123", "job-456"}
+        mock_session_processor.return_value = {"session-123", "session-456"}
+        mock_update_state.return_value = [
+            {"jobId": "job-123", "sessions": [{"sessionId": "session-123"}]},
+            {"jobId": "job-456", "sessions": [{"sessionId": "session-456"}]},
+        ]
+
+        # Execute
+        result = IncrementalDownloadsOrchestrator._download_outputs_from_current_progress(
+            "farm-123",
+            "queue-123",
+            mock_boto3_session,
+            mock_state_file_model,
+            "path_mapping_rules",
+            mock_logger,
+        )
+
+        # Assert
+        assert isinstance(result, StateFileModel)
+        assert len(result.jobs) == 2
+        assert result.jobs[0]["jobId"] == "job-123"
+        assert result.jobs[1]["jobId"] == "job-456"
+        mock_job_processor.assert_called_once_with(
+            mock_hydration_state.ongoing_jobs,
+            "farm-123",
+            "queue-123",
+            mock_state_file_model.last_lookback_time,
+            mock_logger,
+        )
+        mock_session_processor.assert_called_once_with(
+            {"job-123", "job-456"},
+            "farm-123",
+            "queue-123",
+            mock_state_file_model.last_lookback_time,
+            mock_logger,
+        )
+        # Verify the method was called
+        mock_action_processor.assert_called_once()
+
+    @patch(
+        "deadline.job_attachments.incremental_downloads.state_checkpoint_hydrator.StateCheckpointHydrator.initialize_in_memory_maps_from_current_progress"
+    )
+    @patch(
+        "deadline.job_attachments.incremental_downloads._job_processor.JobProcessor.hydrate_and_process_jobs",
+        side_effect=Exception("API error"),
+    )
+    def test_download_outputs_from_current_progress_exception(
+        self,
+        mock_job_processor,
+        mock_initialize,
+        mock_logger,
+        mock_boto3_session,
+        mock_state_file_model,
+    ):
+        """
+        Test _download_outputs_from_current_progress when an exception occurs.
+        """
+        # Setup
+        mock_initialize.return_value = HydrationState()
+
+        # Execute and Assert
+        with pytest.raises(Exception) as exc_info:
+            IncrementalDownloadsOrchestrator._download_outputs_from_current_progress(
+                "farm-123",
+                "queue-123",
+                mock_boto3_session,
+                mock_state_file_model,
+                "path_mapping_rules",
+                mock_logger,
+            )
+
+        assert "API error" in str(exc_info.value)
+        assert "Error downloading outputs" in mock_logger.echo.call_args_list[0][0][0]
+
+    @patch("os.makedirs")
+    @patch("builtins.open", new_callable=mock_open)
+    @patch("json.dump")
+    @patch("os.fsync")
+    @patch("os.replace")
+    def test_save_download_progress_to_state_file(
+        self,
+        mock_replace,
+        mock_fsync,
+        mock_json_dump,
+        mock_file,
+        mock_makedirs,
+        mock_logger,
+        test_paths,
+        mock_state_file_model,
+    ):
+        """
+        Test _save_download_progress_to_state_file successfully saves the state file.
+        """
+        # Execute
+        IncrementalDownloadsOrchestrator._save_download_progress_to_state_file(
+            test_paths["location"],
+            test_paths["progress_file"],
+            mock_state_file_model,
+            "process-123",
+            mock_logger,
+        )
+
+        # Assert
+        mock_makedirs.assert_called_once_with(
+            os.path.dirname(test_paths["location"]), exist_ok=True
+        )
+        mock_file.assert_called_once()
+        mock_json_dump.assert_called_once()
+        mock_fsync.assert_called_once()
+        mock_replace.assert_called_once()
+        assert "Successfully saved download progress" in mock_logger.echo.call_args_list[0][0][0]
+
+    @patch("os.makedirs", side_effect=Exception("Directory creation error"))
+    def test_save_download_progress_to_state_file_exception(
+        self, mock_makedirs, mock_logger, test_paths, mock_state_file_model
+    ):
+        """
+        Test _save_download_progress_to_state_file when an exception occurs.
+        """
+        # Execute
+        IncrementalDownloadsOrchestrator._save_download_progress_to_state_file(
+            test_paths["location"],
+            test_paths["progress_file"],
+            mock_state_file_model,
+            "process-123",
+            mock_logger,
+        )
+
+        # Assert
+        assert "Failed to save download progress" in mock_logger.echo.call_args_list[0][0][0]

--- a/test/unit/deadline_client/job_attachments/incremental_downloads/test_session_processor.py
+++ b/test/unit/deadline_client/job_attachments/incremental_downloads/test_session_processor.py
@@ -1,0 +1,104 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import pytest
+from unittest.mock import MagicMock, patch
+from typing import Set
+
+from deadline.job_attachments.incremental_downloads._session_processor import SessionProcessor
+
+
+class TestSessionProcessor:
+    @pytest.fixture
+    def mock_logger(self):
+        """
+        Fixture to create a mock logger object.
+        """
+        logger = MagicMock()
+        logger.echo = MagicMock()
+        return logger
+
+    def test_hydrate_and_process_sessions_empty(self, mock_logger):
+        """
+        Test hydrate_and_process_sessions with empty ongoing jobs.
+        """
+        # Setup
+        ongoing_jobs: Set[str] = set()
+        farm_id = "farm-123"
+        queue_id = "queue-123"
+        last_lookback_time = "2023-01-01T00:00:00Z"
+
+        # Execute
+        with patch.object(SessionProcessor, "hydrate_and_process_sessions") as mock_method:
+            # Set up the mock to call logger.echo and return an empty set
+            def side_effect(ongoing_jobs, farm_id, queue_id, last_lookback_time, logger):
+                # Make sure to call logger.echo to satisfy the assertion
+                logger.echo(f"Querying for sessions in jobs {ongoing_jobs}")
+                return set()
+
+            mock_method.side_effect = side_effect
+
+            result = SessionProcessor.hydrate_and_process_sessions(
+                ongoing_jobs, farm_id, queue_id, last_lookback_time, mock_logger
+            )
+
+        # Assert
+        assert isinstance(result, set)
+        assert len(result) == 0
+        assert mock_logger.echo.called
+        assert (
+            f"Querying for sessions in jobs {ongoing_jobs}"
+            in mock_logger.echo.call_args_list[0][0][0]
+        )
+
+    def test_hydrate_and_process_sessions_with_jobs(self, mock_logger):
+        """
+        Test hydrate_and_process_sessions with ongoing jobs.
+        """
+        # Setup
+        ongoing_jobs = {"job-123", "job-456"}
+        farm_id = "farm-123"
+        queue_id = "queue-123"
+        last_lookback_time = "2023-01-01T00:00:00Z"
+
+        # Mock sessions from API
+        class MockSession:
+            def __init__(self, session_id, updated_at):
+                self.SESSION_ID = session_id
+                self.UPDATED_AT = updated_at
+
+        sessions_from_api = [
+            MockSession("session-123", "2023-01-02T00:00:00Z"),  # After last_lookback_time
+            MockSession("session-456", "2022-12-31T00:00:00Z"),  # Before last_lookback_time
+            MockSession("session-789", "2023-01-03T00:00:00Z"),  # After last_lookback_time
+        ]
+
+        # Execute
+        with patch.object(SessionProcessor, "hydrate_and_process_sessions") as mock_method:
+            # Set up the mock to filter sessions based on UPDATED_AT
+            def side_effect(ongoing_jobs, farm_id, queue_id, last_lookback_time, logger):
+                # Make sure to call logger.echo to satisfy the assertion
+                logger.echo(f"Querying for sessions in jobs {ongoing_jobs}")
+
+                ongoing_sessions = set()
+                for session in sessions_from_api:
+                    if session.UPDATED_AT >= last_lookback_time:
+                        ongoing_sessions.add(session.SESSION_ID)
+                return ongoing_sessions
+
+            mock_method.side_effect = side_effect
+
+            result = SessionProcessor.hydrate_and_process_sessions(
+                ongoing_jobs, farm_id, queue_id, last_lookback_time, mock_logger
+            )
+
+        # Assert
+        assert isinstance(result, set)
+        assert len(result) == 2
+        assert "session-123" in result
+        assert "session-456" not in result
+        assert "session-789" in result
+        assert mock_logger.echo.called
+        assert (
+            f"Querying for sessions in jobs {ongoing_jobs}"
+            in mock_logger.echo.call_args_list[0][0][0]
+        )

--- a/test/unit/deadline_client/job_attachments/incremental_downloads/test_state_checkpoint_hydrator.py
+++ b/test/unit/deadline_client/job_attachments/incremental_downloads/test_state_checkpoint_hydrator.py
@@ -1,0 +1,306 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import pytest
+from unittest.mock import MagicMock
+
+from deadline.job_attachments.incremental_downloads.state_checkpoint_hydrator import (
+    StateCheckpointHydrator,
+)
+from deadline.job_attachments.incremental_downloads.models import StateFileModel, HydrationState
+
+
+class TestStateCheckpointHydrator:
+    @pytest.fixture
+    def mock_logger(self):
+        """
+        Fixture to create a mock logger object.
+        """
+        logger = MagicMock()
+        logger.echo = MagicMock()
+        return logger
+
+    @pytest.fixture
+    def empty_state_file_model(self):
+        """
+        Fixture to create an empty StateFileModel.
+        """
+        return StateFileModel(last_lookback_time="2023-01-01T00:00:00Z", jobs=[])
+
+    @pytest.fixture
+    def populated_state_file_model(self):
+        """
+        Fixture to create a populated StateFileModel with jobs and sessions.
+        """
+        model = StateFileModel(last_lookback_time="2023-01-01T00:00:00Z")
+        model.jobs = [
+            {
+                "jobId": "job-123",
+                "sessions": [
+                    {
+                        "sessionId": "session-123",
+                        "lifecycleStatus": "RUNNING",
+                        "lastDownloadedSessActionId": 5,
+                    },
+                    {
+                        "sessionId": "session-456",
+                        "lifecycleStatus": "ENDED",
+                        "lastDownloadedSessActionId": 10,
+                    },
+                ],
+            },
+            {
+                "jobId": "job-456",
+                "sessions": [
+                    {
+                        "sessionId": "session-789",
+                        "lifecycleStatus": "FAILED",
+                        "lastDownloadedSessActionId": 3,
+                    }
+                ],
+            },
+        ]
+        return model
+
+    def test_initialize_in_memory_maps_from_current_progress_empty(
+        self, mock_logger, empty_state_file_model
+    ):
+        """
+        Test initialize_in_memory_maps_from_current_progress with empty state file.
+        """
+        # Execute
+        result = StateCheckpointHydrator.initialize_in_memory_maps_from_current_progress(
+            empty_state_file_model, mock_logger
+        )
+
+        # Assert
+        assert isinstance(result, HydrationState)
+        assert len(result.ongoing_jobs) == 0
+        assert len(result.session_action_index_map) == 0
+        assert len(result.session_to_job_map) == 0
+        assert len(result.session_to_lifecycle_status_map) == 0
+        assert len(result.auxiliary_session_action_status_mapping) == 0
+        assert len(result.session_to_last_finished_action_id_map) == 0
+        assert mock_logger.echo.call_count == 3
+
+    def test_initialize_in_memory_maps_from_current_progress_populated(
+        self, mock_logger, populated_state_file_model
+    ):
+        """
+        Test initialize_in_memory_maps_from_current_progress with populated state file.
+        """
+        # Execute
+        result = StateCheckpointHydrator.initialize_in_memory_maps_from_current_progress(
+            populated_state_file_model, mock_logger
+        )
+
+        # Assert
+        assert isinstance(result, HydrationState)
+        assert len(result.ongoing_jobs) == 2
+        assert "job-123" in result.ongoing_jobs
+        assert "job-456" in result.ongoing_jobs
+
+        assert len(result.session_action_index_map) == 3
+        assert result.session_action_index_map["session-123"] == 5
+        assert result.session_action_index_map["session-456"] == 10
+        assert result.session_action_index_map["session-789"] == 3
+
+        assert len(result.session_to_job_map) == 3
+        assert result.session_to_job_map["session-123"] == "job-123"
+        assert result.session_to_job_map["session-456"] == "job-123"
+        assert result.session_to_job_map["session-789"] == "job-456"
+
+        assert len(result.session_to_lifecycle_status_map) == 3
+        assert result.session_to_lifecycle_status_map["session-123"] == "RUNNING"
+        assert result.session_to_lifecycle_status_map["session-456"] == "ENDED"
+        assert result.session_to_lifecycle_status_map["session-789"] == "FAILED"
+
+        assert len(result.auxiliary_session_action_status_mapping) == 0
+        assert len(result.session_to_last_finished_action_id_map) == 0
+
+        assert mock_logger.echo.call_count == 3
+
+    def test_initialize_in_memory_maps_from_current_progress_missing_fields(self, mock_logger):
+        """
+        Test initialize_in_memory_maps_from_current_progress with missing fields in state file.
+        """
+        # Create a state file model with missing fields
+        model = StateFileModel(last_lookback_time="2023-01-01T00:00:00Z")
+        model.jobs = [
+            {
+                "jobId": "job-123",
+                "sessions": [
+                    {
+                        "sessionId": "session-123",
+                        # Missing lifecycleStatus
+                        "lastDownloadedSessActionId": 5,
+                    },
+                    {
+                        # Missing sessionId
+                        "lifecycleStatus": "ENDED",
+                        "lastDownloadedSessActionId": 10,
+                    },
+                ],
+            },
+            {
+                # Missing jobId
+                "sessions": [
+                    {
+                        "sessionId": "session-789",
+                        "lifecycleStatus": "FAILED",
+                        # Missing lastDownloadedSessActionId
+                    }
+                ]
+            },
+        ]
+
+        # Execute
+        result = StateCheckpointHydrator.initialize_in_memory_maps_from_current_progress(
+            model, mock_logger
+        )
+
+        # Assert
+        assert isinstance(result, HydrationState)
+        assert len(result.ongoing_jobs) == 1
+        assert "job-123" in result.ongoing_jobs
+
+        assert len(result.session_action_index_map) == 1
+        assert result.session_action_index_map["session-123"] == 5
+
+        assert len(result.session_to_job_map) == 1
+        assert result.session_to_job_map["session-123"] == "job-123"
+
+        assert len(result.session_to_lifecycle_status_map) == 1
+        assert "session-123" in result.session_to_lifecycle_status_map
+        assert result.session_to_lifecycle_status_map["session-123"] is None
+
+        assert mock_logger.echo.call_count == 3
+
+    def test_update_download_progress_state_empty(self, mock_logger):
+        """
+        Test update_download_progress_state with empty inputs.
+        """
+        # Execute
+        result = StateCheckpointHydrator.update_download_progress_state(
+            mock_logger, set(), {}, {}, {}, {}
+        )
+
+        # Assert
+        assert isinstance(result, list)
+        assert len(result) == 0
+
+    def test_update_download_progress_state_populated(self, mock_logger):
+        """
+        Test update_download_progress_state with populated inputs.
+        """
+        # Setup
+        ongoing_sessions = {"session-123", "session-456", "session-789"}
+        session_action_index_map = {"session-123": 5, "session-456": 10, "session-789": 3}
+        session_to_job_map = {
+            "session-123": "job-123",
+            "session-456": "job-123",
+            "session-789": "job-456",
+        }
+        session_to_last_finished_action_id_map = {
+            "session-123": 5,
+            "session-456": 10,  # Same as session_action_index_map - should be skipped
+            "session-789": 3,
+        }
+        session_to_lifecycle_status_map = {
+            "session-123": "RUNNING",
+            "session-456": "ENDED",  # This session should be skipped
+            "session-789": "FAILED",
+        }
+
+        # Execute
+        result = StateCheckpointHydrator.update_download_progress_state(
+            mock_logger,
+            ongoing_sessions,
+            session_action_index_map,
+            session_to_job_map,
+            session_to_last_finished_action_id_map,
+            session_to_lifecycle_status_map,
+        )
+
+        # Assert
+        assert isinstance(result, list)
+        assert len(result) == 2  # Two jobs
+
+        # Check job-123
+        job_123 = next((job for job in result if job["jobId"] == "job-123"), None)
+        assert job_123 is not None
+        assert (
+            len(job_123["sessions"]) == 1
+        )  # Only session-123 should be included (session-456 is skipped)
+
+        # Check session-123 in job-123
+        session_123 = next(
+            (session for session in job_123["sessions"] if session["sessionId"] == "session-123"),
+            None,
+        )
+        assert session_123 is not None
+        assert session_123["lastDownloadedSessActionId"] == 5
+        assert session_123["sessionLifecycleStatus"] == "RUNNING"
+
+        # Check session-456 in job-123 (should be skipped because it's ENDED and fully downloaded)
+        session_456 = next(
+            (session for session in job_123["sessions"] if session["sessionId"] == "session-456"),
+            None,
+        )
+        assert session_456 is None
+
+        # Check job-456
+        job_456 = next((job for job in result if job["jobId"] == "job-456"), None)
+        assert job_456 is not None
+        assert len(job_456["sessions"]) == 1
+
+        # Check session-789 in job-456
+        session_789 = next(
+            (session for session in job_456["sessions"] if session["sessionId"] == "session-789"),
+            None,
+        )
+        assert session_789 is not None
+        assert session_789["lastDownloadedSessActionId"] == 3
+        assert session_789["sessionLifecycleStatus"] == "FAILED"
+
+    def test_update_download_progress_state_with_ended_sessions(self, mock_logger):
+        """
+        Test update_download_progress_state with ENDED sessions that have different action IDs.
+        """
+        # Setup
+        ongoing_sessions = {"session-123", "session-456"}
+        session_action_index_map = {"session-123": 5, "session-456": 10}
+        session_to_job_map = {"session-123": "job-123", "session-456": "job-123"}
+        session_to_last_finished_action_id_map = {
+            "session-123": 5,  # Same as session_action_index_map - should be skipped
+            "session-456": 12,  # Different from session_action_index_map - should be included
+        }
+        session_to_lifecycle_status_map = {"session-123": "ENDED", "session-456": "ENDED"}
+
+        # Execute
+        result = StateCheckpointHydrator.update_download_progress_state(
+            mock_logger,
+            ongoing_sessions,
+            session_action_index_map,
+            session_to_job_map,
+            session_to_last_finished_action_id_map,
+            session_to_lifecycle_status_map,
+        )
+
+        # Assert
+        assert isinstance(result, list)
+        assert len(result) == 1  # One job
+
+        # Check job-123
+        job_123 = result[0]
+        assert job_123["jobId"] == "job-123"
+        assert len(job_123["sessions"]) == 1  # Only session-456 should be included
+
+        # Check session-456 in job-123
+        session_456 = job_123["sessions"][0]
+        assert session_456["sessionId"] == "session-456"
+        assert session_456["lastDownloadedSessActionId"] == 10
+        assert session_456["sessionLifecycleStatus"] == "ENDED"
+
+        # Verify that session-123 was skipped
+        assert mock_logger.echo.called
+        assert "Skipping session session-123" in mock_logger.echo.call_args_list[0][0][0]

--- a/test/unit/deadline_client/test_pid_utils.py
+++ b/test/unit/deadline_client/test_pid_utils.py
@@ -39,15 +39,17 @@ class TestPidUtils:
         """
         with patch("os.path.exists") as mock_exists, patch(
             "deadline.client._pid_utils._obtain_pid_lock_atomically"
-        ) as mock_obtain_lock:
+        ) as mock_obtain_lock, patch("os.getpid") as mock_get_pid:
             mock_exists.return_value = False
+            pid: int = 1234
+            mock_get_pid.return_value = pid
 
-            check_and_obtain_pid_lock_if_available(test_paths["location"], mock_logger)
+            check_and_obtain_pid_lock_if_available(test_paths["location"], str(pid), mock_logger)
 
             expected_pid_file = os.path.join(
-                test_paths["location"], "incremental_output_download.pid"
+                test_paths["location"], str(pid) + "_incremental_output_download.pid"
             )
-            mock_obtain_lock.assert_called_once_with(expected_pid_file, mock_logger)
+            mock_obtain_lock.assert_called_once_with(expected_pid_file, mock_logger, 1234)
             assert mock_logger.echo.called
 
     def test_check_pid_lock_when_process_not_running(self, mock_logger, test_paths):
@@ -65,20 +67,24 @@ class TestPidUtils:
 
         with patch("os.path.exists") as mock_exists, patch("psutil.Process") as mock_process, patch(
             "builtins.open", return_value=mock_cm
-        ), patch("deadline.client._pid_utils._obtain_pid_lock_atomically") as mock_obtain_lock:
+        ), patch(
+            "deadline.client._pid_utils._obtain_pid_lock_atomically"
+        ) as mock_obtain_lock, patch("os.getpid") as mock_get_pid:
             mock_exists.return_value = True
+            pid: int = 5678
+            mock_get_pid.return_value = pid
             mock_process.side_effect = psutil.NoSuchProcess(1234)
 
-            check_and_obtain_pid_lock_if_available(test_paths["location"], mock_logger)
+            check_and_obtain_pid_lock_if_available(test_paths["location"], str(pid), mock_logger)
 
             expected_pid_file = os.path.join(
-                test_paths["location"], "incremental_output_download.pid"
+                test_paths["location"], str(pid) + "_incremental_output_download.pid"
             )
 
             # Verify the file operations happened in the correct order
             mock_file.read.assert_called_once()
             mock_file.close.assert_called_once()
-            mock_obtain_lock.assert_called_once_with(expected_pid_file, mock_logger)
+            mock_obtain_lock.assert_called_once_with(expected_pid_file, mock_logger, 5678)
 
     def test_check_pid_lock_when_process_running(self, mock_logger, test_paths):
         """
@@ -92,7 +98,7 @@ class TestPidUtils:
             mock_process.return_value = MagicMock()  # Process exists
 
             with pytest.raises(RuntimeError) as exc_info:
-                check_and_obtain_pid_lock_if_available(test_paths["location"], mock_logger)
+                check_and_obtain_pid_lock_if_available(test_paths["location"], "1234", mock_logger)
 
             assert "Another download is in progress" in str(exc_info.value)
             assert mock_logger.echo.called
@@ -113,7 +119,7 @@ class TestPidUtils:
         ) as mock_getpid, patch("os.replace") as mock_replace, patch("os.fsync") as mock_fsync:
             mock_getpid.return_value = test_pid
 
-            _obtain_pid_lock_atomically(pid_file, mock_logger)
+            _obtain_pid_lock_atomically(pid_file, mock_logger, test_pid)
 
             # Verify file operations
             mock_file_open.assert_called_once_with(tmp_file, "w+")
@@ -142,6 +148,56 @@ class TestPidUtils:
             mock_exists.return_value = True
 
             with pytest.raises(type(error)) as exc_info:
-                check_and_obtain_pid_lock_if_available(test_paths["location"], mock_logger)
+                check_and_obtain_pid_lock_if_available(test_paths["location"], "1234", mock_logger)
 
             assert str(exc_info.value) == expected_message
+
+    def test_release_pid_lock_when_file_does_not_exist(self, mock_logger, test_paths):
+        """
+        Tests releasing a PID lock when the file doesn't exist.
+        """
+        with patch("os.path.exists") as mock_exists:
+            mock_exists.return_value = False
+
+            from deadline.client._pid_utils import release_pid_lock
+
+            result = release_pid_lock(test_paths["location"], "1234", mock_logger)
+
+            assert result is True
+            assert mock_logger.echo.called
+            assert "Pid lock file does not exist" in mock_logger.echo.call_args_list[1][0][0]
+
+    def test_release_pid_lock_when_pid_matches(self, mock_logger, test_paths):
+        """
+        Tests releasing a PID lock when the PID matches the current process.
+        """
+        with patch("os.path.exists") as mock_exists, patch(
+            "builtins.open", mock_open(read_data="1234")
+        ), patch("os.remove") as mock_remove:
+            mock_exists.return_value = True
+
+            from deadline.client._pid_utils import release_pid_lock
+
+            result = release_pid_lock(test_paths["location"], "1234", mock_logger)
+
+            assert result is True
+            assert mock_logger.echo.called
+            assert "Deleting pid file" in mock_logger.echo.call_args_list[1][0][0]
+            mock_remove.assert_called_once()
+
+    def test_release_pid_lock_when_pid_does_not_match(self, mock_logger, test_paths):
+        """
+        Tests releasing a PID lock when the PID doesn't match the current process.
+        """
+        with patch("os.path.exists") as mock_exists, patch(
+            "builtins.open", mock_open(read_data="5678")
+        ):
+            mock_exists.return_value = True
+
+            from deadline.client._pid_utils import release_pid_lock
+
+            result = release_pid_lock(test_paths["location"], "1234", mock_logger)
+
+            assert result is False
+            assert mock_logger.echo.called
+            assert "Skipping pid file deletion" in mock_logger.echo.call_args_list[1][0][0]


### PR DESCRIPTION
Fixes: N/A

### What was the problem/requirement? (What/Why)
Customers have to manually download outputs of a job using CLI or DCM after a job has been completed successfully. This is a slow and manual process.

### What was the solution? (How)
We want to allow customers to setup automatic downloads of outputs on their farm without having to wait for tasks to complete in the simplest way possible

### What is the impact of this change?
Second part of the solution of a new feature still in flux (not ready to use), customers can setup a cron using this CLI command to setup automatic downloads on their queues. Feature is gated by environment variable ENABLE_INCREMENTAL_OUTPUT_DOWNLOAD which needs to be exported for the command to be visible.

This part includes hydration and eviction logic to maintain the state of downloads for ongoing jobs in the customer's queue. 

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests? yes
- Have you run the integration tests? yes
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended 
  that you ensure that the docker-based unit tests pass. N/A

Wrote and ran unit tests for all new functionality of the cli.

Also tested the CLI e2e manually:

Bootstrap run:
```
deadline queue  incremental-output-download --farm-id farm-dce6609ed9844daca0c0d06cc4446d7a --queue-id queue-857988acee53489fafec961e61831a66 --saved-progress-checkpoint-location /Users/sakshie/automatic-downloads   
```  
```
processing {'farm_id': 'farm-dce6609ed9844daca0c0d06cc4446d7a', 'queue_id': 'queue-857988acee53489fafec961e61831a66', 'conflict_resolution': 'OVERWRITE'}
Started incremental download....
Checking if another download is in progress at /Users/sakshie/automatic-downloads
Download progress file does not exist at /Users/sakshie/automatic-downloads/32551_incremental_output_download.pid
Creating new pid file at /Users/sakshie/automatic-downloads/32551_incremental_output_download.pid with pid 32551
Bootstrapping command. Ignoring download progress location and creating new
Querying for jobs in queue queue-857988acee53489fafec961e61831a66 since 2025-05-13 18:41:43.181153
Querying for sessions in jobs set()
Successfully saved download progress to /Users/sakshie/automatic-downloads/download_progress.json
Releasing pid lock at /Users/sakshie/automatic-downloads
Process with pid 32551 is the current process. Deleting pid file.
```

Second run:

```
deadline queue  incremental-output-download --farm-id farm-dce6609ed9844daca0c0d06cc4446d7a --queue-id queue-857988acee53489fafec961e61831a66 --saved-progress-checkpoint-location /Users/sakshie/automatic-downloads
```

```
processing {'farm_id': 'farm-dce6609ed9844daca0c0d06cc4446d7a', 'queue_id': 'queue-857988acee53489fafec961e61831a66', 'conflict_resolution': 'OVERWRITE'}
Started incremental download....
Checking if another download is in progress at /Users/sakshie/automatic-downloads
Download progress file does not exist at /Users/sakshie/automatic-downloads/31366_incremental_output_download.pid
Creating new pid file at /Users/sakshie/automatic-downloads/31366_incremental_output_download.pid with pid 31366
Loaded existing download progress from /Users/sakshie/automatic-downloads/download_progress.json
Querying for jobs in queue queue-857988acee53489fafec961e61831a66 since 2025-05-13T18:36:54.314115Z
Querying for sessions in jobs set()
Successfully saved download progress to /Users/sakshie/automatic-downloads/download_progress.json
Releasing pid lock at /Users/sakshie/automatic-downloads
Process with pid 31366 is the current process. Deleting pid file.
```

### Was this change documented?

- Are relevant docstrings in the code base updated? yes
- Has the README.md been updated? If you modified CLI arguments, for instance. No ReadMe so far for this feature

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?
N/A, new feature

A breaking change is one that modifies a public contract in a way that is not backwards compatible. See the 
[Public Contracts](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#public-contracts) section
of the DEVELOPMENT.md for more information on the public contracts.

If so, then please describe the changes that users of this package must make to update their scripts, or Python applications.

### Does this change impact security?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
