### PR TITLE
fix: sdist failed to install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ path = "hatch_custom_hook.py"
 destinations = ["src/deadline/client", "src/deadline/job_attachments"]
 
 [tool.hatch.build.targets.sdist]
-include = ["src/*", "hatch_version_hook.py", "THIRD_PARTY_LICENSES"]
+include = ["src/*", "hatch_custom_hook.py", "THIRD_PARTY_LICENSES"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/deadline"]


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

When running `pip install` with an sdist (compressed or uncompressed) you get:
```
OSError: Build script does not exist: hatch_custom_hook.py
```

### What was the solution? (How)

The `_version.py` are already generated and shipped, but we need to ensure the hook file exists so that the build backend can succeed in generating a whl (it doesn't try to re-generate the package information from vcs). Turns out there was a typo preventing it from being shipped.

### What is the impact of this change?

Working sdists!

### How was this change tested?

Before
```
$ pip install ./dist/deadline-0.49.8.post20+g263093f.tar.gz  --force-reinstall
Processing ./dist/deadline-0.49.8.post20+g263093f.tar.gz
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [20 lines of output]
      Traceback (most recent call last):
        File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
          main()
        File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 373, in main
          json_out["return_val"] = hook(**hook_input["kwargs"])
        File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 143, in get_requires_for_build_wheel
          return hook(config_settings)
        File "/private/var/folders/j_/kh9hgnt51jn_4rk3z3dz6m_h0000gr/T/pip-build-env-8ilfxa3h/overlay/lib/python3.10/site-packages/hatchling/build.py", line 44, in get_requires_for_build_wheel
          return builder.config.dependencies
        File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/functools.py", line 981, in __get__
          val = self.func(instance)
        File "/private/var/folders/j_/kh9hgnt51jn_4rk3z3dz6m_h0000gr/T/pip-build-env-8ilfxa3h/overlay/lib/python3.10/site-packages/hatchling/builders/config.py", line 577, in dependencies
          for dependency in self.dynamic_dependencies:
        File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/functools.py", line 981, in __get__
          val = self.func(instance)
        File "/private/var/folders/j_/kh9hgnt51jn_4rk3z3dz6m_h0000gr/T/pip-build-env-8ilfxa3h/overlay/lib/python3.10/site-packages/hatchling/builders/config.py", line 593, in dynamic_dependencies
          build_hook = build_hook_cls(
        File "/private/var/folders/j_/kh9hgnt51jn_4rk3z3dz6m_h0000gr/T/pip-build-env-8ilfxa3h/overlay/lib/python3.10/site-packages/hatchling/builders/hooks/custom.py", line 33, in __new__
          raise OSError(message)
      OSError: Build script does not exist: hatch_custom_hook.py
      [end of output]
```

After 
```
$ pip install ./dist/deadline-0.49.8.post19+g38d8b12.d20250603.tar.gz --force-reinstall
Processing ./dist/deadline-0.49.8.post19+g38d8b12.d20250603.tar.gz
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
...
Building wheels for collected packages: deadline
  Building wheel for deadline (pyproject.toml) ... done
  Created wheel for deadline: filename=deadline-0.49.8.post19+g38d8b12.d20250603-py3-none-any.whl size=279211 sha256=3ff07aaff6bb40b6e9dc785741e5afdd431ba39dd0fff8e906d1dc5f67af9422
Successfully built deadline
```



### Was this change documented?

N/A

### Does this PR introduce new dependencies?
N/A

### Is this a breaking change?
Fixing :)

### Does this change impact security?
N/A
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
