### PR TITLE
fix: exiting with exit code zero when missing a required sub-command or missing --help

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,8 @@ classifiers = [
 # limiting dependencies if they want/need to.
 dependencies = [
   "boto3 >= 1.36.8",
-  "click >= 8.1.7,<8.2.0",
+  # Click 8.2 dropped python 3.8/3.9 support
+  "click >= 8.1.7",
   "pyyaml >= 6.0",
   # Job Attachments
   "typing_extensions >= 4.7,< 4.14; python_version == '3.7'",
@@ -146,6 +147,7 @@ markers = [
   "no_setup: mark that test shouldn't use default setups",
   "integ: tests that run against AWS resources",
   "docker: marks tests to be run only in a Docker environment",
+  "cross_account: tests that run against other aws accounts",
 ]
 # looponfailroots is deprecated, this removes the deprecation from the test output
 filterwarnings = ["ignore::DeprecationWarning"]

--- a/src/deadline/client/api/_telemetry.py
+++ b/src/deadline/client/api/_telemetry.py
@@ -249,20 +249,25 @@ class TelemetryClient:
                 return
 
             headers = {"Accept": "application-json", "Content-Type": "application-json"}
-            request_body = {
-                "BatchId": str(uuid.uuid4()),
-                "RumEvents": [
-                    {
-                        "details": str(json.dumps(event_data.event_details)),
-                        "id": str(uuid.uuid4()),
-                        "metadata": str(json.dumps(self._system_metadata)),
-                        "timestamp": int(datetime.now().timestamp()),
-                        "type": event_data.event_type,
-                    },
-                ],
-                "UserDetails": {"sessionId": self.session_id, "userId": self.telemetry_id},
-            }
-            request_body_encoded = str(json.dumps(request_body)).encode("utf-8")
+            try:
+                request_body = {
+                    "BatchId": str(uuid.uuid4()),
+                    "RumEvents": [
+                        {
+                            "details": str(json.dumps(event_data.event_details)),
+                            "id": str(uuid.uuid4()),
+                            "metadata": str(json.dumps(self._system_metadata)),
+                            "timestamp": int(datetime.now().timestamp()),
+                            "type": event_data.event_type,
+                        },
+                    ],
+                    "UserDetails": {"sessionId": self.session_id, "userId": self.telemetry_id},
+                }
+                request_body_encoded = str(json.dumps(request_body)).encode("utf-8")
+            except Exception as exc:
+                logger.debug(f"Failed to serialize telemetry data. {str(exc)}")
+                continue
+
             req = request.Request(url=self.endpoint, data=request_body_encoded, headers=headers)
             try:
                 logger.debug("Sending telemetry data: %s", request_body)

--- a/test/unit/deadline_client/cli/test_cli.py
+++ b/test/unit/deadline_client/cli/test_cli.py
@@ -24,7 +24,7 @@ def test_cli_debug_logging_on(fresh_deadline_config):
     # so we instead run it as a subprocess to match the actual
     # environment.
     output = subprocess.check_output(
-        args=[sys.executable, "-m", "deadline", "--log-level", "DEBUG", "config"],
+        args=[sys.executable, "-m", "deadline", "--log-level", "DEBUG", "config", "--help"],
         stderr=subprocess.STDOUT,
         text=True,
     )
@@ -51,14 +51,12 @@ def test_cli_unfamiliar_exception(fresh_deadline_config):
 @pytest.mark.parametrize("cli_group", ["config", "farm", "queue", "bundle"])
 def test_cli_group_without_command(fresh_deadline_config, cli_group):
     """
-    Test that each group prints the the usage screen if no command is provided
+    Test that each group prints the usage screen if no command is provided
     """
     runner = CliRunner()
     result = runner.invoke(main, [cli_group])
 
     assert result.output.startswith("Usage:")
-    # Click's default, with no clear way to override, is to return success in this case
-    assert result.exit_code == 0
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

When upgrading Click, 5 tests are failing around exit codes
```
==== short test summary info ====
FAILED test/unit/deadline_client/cli/test_cli.py::test_cli_debug_logging_on - subprocess.CalledProcessError: Command '['/Users/morgane/Library/Application Support/hatch/env/virtual/deadline/7XR_zEB6/deadline/bin/python', '-m', 'deadline', '-...
FAILED test/unit/deadline_client/cli/test_cli.py::test_cli_group_without_command[config] - assert 2 == 0
FAILED test/unit/deadline_client/cli/test_cli.py::test_cli_group_without_command[farm] - assert 2 == 0
FAILED test/unit/deadline_client/cli/test_cli.py::test_cli_group_without_command[queue] - assert 2 == 0
FAILED test/unit/deadline_client/cli/test_cli.py::test_cli_group_without_command[bundle] - assert 2 == 0
==== 5 failed, 1455 passed, 55 skipped, 1 xfailed, 1 warning in 26.43s ====
```

Click 8.2.0 released and changed some behaviour that our tests were relying on:

> If help is shown because no_args_is_help is enabled (defaults to True for groups, False for commands), the exit code is 2 instead of 0. [#1489](https://github.com/pallets/click/issues/1489) [#1489](https://github.com/pallets/click/pull/1489)

### What was the solution? (How)

loosen the tests to support both < 8.2 and >= 8.2 versions of click since Click 8.2.0 dropped python 3.7, 3.8, and 3.9 support (3.9 is not EOL yet). Now the tests pass regardless of version.

Note that this means that exit codes for CLI calls like:

```
deadline
```
or
```
deadline job
```
will now return exit code 2 instead of 0 for python 3.10+ since they did not provide required subcommands/args or the --help command. Python 3.9 (EOL October) will still return exit code 0.

Additionally I experienced some warnings when running pytest that I've fixed:

```
==== warnings summary ====
test/unit/deadline_client/api/test_api_farm.py::test_list_farms_paginated
  /Users/morgane/Library/Application Support/hatch/env/virtual/deadline/7XR_zEB6/deadline/lib/python3.12/site-packages/_pytest/threadexception.py:82: PytestUnhandledThreadExceptionWarning: Exception in thread Thread-1 (_process_event_queue_thread)
  
  Traceback (most recent call last):
    File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/threading.py", line 1075, in _bootstrap_inner
      self.run()
    File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/threading.py", line 1012, in run
      self._target(*self._args, **self._kwargs)
    File "/Users/morgane/dev/github/deadline-cloud/src/deadline/client/api/_telemetry.py", line 258, in _process_event_queue_thread
      "metadata": str(json.dumps(self._system_metadata)),
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/json/__init__.py", line 231, in dumps
      return _default_encoder.encode(obj)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/json/encoder.py", line 200, in encode
      chunks = self.iterencode(o, _one_shot=True)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/json/encoder.py", line 258, in iterencode
      return _iterencode(o, 0)
             ^^^^^^^^^^^^^^^^^
    File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/json/encoder.py", line 180, in default
      raise TypeError(f'Object of type {o.__class__.__name__} '
  TypeError: Object of type MagicMock is not JSON serializable
  
    warnings.warn(pytest.PytestUnhandledThreadExceptionWarning(msg))
```
Threw the serialization into a try catch for the event. Mostly a test issue, but it could impact an actual run, now it's more robust!

```
==== warnings summary ====
test/integ/cli/test_cli_attachment.py:93
  /Users/morgane/dev/github/deadline-cloud/test/integ/cli/test_cli_attachment.py:93: PytestUnknownMarkWarning: Unknown pytest.mark.cross_account - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.cross_account
...
```
happens 4 more times, so I added the marker to the pyproject

### What is the impact of this change?

Working tests with the newer version, and updated exit codes for users if they don't specify `--help` or required args

### How was this change tested?

```
hatch run test
```

### Was this change documented?

It'll be in the Changelog.

### Does this PR introduce new dependencies?

N/A

### Is this a breaking change?

N/A

### Does this change impact security?

N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
