### PR TITLE
feat!: Add root information manifest snapshot response

### DIFF
--- a/src/deadline/job_attachments/api/manifest.py
+++ b/src/deadline/job_attachments/api/manifest.py
@@ -178,7 +178,7 @@ def _manifest_snapshot(
         )
         # Output results.
         logger.echo(f"Manifest generated at {local_manifest_file}")
-        return ManifestSnapshot(manifest=local_manifest_file)
+        return ManifestSnapshot(root=root, manifest=local_manifest_file)
     else:
         # No manifest generated.
         logger.echo("No manifest generated")

--- a/src/deadline/job_attachments/models.py
+++ b/src/deadline/job_attachments/models.py
@@ -390,7 +390,8 @@ class GlobConfig:
 class ManifestSnapshot:
     """Data structure to store the results of a manifest snapshot"""
 
-    manifest: str = field(default_factory=str)
+    root: str
+    manifest: str
 
 
 @dataclass

--- a/test/unit/deadline_job_attachments/api/test_snapshot.py
+++ b/test/unit/deadline_job_attachments/api/test_snapshot.py
@@ -58,6 +58,8 @@ class TestSnapshotAPI:
 
         # Then
         assert manifest is not None
+        assert manifest.root is not None
+        assert manifest.root == root_dir
         assert manifest.manifest is not None
         with open(manifest.manifest, "r") as manifest_file:
             manifest_payload = json.load(manifest_file)
@@ -92,6 +94,8 @@ class TestSnapshotAPI:
 
         # Then
         assert manifest is not None
+        assert manifest.root is not None
+        assert manifest.root == root_dir
         assert manifest.manifest is not None
         with open(manifest.manifest, "r") as manifest_file:
             manifest_payload = json.load(manifest_file)
@@ -175,6 +179,8 @@ class TestSnapshotAPI:
 
         # Then
         assert manifest is not None
+        assert manifest.root is not None
+        assert manifest.root == root_dir
         assert manifest.manifest is not None
         with open(manifest.manifest, "r") as manifest_file:
             manifest_payload = json.load(manifest_file)
@@ -207,6 +213,7 @@ class TestSnapshotAPI:
 
         # Then
         assert manifest is not None
+        assert manifest.root is not None
         assert manifest.manifest is not None
 
         # Given a second new file.
@@ -255,6 +262,7 @@ class TestSnapshotAPI:
 
         # Then
         assert manifest is not None
+        assert manifest.root is not None
         assert manifest.manifest is not None
 
         # Given the file's timestamp is updated.
@@ -299,6 +307,7 @@ class TestSnapshotAPI:
 
         # Then
         assert manifest is not None
+        assert manifest.root is not None
         assert manifest.manifest is not None
 
         # Given the file's contents is updated.
@@ -342,6 +351,7 @@ class TestSnapshotAPI:
 
         # Then
         assert manifest is not None
+        assert manifest.root is not None
         assert manifest.manifest is not None
 
         # When snapshot again.
@@ -376,6 +386,7 @@ class TestSnapshotAPI:
 
         # Then
         assert manifest is not None
+        assert manifest.root is not None
         assert manifest.manifest is not None
 
         with open(manifest.manifest, "r") as manifest_file:

--- a/test/unit/deadline_job_attachments/test_models.py
+++ b/test/unit/deadline_job_attachments/test_models.py
@@ -1,16 +1,19 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 from unittest.mock import patch
+from dataclasses import asdict
 
 from deadline.job_attachments.models import (
     PathFormat,
     StorageProfileOperatingSystemFamily,
     PathMappingRule,
     JobAttachmentS3Settings,
+    ManifestSnapshot,
 )
 from deadline.job_attachments.asset_manifests.hash_algorithms import HashAlgorithm
 from deadline.job_attachments.exceptions import MalformedAttachmentSettingError
 
 import pytest
+import json
 
 
 class TestModels:
@@ -110,3 +113,46 @@ class TestModels:
         """
         with pytest.raises(MalformedAttachmentSettingError):
             JobAttachmentS3Settings.from_s3_root_uri("s3://s3BucketOnly")
+
+
+class TestManifestSnapshotClass:
+    """Tests for the ManifestSnapshot class"""
+
+    def test_manifest_snapshot_creation(self):
+        """
+        Test ManifestSnapshot creation with required values
+        """
+        # Test with specific values
+        snapshot = ManifestSnapshot(root="/path/to/root", manifest="manifest-path")
+        assert snapshot.root == "/path/to/root"
+        assert snapshot.manifest == "manifest-path"
+
+    def test_manifest_snapshot_construct_from_json_missing_attribute(self):
+        """
+        Test ManifestSnapshot error when missing attribute
+        """
+        json_str = json.dumps({"manifest": "path/to/manifest"})
+        assert isinstance(json_str, str)
+
+        # Test deserialization
+        with pytest.raises(TypeError):
+            ManifestSnapshot(**json.loads(json_str))
+
+    def test_manifest_snapshot_json_serialization_special_characters(self):
+        """
+        Test ManifestSnapshot serialization with special characters
+        """
+        # Test with paths containing special characters
+        snapshot = ManifestSnapshot(
+            root='/path/with spaces/and"quotes"/and\\backslashes',
+            manifest="manifest-with-unicode-€-£-¥",
+        )
+
+        # Convert to JSON and back
+        json_str = json.dumps(asdict(snapshot))
+        data = json.loads(json_str)
+        recreated = ManifestSnapshot(**data)
+
+        # Verify the special characters are preserved
+        assert recreated.root == '/path/with spaces/and"quotes"/and\\backslashes'
+        assert recreated.manifest == "manifest-with-unicode-€-£-¥"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
WA client need the root information from manifest snapshot response.

### What was the solution? (How)
Added root information.

### What is the impact of this change?
1. Always require both root and manifest path for `manifest snapshot`
2. Added root information to snapshot response

### How was this change tested?
- [x] Have you run the unit tests?
- [x] Have you run the integration tests?
- [N/A] Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended that you ensure that the docker-based unit tests pass.

### Was this change documented?

- [x] Are relevant docstrings in the code base updated?
- Has the README.md been updated? If you modified CLI arguments, for instance. 

### Does this PR introduce new dependencies?
*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?
Yes, `manifest` and `root` are required for constructing `ManifestSnapshot`.

### Does this change impact security?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
