### PR TITLE
fix: run deadline executable as post install step on macOS

### DIFF
--- a/installer/DeadlineCloudClient.xml
+++ b/installer/DeadlineCloudClient.xml
@@ -348,6 +348,14 @@
                         </programTest>
                     </ruleList>
                 </actionGroup>
+
+                <!-- On macOS, run the executable once since first launch can be slow. -->
+
+                <runProgram program="${installdir}/DeadlineClient/deadline" programArguments="--version">
+                    <ruleList>
+                        <platformTest type="osx"/>
+                    </ruleList>
+                </runProgram>
             </postInstallationActionList>
         </component>
     </componentList>


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
On first run, the executable can be slow to launch on macOS due to code signing verification done by the OS. 

### What was the solution? (How)
Running the executable once during installation fixes this.

### What is the impact of this change?
First run of `deadline` for the user will be consistent with each subsequent run.

### How was this change tested?

- Have you run the integration tests?
  - Tested the installer manually and confirmed from the logs that the executable was run. 
  - Ran the installer tests:
```bash
=================================================================== test session starts ===================================================================
platform darwin -- Python 3.12.7, pytest-8.4.0, pluggy-1.6.0 -- /Users/justins/Library/Application Support/hatch/env/virtual/deadline/UeVK9Pdt/deadline/bin/python
cachedir: .pytest_cache
rootdir: /Users/justins/dev/github/aws-deadline/deadline-cloud
configfile: pyproject.toml
plugins: xdist-3.7.0, timeout-2.4.0, cov-6.1.1
10 workers [13 items]     
scheduling tests via LoadScheduling

test/installer/test_installer.py::TestWindows::test_user_permissions 
test/installer/test_installer.py::TestLinuxAndMacOS::test_system_permissions 
test/installer/test_installer.py::test_did_not_build_with_evaluation_mode 
test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions 
test/installer/test_installer.py::TestUserInstall::test_install 
test/installer/test_installer.py::test_default_location 
test/installer/test_installer.py::TestWindows::test_system_permissions 
test/installer/test_installer.py::TestUserInstall::test_uninstall 
test/installer/test_installer.py::TestSystemInstall::test_uninstall 
[gw4] [  7%] SKIPPED test/installer/test_installer.py::TestWindows::test_user_permissions 
[gw1] [ 15%] SKIPPED test/installer/test_installer.py::test_did_not_build_with_evaluation_mode 
test/installer/test_installer.py::TestSystemInstall::test_install 
[gw9] [ 23%] SKIPPED test/installer/test_installer.py::TestSystemInstall::test_uninstall 
[gw5] [ 30%] SKIPPED test/installer/test_installer.py::TestWindows::test_system_permissions 
test/installer/test_installer.py::TestVerifySigning::test_linux_signing 
[gw8] [ 38%] SKIPPED test/installer/test_installer.py::TestSystemInstall::test_install 
[gw3] [ 46%] SKIPPED test/installer/test_installer.py::TestLinuxAndMacOS::test_system_permissions 
[gw1] [ 53%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_linux_signing 
[gw0] [ 61%] PASSED test/installer/test_installer.py::test_default_location 
test/installer/test_installer.py::TestVerifySigning::test_windows_signing 
[gw0] [ 69%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_windows_signing 
[gw2] [ 76%] PASSED test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions 
test/installer/test_installer.py::TestVerifySigning::test_macos_signing 
[gw2] [ 84%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_macos_signing 
[gw6] [ 92%] PASSED test/installer/test_installer.py::TestUserInstall::test_install 
[gw7] [100%] PASSED test/installer/test_installer.py::TestUserInstall::test_uninstall 

=================================================================== slowest 5 durations ===================================================================
28.84s setup    test/installer/test_installer.py::TestUserInstall::test_install
28.79s setup    test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions
26.94s setup    test/installer/test_installer.py::TestUserInstall::test_uninstall
3.68s call     test/installer/test_installer.py::TestUserInstall::test_uninstall
3.09s call     test/installer/test_installer.py::test_default_location
============================================================== 4 passed, 9 skipped in 31.60s ==============================================================
```

### Was this change documented?

N/A

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [X] This PR does not add any new dependencies.

### Is this a breaking change?
No.

### Does this change impact security?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
