### PR TITLE
feat: Add functionality to summarize lists of paths

### DIFF
--- a/examples/summarize_dir.py
+++ b/examples/summarize_dir.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import argparse
+import os
+
+from deadline.job_attachments.api import summarize_path_list
+
+"""
+This is a sample script that uses the path summarization features to summarize
+all the files in a specified directory.
+
+Example usage:
+
+  python summarize_dir.py --max-entries 5 ./mydir
+"""
+
+
+def main():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--max-entries", type=int, default=10, help="How many entries to limit the summary to."
+    )
+    parser.add_argument(
+        "--file-sizes", default=False, action="store_true", help="Include file sizes."
+    )
+    parser.add_argument(
+        "--skip-dot-paths",
+        default=False,
+        action="store_true",
+        help="Skip directories and files that start with '.'.",
+    )
+    parser.add_argument(
+        "--exclude-totals",
+        default=False,
+        action="store_true",
+        help="Exclude totals from the summary.",
+    )
+    parser.add_argument(
+        "--follow-symlinks",
+        default=False,
+        action="store_true",
+        help="Follows symlinks for directory traversal and file sizes.",
+    )
+    parser.add_argument("summary_dir", help="The directory to summarize.")
+
+    args = parser.parse_args()
+
+    if not os.path.exists(args.summary_dir) or not os.path.isdir(args.summary_dir):
+        print(f"Directory not found: {args.summary_dir}")
+
+    total_size_by_path: dict[str, int] = None
+    if args.file_sizes:
+        total_size_by_path = {}
+
+    path_list = []
+
+    dirs_to_visit = [args.summary_dir]
+    while dirs_to_visit:
+        dir = dirs_to_visit.pop()
+        for entry in os.scandir(dir):
+            if entry.is_dir(follow_symlinks=args.follow_symlinks):
+                if not (args.skip_dot_paths and entry.name.startswith(".")):
+                    dirs_to_visit.append(entry.path)
+            elif entry.is_file(follow_symlinks=args.follow_symlinks):
+                if not (args.skip_dot_paths and entry.name.startswith(".")):
+                    path_list.append(entry.path)
+                    if total_size_by_path is not None:
+                        total_size_by_path[entry.path] = entry.stat(
+                            follow_symlinks=args.follow_symlinks
+                        ).st_size
+
+    if path_list:
+        print(
+            summarize_path_list(
+                path_list,
+                total_size_by_path=total_size_by_path,
+                max_entries=args.max_entries,
+                include_totals=not args.exclude_totals,
+            )
+        )
+    else:
+        print(f"No files found in {args.summary_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,12 +39,9 @@ dependencies = [
   "click >= 8.1.7",
   "pyyaml >= 6.0",
   # Job Attachments
-  "typing_extensions >= 4.7,< 4.14; python_version == '3.7'",
-  "typing_extensions >= 4.8; python_version > '3.7'",
-  # Pinning due to 3.4 not being available upstream
+  "typing_extensions >= 4.8",
   "xxhash >= 3.4,< 3.6",
-  # Pinning due to new 4.18 dependencies breaking pyinstaller implementation
-  "jsonschema == 4.17.*",
+  "jsonschema >= 4.17,< 5.0",
   "pywin32 >= 307,< 311; sys_platform == 'win32'",
   "QtPy == 2.4.*",
   "psutil >= 7.0.0"

--- a/src/deadline/client/cli/_common.py
+++ b/src/deadline/client/cli/_common.py
@@ -16,6 +16,7 @@ __all__ = [
 import sys
 from configparser import ConfigParser
 from typing import Any, Callable, Optional, Set
+import logging
 
 import click
 from contextlib import ExitStack
@@ -25,6 +26,8 @@ from ..config import config_file
 from ..exceptions import DeadlineOperationError
 from ..job_bundle import deadline_yaml_dump
 from ._groups._sigint_handler import SigIntHandler
+
+logger = logging.getLogger("deadline.client.cli")
 
 _PROMPT_WHEN_COMPLETE = "PROMPT_WHEN_COMPLETE"
 
@@ -66,9 +69,9 @@ def _handle_error(func: Callable) -> Callable:
             # Log and print out unfamiliar exceptions with additional
             # messaging.
             click.echo(f"The AWS Deadline Cloud CLI encountered the following exception:\n{e}")
-            import traceback
 
-            traceback.print_exc()
+            if logging.DEBUG >= logger.getEffectiveLevel():
+                logger.exception("Exception details:")
             _prompt_at_completion(ctx)
             sys.exit(1)
 

--- a/src/deadline/client/cli/_groups/job_group.py
+++ b/src/deadline/client/cli/_groups/job_group.py
@@ -14,6 +14,7 @@ import sys
 from typing import Callable, Optional, Union
 import datetime
 from typing import Any
+import textwrap
 
 import click
 from botocore.exceptions import ClientError
@@ -33,13 +34,18 @@ from deadline.job_attachments.progress_tracker import (
     DownloadSummaryStatistics,
     ProgressReportMetadata,
 )
-from deadline.job_attachments._utils import _human_readable_file_size
+from deadline.job_attachments._path_summarization import (
+    human_readable_file_size,
+    summarize_path_list,
+)
 
 from ... import api
 from ...config import config_file
 from ...exceptions import DeadlineOperationError
 from .._common import _apply_cli_options_to_config, _cli_object_repr, _handle_error
 from ._sigint_handler import SigIntHandler
+
+logger = logging.getLogger("deadline.client.cli")
 
 JSON_MSG_TYPE_TITLE = "title"
 JSON_MSG_TYPE_PRESUMMARY = "presummary"
@@ -301,12 +307,12 @@ def _download_job_output(
                         )
 
     output_paths_by_root = job_output_downloader.get_output_paths_by_root()
-
-    _check_and_warn_long_output_paths(output_paths_by_root)
     # If no output paths were found, log a message and exit.
     if output_paths_by_root == {}:
         click.echo(_get_no_output_message(is_json_format))
         return
+
+    _check_and_warn_long_output_paths(output_paths_by_root)
 
     # Check if the asset roots came from different OS. If so, prompt users to
     # select alternative root paths to download to, (regardless of the auto-accept.)
@@ -336,6 +342,7 @@ def _download_job_output(
     output_paths_by_root = job_output_downloader.get_output_paths_by_root()
 
     _check_and_warn_long_output_paths(output_paths_by_root)
+
     # Prompt users to confirm local root paths where they will download outputs to,
     # and allow users to select different location to download files to if they want.
     # (If auto-accept is enabled, automatically download to the default root paths.)
@@ -387,6 +394,16 @@ def _download_job_output(
             output_paths_by_root = job_output_downloader.get_output_paths_by_root()
             _check_and_warn_long_output_paths(output_paths_by_root)
 
+    if not is_json_format:
+        # Create and print a summary of all the paths to download
+        all_output_paths: set[str] = set()
+        for asset_root, output_paths in output_paths_by_root.items():
+            all_output_paths.update(
+                os.path.normpath(os.path.join(asset_root, path)) for path in output_paths
+            )
+        click.echo("\nSummary of file paths to download:")
+        click.echo(textwrap.indent(summarize_path_list(all_output_paths), "  "))
+
     # If the conflict resolution option was not specified, auto-accept is false, and
     # if there are any conflicting files in local, prompt users to select a resolution method.
     # (skip, overwrite, or make a copy.)
@@ -431,7 +448,6 @@ def _download_job_output(
         if not is_json_format:
             # Note: click doesn't export the return type of progressbar(), so we suppress mypy warnings for
             # not annotating the type of download_progress.
-            click.echo()
             with click.progressbar(length=100, label="Downloading Outputs") as download_progress:  # type: ignore[var-annotated]
 
                 def _update_download_progress(download_metadata: ProgressReportMetadata) -> bool:
@@ -559,9 +575,9 @@ def _get_download_summary_message(
         return (
             "Download Summary:\n"
             f"    Downloaded {download_summary.processed_files} files totaling"
-            f" {_human_readable_file_size(download_summary.processed_bytes)}.\n"
+            f" {human_readable_file_size(download_summary.processed_bytes)}.\n"
             f"    Total download time of {round(download_summary.total_time, ndigits=5)} seconds"
-            f" at {_human_readable_file_size(int(download_summary.transfer_rate))}/s.\n"
+            f" at {human_readable_file_size(int(download_summary.transfer_rate))}/s.\n"
             f"    Download locations (total file counts):\n        {paths_joined}"
         )
 
@@ -685,6 +701,9 @@ def job_download_output(step_id, task_id, output, **args):
             click.echo(_get_json_line(JSON_MSG_TYPE_ERROR, error_one_liner))
             sys.exit(1)
         else:
+            logger.exception("Exception details:")
+            if logging.DEBUG >= logger.getEffectiveLevel():
+                logger.exception("Exception details:")
             raise DeadlineOperationError(f"Failed to download output:\n{e}") from e
 
 

--- a/src/deadline/client/job_bundle/parameters.py
+++ b/src/deadline/client/job_bundle/parameters.py
@@ -11,7 +11,7 @@ __all__ = [
 
 import os
 from collections import namedtuple
-from typing import Any, TYPE_CHECKING, cast
+from typing import Any, TYPE_CHECKING, cast, Union
 
 # typing_extensions is only needed for type-checking. It fails to import at run-time in Python 3.7
 # so provide stubs at run-time.
@@ -70,8 +70,8 @@ class JobParameter(TypedDict):
     objectType: NotRequired[str]
     maxLength: NotRequired[int]
     minLength: NotRequired[int]
-    maxValue: NotRequired[int | float | str]
-    minValue: NotRequired[int | float | str]
+    maxValue: NotRequired[Union[int, float, str]]
+    minValue: NotRequired[Union[int, float, str]]
     userInterface: NotRequired[UserInterfaceSpec]
 
 

--- a/src/deadline/job_attachments/_path_summarization.py
+++ b/src/deadline/job_attachments/_path_summarization.py
@@ -1,0 +1,460 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+from __future__ import annotations
+import os
+import re
+from typing import Optional, Iterable, Union
+from collections.abc import Collection
+from pathlib import Path
+
+
+def human_readable_file_size(size_in_bytes: int) -> str:
+    """
+    Convert a size in bytes to something human readable. For example 1000 bytes will be converted
+    to 1 KB. Sizes close enough to a postfix threshold will be rounded up to the next threshold.
+    For example 999999 bytes would be output as 1.0 MB and NOT 999.99 KB (or as a consequence of
+    Python's round function 1000.0 KB).
+
+    This function is for display purposes only.
+    """
+    converted_size: Union[int, float] = size_in_bytes
+    rounded: Union[int, float]
+    postfixes = ["B", "KB", "MB", "GB", "TB", "PB"]
+
+    for postfix in postfixes:
+        rounded = round(converted_size, ndigits=2)
+
+        if rounded < 1000:
+            return f"{rounded} {postfix}"
+
+        converted_size /= 1000
+
+    # If we go higher than the provided postfix,
+    # then return as a large amount of the highest postfix we've specified.
+    return f"{rounded} {postfixes[-1]}"
+
+
+_NUMBERED_PATH_REGEX = re.compile(r"^(.*\D|)(\d+)(\.[^/\\]+)?$")
+
+
+class _NumberedPath:
+    """
+    Representation of a file system path that may be numbered like frame_001.png.
+
+    Some example properties for paths:
+      frame_001.png: grouping='frame_#.png', padding_min=3, padding_max=3, number=1
+      sequence_v907: grouping='sequence_v#', padding_min=1, padding_max=3, number=907
+    """
+
+    path: str
+    """The path that may or may not be numbered"""
+    parts: Optional[list[str]] = None
+    """The path split into parts"""
+    grouping: str
+    """The path with the number as '#' for grouping purposes"""
+    padding_min: int
+    """The minimum padding or -1. e.g. '%04d' for padding of 4, that produces the number in the path"""
+    padding_max: int
+    """The maximum padding or -1. e.g. '%04d' for padding of 4, that produces the number in the path"""
+    number: Optional[int] = None
+    """The number in the path, or None if the path is not numbered"""
+
+    def __init__(self, path: Union[Path, str]):
+        if isinstance(path, Path):
+            path = str(path)
+        m = _NUMBERED_PATH_REGEX.match(path)
+        if m:
+            self.path = path
+            self.parts = [m.group(1), m.group(2), m.group(3) or ""]
+            self.grouping = f"{self.parts[0]}#.{self.parts[2]}"
+            number = self.parts[1]
+            if number[0] == "0":
+                self.padding_min = len(number)
+            else:
+                self.padding_min = 1
+            self.padding_max = len(number)
+            self.number = int(number)
+        else:
+            self.path = self.grouping = path
+            self.padding_min = self.padding_max = -1
+
+
+def _divide_numbered_path_group(group: list[_NumberedPath]) -> dict[str, set[int]]:
+    """Given a list of numbered paths that all have the same grouping string, check
+    for padding consistency and split into multiple groups if necessary. Convert
+    into a dictionary from a printf pattern to the set of numbers for it. Groups
+    of size 2 are divided into individual paths.
+
+    For example, the paths frame_001.png and frame_0002.png cannot be together,
+    because they require different padding values."""
+
+    result: dict[str, set[int]] = {}
+
+    while len(group) > 0:
+        # Treat groups of size 1 or 2 as individual paths
+        if len(group) <= 2:
+            for numbered_path in group:
+                result[numbered_path.path] = set()
+            break
+
+        # The largest minimum padding is likely the right padding for the group
+        padding = max(numbered_path.padding_min for numbered_path in group)
+        pattern = f"%0{padding}d" if padding > 1 else "%d"
+        consistent_group = [
+            numbered_path for numbered_path in group if numbered_path.padding_max >= padding
+        ]
+        pattern_path = f"{consistent_group[0].parts[0]}{pattern}{consistent_group[0].parts[2]}"  # type: ignore
+        result[pattern_path] = {numbered_path.number for numbered_path in consistent_group}  # type: ignore
+        # Process the remaining paths separately
+        group = [path for path in group if path.padding_max < padding]
+
+    return result
+
+
+class PathSummary:
+    """
+    Represents a summary of a path, including the path itself, the number of files,
+    and the total size. The summary represents a sequence of files when the index_set
+    value is non-empty. If the summary is a nested accumulation of paths, child
+    paths are in the dictionary 'children'.
+
+    If a path represents a directory, it ends with a directory separator.
+    """
+
+    path: str
+    """Either the path, or a printf pattern if index_set is non-empty"""
+    index_set: set[int]
+    """The set of indexes if the path is a printf pattern or an empty set otherwise"""
+    file_count: int
+    """The number of files"""
+    total_size: Optional[int]
+    """The total size of all files, if sizes are provided"""
+    children: Optional[dict[str, "PathSummary"]]
+    """The children of this path, if the summary is nested"""
+
+    def __init__(
+        self,
+        path: str,
+        *,
+        index_set: Optional[set[int]] = None,
+        file_count: Optional[int] = None,
+        total_size: Optional[int] = None,
+        children: Optional[dict[str, "PathSummary"]] = None,
+    ):
+        self.path = path
+        self.index_set = index_set or set()
+        if index_set:
+            self.file_count = len(index_set)
+        elif file_count is None:
+            self.file_count = 0 if self.is_dir() else 1
+        else:
+            self.file_count = file_count
+        self.total_size = total_size
+        self.children = children
+
+    def is_dir(self) -> bool:
+        """Returns True if the path is a directory (indicated by a trailing '/')"""
+        # On Windows, both '/' and '\\' are directory separators, so check both sep and altsep
+        return self.path.endswith(os.path.sep) or (
+            os.path.altsep and self.path.endswith(os.path.altsep)
+        )  # type: ignore
+
+    def summary(self, *, include_totals=True, relative_to: Optional[Union[Path, str]] = None):
+        """Returns the path summary, including file count and size totals by default."""
+        relpath = self.path
+        if relative_to is not None:
+            relpath = os.path.relpath(self.path, relative_to)
+            # Ensure a trailing separator for directories
+            if self.is_dir():
+                relpath = os.path.join(relpath, "")
+
+        if include_totals:
+            return f"{relpath} ({self.summary_totals()})"
+        elif self.index_set:
+            return f"{relpath} (sequence indexes {_int_set_to_range_expr(self.index_set)})"
+        else:
+            return relpath
+
+    def summary_totals(self) -> str:
+        """Returns the totals of the summary, like 'sequence indexes 1-3, 3 files, 30 MB'
+        if the path represents a sequence or '1 file' if the path represents a file
+        and there is no size information available."""
+        if self.index_set:
+            seq_summary = f", sequence {_int_set_to_range_expr(self.index_set)}"
+        else:
+            seq_summary = ""
+        if self.total_size is not None:
+            size_summary = f", {human_readable_file_size(self.total_size)}"
+        else:
+            size_summary = ""
+        plural = "s" if self.file_count != 1 else ""
+        return f"{self.file_count} file{plural}{size_summary}{seq_summary}"
+
+    def __str__(self):
+        return self.summary()
+
+    def __repr__(self):
+        parts = ["PathSummary(", repr(self.path)]
+        if self.is_dir():
+            if self.file_count != 0:
+                parts.append(f", file_count={self.file_count!r}")
+        else:
+            if self.index_set:
+                parts.append(f", index_set={{{', '.join(str(v) for v in sorted(self.index_set))}}}")
+        if self.total_size is not None:
+            parts.append(f", total_size={self.total_size!r}")
+        if self.children is not None:
+            parts.append(f", children={self.children!r}")
+        parts.append(")")
+        return "".join(parts)
+
+    def __eq__(self, value):
+        if isinstance(value, PathSummary):
+            return (
+                self.path == value.path
+                and self.index_set == value.index_set
+                and self.file_count == value.file_count
+                and self.total_size == value.total_size
+                and self.children == value.children
+            )
+        else:
+            return False
+
+
+def _int_set_to_range_expr(int_set: set[int]) -> str:
+    """
+    Converts a set of integers into a range expression.
+    For example, {1,2,3,4,5,7,8,9,10} -> "1-5,7-10"
+    """
+    int_list = sorted(set(int_set))
+    range_expr_components = []
+    last_interval_start = last_interval_end = int_list[0]
+
+    def add_interval(start: int, end: int):
+        if start == last_interval_end:
+            range_expr_components.append(str(start))
+        else:
+            range_expr_components.append(f"{start}-{end}")
+
+    for value in int_list[1:]:
+        if value == last_interval_end + 1:
+            last_interval_end = value
+        else:
+            add_interval(last_interval_start, last_interval_end)
+            last_interval_start = last_interval_end = value
+    add_interval(last_interval_start, last_interval_end)
+    return ",".join(range_expr_components)
+
+
+def summarize_paths_by_sequence(
+    path_list: Collection[Union[Path, str]], *, total_size_by_path: Optional[dict[str, int]] = None
+) -> list[PathSummary]:
+    """
+    Identifies numbered sequences of files/directories within a list of paths.
+    Returns a sorted list of PathSummary objects. If total_size_by_path is provided, it
+    must provide a total size for every path in path_list.
+
+    >> group_sequence_paths(["frame_1.png", "frame_3.png", "frame_20.png", "readme.txt"])
+    {PathSummary("frame_%d.png", index_set={1, 3, 20}), PathSummary("readme.txt")}
+
+    >> group_sequence_paths(["frame_01.png", "frame_1.png", "frame_30.png", "frame_09.png"])
+    {PathSummary("frame_%02d.png", index_set={1, 9, 20}), PathSummary("frame_1.png")}
+    """
+    if len(path_list) == 0:
+        return []
+
+    # Group according to the _NumberedPath.grouping property
+    raw_grouped_paths: dict[str, list[_NumberedPath]] = {}
+    for path in path_list:
+        numbered_path = _NumberedPath(path)
+        raw_grouped_paths.setdefault(numbered_path.grouping, []).append(numbered_path)
+
+    # Divide any groups with inconsistent padding into smaller consistent groups,
+    # and merge into a dictionary {printf_pattern: set of indexes}.
+    grouped_paths: dict[str, set[int]] = {}
+    for raw_group in raw_grouped_paths.values():
+        grouped_paths.update(_divide_numbered_path_group(raw_group))
+
+    # Sort the result by the printf pattern and convert to PathSummary objects
+    result = [
+        PathSummary(path, index_set=index_set)
+        for path, index_set in sorted(grouped_paths.items(), key=lambda x: x[0])
+    ]
+
+    # If sizes are provided, populate them in the path summary objects
+    if total_size_by_path:
+        for path_summary in result:
+            if path_summary.index_set:
+                path_summary.total_size = sum(
+                    total_size_by_path[path_summary.path % i] for i in path_summary.index_set
+                )
+            else:
+                path_summary.total_size = total_size_by_path[path_summary.path]
+
+    return result
+
+
+def _collapse_each_path_summary(path_summary_list: Iterable[PathSummary]) -> list[PathSummary]:
+    """
+    Collapses each path summary in the list while it has a single child.
+    """
+    result = []
+    for path_summary in path_summary_list:  # type: ignore
+        while path_summary.children is not None and len(path_summary.children) == 1:
+            path_summary = next(iter(path_summary.children.values()))
+        result.append(path_summary)
+
+    return result
+
+
+def summarize_paths_by_nested_directory(
+    path_list: Collection[Union[Path, str]], *, total_size_by_path: Optional[dict[str, int]] = None
+) -> list[PathSummary]:
+    """Summarizes the provided paths by sequence, and then nests them into
+    common parent paths. The returned summaries do not contain a common parent,
+    for example if they are different relative paths, or absolute paths for
+    different drives on Windows"""
+    if len(path_list) == 0:
+        return []
+
+    # First summarize the paths by sequence
+    summary_list = summarize_paths_by_sequence(path_list, total_size_by_path=total_size_by_path)
+
+    # Put all the summaries into a temporary common root.
+    nested_summary = PathSummary("ROOT/")
+    for path_summary in summary_list:
+        # Split the path into its components
+        path_components = Path(path_summary.path).parts
+        # Start with the root component, and build up the nested structure
+        current_level: PathSummary = nested_summary
+        for i in range(len(path_components) - 1):
+            component = path_components[i]
+            # Add the child if it's not already there
+            if current_level.children is None:
+                current_level.children = {}
+            if component not in current_level.children:
+                current_level.children[component] = PathSummary(
+                    os.path.join(*path_components[: i + 1], ""),
+                    total_size=0 if total_size_by_path else None,
+                )
+            # Descend into the new level
+            current_level = current_level.children[component]
+            # Accumulate the file counts and sizes
+            current_level.file_count += path_summary.file_count
+            if total_size_by_path:
+                current_level.total_size += path_summary.total_size  # type: ignore
+        # Add the path summary to the end
+        if current_level.children is None:
+            current_level.children = {}
+        current_level.children[path_components[-1]] = path_summary
+
+    # For each distinct root, collapse it while it contains a single child
+    return _collapse_each_path_summary(nested_summary.children.values())  # type: ignore
+
+
+def summarize_path_list(
+    path_list: Collection[Union[Path, str]],
+    *,
+    total_size_by_path: Optional[dict[str, int]] = None,
+    max_entries=10,
+    include_totals=True,
+) -> str:
+    """
+    Creates a string summary of the files in the list provided,
+    grouping numbered filenames by their sequence pattern, and nesting
+    summaries of the directory into the specified maximum number of entries.
+
+    If total_size_by_path is provided, it must provide a total size for every path in path_list.
+
+        >>> print(summarize_path_list(["frame_1.png", "frame_3.png", "frame_20.png", "readme.txt"]))
+        frame_%d.png (3 files, sequence 1,3,20)
+        readme.txt (1 file)
+    """
+    if len(path_list) == 0:
+        return ""
+
+    lines = []
+    summary_list = summarize_paths_by_nested_directory(
+        path_list, total_size_by_path=total_size_by_path
+    )
+
+    # If the summary list has one entry, and its path is a very shallow root like '/' or 'C:/',
+    # then take all its children at the outer level. This makes the root paths longer so
+    # the individually summarized paths will be shorter and easier to look through.
+    if (
+        len(summary_list) == 1
+        and summary_list[0].children is not None
+        and len(summary_list[0].children) <= max_entries / 2
+    ):
+        summary_list = _collapse_each_path_summary(summary_list[0].children.values())
+
+    if total_size_by_path:
+        # Sort the list so the largest size is first
+        summary_list.sort(key=lambda v: (-v.total_size, v.path))  # type: ignore
+    else:
+        # Sort the list so the largest file count is first
+        summary_list.sort(key=lambda v: (-v.file_count, v.path))  # type: ignore
+
+    # Determine how many entries to show at the outer level and one level in,
+    # with a total less than or equal to max_entries
+    entry_counts = [
+        0 if summary_path.children is None else min(len(summary_path.children), max_entries)
+        for summary_path in summary_list[:max_entries]
+    ]
+    while len(entry_counts) + sum(entry_counts) > max_entries:
+        max_entry_count = max(entry_counts)
+        if max_entry_count > len(entry_counts):
+            # If the largest entry count under a root path is more than the number of root paths,
+            # then decrease that entry count.
+            for i, entry_count in enumerate(reversed(entry_counts)):
+                if entry_count == max_entry_count:
+                    entry_counts[len(entry_counts) - i - 1] -= 1
+                    break
+        else:
+            # Otherwise drop a root path from the summary
+            entry_counts.pop()
+
+    # If we're going to show "... and 1 more ..." after the items, might as well show
+    # the last item instead
+    if len(entry_counts) == len(summary_list) - 1 and not summary_list[-1].is_dir():
+        entry_counts.append(0)
+
+    for entry_count, summary_path in zip(entry_counts, summary_list):
+        if summary_path.children is None:
+            lines.append(f"{summary_path.summary(include_totals=include_totals)}\n")
+        else:
+            lines.append(f"{summary_path.summary(include_totals=include_totals)}:\n")
+            children = list(summary_path.children.values())
+            if total_size_by_path:
+                # Sort the list so the largest size is first
+                children.sort(key=lambda v: (-v.total_size, v.path))  # type: ignore
+            else:
+                # Sort the list so the largest file count is first
+                children.sort(key=lambda v: (-v.file_count, v.path))  # type: ignore
+
+            # If we're going to show "... and 1 more ..." after the items, might as well show
+            # the last item instead
+            if entry_count == len(children) - 1:
+                entry_count += 1
+
+            for child in children[:entry_count]:
+                lines.append(
+                    f"  {child.summary(include_totals=include_totals, relative_to=summary_path.path)}\n"
+                )
+            if len(summary_path.children) > entry_count:
+                lines.append(f"  ... and {len(summary_path.children) - entry_count} more\n")
+
+    if len(summary_list) > len(entry_counts):
+        file_count = sum(v.file_count for v in summary_list[len(entry_counts) :])
+        if total_size_by_path and include_totals:
+            total_size = sum(v.total_size for v in summary_list[len(entry_counts) :])  # type: ignore
+            lines.append(
+                f"... and {len(summary_list) - len(entry_counts)} more ({file_count} files, {human_readable_file_size(total_size)})\n"
+            )
+        elif include_totals:
+            lines.append(
+                f"... and {len(summary_list) - len(entry_counts)} more ({file_count} files)\n"
+            )
+        else:
+            lines.append(f"... and {len(summary_list) - len(entry_counts)} more\n")
+
+    return "".join(lines)

--- a/src/deadline/job_attachments/_utils.py
+++ b/src/deadline/job_attachments/_utils.py
@@ -14,7 +14,6 @@ __all__ = [
     "_join_s3_paths",
     "_generate_random_guid",
     "_float_to_iso_datetime_string",
-    "_human_readable_file_size",
     "_get_unique_dest_dir_name",
     "_get_bucket_and_object_key",
     "_is_relative_to",
@@ -35,7 +34,7 @@ https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitat
 
 WINDOWS_UNC_PATH_STRING_PREFIX = "\\\\?\\"
 """
-When this is prepended to any path on Windows, 
+When this is prepended to any path on Windows,
 it becomes a UNC path and is allowed to go over the 260 max path length limit.
 """
 
@@ -56,32 +55,6 @@ def _float_to_iso_datetime_string(time: float):
     iso_string = dt.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
 
     return iso_string
-
-
-def _human_readable_file_size(size_in_bytes: int) -> str:
-    """
-    Convert a size in bytes to something human readable. For example 1000 bytes will be converted
-    to 1 KB. Sizes close enough to a postfix threshold will be rounded up to the next threshold.
-    For example 999999 bytes would be output as 1.0 MB and NOT 999.99 MB (or as a consequence of
-    Python's round function 1000.0 KB).
-
-    This function is inherently lossy, so it should be used for display purposes only.
-    """
-    converted_size = float(size_in_bytes)
-    rounded: float
-    postfixes = ["B", "KB", "MB", "GB", "TB", "PB"]
-
-    for postfix in postfixes:
-        rounded = round(converted_size, ndigits=2)
-
-        if rounded < 1000:
-            return f"{rounded} {postfix}"
-
-        converted_size /= 1000
-
-    # If we go higher than the provided postfix,
-    # then return as a large amount of the highest postfix we've specified.
-    return f"{rounded} {postfixes[-1]}"
 
 
 def _get_unique_dest_dir_name(source_root: str) -> str:

--- a/src/deadline/job_attachments/api/__init__.py
+++ b/src/deadline/job_attachments/api/__init__.py
@@ -1,5 +1,20 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
-__all__ = ["attachment_download", "attachment_upload"]
+__all__ = [
+    "attachment_download",
+    "attachment_upload",
+    "summarize_paths_by_nested_directory",
+    "summarize_paths_by_sequence",
+    "human_readable_file_size",
+    "summarize_path_list",
+    "PathSummary",
+]
 
 from .attachment import attachment_download, attachment_upload
+from .._path_summarization import (
+    human_readable_file_size,
+    summarize_paths_by_nested_directory,
+    summarize_paths_by_sequence,
+    summarize_path_list,
+    PathSummary,
+)

--- a/src/deadline/job_attachments/api/_utils.py
+++ b/src/deadline/job_attachments/api/_utils.py
@@ -5,9 +5,9 @@ import os
 from contextlib import ExitStack
 from typing import List, Dict
 
-from deadline.client.exceptions import NonValidInputError
-from deadline.job_attachments.asset_manifests.base_manifest import BaseAssetManifest
-from deadline.job_attachments.asset_manifests.decode import decode_manifest
+from ...client.exceptions import NonValidInputError
+from ..asset_manifests.base_manifest import BaseAssetManifest
+from ..asset_manifests.decode import decode_manifest
 
 
 def _read_manifests(manifest_paths: List[str]) -> Dict[str, BaseAssetManifest]:

--- a/src/deadline/job_attachments/asset_sync.py
+++ b/src/deadline/job_attachments/asset_sync.py
@@ -62,10 +62,10 @@ from .models import (
 )
 from .upload import S3AssetUploader
 from .os_file_permission import FileSystemPermissionSettings, PosixFileSystemPermissionSettings
+from ._path_summarization import human_readable_file_size
 from ._utils import (
     _float_to_iso_datetime_string,
     _get_unique_dest_dir_name,
-    _human_readable_file_size,
     _join_s3_paths,
 )
 
@@ -675,7 +675,7 @@ class AssetSync:
 
             self.logger.info(
                 f"Found {total_file_count} file{'' if total_file_count == 1 else 's'}"
-                f" totaling {_human_readable_file_size(total_file_size)}"
+                f" totaling {human_readable_file_size(total_file_size)}"
                 f" in output directory: {str(output_root)}"
             )
 
@@ -732,8 +732,8 @@ class AssetSync:
         """
         disk_free: int = shutil.disk_usage(session_dir).free
         if total_input_bytes > disk_free:
-            input_size_readable = _human_readable_file_size(total_input_bytes)
-            disk_free_readable = _human_readable_file_size(disk_free)
+            input_size_readable = human_readable_file_size(total_input_bytes)
+            disk_free_readable = human_readable_file_size(disk_free)
             raise AssetSyncError(
                 "Error occurred while attempting to sync input files: "
                 f"Total file size required for download ({input_size_readable}) is larger than available disk space ({disk_free_readable})"

--- a/src/deadline/job_attachments/exceptions.py
+++ b/src/deadline/job_attachments/exceptions.py
@@ -6,8 +6,6 @@ Exceptions that the Deadline Job Attachments library can raise.
 
 from typing import Optional
 
-from deadline.job_attachments.progress_tracker import SummaryStatistics
-
 
 COMMON_ERROR_GUIDANCE_FOR_S3 = {
     408: "Request timeout. Please consider retrying later, or ensure your network connection is stable.",
@@ -139,12 +137,9 @@ class AssetSyncCancelledError(JobAttachmentsError):
     Exception thrown when an operation (synching files to/from S3) has been cancelled.
     """
 
-    summary_statistics: Optional[SummaryStatistics] = None
-
-    def __init__(self, message, summary_statistics: Optional[SummaryStatistics] = None):
+    def __init__(self, message, summary_statistics=None):
         super().__init__(message)
-        if summary_statistics:
-            self.summary_statistics = summary_statistics
+        self.summary_statistics = summary_statistics
 
 
 class PathOutsideDirectoryError(JobAttachmentsError):

--- a/src/deadline/job_attachments/progress_tracker.py
+++ b/src/deadline/job_attachments/progress_tracker.py
@@ -10,7 +10,7 @@ from enum import Enum
 from threading import Lock
 from typing import Callable, Dict, Optional, Union
 
-from deadline.job_attachments._utils import _human_readable_file_size
+from ._path_summarization import human_readable_file_size
 
 CALLBACK_INTERVAL = 1  # in seconds
 MAX_FILES_IN_CHUNK = 50
@@ -59,11 +59,11 @@ class SummaryStatistics:
     def __str__(self):
         return (
             f"Processed {self.processed_files} file{'' if self.processed_files == 1 else 's'}"
-            + f" totaling {_human_readable_file_size(self.processed_bytes)}.\n"
+            + f" totaling {human_readable_file_size(self.processed_bytes)}.\n"
             + f"Skipped re-processing {self.skipped_files} files totaling"
-            + f" {_human_readable_file_size(self.skipped_bytes)}.\n"
+            + f" {human_readable_file_size(self.skipped_bytes)}.\n"
             + f"Total processing time of {round(self.total_time, ndigits=5)} seconds"
-            + f" at {_human_readable_file_size(int(self.transfer_rate))}/s.\n"
+            + f" at {human_readable_file_size(int(self.transfer_rate))}/s.\n"
         )
 
 
@@ -306,9 +306,9 @@ class ProgressTracker:
 
         progress_message = (
             f"{self.status.verb_in_message}"
-            f" {_human_readable_file_size(completed_bytes)} / {_human_readable_file_size(self.total_bytes)}"
+            f" {human_readable_file_size(completed_bytes)} / {human_readable_file_size(self.total_bytes)}"
             f" of {self.total_files} file{'' if self.total_files == 1 else 's'}"
-            f" ({transfer_rate_name}: {_human_readable_file_size(int(transfer_rate))}/s)"
+            f" ({transfer_rate_name}: {human_readable_file_size(int(transfer_rate))}/s)"
         )
 
         return ProgressReportMetadata(

--- a/test/installer/test_installer.py
+++ b/test/installer/test_installer.py
@@ -483,7 +483,7 @@ class TestVerifySigning:
             ========================================
             0      sha256     Authenticode
 
-            Successfully verified: C:\*.exe
+            Successfully verified: C:\\*.exe
 
         Example failure:
 

--- a/test/unit/deadline_client/cli/test_cli_handle_web_url.py
+++ b/test/unit/deadline_client/cli/test_cli_handle_web_url.py
@@ -13,6 +13,7 @@ import pytest
 from click.testing import CliRunner
 
 from deadline.client import api
+from deadline.client.config import set_setting
 from deadline.client.cli import main
 from deadline.client.cli._deadline_web_url import (
     parse_query_string,
@@ -25,6 +26,9 @@ from deadline.job_attachments.models import (
     FileConflictResolution,
     JobAttachmentS3Settings,
     PathFormat,
+)
+from deadline.job_attachments.progress_tracker import (
+    DownloadSummaryStatistics,
 )
 
 from ..api.test_job_bundle_submission import (
@@ -256,12 +260,17 @@ def test_cli_handle_web_url_download_output_only_required_input(fresh_deadline_c
     Confirm that the CLI interface prints out the expected list of
     farms, given mock data.
     """
+    set_setting("settings.auto_accept", "true")
+
     with patch.object(api, "get_boto3_client") as boto3_client_mock, patch.object(
         job_group, "OutputDownloader"
-    ) as MockOutputDownloader, patch.object(job_group, "round", return_value=0), patch.object(
-        api, "get_queue_user_boto3_session"
-    ):
+    ) as MockOutputDownloader, patch.object(api, "get_queue_user_boto3_session"):
         mock_download = MagicMock()
+        mock_download.return_value = DownloadSummaryStatistics(
+            total_time=12,
+            processed_files=3,
+            processed_bytes=1024,
+        )
         MockOutputDownloader.return_value.download_job_output = mock_download
         mock_host_path_format_name = PathFormat.get_host_path_format_string()
 
@@ -297,7 +306,7 @@ def test_cli_handle_web_url_download_output_only_required_input(fresh_deadline_c
             file_conflict_resolution=FileConflictResolution.CREATE_COPY,
             on_downloading_files=ANY,
         )
-        assert result.exit_code == 0
+        assert result.exit_code == 0, result.output
 
 
 def test_cli_handle_web_url_download_output_with_optional_input(fresh_deadline_config):
@@ -305,12 +314,19 @@ def test_cli_handle_web_url_download_output_with_optional_input(fresh_deadline_c
     Confirm that the CLI interface prints out the expected list of
     farms, given mock data.
     """
+    set_setting("settings.auto_accept", "true")
+
     with patch.object(api, "get_boto3_client") as boto3_client_mock, patch.object(
         job_group, "OutputDownloader"
     ) as MockOutputDownloader, patch.object(job_group, "round", return_value=0), patch.object(
         api, "get_queue_user_boto3_session"
     ):
         mock_download = MagicMock()
+        mock_download.return_value = DownloadSummaryStatistics(
+            total_time=12,
+            processed_files=3,
+            processed_bytes=1024,
+        )
         MockOutputDownloader.return_value.download_job_output = mock_download
         mock_host_path_format_name = PathFormat.get_host_path_format_string()
 

--- a/test/unit/deadline_client/cli/test_cli_job.py
+++ b/test/unit/deadline_client/cli/test_cli_job.py
@@ -27,7 +27,9 @@ from deadline.job_attachments.models import (
     JobAttachmentS3Settings,
     PathFormat,
 )
-
+from deadline.job_attachments.progress_tracker import (
+    DownloadSummaryStatistics,
+)
 from ..api.test_job_bundle_submission import (
     MOCK_GET_QUEUE_RESPONSE,
 )
@@ -356,6 +358,11 @@ def test_cli_job_download_output_stdout_with_only_required_input(
         api, "get_queue_user_boto3_session"
     ):
         mock_download = MagicMock()
+        mock_download.return_value = DownloadSummaryStatistics(
+            total_time=12,
+            processed_files=3,
+            processed_bytes=1024,
+        )
         MockOutputDownloader.return_value.download_job_output = mock_download
         mock_root_path = "/root/path" if sys.platform != "win32" else "C:\\Users\\username"
         mock_files_list = ["outputs/file1.txt", "outputs/file2.txt", "outputs/file3.txt"]
@@ -462,6 +469,11 @@ def test_cli_job_download_output_stdout_with_mismatching_path_format(
         api, "get_queue_user_boto3_session"
     ):
         mock_download = MagicMock()
+        mock_download.return_value = DownloadSummaryStatistics(
+            total_time=12,
+            processed_files=3,
+            processed_bytes=1024,
+        )
         MockOutputDownloader.return_value.download_job_output = mock_download
 
         mock_root_path = "C:\\Users\\username" if sys.platform != "win32" else "/root/path"
@@ -557,6 +569,11 @@ def test_cli_job_download_output_handles_unc_path_on_windows(fresh_deadline_conf
         api, "get_queue_user_boto3_session"
     ):
         mock_download = MagicMock()
+        mock_download.return_value = DownloadSummaryStatistics(
+            total_time=12,
+            processed_files=3,
+            processed_bytes=1024,
+        )
         MockOutputDownloader.return_value.download_job_output = mock_download
 
         # UNC format (which refers to the same location as 'C:\Users\username')
@@ -628,7 +645,7 @@ You are about to download files which may come from multiple root directories. H
             in result.output
         )
         assert "Download Summary:" in result.output
-        assert result.exit_code == 0
+        assert result.exit_code == 0, result.output
 
 
 def test_cli_job_download_no_output_stdout(fresh_deadline_config, tmp_path: Path):
@@ -647,6 +664,11 @@ def test_cli_job_download_no_output_stdout(fresh_deadline_config, tmp_path: Path
         api, "get_queue_user_boto3_session"
     ):
         mock_download = MagicMock()
+        mock_download.return_value = DownloadSummaryStatistics(
+            total_time=12,
+            processed_files=3,
+            processed_bytes=1024,
+        )
         MockOutputDownloader.return_value.download_job_output = mock_download
         MockOutputDownloader.return_value.get_output_paths_by_root.return_value = {}
 
@@ -710,6 +732,11 @@ def test_cli_job_download_output_stdout_with_json_format(
         api, "get_queue_user_boto3_session"
     ):
         mock_download = MagicMock()
+        mock_download.return_value = DownloadSummaryStatistics(
+            total_time=12,
+            processed_files=3,
+            processed_bytes=1024,
+        )
         MockOutputDownloader.return_value.download_job_output = mock_download
         mock_root_path = "/root/path" if sys.platform != "win32" else "C:\\Users\\username"
         mock_files_list = ["outputs/file1.txt", "outputs/file2.txt", "outputs/file3.txt"]
@@ -884,12 +911,19 @@ def test_cli_job_download_output_handle_web_url_with_optional_input(fresh_deadli
     Confirm that the CLI interface prints out the expected list of
     farms, given mock data.
     """
+    config.set_setting("settings.auto_accept", "true")
+
     with patch.object(api, "get_boto3_client") as boto3_client_mock, patch.object(
         job_group, "OutputDownloader"
     ) as MockOutputDownloader, patch.object(job_group, "round", return_value=0), patch.object(
         api, "get_queue_user_boto3_session"
     ):
         mock_download = MagicMock()
+        mock_download.return_value = DownloadSummaryStatistics(
+            total_time=12,
+            processed_files=3,
+            processed_bytes=1024,
+        )
         MockOutputDownloader.return_value.download_job_output = mock_download
         mock_host_path_format_name = PathFormat.get_host_path_format_string()
 
@@ -1026,6 +1060,11 @@ def test_cli_job_download_output_with_different_asset_root_path_format_than_job(
         return_value=tmp_path,
     ) as mock_expanduser:
         mock_download = MagicMock()
+        mock_download.return_value = DownloadSummaryStatistics(
+            total_time=12,
+            processed_files=3,
+            processed_bytes=1024,
+        )
         MockOutputDownloader.return_value.download_job_output = mock_download
         windows_root_path = "C:\\Users\\username"
         not_windows_root_path = "/root/path"

--- a/test/unit/deadline_job_attachments/api/test_path_summarization.py
+++ b/test/unit/deadline_job_attachments/api/test_path_summarization.py
@@ -1,0 +1,630 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+import os
+
+import pytest
+
+from deadline.job_attachments.api import (
+    PathSummary,
+    human_readable_file_size,
+    summarize_paths_by_sequence,
+    summarize_paths_by_nested_directory,
+    summarize_path_list,
+)
+
+
+PARAMETRIZE_CASES: tuple = (
+    (1000000000000000000, "1000.0 PB"),
+    (89234597823492938, "89.23 PB"),
+    (1000000000000001, "1.0 PB"),
+    (1000000000000000, "1.0 PB"),
+    (999999999999999, "1.0 PB"),
+    (999995000000000, "1.0 PB"),
+    (999994000000000, "999.99 TB"),
+    (8934587945678, "8.93 TB"),
+    (1000000000001, "1.0 TB"),
+    (1000000000000, "1.0 TB"),
+    (999999999999, "1.0 TB"),
+    (999995000000, "1.0 TB"),
+    (999994000000, "999.99 GB"),
+    (83748237582, "83.75 GB"),
+    (1000000001, "1.0 GB"),
+    (1000000000, "1.0 GB"),
+    (999999999, "1.0 GB"),
+    (999995000, "1.0 GB"),
+    (999994000, "999.99 MB"),
+    (500229150, "500.23 MB"),
+    (1000001, "1.0 MB"),
+    (1000000, "1.0 MB"),
+    (999999, "1.0 MB"),
+    (999995, "1.0 MB"),
+    (999994, "999.99 KB"),
+    (96771, "96.77 KB"),
+    (1001, "1.0 KB"),
+    (1000, "1.0 KB"),
+    (999, "999 B"),
+    (934, "934 B"),
+    (0, "0 B"),
+)
+
+
+@pytest.mark.parametrize(
+    ("file_size", "expected_output"),
+    PARAMETRIZE_CASES,
+)
+def test_human_readable_file_size(file_size: int, expected_output: str):
+    """
+    Test that given a file size in bytes, the expected human readable file size is output.
+    """
+    assert human_readable_file_size(file_size) == expected_output
+
+
+@pytest.mark.parametrize(
+    ("path_list", "expected_output"),
+    [
+        (
+            ["frame_1.png", "frame_3.png", "frame_20.png", "readme.txt"],
+            [PathSummary("frame_%d.png", index_set={1, 3, 20}), PathSummary("readme.txt")],
+        ),
+        (
+            ["frame_01.png", "frame_1.png", "frame_30.png", "frame_09.png"],
+            [PathSummary("frame_%02d.png", index_set={1, 9, 30}), PathSummary("frame_1.png")],
+        ),
+        (["00", "02", "03", "07", "10"], [PathSummary("%02d", index_set={0, 2, 3, 7, 10})]),
+        (["0", "5", "99", "207"], [PathSummary("%d", index_set={0, 5, 99, 207})]),
+        (
+            [
+                "dataset_2.tar.gz",
+                "dataset_821.tar.gz",
+                "dataset_1.tar.gz",
+                "dataset_3.tar.gz",
+                "dataset_12345.tar.gz",
+                "dataset_23.tar.gz",
+            ],
+            [PathSummary("dataset_%d.tar.gz", index_set={1, 2, 3, 23, 821, 12345})],
+        ),
+        (
+            ["frame_1.png", "frame_20.png", "7", "12", "000", "100", "789", "1000"],
+            [
+                PathSummary("%03d", index_set={0, 100, 789, 1000}),
+                PathSummary("12"),
+                PathSummary("7"),
+                PathSummary("frame_1.png"),
+                PathSummary("frame_20.png"),
+            ],
+        ),
+    ],
+)
+def test_summarize_paths_without_nesting_without_sizes(path_list, expected_output):
+    """Given each list of paths, confirm the expected output."""
+    assert summarize_paths_by_sequence(path_list) == expected_output
+    # Since there's no nesting in these cases, this is equivalent
+    assert summarize_paths_by_nested_directory(path_list) == expected_output
+
+
+PARAMETRIZE_CASES = (
+    (
+        ["frame_1.png", "frame_3.png", "frame_20.png", "readme.txt"],
+        {"frame_1.png": 1, "frame_3.png": 2, "frame_20.png": 4, "readme.txt": 8},
+        [
+            PathSummary("frame_%d.png", index_set={1, 3, 20}, total_size=7),
+            PathSummary("readme.txt", total_size=8),
+        ],
+    ),
+    (
+        ["frame_01.png", "frame_1.png", "frame_30.png", "frame_09.png"],
+        {"frame_01.png": 1, "frame_1.png": 2, "frame_30.png": 4, "frame_09.png": 8},
+        [
+            PathSummary("frame_%02d.png", index_set={1, 9, 30}, total_size=13),
+            PathSummary("frame_1.png", total_size=2),
+        ],
+    ),
+    (
+        ["00", "02", "03", "07", "10"],
+        {"00": 1, "02": 2, "03": 4, "07": 8, "10": 16},
+        [PathSummary("%02d", index_set={0, 2, 3, 7, 10}, total_size=31)],
+    ),
+    (
+        ["0", "5", "99", "207"],
+        {"0": 1, "5": 2, "99": 4, "207": 8},
+        [PathSummary("%d", index_set={0, 5, 99, 207}, total_size=15)],
+    ),
+    (
+        [
+            "dataset_2.tar.gz",
+            "dataset_821.tar.gz",
+            "dataset_1.tar.gz",
+            "dataset_3.tar.gz",
+            "dataset_12345.tar.gz",
+            "dataset_23.tar.gz",
+        ],
+        {
+            "dataset_2.tar.gz": 1,
+            "dataset_821.tar.gz": 2,
+            "dataset_1.tar.gz": 4,
+            "dataset_3.tar.gz": 8,
+            "dataset_12345.tar.gz": 16,
+            "dataset_23.tar.gz": 32,
+        },
+        [PathSummary("dataset_%d.tar.gz", index_set={1, 2, 3, 23, 821, 12345}, total_size=63)],
+    ),
+    (
+        ["frame_1.png", "frame_20.png", "7", "12", "000", "100", "789", "1000"],
+        {
+            "frame_1.png": 1,
+            "frame_20.png": 2,
+            "7": 4,
+            "12": 8,
+            "000": 16,
+            "100": 32,
+            "789": 64,
+            "1000": 128,
+        },
+        [
+            PathSummary("%03d", index_set={0, 100, 789, 1000}, total_size=16 + 32 + 64 + 128),
+            PathSummary("12", total_size=8),
+            PathSummary("7", total_size=4),
+            PathSummary("frame_1.png", total_size=1),
+            PathSummary("frame_20.png", total_size=2),
+        ],
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    ("path_list", "sizes", "expected_output"),
+    PARAMETRIZE_CASES,
+)
+def test_summarize_paths_without_nesting_with_sizes(path_list, sizes, expected_output):
+    """Given each list of paths, confirm the expected output."""
+    assert summarize_paths_by_sequence(path_list, total_size_by_path=sizes) == expected_output
+    # Since there's no nesting in these cases, this is equivalent
+    assert (
+        summarize_paths_by_nested_directory(path_list, total_size_by_path=sizes) == expected_output
+    )
+
+
+PARAMETRIZE_CASES = (
+    (
+        [],
+        [],
+        [],
+    ),
+    (
+        ["a/b/c/frame_1.png", "a/b/c/frame_3.png", "a/b/c/frame_20.png", "a/b/d/readme.txt"],
+        [
+            PathSummary("a/b/c/frame_%d.png", index_set={1, 3, 20}),
+            PathSummary("a/b/d/readme.txt"),
+        ],
+        [
+            PathSummary(
+                "a/b/".replace("/", os.path.sep),
+                file_count=4,
+                children={
+                    "c": PathSummary(
+                        "a/b/c/".replace("/", os.path.sep),
+                        file_count=3,
+                        children={
+                            "frame_%d.png": PathSummary(
+                                "a/b/c/frame_%d.png",
+                                index_set={1, 3, 20},
+                            )
+                        },
+                    ),
+                    "d": PathSummary(
+                        "a/b/d/".replace("/", os.path.sep),
+                        file_count=1,
+                        children={"readme.txt": PathSummary("a/b/d/readme.txt")},
+                    ),
+                },
+            )
+        ],
+    ),
+    (
+        ["seq/frame_01.png", "frame_1.png", "seq/frame_30.png", "seq/frame_09.png"],
+        [
+            PathSummary("frame_1.png"),
+            PathSummary("seq/frame_%02d.png", index_set={1, 9, 30}),
+        ],
+        [
+            PathSummary("frame_1.png"),
+            PathSummary("seq/frame_%02d.png", index_set={1, 9, 30}),
+        ],
+    ),
+    (
+        ["/abc/def/ghi/00", "/abc/xyz/02", "/abc/def/jkl/mno/03", "/www/07", "/abc/def/10"],
+        [
+            PathSummary("/abc/def/10"),
+            PathSummary("/abc/def/ghi/00"),
+            PathSummary("/abc/def/jkl/mno/03"),
+            PathSummary("/abc/xyz/02"),
+            PathSummary("/www/07"),
+        ],
+        [
+            PathSummary(
+                os.path.sep,
+                file_count=5,
+                children={
+                    "abc": PathSummary(
+                        "/abc/".replace("/", os.path.sep),
+                        file_count=4,
+                        children={
+                            "def": PathSummary(
+                                "/abc/def/".replace("/", os.path.sep),
+                                file_count=3,
+                                children={
+                                    "ghi": PathSummary(
+                                        "/abc/def/ghi/".replace("/", os.path.sep),
+                                        file_count=1,
+                                        children={"00": PathSummary("/abc/def/ghi/00")},
+                                    ),
+                                    "jkl": PathSummary(
+                                        "/abc/def/jkl/".replace("/", os.path.sep),
+                                        file_count=1,
+                                        children={
+                                            "mno": PathSummary(
+                                                "/abc/def/jkl/mno/".replace("/", os.path.sep),
+                                                file_count=1,
+                                                children={"03": PathSummary("/abc/def/jkl/mno/03")},
+                                            )
+                                        },
+                                    ),
+                                    "10": PathSummary("/abc/def/10"),
+                                },
+                            ),
+                            "xyz": PathSummary(
+                                "/abc/xyz/".replace("/", os.path.sep),
+                                file_count=1,
+                                children={"02": PathSummary("/abc/xyz/02")},
+                            ),
+                        },
+                    ),
+                    "www": PathSummary(
+                        "/www/".replace("/", os.path.sep),
+                        file_count=1,
+                        children={"07": PathSummary("/www/07")},
+                    ),
+                },
+            )
+        ],
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    ("path_list", "expected_seq_output", "expected_nest_output"),
+    PARAMETRIZE_CASES,
+)
+def test_summarize_paths_with_nesting_without_sizes(
+    path_list, expected_seq_output, expected_nest_output
+):
+    """Given each list of paths, confirm the expected output."""
+    assert summarize_paths_by_sequence(path_list) == expected_seq_output
+    assert summarize_paths_by_nested_directory(path_list) == expected_nest_output
+
+
+PARAMETRIZE_CASES = (
+    ([], {}, [], []),
+    (
+        ["a/b/c/frame_1.png", "a/b/c/frame_3.png", "a/b/c/frame_20.png", "a/b/d/readme.txt"],
+        {
+            "a/b/c/frame_1.png": 1,
+            "a/b/c/frame_3.png": 2,
+            "a/b/c/frame_20.png": 4,
+            "a/b/d/readme.txt": 8,
+        },
+        [
+            PathSummary("a/b/c/frame_%d.png", index_set={1, 3, 20}, total_size=7),
+            PathSummary("a/b/d/readme.txt", total_size=8),
+        ],
+        [
+            PathSummary(
+                "a/b/".replace("/", os.path.sep),
+                file_count=4,
+                total_size=15,
+                children={
+                    "c": PathSummary(
+                        "a/b/c/".replace("/", os.path.sep),
+                        file_count=3,
+                        total_size=7,
+                        children={
+                            "frame_%d.png": PathSummary(
+                                "a/b/c/frame_%d.png",
+                                index_set={1, 3, 20},
+                                total_size=7,
+                            )
+                        },
+                    ),
+                    "d": PathSummary(
+                        "a/b/d/".replace("/", os.path.sep),
+                        file_count=1,
+                        total_size=8,
+                        children={"readme.txt": PathSummary("a/b/d/readme.txt", total_size=8)},
+                    ),
+                },
+            )
+        ],
+    ),
+    (
+        ["seq/frame_01.png", "frame_1.png", "seq/frame_30.png", "seq/frame_09.png"],
+        {"seq/frame_01.png": 1, "frame_1.png": 2, "seq/frame_30.png": 4, "seq/frame_09.png": 8},
+        [
+            PathSummary("frame_1.png", total_size=2),
+            PathSummary("seq/frame_%02d.png", index_set={1, 9, 30}, total_size=13),
+        ],
+        [
+            PathSummary("frame_1.png", total_size=2),
+            PathSummary("seq/frame_%02d.png", index_set={1, 9, 30}, total_size=13),
+        ],
+    ),
+    (
+        ["/abc/def/ghi/00", "/abc/xyz/02", "/abc/def/jkl/mno/03", "/www/07", "/abc/def/10"],
+        {
+            "/abc/def/ghi/00": 1,
+            "/abc/xyz/02": 2,
+            "/abc/def/jkl/mno/03": 4,
+            "/www/07": 8,
+            "/abc/def/10": 16,
+        },
+        [
+            PathSummary("/abc/def/10", total_size=16),
+            PathSummary("/abc/def/ghi/00", total_size=1),
+            PathSummary("/abc/def/jkl/mno/03", total_size=4),
+            PathSummary("/abc/xyz/02", total_size=2),
+            PathSummary("/www/07", total_size=8),
+        ],
+        [
+            PathSummary(
+                os.path.sep,
+                file_count=5,
+                total_size=31,
+                children={
+                    "abc": PathSummary(
+                        "/abc/".replace("/", os.path.sep),
+                        file_count=4,
+                        total_size=23,
+                        children={
+                            "def": PathSummary(
+                                "/abc/def/".replace("/", os.path.sep),
+                                file_count=3,
+                                total_size=21,
+                                children={
+                                    "ghi": PathSummary(
+                                        "/abc/def/ghi/".replace("/", os.path.sep),
+                                        file_count=1,
+                                        total_size=1,
+                                        children={
+                                            "00": PathSummary("/abc/def/ghi/00", total_size=1)
+                                        },
+                                    ),
+                                    "jkl": PathSummary(
+                                        "/abc/def/jkl/".replace("/", os.path.sep),
+                                        file_count=1,
+                                        total_size=4,
+                                        children={
+                                            "mno": PathSummary(
+                                                "/abc/def/jkl/mno/".replace("/", os.path.sep),
+                                                file_count=1,
+                                                total_size=4,
+                                                children={
+                                                    "03": PathSummary(
+                                                        "/abc/def/jkl/mno/03", total_size=4
+                                                    )
+                                                },
+                                            )
+                                        },
+                                    ),
+                                    "10": PathSummary("/abc/def/10", total_size=16),
+                                },
+                            ),
+                            "xyz": PathSummary(
+                                "/abc/xyz/".replace("/", os.path.sep),
+                                file_count=1,
+                                total_size=2,
+                                children={"02": PathSummary("/abc/xyz/02", total_size=2)},
+                            ),
+                        },
+                    ),
+                    "www": PathSummary(
+                        "/www/".replace("/", os.path.sep),
+                        file_count=1,
+                        total_size=8,
+                        children={"07": PathSummary("/www/07", total_size=8)},
+                    ),
+                },
+            )
+        ],
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    ("path_list", "sizes", "expected_seq_output", "expected_nest_output"), PARAMETRIZE_CASES
+)
+def test_summarize_paths_with_nesting_with_sizes(
+    path_list, sizes, expected_seq_output, expected_nest_output
+):
+    """Given each list of paths, confirm the expected output."""
+    assert summarize_paths_by_sequence(path_list, total_size_by_path=sizes) == expected_seq_output
+    assert (
+        summarize_paths_by_nested_directory(path_list, total_size_by_path=sizes)
+        == expected_nest_output
+    )
+
+
+PATH_LIST_DATASET_SEQ_TAR_GZ = [
+    "dataset_2.tar.gz",
+    "dataset_821.tar.gz",
+    "dataset_1.tar.gz",
+    "dataset_3.tar.gz",
+    "dataset_12345.tar.gz",
+    "dataset_23.tar.gz",
+]
+PATH_LIST_DATASET_SEQ_TAR_GZ_SIZES = {
+    "dataset_2.tar.gz": 1,
+    "dataset_821.tar.gz": 2,
+    "dataset_1.tar.gz": 4,
+    "dataset_3.tar.gz": 8,
+    "dataset_12345.tar.gz": 16,
+    "dataset_23.tar.gz": 32,
+}
+
+PATH_LIST_UNNUMBERED_FILES = [
+    "file1.tar.gz",
+    "file2.tar.gz",
+    "sword.txt",
+    "stone.png",
+    "imagination.md",
+]
+PATH_LIST_UNNUMBERED_FILES_SIZES = {
+    "file1.tar.gz": 1,
+    "file2.tar.gz": 2,
+    "sword.txt": 4,
+    "stone.png": 8,
+    "imagination.md": 16,
+}
+
+PATH_LIST_NESTED_FILES = [
+    "seq/file1.tar.gz",
+    "seq/file2.tar.gz",
+    "seq/file3.tar.gz",
+    "doc/sword.txt",
+    "doc/images/stone.png",
+    "doc/imagination.md",
+    "README.md",
+]
+PATH_LIST_NESTED_FILES_SIZES = {
+    "seq/file1.tar.gz": 1,
+    "seq/file2.tar.gz": 2,
+    "seq/file3.tar.gz": 4,
+    "doc/sword.txt": 8,
+    "doc/images/stone.png": 16,
+    "doc/imagination.md": 32,
+    "README.md": 64,
+}
+
+PARAMETRIZE_CASES = (
+    (
+        [],
+        dict(),
+        "",
+    ),
+    (
+        PATH_LIST_DATASET_SEQ_TAR_GZ,
+        dict(),
+        "dataset_%d.tar.gz (6 files, sequence 1-3,23,821,12345)\n",
+    ),
+    (
+        PATH_LIST_DATASET_SEQ_TAR_GZ,
+        dict(include_totals=False),
+        "dataset_%d.tar.gz (sequence indexes 1-3,23,821,12345)\n",
+    ),
+    (
+        PATH_LIST_DATASET_SEQ_TAR_GZ,
+        dict(total_size_by_path=PATH_LIST_DATASET_SEQ_TAR_GZ_SIZES),
+        "dataset_%d.tar.gz (6 files, 63 B, sequence 1-3,23,821,12345)\n",
+    ),
+    (
+        PATH_LIST_DATASET_SEQ_TAR_GZ,
+        dict(total_size_by_path=PATH_LIST_DATASET_SEQ_TAR_GZ_SIZES, include_totals=False),
+        "dataset_%d.tar.gz (sequence indexes 1-3,23,821,12345)\n",
+    ),
+    (
+        PATH_LIST_UNNUMBERED_FILES,
+        dict(),
+        "file1.tar.gz (1 file)\nfile2.tar.gz (1 file)\nimagination.md (1 file)\nstone.png (1 file)\nsword.txt (1 file)\n",
+    ),
+    (
+        PATH_LIST_UNNUMBERED_FILES,
+        dict(max_entries=5),
+        "file1.tar.gz (1 file)\nfile2.tar.gz (1 file)\nimagination.md (1 file)\nstone.png (1 file)\nsword.txt (1 file)\n",
+    ),
+    (
+        PATH_LIST_UNNUMBERED_FILES,
+        dict(
+            max_entries=4
+        ),  # Special case, this shows 5 entries because the 5th line "..." would be less info than showing the actual file
+        "file1.tar.gz (1 file)\nfile2.tar.gz (1 file)\nimagination.md (1 file)\nstone.png (1 file)\nsword.txt (1 file)\n",
+    ),
+    (
+        PATH_LIST_UNNUMBERED_FILES,
+        dict(include_totals=False),
+        "file1.tar.gz\nfile2.tar.gz\nimagination.md\nstone.png\nsword.txt\n",
+    ),
+    (
+        PATH_LIST_UNNUMBERED_FILES,
+        dict(include_totals=False, max_entries=3),
+        "file1.tar.gz\nfile2.tar.gz\nimagination.md\n... and 2 more\n",
+    ),
+    (
+        PATH_LIST_UNNUMBERED_FILES,
+        dict(total_size_by_path=PATH_LIST_UNNUMBERED_FILES_SIZES),
+        "imagination.md (1 file, 16 B)\nstone.png (1 file, 8 B)\nsword.txt (1 file, 4 B)\nfile2.tar.gz (1 file, 2 B)\nfile1.tar.gz (1 file, 1 B)\n",
+    ),
+    (
+        PATH_LIST_UNNUMBERED_FILES,
+        dict(total_size_by_path=PATH_LIST_UNNUMBERED_FILES_SIZES, max_entries=3),
+        "imagination.md (1 file, 16 B)\nstone.png (1 file, 8 B)\nsword.txt (1 file, 4 B)\n... and 2 more (2 files, 3 B)\n",
+    ),
+    (
+        PATH_LIST_UNNUMBERED_FILES,
+        dict(total_size_by_path=PATH_LIST_UNNUMBERED_FILES_SIZES, include_totals=False),
+        "imagination.md\nstone.png\nsword.txt\nfile2.tar.gz\nfile1.tar.gz\n",
+    ),
+    (
+        PATH_LIST_UNNUMBERED_FILES,
+        dict(
+            total_size_by_path=PATH_LIST_UNNUMBERED_FILES_SIZES, include_totals=False, max_entries=3
+        ),
+        "imagination.md\nstone.png\nsword.txt\n... and 2 more\n",
+    ),
+    (
+        PATH_LIST_NESTED_FILES,
+        dict(),
+        "doc/ (3 files):\n  images/ (1 file)\n  imagination.md (1 file)\n  sword.txt (1 file)\nseq/file%d.tar.gz (3 files, sequence 1-3)\nREADME.md (1 file)\n",
+    ),
+    (
+        PATH_LIST_NESTED_FILES,
+        dict(max_entries=2),
+        "doc/ (3 files):\n  images/ (1 file)\n  ... and 2 more\n... and 2 more (4 files)\n".replace(
+            "/", os.path.sep
+        ),
+    ),
+    (
+        PATH_LIST_NESTED_FILES,
+        dict(max_entries=2, total_size_by_path=PATH_LIST_NESTED_FILES_SIZES),
+        "README.md (1 file, 64 B)\n... and 2 more (6 files, 63 B)\n".replace("/", os.path.sep),
+    ),
+    (
+        PATH_LIST_NESTED_FILES,
+        dict(max_entries=5, total_size_by_path=PATH_LIST_NESTED_FILES_SIZES),
+        "README.md (1 file, 64 B)\ndoc/ (3 files, 56 B):\n  imagination.md (1 file, 32 B)\n  images/ (1 file, 16 B)\n  sword.txt (1 file, 8 B)\nseq/file%d.tar.gz (3 files, 7 B, sequence 1-3)\n".replace(
+            "/", os.path.sep
+        ),
+    ),
+    (
+        PATH_LIST_NESTED_FILES,
+        dict(max_entries=5, total_size_by_path=PATH_LIST_NESTED_FILES_SIZES, include_totals=False),
+        "README.md\ndoc/:\n  imagination.md\n  images/\n  sword.txt\nseq/file%d.tar.gz (sequence indexes 1-3)\n".replace(
+            "/", os.path.sep
+        ),
+    ),
+    (
+        PATH_LIST_NESTED_FILES,
+        dict(max_entries=5, include_totals=False),
+        "doc/:\n  images/\n  imagination.md\n  sword.txt\nseq/file%d.tar.gz (sequence indexes 1-3)\nREADME.md\n".replace(
+            "/", os.path.sep
+        ),
+    ),
+)
+
+
+@pytest.mark.parametrize(("path_list", "kwargs", "expected_output"), PARAMETRIZE_CASES)
+def test_summarize_path_list(path_list, kwargs, expected_output):
+    if "total_size_by_path" in kwargs:
+        kwargs["total_size_by_path"] = {
+            path.replace("/", os.path.sep): size
+            for path, size in kwargs["total_size_by_path"].items()
+        }
+    assert summarize_path_list(
+        [path.replace("/", os.path.sep) for path in path_list], **kwargs
+    ) == expected_output.replace("/", os.path.sep)

--- a/test/unit/deadline_job_attachments/test_asset_sync.py
+++ b/test/unit/deadline_job_attachments/test_asset_sync.py
@@ -40,7 +40,7 @@ from deadline.job_attachments.progress_tracker import (
     ProgressStatus,
     SummaryStatistics,
 )
-from deadline.job_attachments._utils import _human_readable_file_size
+from deadline.job_attachments.api import human_readable_file_size
 from ..conftest import is_windows_non_admin
 
 
@@ -72,47 +72,6 @@ class TestAssetSync:
         asset_sync = AssetSync(farm_id)
         asset_sync.s3_uploader._s3 = client
         return asset_sync
-
-    @pytest.mark.parametrize(
-        ("file_size", "expected_output"),
-        [
-            (1000000000000000000, "1000.0 PB"),
-            (89234597823492938, "89.23 PB"),
-            (1000000000000001, "1.0 PB"),
-            (1000000000000000, "1.0 PB"),
-            (999999999999999, "1.0 PB"),
-            (999995000000000, "1.0 PB"),
-            (999994000000000, "999.99 TB"),
-            (8934587945678, "8.93 TB"),
-            (1000000000001, "1.0 TB"),
-            (1000000000000, "1.0 TB"),
-            (999999999999, "1.0 TB"),
-            (999995000000, "1.0 TB"),
-            (999994000000, "999.99 GB"),
-            (83748237582, "83.75 GB"),
-            (1000000001, "1.0 GB"),
-            (1000000000, "1.0 GB"),
-            (999999999, "1.0 GB"),
-            (999995000, "1.0 GB"),
-            (999994000, "999.99 MB"),
-            (500229150, "500.23 MB"),
-            (1000001, "1.0 MB"),
-            (1000000, "1.0 MB"),
-            (999999, "1.0 MB"),
-            (999995, "1.0 MB"),
-            (999994, "999.99 KB"),
-            (96771, "96.77 KB"),
-            (1001, "1.0 KB"),
-            (1000, "1.0 KB"),
-            (999, "999.0 B"),
-            (934, "934.0 B"),
-        ],
-    )
-    def test_human_readable_file_size(self, file_size: int, expected_output: str) -> None:
-        """
-        Test that given a file size in bytes, the expected human readable file size is output.
-        """
-        assert _human_readable_file_size(file_size) == expected_output
 
     def test_sync_inputs_no_inputs_successful(
         self,
@@ -690,7 +649,7 @@ class TestAssetSync:
                 f'"totalSize":{expected_total_bytes}}}',
             )
 
-            readable_total_input_bytes = _human_readable_file_size(expected_total_bytes)
+            readable_total_input_bytes = human_readable_file_size(expected_total_bytes)
 
             expected_summary_statistics = SummaryStatistics(
                 total_time=summary_statistics.total_time,

--- a/test/unit/deadline_job_attachments/test_download.py
+++ b/test/unit/deadline_job_attachments/test_download.py
@@ -82,7 +82,7 @@ from deadline.job_attachments.os_file_permission import (
     WindowsFileSystemPermissionSettings,
     WindowsPermissionEnum,
 )
-from deadline.job_attachments._utils import _human_readable_file_size
+from deadline.job_attachments.api import human_readable_file_size
 
 from .conftest import has_posix_target_user, has_posix_disjoint_user
 from ..conftest import is_windows_non_admin
@@ -376,7 +376,7 @@ def assert_progress_tracker_values(
     expected_total_bytes: int,
     mock_on_downloading_files: MagicMock,
 ):
-    readable_total_input_bytes = _human_readable_file_size(expected_total_bytes)
+    readable_total_input_bytes = human_readable_file_size(expected_total_bytes)
     expected_files_set = set().union(*expected_files.values())
     file_counts_by_root_directory = {root: len(paths) for root, paths in expected_files.items()}
 

--- a/test/unit/deadline_job_attachments/test_upload.py
+++ b/test/unit/deadline_job_attachments/test_upload.py
@@ -55,7 +55,7 @@ from deadline.job_attachments.progress_tracker import (
     SummaryStatistics,
 )
 from deadline.job_attachments.upload import FileStatus, S3AssetManager, S3AssetUploader
-from deadline.job_attachments._utils import _human_readable_file_size
+from deadline.job_attachments.api import human_readable_file_size
 from ..conftest import is_windows_non_admin
 
 
@@ -2797,7 +2797,7 @@ def assert_progress_report_last_callback(
     """
     Assert that the argument of the last callback (when the progress is 100%) is as expected.
     """
-    readable_total_input_bytes = _human_readable_file_size(expected_total_input_bytes)
+    readable_total_input_bytes = human_readable_file_size(expected_total_input_bytes)
     actual_args, _ = on_preparing_to_submit.call_args
     actual_last_hashing_progress_report = actual_args[0]
     assert actual_last_hashing_progress_report.status == ProgressStatus.PREPARING_IN_PROGRESS


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

When submitting a job with job attachments, it's often not clear what files from what directories are being uploaded. A short summary of the file paths that will be uploaded would be more useful to address this than the current root paths and file counts that are shown. This is especially true when the root path is "/" or "C:\".

### What was the solution? (How)

* Change _human_readable_file_size to skip the ".0" for "B" bytes
* Add path summarization functions to the job_attachments.api module.
    * human_readable_file_size creates a human-readable representation of a file size.
    * PathSummary holds data summarizing the contents of a path, either a directory, a sequence of files, or a single file. It optionally holds a dictionary 'children' of child PathSummary objects.
    * summarize_paths_by_sequence takes a list of paths, detects sequences in it, and returns a list of PathSummary objects.
    * summarize_paths_by_nested_directory takes a list of paths, summarizes by sequence, then accumulates file counts and sizes into a nested tree of PathSummary objects.
    * summarize_path_list takes a list of paths, and creates a truncated summary of the nested summarization.
* Use the path summarization in the bundle submit and gui-submit warning messages about files that will be uploaded.
* Use the path summarization in the job download-output messages to provide information about download paths before downloading.
* Add a script examples/summarize_dir.py that uses the path summarization on a local file system directory.
* Add DownloadSummaryStatistics values to mock download objects so that the output summaries work.
* Update the dependencies in pyproject.toml to be less constrained, reflecting that Python 3.7 is no longer supported by the library and allowing newer jsonschema.

### What is the impact of this change?

#### Example submission before this change:

```
$ deadline bundle submit gsplat_pipeline/ -p 'InputVideoFile=C:\DataSets\classic_car\classic_car.mov' -p ApproxImageCount=800 -p 'OutputPlyFile=C:\DataSets\classic_car_test.ply' -p 'WorkspaceDir=C:\DataSets\workspaces\classic_car_test'
Submitting to Queue: Production Job Queue
Job submission contains 6 input files totaling 300.72 MB.  All input files will be uploaded to S3 if they are not already present in the job attachments bucket.

Files were specified outside of the configured storage profile location(s).  Please confirm that you intend to submit a job that uses files from the following directories:

Under the directory 'C:\':
        6 input files
        2 output directories

To permanently remove this warning you must only use files located within a storage profile location.

Do you wish to proceed? [y/N]:
```

#### Example submission after this change::

```
$ deadline bundle submit gsplat_pipeline/ -p 'InputVideoFile=C:\DataSets\classic_car\classic_car.mov' -p ApproxImageCount=800 -p 'OutputPlyFile=C:\DataSets\classic_car_test.ply' -p 'WorkspaceDir=C:\DataSets\workspaces\classic_car_test'
Submitting to Queue: Production Job Queue
Job submission contains 6 input files totaling 300.72 MB.  All input files will be uploaded to S3 if they are not already present in the job attachments bucket.

Files were specified outside of the configured storage profile location(s).  Please confirm that you intend to submit a job that uses files from the following directories:
Locations for upload:
  C:\Dev\deadline-cloud-samples\job_bundles\gsplat_pipeline\scripts\ (5 files):
    extract_video_frames.sh (1 file)
    print_workspace_dir_summary.py (1 file)
    solve_glomap_sfm.sh (1 file)
    train_gsplat_simple_trainer.sh (1 file)
    train_nerfstudio_splatfacto.sh (1 file)
  C:\DataSets\classic_car\classic_car.mov (1 file)
Locations to collect job outputs for download:
  C:\DataSets
  C:\DataSets\workspaces\classic_car_test

To permanently remove this warning you must only use files located within a storage profile location.

Do you wish to proceed? [y/N]:
```

#### Example output download before this change:

```
$ deadline job download-output --job-id job-123
Downloading output from Job 'Gaussian Splatting pipeline (FFmpeg -> COLMAP/GLOMAP -> NeRF Studio)'

Downloading Outputs  [####################################]  100%
Download Summary:
    Downloaded 4657 files totaling 2.52 GB.
    Total download time of 156.87092 seconds at 16.05 MB/s.
    Download locations (total file counts):
        C:\ (4657 files)
```

#### Example output download after this change:

```
$ deadline job download-output --job-id job-123
Downloading output from Job 'Gaussian Splatting pipeline (FFmpeg -> COLMAP/GLOMAP -> NeRF Studio)'

Summary of file paths to download:
  C:\DataSets\workspaces\classic_car_test\ (4656 files):
    images\ (1548 files)
    images_2\ (774 files)
    images_4\ (774 files)
    images_8\ (774 files)
    source_images\ (774 files)
    sfm_workspace\ (4 files)
    nerfstudio_workspace\ (3 files)
    sparse\ (3 files)
    ... and 2 more
  C:\DataSets\classic_car_test.ply (1 file)

Downloading Outputs  [####################################]  100%
Download Summary:
    Downloaded 4657 files totaling 2.52 GB.
    Total download time of 168.79934 seconds at 14.91 MB/s.
    Download locations (total file counts):
        C:\ (4657 files)
```

### How was this change tested?

Wrote a new unit test file to cover the new path list summarization functions.

- Have you run the unit tests?
Yes
- Have you run the integration tests?
No
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass.

### Was this change documented?

- Are relevant docstrings in the code base updated?
- Has the README.md been updated? If you modified CLI arguments, for instance.

### Does this PR introduce new dependencies?

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?

No. It changes the human-readable output format of some commands, but not the JSON output that is part of the contract for scripted usage.

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
