### PR TITLE
fix: fix PATH env var deletion on uninstall

### DIFF
--- a/installer/DeadlineCloudClient.xml
+++ b/installer/DeadlineCloudClient.xml
@@ -444,15 +444,21 @@
 ${_fnAddEnvironmentVariable_list}
             </text>
         </writeFile>
+        <addFilesToUninstaller>
+            <ruleList>
+                <compareTextLength text="${_fnAddEnvironmentVariable_list}" logic="greater" length="0"/>
+            </ruleList>
+            <files>/etc/profile.d/deadline.sh</files>
+        </addFilesToUninstaller>
         <writeFile>
             <progressText>Writing version file</progressText>
             <path>${installdir}/DeadlineClient/installer_version.txt</path>
             <text>${project.version}</text>
         </writeFile>
         <changePermissions permissions="0644" files="${installdir}/DeadlineClient/installer_version.txt"/>
-        <addFilesToUninstaller>
-          <files>${installdir}/DeadlineClient/</files>
-        </addFilesToUninstaller>
+        <addDirectoriesToUninstaller>
+          <files>${installdir}/DeadlineClient</files>
+        </addDirectoriesToUninstaller>
     </postInstallationActionList>
 
     <preUninstallationActionList>
@@ -552,6 +558,10 @@ ${_fnAddEnvironmentVariable_list}
                 </programTest>
             </ruleList>
         </actionGroup>
+        <!-- =======================================
+        Removing deadline from path
+        =========================================-->
+        <removeDirectoryFromPath path="${installdir}/DeadlineClient" scope="${installscope}"/>
     </postUninstallationActionList>
     <width>550</width>
 </project>


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Our installer would add the deadline-cloud executable to the `PATH` but would fail to clean them up on uninstallation.

### What was the solution? (How)
Add the appropriate removal steps to the uninstaller.

### What is the impact of this change?
Environment variables are properly cleaned up

### How was this change tested?
- Have you run the unit tests?
  - No, this code doesn't touch anything unit test related.
- Have you run the integration tests?
  - No, this code doesn't touch anything integ test related.
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass.
   - No.
 - Tests performed:
   - Built and ran both the installer and uninstaller on all supported platforms and confirmed that the env vars were cleaned up successfully. Also confirmed the installation still worked.

### Was this change documented?
No.

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [X] This PR does not add any new dependencies.

### Is this a breaking change?

No.

### Does this change impact security?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
