### PR TITLE
chore(deps): update pytest-cov to 6.*

### DIFF
--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -2,7 +2,8 @@ coverage[toml] ~= 7.6; python_version == '3.7'
 coverage[toml] == 7.*; python_version > '3.7'
 coverage-conditional-plugin == 0.9.*
 pytest == 8.*
-pytest-cov == 5.*
+pytest-cov == 6.*; python_version > '3.8'
+pytest-cov == 5.*; python_version <= '3.8'
 pytest-timeout == 2.*
 pytest-xdist == 3.*
 freezegun == 1.*


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Updating to `pytest-cov 6*`, but it drops support for 3.8.

### What was the solution? (How)
Add python constraints to support both python 3.8 and later

### What is the impact of this change?
Later versions of python get the latest pytest-cov version.

### How was this change tested?

```
hatch run lint
hatch run test
```

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [X] This PR does not add any new dependencies.

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
