### PR TITLE
fix: trace-schedule fails on in progress jobs

### DIFF
--- a/src/deadline/client/cli/_groups/job_group.py
+++ b/src/deadline/client/cli/_groups/job_group.py
@@ -725,7 +725,7 @@ def job_download_output(step_id, task_id, output, **args):
 @_handle_error
 def job_trace_schedule(verbose, trace_format, trace_file, **args):
     """
-    EXPERIMENTAL - Generate statistics from a completed job.
+    EXPERIMENTAL - Generate statistics from a job.
 
     To visualize the trace output file when providing the options
     "--trace-format chrome --trace-file <output>.json", use
@@ -744,10 +744,15 @@ def job_trace_schedule(verbose, trace_format, trace_file, **args):
         raise DeadlineOperationError("Error: Must provide --trace-format with --trace-file.")
 
     deadline = api.get_boto3_client("deadline", config=config)
+    trace_end_utc = datetime.datetime.now(datetime.timezone.utc)
 
     click.echo("Getting the job...")
     job = deadline.get_job(farmId=farm_id, queueId=queue_id, jobId=job_id)
     job.pop("ResponseMetadata", None)
+
+    if "startedAt" not in job:
+        raise DeadlineOperationError("No trace available - Job hasn't started yet, exiting")
+    started_at = job["startedAt"]
 
     click.echo("Getting all the sessions for the job...")
     response = deadline.list_sessions(farmId=farm_id, queueId=queue_id, jobId=job_id)
@@ -833,14 +838,14 @@ def job_trace_schedule(verbose, trace_format, trace_file, **args):
     click.echo("Processing the trace data...")
     trace_events = []
 
-    started_at = job["startedAt"]
-
     def time_int(timestamp: datetime.datetime):
         return int((timestamp - started_at) / datetime.timedelta(microseconds=1))
 
     def duration_of(resource):
         try:
-            return time_int(resource["endedAt"]) - time_int(resource["startedAt"])
+            return time_int(resource.get("endedAt", trace_end_utc)) - time_int(
+                resource["startedAt"]
+            )
         except KeyError:
             return 0
 
@@ -863,6 +868,8 @@ def job_trace_schedule(verbose, trace_format, trace_file, **args):
 
         pid = workers[session["workerId"]]
         session_event_name = f"{session['step']['name']} - {session['index']}"
+        if "endedAt" not in session:
+            session_event_name = f"{session_event_name} - In Progress"
         trace_events.append(
             {
                 "name": session_event_name,
@@ -910,6 +917,8 @@ def job_trace_schedule(verbose, trace_format, trace_file, **args):
                     name = "Sync Job Attchmnt (Dependencies)"
                 else:
                     name = "Sync Job Attchmnt (Submitted)"
+            if "endedAt" not in action:
+                name = f"{name} - In Progress"
             if "startedAt" in action:
                 trace_events.append(
                     {
@@ -927,12 +936,13 @@ def job_trace_schedule(verbose, trace_format, trace_file, **args):
                         },
                     }
                 )
+
         trace_events.append(
             {
                 "name": session_event_name,
                 "cat": "SESSION",
                 "ph": "E",  # End Event
-                "ts": time_int(session["endedAt"]),
+                "ts": time_int(session.get("endedAt", trace_end_utc)),
                 "pid": pid,
                 "tid": 0,
             }


### PR DESCRIPTION
Fixes: #524 

### What was the problem/requirement? (What/Why)

If a user ran `deadline job trace-schedule` on a job that was in progress or not started, it would fail to generate the trace since it was missing `startedAt` and `endedAt` datetimes.

1. No `startedAt`:
```
The AWS Deadline Cloud CLI encountered the following exception:
'startedAt'
Traceback (most recent call last):
  File "client\cli\_common.py", line 55, in wraps
    func(*args, **kwargs)
  File "client\cli\_groups\job_group.py", line 817, in job_trace_schedule
    started_at = job["startedAt"]
KeyError: 'startedAt'
```

2. No `endedAt`:

```
The AWS Deadline Cloud CLI encountered the following exception:
'endedAt'
Traceback (most recent call last):
  File "client\cli\_common.py", line 54, in wraps
    func(*args, **kwargs)
  File "client\cli\_groups\job_group.py", line 885, in job_trace_schedule
    "ts": time_int(session["endedAt"]),
```


### What was the solution? (How)

1. If the job hasn't started we now return with exit code 1 and a clear indication that a schedule could not be created for something that hasn't started
4. If the job hasn't finished, we now check sessions and session actions to determine if they've completed. If they haven't completed we append ` - In Progress` to the resource name, and default the `endedAt` time to when the `trace-schedule` command was invoked.

### What is the impact of this change?

More helpful messages, and additional functionality!

### How was this change tested?

1. Job that hasn't started:

```
λ deadline job trace-schedule --job-id job-...
Getting the job...
No trace available - Job hasn't started yet, exiting
λ echo $?
1
```

2. For in-progress jobs, submitted [test_bundle.zip](https://github.com/user-attachments/files/20466130/test_bundle.zip) that slept so that I could generate this 
[complete_and_in_progress.txt](https://github.com/user-attachments/files/20466347/complete_and_in_progress.txt)

Completed session/session action:

![image](https://github.com/user-attachments/assets/ac38da8a-9409-439c-9446-4024286ccb04)

In Progress session/session action:

![image](https://github.com/user-attachments/assets/34765e41-3f82-41b7-a8fc-c73379d76d0d)

### Was this change documented?

- Yup, updated the CLI help text

### Does this PR introduce new dependencies?

N/A

### Is this a breaking change?

Fixing!

### Does this change impact security?

Nope

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
