### PR TITLE
feat: Add function to construct partial s3 prefix for job attachments output manifests

### DIFF
--- a/src/deadline/job_attachments/models.py
+++ b/src/deadline/job_attachments/models.py
@@ -27,6 +27,7 @@ from deadline.job_attachments.exceptions import (
 from ._utils import (
     _generate_random_guid,
     _join_s3_paths,
+    _float_to_iso_datetime_string,
 )
 
 S3_DATA_FOLDER_NAME = "Data"
@@ -288,6 +289,32 @@ class JobAttachmentS3Settings:
             step_id,
             task_id,
             session_action_id,
+        )
+
+    @staticmethod
+    def partial_session_action_manifest_prefix(
+        farm_id: str,
+        queue_id: str,
+        job_id: str,
+        step_id: str,
+        task_id: str,
+        session_action_id: str,
+        time: float,
+    ) -> str:
+        """
+        Constructs the partial S3 prefix for storing session action output manifests.
+
+        This method creates a hierarchical path structure for organizing output manifests in S3,
+        following the pattern: farm_id/queue_id/job_id/step_id/task_id/timestamp_session_action_id.
+        The timestamp is converted from a float to an ISO datetime string format.
+        """
+        return _join_s3_paths(
+            farm_id,
+            queue_id,
+            job_id,
+            step_id,
+            task_id,
+            f"{_float_to_iso_datetime_string(time)}_{session_action_id}",
         )
 
     def partial_manifest_prefix(self, farm_id, queue_id) -> str:

--- a/test/unit/deadline_job_attachments/test_models.py
+++ b/test/unit/deadline_job_attachments/test_models.py
@@ -72,6 +72,8 @@ class TestModels:
             HashAlgorithm.XXH128
         )
 
+
+class TestJobAttachmentS3SettingsModel:
     @pytest.mark.parametrize(
         ("input", "output"),
         [
@@ -114,8 +116,32 @@ class TestModels:
         with pytest.raises(MalformedAttachmentSettingError):
             JobAttachmentS3Settings.from_s3_root_uri("s3://s3BucketOnly")
 
+    def test_job_attachment_s3_settings_partial_session_action_manifest_prefix(self):
+        """
+        Test JobAttachmentS3Settings partial_session_action_manifest_prefix method
+        """
+        # Mock the _float_to_iso_datetime_string function to return a predictable value
+        with patch(
+            "deadline.job_attachments.models._float_to_iso_datetime_string",
+            return_value="2025-05-22T22:17:03.409012Z",
+        ):
+            # Call the partial_session_action_manifest_prefix method
+            result = JobAttachmentS3Settings.partial_session_action_manifest_prefix(
+                farm_id="farm1",
+                queue_id="queue1",
+                job_id="job1",
+                step_id="step1",
+                task_id="task1",
+                session_action_id="session1",
+                time=1747952223.4090126,  # This is 2025-05-22T22:17:03.409012Z in timestamp
+            )
 
-class TestManifestSnapshotClass:
+            # Verify the result
+            expected = "farm1/queue1/job1/step1/task1/2025-05-22T22:17:03.409012Z_session1"
+            assert result == expected
+
+
+class TestManifestSnapshotModel:
     """Tests for the ManifestSnapshot class"""
 
     def test_manifest_snapshot_creation(self):


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We'd like to define where the output manifest should be uploaded too.

### What was the solution? (How)
Create a function in JobAttachmentS3Settings.

### What is the impact of this change?
WA caller can simply call this to construct the path to put output manifest, and pass that to attachment upload.

### How was this change tested?
- [x] Have you run the unit tests?
- [ ] Have you run the integration tests?
- [ ] Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended that you ensure that the docker-based unit tests pass.

Run WA E2E tests `pytest -- test/e2e/test_job_submissions.py::TestJobSubmission::test_worker_job_attachments_dep_data_flow_linux` to make sure
1. job succeeded, which accounted for step-step dependencies
2. downloaded job output, and verified they're as expected
 
### Was this change documented?

- Are relevant docstrings in the code base updated?
- Has the README.md been updated? If you modified CLI arguments, for instance.

### Does this PR introduce new dependencies?
*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?
No

### Does this change impact security?
No

- Does the change need to be threat modeled? For example, does it create or modify files/directories that must only be readable by the process owner?
    - If so, then please label this pull request with the "security" label. We'll work with you to analyze the threats.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
