### PR TITLE
job 'wait' and 'logs API/CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,64 @@ and removing them by logging out:
 $ deadline auth logout
 ```
 
+## Job Monitoring and Logs
+
+### Waiting for Job Completion
+
+After submitting a job, you can wait for it to complete using the `wait` command:
+
+```sh
+# Wait for a job to complete with default settings
+$ deadline job wait --job-id job-12345
+
+# Customize the maximum polling interval (default is 120 seconds)
+# The polling interval starts at 0.5 seconds and doubles until reaching this maximum
+$ deadline job wait --job-id job-12345 --max-poll-interval 30
+
+# Set a timeout (default is 0, meaning no timeout)
+$ deadline job wait --job-id job-12345 --timeout 3600
+
+# Get the result in JSON format
+$ deadline job wait --job-id job-12345 --output json
+```
+
+The command blocks until the job reaches a terminal state (SUCCEEDED, FAILED, CANCELED, SUSPENDED, NOT_COMPATIBLE), then returns information about the job's status and any failed tasks. It uses exponential backoff for polling, starting at 0.5 seconds and doubling the interval after each check until it reaches the maximum polling interval.
+
+**Exit Codes:**
+- `0` - Job succeeded
+- `1` - Timeout waiting for job completion
+- `2` - Job failed or has failed tasks
+- `3` - Job was canceled
+- `4` - Job was archived
+- `5` - Job is not compatible 
+
+### Retrieving Job Logs
+
+You can monitor job status and retrieve logs using the CLI. The logs lines are returned starting from the most recent log event.:
+
+```sh
+# Get logs for a specific session
+$ deadline job logs --session-id session-12345
+
+# Get logs for a job (automatically selects session: ongoing sessions preferred, then most recently started/ended)
+$ deadline job logs --job-id job-12345
+
+# Limit the number of log lines returned to the 50 most recent.
+$ deadline job logs --session-id session-12345 --limit 50
+
+# Filter logs by time range
+$ deadline job logs --session-id session-12345 --start-time 2023-01-01T12:00:00Z --end-time 2023-01-01T13:00:00Z
+
+# Get logs in JSON format
+$ deadline job logs --session-id session-12345 --output json
+
+# Paginate through logs
+$ deadline job logs --session-id session-12345 --next-token next-token-value
+```
+
+When using a Deadline Cloud monitor profile, the `job logs` command will use the Queue role credentials to read logs. Otherwise, the chosen profile credentials are used for all API invocations. This allows you to access logs with the appropriate permissions based on your authentication method.
+
+
 ## AWS Credentials Integration
 
 You can use the Deadline Cloud client to obtain temporary AWS credentials for a queue and use them with the AWS CLI or SDK. This enables you to create AWS profiles that have queue-specific permissions for use in programmatic workflows.

--- a/src/deadline/client/api/__init__.py
+++ b/src/deadline/client/api/__init__.py
@@ -28,6 +28,12 @@ __all__ = [
     "record_function_latency_telemetry_event",
     "assume_queue_role_for_user",
     "assume_queue_role_for_read",
+    "wait_for_job_completion",
+    "JobCompletionResult",
+    "FailedTask",
+    "get_session_logs",
+    "SessionLogResult",
+    "LogEvent",
 ]
 
 # The following import is needed to prevent the following sporadic failure:
@@ -76,6 +82,14 @@ from ._submit_job_bundle import (
     wait_for_create_job_to_complete,
 )
 from ._get_storage_profile_for_queue import get_storage_profile_for_queue
+from ._job_monitoring import (
+    wait_for_job_completion,
+    JobCompletionResult,
+    FailedTask,
+    get_session_logs,
+    SessionLogResult,
+    LogEvent,
+)
 
 logger = getLogger(__name__)
 

--- a/src/deadline/client/api/_job_monitoring.py
+++ b/src/deadline/client/api/_job_monitoring.py
@@ -1,0 +1,320 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Functions for monitoring job status and retrieving job information.
+"""
+
+from __future__ import annotations
+import datetime
+import time
+from typing import List, Dict, Any, Optional, Callable
+from configparser import ConfigParser
+from dataclasses import dataclass
+
+from botocore.exceptions import ClientError
+
+from deadline.client.exceptions import DeadlineOperationError, DeadlineOperationTimedOut
+from deadline.client.api._session import (
+    get_boto3_client,
+    get_queue_user_boto3_session,
+    get_user_and_identity_store_id,
+)
+
+
+@dataclass
+class FailedTask:
+    """
+    Represents a failed task in a job.
+    """
+
+    step_id: str
+    task_id: str
+    step_name: str
+    parameters: Dict[str, Any]
+    session_id: Optional[str] = None
+
+
+@dataclass
+class JobCompletionResult:
+    """
+    Result of waiting for a job to complete.
+    """
+
+    status: str
+    failed_tasks: List[FailedTask]
+    elapsed_time: float
+
+
+@dataclass
+class LogEvent:
+    """
+    Represents a single log event from CloudWatch Logs.
+    """
+
+    timestamp: datetime.datetime
+    message: str
+    ingestion_time: Optional[datetime.datetime] = None
+    event_id: Optional[str] = None
+
+
+@dataclass
+class SessionLogResult:
+    """
+    Result of retrieving logs for a session.
+    """
+
+    events: List[LogEvent]
+    next_token: Optional[str]
+    log_group: str
+    log_stream: str
+    count: int
+
+
+def wait_for_job_completion(
+    farm_id: str,
+    queue_id: str,
+    job_id: str,
+    max_poll_interval: int = 120,
+    timeout: int = 0,
+    config: Optional[ConfigParser] = None,
+    status_callback: Optional[Callable] = None,
+) -> JobCompletionResult:
+    """
+    Wait for a job to complete and return information about its status and any failed tasks.
+
+    This function blocks until the job's taskRunStatus reaches a terminal state
+    (SUCCEEDED, FAILED, CANCELED, SUSPENDED, or NOT_COMPATIBLE), then returns a JobCompletionResult
+    object containing the final status and any failed tasks.
+
+    The function uses exponential backoff for polling, starting at 0.5 seconds and doubling
+    the interval after each check until it reaches the maximum polling interval.
+
+    Args:
+        farm_id: The ID of the farm containing the job.
+        queue_id: The ID of the queue containing the job.
+        job_id: The ID of the job to wait for.
+        max_poll_interval: Maximum time in seconds between status checks (default: 120).
+        timeout: Maximum time in seconds to wait (0 for no timeout).
+        config: Optional configuration object.
+        status_callback: Optional callback function that receives the current status during polling.
+
+    Returns:
+        A JobCompletionResult object containing the job's final status and any failed tasks.
+
+    Raises:
+        DeadlineOperationError: If the timeout is reached or there's an error retrieving job information.
+    """
+    deadline = get_boto3_client("deadline", config=config)
+
+    start_time = datetime.datetime.now()
+    terminal_states = ["SUCCEEDED", "FAILED", "CANCELED", "SUSPENDED", "NOT_COMPATIBLE"]
+    status = ""
+
+    # Initial polling interval of 0.5 seconds
+    current_interval = 0.5
+
+    while True:
+        # Check timeout
+        if timeout > 0:
+            elapsed = (datetime.datetime.now() - start_time).total_seconds()
+            if elapsed > timeout:
+                raise DeadlineOperationTimedOut(
+                    f"Timeout waiting for job {job_id} to complete after {elapsed:.1f} seconds"
+                )
+
+        # Get job status
+        try:
+            job = deadline.get_job(farmId=farm_id, queueId=queue_id, jobId=job_id)
+            status = job.get("taskRunStatus", "")
+
+            # Call the status callback if provided with elapsed time and timeout info
+            if status_callback:
+                elapsed = (datetime.datetime.now() - start_time).total_seconds()
+                status_callback(status, elapsed, timeout)
+
+        except ClientError as exc:
+            raise DeadlineOperationError(f"Failed to get job status: {exc}") from exc
+
+        if status in terminal_states:
+            break
+
+        # Sleep using current interval
+        time.sleep(current_interval)
+
+        # Exponential backoff with a maximum interval
+        current_interval = min(current_interval * 2, max_poll_interval)
+
+    elapsed_time = (datetime.datetime.now() - start_time).total_seconds()
+
+    # If job failed, collect failed tasks
+    failed_tasks = []
+    if status != "SUCCEEDED":
+        try:
+            # Get all steps with pagination
+            paginator = deadline.get_paginator("list_steps")
+            for page in paginator.paginate(farmId=farm_id, queueId=queue_id, jobId=job_id):
+                # For each step, get tasks and filter for failed ones client-side
+                for step in page["steps"]:
+                    step_id = step["stepId"]
+                    step_name = step.get("name", "")
+
+                    # Only query for tasks if the step has any failed tasks
+                    if step.get("taskRunStatusCounts", {}).get("FAILED", 0) > 0:
+                        # Get all tasks with pagination
+                        task_paginator = deadline.get_paginator("list_tasks")
+                        for tasks_page in task_paginator.paginate(
+                            farmId=farm_id, queueId=queue_id, jobId=job_id, stepId=step_id
+                        ):
+                            # Filter failed tasks client-side
+                            for task in tasks_page["tasks"]:
+                                if task.get("runStatus") == "FAILED":
+                                    # Extract session ID from latestSessionActionId
+                                    session_id = None
+                                    latest_session_action_id = task.get("latestSessionActionId")
+                                    if latest_session_action_id:
+                                        # Format is typically "sessionaction-{session_id}-{action_number}"
+                                        # Extract the session ID part
+                                        parts = latest_session_action_id.split("-")
+                                        if len(parts) >= 3 and parts[0] == "sessionaction":
+                                            session_id = f"session-{parts[1]}"
+
+                                    failed_tasks.append(
+                                        FailedTask(
+                                            step_id=step_id,
+                                            task_id=task["taskId"],
+                                            step_name=step_name,
+                                            parameters=task.get("parameters", {}),
+                                            session_id=session_id,
+                                        )
+                                    )
+        except ClientError as exc:
+            raise DeadlineOperationError(f"Failed to retrieve failed tasks: {exc}") from exc
+
+    return JobCompletionResult(status=status, failed_tasks=failed_tasks, elapsed_time=elapsed_time)
+
+
+def get_session_logs(
+    farm_id: str,
+    queue_id: str,
+    session_id: str,
+    limit: int = 100,
+    start_time: Optional[datetime.datetime] = None,
+    end_time: Optional[datetime.datetime] = None,
+    next_token: Optional[str] = None,
+    config: Optional[ConfigParser] = None,
+) -> SessionLogResult:
+    """
+    Get CloudWatch logs for a specific session.
+
+    This function retrieves logs from CloudWatch for the specified session ID.
+    By default, it returns the most recent 100 log lines, but this can be
+    adjusted using the limit parameter.
+
+    Args:
+        farm_id: The ID of the farm containing the session.
+        queue_id: The ID of the queue containing the session.
+        session_id: The ID of the session to get logs for.
+        limit: Maximum number of log lines to return.
+        start_time: Optional start time for logs as a datetime object.
+        end_time: Optional end time for logs as a datetime object.
+        next_token: Optional token for pagination of results.
+        config: Optional configuration object.
+
+    Returns:
+        A SessionLogResult object containing the log events and metadata.
+
+    Raises:
+        DeadlineOperationError: If there's an error retrieving the logs.
+    """
+    # Get the Deadline client to use for getting queue credentials
+    deadline = get_boto3_client("deadline", config=config)
+
+    # Check if we have user and identity store ID (from Deadline Cloud monitor)
+    user_id, identity_store_id = get_user_and_identity_store_id(config=config)
+
+    # Create logs client - either with queue credentials or directly
+    if user_id and identity_store_id:
+        # Get a session with queue user credentials
+        try:
+            queue_session = get_queue_user_boto3_session(
+                deadline=deadline, config=config, farm_id=farm_id, queue_id=queue_id
+            )
+            logs_client = queue_session.client("logs")
+        except Exception as e:
+            raise DeadlineOperationError(f"Failed to get queue credentials: {e}")
+    else:
+        # Use the same boto session as for deadline
+        logs_client = get_boto3_client("logs", config=config)
+
+    # Construct the log group name
+    log_group_name = f"/aws/deadline/{farm_id}/{queue_id}"
+
+    # Prepare parameters for GetLogEvents
+    params = {
+        "logGroupName": log_group_name,
+        "logStreamName": session_id,
+        "limit": limit,
+        "startFromHead": False,  # Get the most recent logs first
+    }
+
+    # Add next_token if provided
+    if next_token:
+        params["nextToken"] = next_token
+
+    # Add optional time parameters if provided
+    if start_time:
+        try:
+            # Convert datetime to milliseconds since epoch
+            start_timestamp = int(start_time.timestamp() * 1000)
+            params["startTime"] = start_timestamp
+        except (ValueError, AttributeError) as e:
+            raise DeadlineOperationError(f"Invalid start time: {e}")
+
+    if end_time:
+        try:
+            # Convert datetime to milliseconds since epoch
+            end_timestamp = int(end_time.timestamp() * 1000)
+            params["endTime"] = end_timestamp
+        except (ValueError, AttributeError) as e:
+            raise DeadlineOperationError(f"Invalid end time: {e}")
+
+    try:
+        response = logs_client.get_log_events(**params)
+
+        # Convert to strongly typed objects
+        events = []
+        for event in response.get("events", []):
+            events.append(
+                LogEvent(
+                    timestamp=datetime.datetime.fromtimestamp(
+                        event["timestamp"] / 1000, tz=datetime.timezone.utc
+                    ),
+                    message=event["message"].rstrip(),
+                    ingestion_time=(
+                        datetime.datetime.fromtimestamp(event["ingestionTime"] / 1000)
+                        if "ingestionTime" in event
+                        else None
+                    ),
+                    event_id=event.get("eventId"),
+                )
+            )
+
+        return SessionLogResult(
+            events=events,
+            next_token=response.get("nextForwardToken"),
+            log_group=log_group_name,
+            log_stream=session_id,
+            count=len(events),
+        )
+
+    except logs_client.exceptions.ResourceNotFoundException:
+        # Return an empty result if the log group or stream doesn't exist
+        return SessionLogResult(
+            events=[],
+            next_token=None,
+            log_group=log_group_name,
+            log_stream=session_id,
+            count=0,
+        )
+    except Exception as e:
+        raise DeadlineOperationError(f"Failed to retrieve logs: {e}")

--- a/src/deadline/client/cli/_groups/job_group.py
+++ b/src/deadline/client/cli/_groups/job_group.py
@@ -41,7 +41,7 @@ from deadline.job_attachments._path_summarization import (
 
 from ... import api
 from ...config import config_file
-from ...exceptions import DeadlineOperationError
+from ...exceptions import DeadlineOperationError, DeadlineOperationTimedOut
 from .._common import _apply_cli_options_to_config, _cli_object_repr, _handle_error
 from ._sigint_handler import SigIntHandler
 
@@ -261,7 +261,11 @@ def _download_job_output(
         step = deadline.get_step(farmId=farm_id, queueId=queue_id, jobId=job_id, stepId=step_id)
     if task_id:
         task = deadline.get_task(
-            farmId=farm_id, queueId=queue_id, jobId=job_id, stepId=step_id, taskId=task_id
+            farmId=farm_id,
+            queueId=queue_id,
+            jobId=job_id,
+            stepId=step_id,
+            taskId=task_id,
         )
 
     click.echo(
@@ -296,7 +300,9 @@ def _download_job_output(
         session=queue_role_session,
     )
 
-    def _check_and_warn_long_output_paths(output_paths_by_root: dict[str, list[str]]) -> None:
+    def _check_and_warn_long_output_paths(
+        output_paths_by_root: dict[str, list[str]],
+    ) -> None:
         if sys.platform == "win32" and not _is_windows_long_path_registry_enabled():
             for root, paths in output_paths_by_root.items():
                 for output_path in paths:
@@ -358,7 +364,11 @@ def _download_job_output(
                 user_choice = click.prompt(
                     "> Please enter the index of root directory to edit, y to proceed without changes, or n to cancel the download",
                     type=click.Choice(
-                        [*[str(num) for num in list(range(0, len(asset_roots)))], "y", "n"]
+                        [
+                            *[str(num) for num in list(range(0, len(asset_roots)))],
+                            "y",
+                            "n",
+                        ]
                     ),
                     default="y",
                 )
@@ -450,7 +460,9 @@ def _download_job_output(
             # not annotating the type of download_progress.
             with click.progressbar(length=100, label="Downloading Outputs") as download_progress:  # type: ignore[var-annotated]
 
-                def _update_download_progress(download_metadata: ProgressReportMetadata) -> bool:
+                def _update_download_progress(
+                    download_metadata: ProgressReportMetadata,
+                ) -> bool:
                     new_progress = int(download_metadata.progress) - download_progress.pos
                     if new_progress > 0:
                         download_progress.update(new_progress)
@@ -462,7 +474,9 @@ def _download_job_output(
                 )
         else:
 
-            def _update_download_progress(download_metadata: ProgressReportMetadata) -> bool:
+            def _update_download_progress(
+                download_metadata: ProgressReportMetadata,
+            ) -> bool:
                 click.echo(
                     _get_json_line(JSON_MSG_TYPE_PROGRESS, str(int(download_metadata.progress)))
                 )
@@ -479,7 +493,10 @@ def _download_job_output(
 
 
 def _get_start_message(
-    job_name: str, step_name: Optional[str], task_parameters: Optional[dict], is_json_format: bool
+    job_name: str,
+    step_name: Optional[str],
+    task_parameters: Optional[dict],
+    is_json_format: bool,
 ) -> str:
     if is_json_format:
         return _get_json_line(JSON_MSG_TYPE_TITLE, job_name)
@@ -565,7 +582,8 @@ def _get_download_summary_message(
 ) -> str:
     if is_json_format:
         return _get_json_line(
-            JSON_MSG_TYPE_SUMMARY, f"Downloaded {download_summary.processed_files} files"
+            JSON_MSG_TYPE_SUMMARY,
+            f"Downloaded {download_summary.processed_files} files",
         )
     else:
         paths_joined = "\n        ".join(
@@ -706,6 +724,321 @@ def job_download_output(step_id, task_id, output, **args):
             raise DeadlineOperationError(f"Failed to download output:\n{e}") from e
 
 
+@cli_job.command(name="wait")
+@click.option("--profile", help="The AWS profile to use.")
+@click.option("--farm-id", help="The farm to use.")
+@click.option("--queue-id", help="The queue to use.")
+@click.option("--job-id", help="The job to wait for.")
+@click.option("--max-poll-interval", default=120, help="Maximum polling interval in seconds.")
+@click.option("--timeout", default=0, help="Timeout in seconds (0 for no timeout).")
+@click.option(
+    "--output",
+    type=click.Choice(["verbose", "json"], case_sensitive=False),
+    default="verbose",
+    help="Output format (verbose or json).",
+)
+@_handle_error
+def job_wait_for_completion(max_poll_interval, timeout, output, **args):
+    """
+    Wait for a job to complete and return failed step-task IDs.
+
+    This command blocks until the job's taskRunStatus reaches a terminal state (SUCCEEDED, FAILED, CANCELED, SUSPENDED, or NOT_COMPATIBLE),
+    then returns a list of any failed step-task combinations.
+
+    The command uses exponential backoff for polling, starting at 0.5 seconds and doubling
+    the interval after each check until it reaches the maximum polling interval.
+
+    Exit codes:
+    0 - Job succeeded
+    1 - Timeout waiting for job completion
+    2 - Job failed (any tasks failed)
+    3 - Job was canceled
+    4 - Job was suspended
+    5 - Job is not compatible
+    """
+    # Get a temporary config object with the standard options handled
+    config = _apply_cli_options_to_config(
+        required_options={"farm_id", "queue_id", "job_id"}, **args
+    )
+
+    farm_id = config_file.get_setting("defaults.farm_id", config=config)
+    queue_id = config_file.get_setting("defaults.queue_id", config=config)
+    job_id = config_file.get_setting("defaults.job_id", config=config)
+
+    is_json_output = output.lower() == "json"
+
+    # Define a status callback for verbose output
+    def status_callback(status, elapsed_time=0, total_timeout=0):
+        if not is_json_output:
+            timeout_info = ""
+            if total_timeout > 0:
+                remaining = max(0, total_timeout - elapsed_time)
+                timeout_info = f" [{elapsed_time:.1f}s elapsed, {remaining:.1f}s remaining]"
+            else:
+                timeout_info = f" [{elapsed_time:.1f}s elapsed]"
+
+            # Clear the current line and update in place
+            click.echo(
+                f"\rCurrent status: {status}.{timeout_info}",
+                nl=False,
+            )
+
+    if not is_json_output:
+        click.echo(f"Waiting for job {job_id} to complete...")
+
+    try:
+        result = api.wait_for_job_completion(
+            farm_id=farm_id,
+            queue_id=queue_id,
+            job_id=job_id,
+            max_poll_interval=max_poll_interval,
+            timeout=timeout,
+            config=config,
+            status_callback=status_callback,
+        )
+
+        if is_json_output:
+            # Return everything as JSON
+            response = {
+                "status": result.status,
+                "elapsedTime": result.elapsed_time,
+                "failedTasks": [
+                    {
+                        "stepId": task.step_id,
+                        "taskId": task.task_id,
+                        "stepName": task.step_name,
+                        "sessionId": task.session_id,
+                    }
+                    for task in result.failed_tasks
+                ],
+            }
+            click.echo(json.dumps(response, indent=2))
+        else:
+            # Use verbose output with YAML formatting
+            click.echo(f"Job completed with status: {result.status}")
+            click.echo(f"Elapsed time: {result.elapsed_time:.1f} seconds")
+
+            if result.failed_tasks:
+                click.echo(f"Found {len(result.failed_tasks)} failed tasks:")
+                failed_tasks_dict = [
+                    {
+                        "stepId": task.step_id,
+                        "taskId": task.task_id,
+                        "stepName": task.step_name,
+                        "sessionId": task.session_id,
+                    }
+                    for task in result.failed_tasks
+                ]
+                click.echo(_cli_object_repr(failed_tasks_dict))
+            else:
+                click.echo("No failed tasks found.")
+
+        # Determine exit code based on job status
+        exit_code = 0
+        if result.status == "SUCCEEDED" and not result.failed_tasks:
+            exit_code = 0
+        elif result.status == "FAILED" or result.failed_tasks:
+            exit_code = 2
+        elif result.status == "CANCELED":
+            exit_code = 3
+        elif result.status == "SUSPENDED":
+            exit_code = 4
+        elif result.status == "ARCHIVED":
+            exit_code = 4
+        elif result.status == "NOT_COMPATIBLE":
+            exit_code = 5
+        else:
+            # Unknown status, treat as failure
+            exit_code = 2
+
+        sys.exit(exit_code)
+
+    except DeadlineOperationTimedOut as e:
+        if is_json_output:
+            error_response = {"error": str(e), "timeout": True}
+            click.echo(json.dumps(error_response, indent=2))
+        else:
+            click.echo(f"Error waiting for job completion: {e}")
+        sys.exit(1)
+    except DeadlineOperationError as e:
+        if is_json_output:
+            error_response = {"error": str(e)}
+            click.echo(json.dumps(error_response, indent=2))
+        else:
+            click.echo(f"Error waiting for job completion: {e}")
+        sys.exit(2)
+
+
+@cli_job.command(name="logs")
+@click.option("--profile", help="The AWS profile to use.")
+@click.option("--farm-id", help="The farm to use.")
+@click.option("--queue-id", help="The queue to use.")
+@click.option("--job-id", help="The job to get logs for.")
+@click.option(
+    "--session-id",
+    help="The session ID to get logs for. If not provided and job-id is specified, will use the latest session based on endedAt time.",
+)
+@click.option("--limit", default=100, help="Maximum number of log lines to return.")
+@click.option(
+    "--start-time",
+    help="Start time for logs in ISO format (e.g., 2023-01-01T12:00:00Z).",
+)
+@click.option("--end-time", help="End time for logs in ISO format (e.g., 2023-01-01T13:00:00Z).")
+@click.option("--next-token", help="Token for pagination of results.")
+@click.option(
+    "--output",
+    type=click.Choice(["verbose", "json"], case_sensitive=False),
+    default="verbose",
+    help="Output format (verbose or json).",
+)
+@_handle_error
+def job_logs(session_id, limit, start_time, end_time, next_token, output, **args):
+    """
+    Get CloudWatch logs for a specific session.
+
+    This command retrieves logs from CloudWatch for the specified session ID.
+    By default, it returns the most recent 100 log lines, but this can be
+    adjusted using the --limit parameter.
+
+    If session-id is not provided but job-id is, the command will automatically
+    select a session using the following priority:
+    1. If there are ongoing sessions (no endedAt time), always prefer them
+    2. Among ongoing sessions, select the one that started most recently
+    3. If no ongoing sessions exist, select the completed session that ended most recently
+
+    Use --next-token with the value from a previous response to get the next page of results.
+    """
+    # Get a temporary config object with the standard options handled
+    config = _apply_cli_options_to_config(required_options={"farm_id", "queue_id"}, **args)
+
+    farm_id = config_file.get_setting("defaults.farm_id", config=config)
+    queue_id = config_file.get_setting("defaults.queue_id", config=config)
+    job_id = config_file.get_setting("defaults.job_id", config=config)
+
+    is_json_output = output.lower() == "json"
+
+    # If session_id is not provided but job_id is, try to find the session
+    if not session_id and job_id:
+        deadline = api.get_boto3_client("deadline", config=config)
+        try:
+            # Use paginator to get all sessions
+            paginator = deadline.get_paginator("list_sessions")
+            sessions = []
+
+            for page in paginator.paginate(farmId=farm_id, queueId=queue_id, jobId=job_id):
+                sessions.extend(page.get("sessions", []))
+
+            if not sessions:
+                raise DeadlineOperationError(f"No sessions found for job {job_id}")
+            elif len(sessions) == 1:
+                session_id = sessions[0]["sessionId"]
+                if not is_json_output:
+                    click.echo(f"Using the only available session: {session_id}")
+            else:
+                # Multiple sessions found, select the latest one
+                # Prioritize ongoing sessions (no endedAt) over completed ones
+                # Among ongoing sessions, select the one that started most recently
+                # Among completed sessions, select the one that ended most recently
+                ongoing_sessions = [s for s in sessions if "endedAt" not in s]
+                completed_sessions = [s for s in sessions if "endedAt" in s]
+
+                if ongoing_sessions:
+                    # Always prefer ongoing sessions, select the most recently started one
+                    latest_session = max(
+                        ongoing_sessions,
+                        key=lambda s: s.get(
+                            "startedAt", datetime.datetime.min.replace(tzinfo=datetime.timezone.utc)
+                        ),
+                    )
+                else:
+                    # No ongoing sessions, select the most recently completed one
+                    latest_session = max(
+                        completed_sessions,
+                        key=lambda s: s.get(
+                            "endedAt", datetime.datetime.min.replace(tzinfo=datetime.timezone.utc)
+                        ),
+                    )
+
+                session_id = latest_session["sessionId"]
+                if not is_json_output:
+                    click.echo(f"Using the latest session: {session_id}")
+        except ClientError as exc:
+            raise DeadlineOperationError(
+                f"Failed to list sessions for job {job_id}:\n{exc}"
+            ) from exc
+
+    # Ensure we have a session ID at this point
+    if not session_id:
+        raise DeadlineOperationError(
+            "Session ID is required. Provide it with --session-id or specify a --job-id with at least one session."
+        )
+
+    if not is_json_output:
+        click.echo(
+            f"Retrieving logs for session {session_id} from log group /aws/deadline/{farm_id}/{queue_id}..."
+        )
+
+    try:
+        result = api.get_session_logs(
+            farm_id=farm_id,
+            queue_id=queue_id,
+            session_id=session_id,
+            limit=limit,
+            start_time=start_time,
+            end_time=end_time,
+            next_token=next_token,
+            config=config,
+        )
+
+        if is_json_output:
+            # Return everything as JSON
+            response = {
+                "events": [
+                    {
+                        "timestamp": event.timestamp.strftime("%Y-%m-%d %H:%M:%S"),
+                        "message": event.message,
+                        "ingestionTime": (
+                            event.ingestion_time.strftime("%Y-%m-%d %H:%M:%S")
+                            if event.ingestion_time
+                            else None
+                        ),
+                        "eventId": event.event_id,
+                    }
+                    for event in result.events
+                ],
+                "count": result.count,
+                "nextToken": result.next_token,
+                "logGroup": result.log_group,
+                "logStream": result.log_stream,
+            }
+            click.echo(json.dumps(response, indent=2))
+        else:
+            # Display the logs in verbose format
+            if not result.events:
+                click.echo("No logs found for the specified session.")
+                return
+
+            for event in result.events:
+                timestamp = event.timestamp.strftime("%Y-%m-%d %H:%M:%S")
+                click.echo(f"[{timestamp}] {event.message}")
+
+            click.echo(f"\nRetrieved {result.count} log events.")
+
+            # If there are more logs available, inform the user
+            if result.next_token:
+                click.echo(
+                    f'More logs are available. Use --next-token "{result.next_token}" to retrieve the next page.'
+                )
+
+    except Exception as e:
+        if is_json_output:
+            error_response = {"error": str(e)}
+            click.echo(json.dumps(error_response, indent=2))
+            sys.exit(1)
+        else:
+            raise DeadlineOperationError(f"Error retrieving logs: {e}")
+
+
 @cli_job.command(name="trace-schedule")
 @click.option("--profile", help="The AWS profile to use.")
 @click.option("--farm-id", help="The farm to use.")
@@ -758,7 +1091,10 @@ def job_trace_schedule(verbose, trace_format, trace_file, **args):
     while "nextToken" in response:
         old_list = response["sessions"]
         response = deadline.list_sessions(
-            farmId=farm_id, queueId=queue_id, jobId=job_id, nextToken=response["nextToken"]
+            farmId=farm_id,
+            queueId=queue_id,
+            jobId=job_id,
+            nextToken=response["nextToken"],
         )
         response["sessions"] = old_list + response["sessions"]
     response.pop("ResponseMetadata", None)
@@ -768,7 +1104,10 @@ def job_trace_schedule(verbose, trace_format, trace_file, **args):
     click.echo("Getting all the session actions for the job...")
     for session in sessions:
         response = deadline.list_session_actions(
-            farmId=farm_id, queueId=queue_id, jobId=job_id, sessionId=session["sessionId"]
+            farmId=farm_id,
+            queueId=queue_id,
+            jobId=job_id,
+            sessionId=session["sessionId"],
         )
         while "nextToken" in response:
             old_list = response["sessionActions"]
@@ -802,7 +1141,10 @@ def job_trace_schedule(verbose, trace_format, trace_file, **args):
                             step = steps[step_id]
                         else:
                             step = deadline.get_step(
-                                farmId=farm_id, queueId=queue_id, jobId=job_id, stepId=step_id
+                                farmId=farm_id,
+                                queueId=queue_id,
+                                jobId=job_id,
+                                stepId=step_id,
                             )
                             step.pop("ResponseMetadata", None)
                             steps[step_id] = step

--- a/src/deadline/client/exceptions.py
+++ b/src/deadline/client/exceptions.py
@@ -16,6 +16,13 @@ class DeadlineOperationCanceled(DeadlineOperationError):
         super().__init__(message)
 
 
+class DeadlineOperationTimedOut(DeadlineOperationError):
+    """DeadlineOperationError for when an operation timed out"""
+
+    def __init__(self, message: str = "Operation timed out"):
+        super().__init__(message)
+
+
 class CreateJobWaiterCanceled(DeadlineOperationCanceled):
     """Error for when the waiter after CreateJob is interrupted"""
 

--- a/test/unit/deadline_client/api/test_job_monitoring.py
+++ b/test/unit/deadline_client/api/test_job_monitoring.py
@@ -1,0 +1,670 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Tests for the job monitoring API functions.
+"""
+
+import datetime
+from unittest.mock import patch, MagicMock
+import pytest
+
+from deadline.client.api._job_monitoring import (
+    wait_for_job_completion,
+    get_session_logs,
+    JobCompletionResult,
+    SessionLogResult,
+)
+from deadline.client.exceptions import DeadlineOperationError
+
+from ..shared_constants import (
+    MOCK_FARM_ID,
+    MOCK_JOB_ID,
+    MOCK_QUEUE_ID,
+)
+
+MOCK_JOB_RUNNING = {
+    "jobId": MOCK_JOB_ID,
+    "name": "Test Job",
+    "taskRunStatus": "RUNNING",
+    "lifecycleStatus": "ACTIVE",
+    "createdBy": "test-user",
+    "createdAt": datetime.datetime(2023, 1, 27, 7, 34, 41),
+    "startedAt": datetime.datetime(2023, 1, 27, 7, 37, 53),
+}
+
+MOCK_JOB_SUCCEEDED = {
+    "jobId": MOCK_JOB_ID,
+    "name": "Test Job",
+    "taskRunStatus": "SUCCEEDED",
+    "lifecycleStatus": "ACTIVE",
+    "createdBy": "test-user",
+    "createdAt": datetime.datetime(2023, 1, 27, 7, 34, 41),
+    "startedAt": datetime.datetime(2023, 1, 27, 7, 37, 53),
+    "endedAt": datetime.datetime(2023, 1, 27, 7, 39, 17),
+}
+
+MOCK_JOB_FAILED = {
+    "jobId": MOCK_JOB_ID,
+    "name": "Test Job",
+    "taskRunStatus": "FAILED",
+    "lifecycleStatus": "ACTIVE",
+    "createdBy": "test-user",
+    "createdAt": datetime.datetime(2023, 1, 27, 7, 34, 41),
+    "startedAt": datetime.datetime(2023, 1, 27, 7, 37, 53),
+    "endedAt": datetime.datetime(2023, 1, 27, 7, 39, 17),
+}
+
+MOCK_STEPS = {
+    "steps": [
+        {
+            "stepId": "step-123",
+            "name": "Step 1",
+            "lifecycleStatus": "CREATE_COMPLETE",
+            "taskRunStatus": "SUCCEEDED",
+            "taskRunStatusCounts": {"FAILED": 0},
+        },
+        {
+            "stepId": "step-456",
+            "name": "Step 2",
+            "lifecycleStatus": "CREATE_COMPLETE",
+            "taskRunStatus": "FAILED",
+            "taskRunStatusCounts": {"FAILED": 2},
+        },
+    ]
+}
+
+MOCK_TASKS = {
+    "tasks": [
+        {
+            "taskId": "task-123",
+            "runStatus": "FAILED",
+            "latestSessionActionId": "sessionaction-abc123-0",
+        },
+        {
+            "taskId": "task-456",
+            "runStatus": "FAILED",
+            "latestSessionActionId": "sessionaction-def456-1",
+        },
+        {
+            "taskId": "task-789",
+            "runStatus": "SUCCEEDED",
+            "latestSessionActionId": "sessionaction-ghi789-2",
+        },
+    ]
+}
+
+
+def test_wait_for_job_completion_success():
+    """
+    Test that wait_for_job_completion works correctly when job succeeds.
+    """
+    with patch("deadline.client.api._job_monitoring.get_boto3_client") as mock_get_client:
+        deadline_mock = MagicMock()
+        mock_get_client.return_value = deadline_mock
+
+        # First call returns RUNNING, second call returns SUCCEEDED
+        deadline_mock.get_job.side_effect = [MOCK_JOB_RUNNING, MOCK_JOB_SUCCEEDED]
+
+        # Mock time.sleep to avoid waiting in tests
+        with patch("time.sleep"):
+            # Mock datetime.now to simulate elapsed time
+            start_time = datetime.datetime(2023, 1, 1, 12, 0, 0)
+            end_time = datetime.datetime(2023, 1, 1, 12, 0, 10)
+
+            with patch("datetime.datetime") as dt_mock:
+                dt_mock.now.side_effect = [start_time, end_time]
+
+                result = wait_for_job_completion(
+                    farm_id=MOCK_FARM_ID,
+                    queue_id=MOCK_QUEUE_ID,
+                    job_id=MOCK_JOB_ID,
+                    max_poll_interval=1,
+                )
+
+                assert isinstance(result, JobCompletionResult)
+                assert result.status == "SUCCEEDED"
+                assert result.elapsed_time == pytest.approx(10.0)
+                assert len(result.failed_tasks) == 0
+
+                # Verify the correct parameters were used
+                deadline_mock.get_job.assert_called_with(
+                    farmId=MOCK_FARM_ID, queueId=MOCK_QUEUE_ID, jobId=MOCK_JOB_ID
+                )
+
+
+def test_wait_for_job_completion_failure():
+    """
+    Test that wait_for_job_completion works correctly when job fails.
+    """
+    with patch("deadline.client.api._job_monitoring.get_boto3_client") as mock_get_client:
+        deadline_mock = MagicMock()
+        mock_get_client.return_value = deadline_mock
+
+        # First call returns RUNNING, second call returns FAILED
+        deadline_mock.get_job.side_effect = [MOCK_JOB_RUNNING, MOCK_JOB_FAILED]
+
+        # Set up paginator mock for list_steps
+        steps_paginator_mock = MagicMock()
+        steps_paginator_mock.paginate.return_value = [MOCK_STEPS]
+
+        # Set up paginator mock for list_tasks
+        tasks_paginator_mock = MagicMock()
+        tasks_paginator_mock.paginate.return_value = [MOCK_TASKS]
+
+        # Configure get_paginator to return the appropriate paginator based on the operation
+        def get_paginator_side_effect(operation):
+            if operation == "list_steps":
+                return steps_paginator_mock
+            elif operation == "list_tasks":
+                return tasks_paginator_mock
+            return MagicMock()
+
+        deadline_mock.get_paginator.side_effect = get_paginator_side_effect
+
+        # Mock time.sleep to avoid waiting in tests
+        with patch("time.sleep"):
+            # Mock datetime.now to simulate elapsed time
+            start_time = datetime.datetime(2023, 1, 1, 12, 0, 0)
+            end_time = datetime.datetime(2023, 1, 1, 12, 0, 15)
+
+            with patch("datetime.datetime") as dt_mock:
+                dt_mock.now.side_effect = [start_time, end_time]
+
+                result = wait_for_job_completion(
+                    farm_id=MOCK_FARM_ID,
+                    queue_id=MOCK_QUEUE_ID,
+                    job_id=MOCK_JOB_ID,
+                    max_poll_interval=1,
+                )
+
+                assert isinstance(result, JobCompletionResult)
+                assert result.status == "FAILED"
+                assert result.elapsed_time == pytest.approx(15.0)
+                assert len(result.failed_tasks) == 2
+
+                # Verify the failed tasks have the correct data
+                assert result.failed_tasks[0].step_id == "step-456"
+                assert result.failed_tasks[0].task_id == "task-123"
+                assert result.failed_tasks[0].step_name == "Step 2"
+                assert result.failed_tasks[0].session_id == "session-abc123"
+
+                assert result.failed_tasks[1].step_id == "step-456"
+                assert result.failed_tasks[1].task_id == "task-456"
+                assert result.failed_tasks[1].step_name == "Step 2"
+                assert result.failed_tasks[1].session_id == "session-def456"
+
+                # Verify paginators were called with correct parameters
+                deadline_mock.get_paginator.assert_any_call("list_steps")
+                steps_paginator_mock.paginate.assert_called_with(
+                    farmId=MOCK_FARM_ID, queueId=MOCK_QUEUE_ID, jobId=MOCK_JOB_ID
+                )
+
+                deadline_mock.get_paginator.assert_any_call("list_tasks")
+                tasks_paginator_mock.paginate.assert_called_with(
+                    farmId=MOCK_FARM_ID, queueId=MOCK_QUEUE_ID, jobId=MOCK_JOB_ID, stepId="step-456"
+                )
+
+
+def test_wait_for_job_completion_timeout():
+    """
+    Test that wait_for_job_completion times out correctly.
+    """
+    with patch("deadline.client.api._job_monitoring.get_boto3_client") as mock_get_client:
+        deadline_mock = MagicMock()
+        mock_get_client.return_value = deadline_mock
+
+        # Always return RUNNING to trigger timeout
+        deadline_mock.get_job.return_value = MOCK_JOB_RUNNING
+
+        # Mock time.sleep to avoid waiting in tests
+        with patch("time.sleep"):
+            # Mock datetime.now to simulate time passing beyond timeout
+            start_time = datetime.datetime(2023, 1, 1, 12, 0, 0)
+            check_time = datetime.datetime(2023, 1, 1, 12, 0, 3)
+
+            with patch("datetime.datetime") as dt_mock:
+                dt_mock.now.side_effect = [start_time, check_time]
+
+                with patch.object(dt_mock, "now", side_effect=[start_time, check_time]):
+                    try:
+                        wait_for_job_completion(
+                            farm_id=MOCK_FARM_ID,
+                            queue_id=MOCK_QUEUE_ID,
+                            job_id=MOCK_JOB_ID,
+                            max_poll_interval=1,
+                            timeout=2,
+                        )
+                        assert False, "Expected DeadlineOperationError was not raised"
+                    except DeadlineOperationError as e:
+                        assert "Timeout waiting for job" in str(e)
+
+
+def test_wait_for_job_completion_with_pagination():
+    """
+    Test that wait_for_job_completion correctly handles pagination for steps and tasks.
+    """
+    with patch("deadline.client.api._job_monitoring.get_boto3_client") as mock_get_client:
+        deadline_mock = MagicMock()
+        mock_get_client.return_value = deadline_mock
+
+        # Return FAILED job status
+        deadline_mock.get_job.return_value = MOCK_JOB_FAILED
+
+        # Set up paginator mock for list_steps with multiple pages
+        steps_page1 = {"steps": [MOCK_STEPS["steps"][0]]}
+        steps_page2 = {"steps": [MOCK_STEPS["steps"][1]]}
+        steps_paginator_mock = MagicMock()
+        steps_paginator_mock.paginate.return_value = [steps_page1, steps_page2]
+
+        # Set up paginator mock for list_tasks with multiple pages
+        tasks_page1 = {"tasks": [MOCK_TASKS["tasks"][0]]}
+        tasks_page2 = {"tasks": [MOCK_TASKS["tasks"][1], MOCK_TASKS["tasks"][2]]}
+        tasks_paginator_mock = MagicMock()
+        tasks_paginator_mock.paginate.return_value = [tasks_page1, tasks_page2]
+
+        # Configure get_paginator to return the appropriate paginator based on the operation
+        def get_paginator_side_effect(operation):
+            if operation == "list_steps":
+                return steps_paginator_mock
+            elif operation == "list_tasks":
+                return tasks_paginator_mock
+            return MagicMock()
+
+        deadline_mock.get_paginator.side_effect = get_paginator_side_effect
+
+        # Mock time.sleep to avoid waiting in tests
+        with patch("time.sleep"):
+            # Mock datetime.now to simulate elapsed time
+            start_time = datetime.datetime(2023, 1, 1, 12, 0, 0)
+            end_time = datetime.datetime(2023, 1, 1, 12, 0, 5)
+
+            with patch("datetime.datetime") as dt_mock:
+                dt_mock.now.side_effect = [start_time, end_time]
+
+                result = wait_for_job_completion(
+                    farm_id=MOCK_FARM_ID,
+                    queue_id=MOCK_QUEUE_ID,
+                    job_id=MOCK_JOB_ID,
+                    max_poll_interval=1,
+                )
+
+                assert isinstance(result, JobCompletionResult)
+                assert result.status == "FAILED"
+                assert result.elapsed_time == pytest.approx(5.0)
+                assert len(result.failed_tasks) == 2
+
+                # Verify paginators were called with correct parameters
+                deadline_mock.get_paginator.assert_any_call("list_steps")
+                steps_paginator_mock.paginate.assert_called_with(
+                    farmId=MOCK_FARM_ID, queueId=MOCK_QUEUE_ID, jobId=MOCK_JOB_ID
+                )
+
+                deadline_mock.get_paginator.assert_any_call("list_tasks")
+                tasks_paginator_mock.paginate.assert_called_with(
+                    farmId=MOCK_FARM_ID, queueId=MOCK_QUEUE_ID, jobId=MOCK_JOB_ID, stepId="step-456"
+                )
+
+
+# Mock CloudWatch log events for testing
+MOCK_LOG_EVENTS = [
+    {
+        "timestamp": 1672574400000,  # 2023-01-01 12:00:00 UTC
+        "message": "Log message 1",
+        "ingestionTime": 1672574410000,  # 2023-01-01 12:00:10 UTC
+        "eventId": "event-1",
+    },
+    {
+        "timestamp": 1672574460000,  # 2023-01-01 12:01:00 UTC
+        "message": "Log message 2",
+        "ingestionTime": 1672574470000,  # 2023-01-01 12:01:10 UTC
+        "eventId": "event-2",
+    },
+]
+
+# Mock CloudWatch GetLogEvents response
+MOCK_GET_LOG_EVENTS_RESPONSE = {
+    "events": MOCK_LOG_EVENTS,
+    "nextForwardToken": "next-token",
+    "nextBackwardToken": "back-token",
+}
+
+
+def test_wait_for_job_completion_exponential_backoff():
+    """
+    Test that wait_for_job_completion uses exponential backoff correctly.
+    """
+    with patch("deadline.client.api._job_monitoring.get_boto3_client") as mock_get_client:
+        deadline_mock = MagicMock()
+        mock_get_client.return_value = deadline_mock
+
+        # Return RUNNING for several calls, then SUCCEEDED
+        deadline_mock.get_job.side_effect = [
+            MOCK_JOB_RUNNING,
+            MOCK_JOB_RUNNING,
+            MOCK_JOB_RUNNING,
+            MOCK_JOB_SUCCEEDED,
+        ]
+
+        # Mock time.sleep to track the intervals
+        sleep_intervals = []
+
+        def mock_sleep(interval):
+            sleep_intervals.append(interval)
+
+        with patch("time.sleep", side_effect=mock_sleep):
+            # Mock datetime.now to simulate elapsed time
+            start_time = datetime.datetime(2023, 1, 1, 12, 0, 0)
+            end_time = datetime.datetime(2023, 1, 1, 12, 0, 10)
+
+            with patch("datetime.datetime") as dt_mock:
+                dt_mock.now.side_effect = [start_time, end_time]
+
+                result = wait_for_job_completion(
+                    farm_id=MOCK_FARM_ID,
+                    queue_id=MOCK_QUEUE_ID,
+                    job_id=MOCK_JOB_ID,
+                    max_poll_interval=10,
+                )
+
+                assert isinstance(result, JobCompletionResult)
+                assert result.status == "SUCCEEDED"
+
+                # Verify exponential backoff: 0.5, 1.0, 2.0
+                assert len(sleep_intervals) == pytest.approx(3)
+                assert sleep_intervals[0] == pytest.approx(0.5)
+                assert sleep_intervals[1] == pytest.approx(1.0)
+                assert sleep_intervals[2] == pytest.approx(2.0)
+
+
+def test_wait_for_job_completion_max_interval_cap():
+    """
+    Test that wait_for_job_completion caps at max_poll_interval.
+    """
+    with patch("deadline.client.api._job_monitoring.get_boto3_client") as mock_get_client:
+        deadline_mock = MagicMock()
+        mock_get_client.return_value = deadline_mock
+
+        # Return RUNNING for many calls, then SUCCEEDED
+        deadline_mock.get_job.side_effect = [MOCK_JOB_RUNNING] * 10 + [MOCK_JOB_SUCCEEDED]
+
+        # Mock time.sleep to track the intervals
+        sleep_intervals = []
+
+        def mock_sleep(interval):
+            sleep_intervals.append(interval)
+
+        with patch("time.sleep", side_effect=mock_sleep):
+            # Mock datetime.now to simulate elapsed time
+            start_time = datetime.datetime(2023, 1, 1, 12, 0, 0)
+            end_time = datetime.datetime(2023, 1, 1, 12, 0, 10)
+
+            with patch("datetime.datetime") as dt_mock:
+                dt_mock.now.side_effect = [start_time, end_time]
+
+                result = wait_for_job_completion(
+                    farm_id=MOCK_FARM_ID,
+                    queue_id=MOCK_QUEUE_ID,
+                    job_id=MOCK_JOB_ID,
+                    max_poll_interval=3,  # Small max to test capping
+                )
+
+                assert isinstance(result, JobCompletionResult)
+                assert result.status == "SUCCEEDED"
+
+                # Verify intervals cap at max_poll_interval: 0.5, 1.0, 2.0, 3.0, 3.0, ...
+                assert len(sleep_intervals) == 10
+                assert sleep_intervals[0] == pytest.approx(0.5)
+                assert sleep_intervals[1] == pytest.approx(1.0)
+                assert sleep_intervals[2] == pytest.approx(2.0)
+                # All subsequent intervals should be capped at 3.0
+                for i in range(3, 10):
+                    assert sleep_intervals[i] == pytest.approx(3.0)
+
+
+def test_get_session_logs_basic():
+    """
+    Test that get_session_logs works correctly with basic parameters.
+    """
+    with patch("deadline.client.api._job_monitoring.get_boto3_client") as mock_get_client, patch(
+        "deadline.client.api._job_monitoring.get_user_and_identity_store_id"
+    ) as mock_get_user:
+        # Mock user and identity store ID to be None (standard credentials path)
+        mock_get_user.return_value = (None, None)
+
+        # Set up logs client mock
+        logs_client_mock = MagicMock()
+        logs_client_mock.get_log_events.return_value = MOCK_GET_LOG_EVENTS_RESPONSE
+        mock_get_client.return_value = logs_client_mock
+
+        # Call the function
+        result = get_session_logs(
+            farm_id=MOCK_FARM_ID,
+            queue_id=MOCK_QUEUE_ID,
+            session_id="session-test-session",
+            limit=100,
+        )
+
+        # Verify the result
+        assert isinstance(result, SessionLogResult)
+        assert len(result.events) == 2
+        assert result.events[0].message == "Log message 1"
+        assert result.events[1].message == "Log message 2"
+        assert result.next_token == "next-token"
+        assert result.log_group == f"/aws/deadline/{MOCK_FARM_ID}/{MOCK_QUEUE_ID}"
+        assert result.log_stream == "session-test-session"
+        assert result.count == 2
+
+        # Verify the logs client was called with correct parameters
+        logs_client_mock.get_log_events.assert_called_once_with(
+            logGroupName=f"/aws/deadline/{MOCK_FARM_ID}/{MOCK_QUEUE_ID}",
+            logStreamName="session-test-session",
+            limit=100,
+            startFromHead=False,
+        )
+
+
+def test_get_session_logs_with_datetime_params():
+    """
+    Test that get_session_logs works correctly with datetime parameters.
+    """
+    with patch("deadline.client.api._job_monitoring.get_boto3_client") as mock_get_client, patch(
+        "deadline.client.api._job_monitoring.get_user_and_identity_store_id"
+    ) as mock_get_user:
+        # Mock user and identity store ID to be None (standard credentials path)
+        mock_get_user.return_value = (None, None)
+
+        # Set up logs client mock
+        logs_client_mock = MagicMock()
+        logs_client_mock.get_log_events.return_value = MOCK_GET_LOG_EVENTS_RESPONSE
+        mock_get_client.return_value = logs_client_mock
+
+        # Create datetime objects for start and end times
+        start_time = datetime.datetime(2023, 1, 1, 12, 0, 0)
+        end_time = datetime.datetime(2023, 1, 1, 13, 0, 0)
+
+        # Call the function with datetime parameters
+        result = get_session_logs(
+            farm_id=MOCK_FARM_ID,
+            queue_id=MOCK_QUEUE_ID,
+            session_id="session-test-session",
+            limit=100,
+            start_time=start_time,
+            end_time=end_time,
+        )
+
+        # Verify the result
+        assert isinstance(result, SessionLogResult)
+        assert len(result.events) == 2
+
+        # Verify the logs client was called with correct parameters
+        logs_client_mock.get_log_events.assert_called_once_with(
+            logGroupName=f"/aws/deadline/{MOCK_FARM_ID}/{MOCK_QUEUE_ID}",
+            logStreamName="session-test-session",
+            limit=100,
+            startFromHead=False,
+            startTime=int(start_time.timestamp() * 1000),
+            endTime=int(end_time.timestamp() * 1000),
+        )
+
+
+def test_get_session_logs_with_monitor_credentials():
+    """
+    Test that get_session_logs works correctly with Deadline Cloud monitor credentials.
+    """
+    with patch("deadline.client.api._job_monitoring.get_boto3_client") as mock_get_client, patch(
+        "deadline.client.api._job_monitoring.get_user_and_identity_store_id"
+    ) as mock_get_user, patch(
+        "deadline.client.api._job_monitoring.get_queue_user_boto3_session"
+    ) as mock_get_session:
+        # Mock user and identity store ID to simulate monitor credentials
+        mock_get_user.return_value = ("user-123", "identity-store-456")
+
+        # Set up queue session mock
+        queue_session_mock = MagicMock()
+        logs_client_mock = MagicMock()
+        logs_client_mock.get_log_events.return_value = MOCK_GET_LOG_EVENTS_RESPONSE
+        queue_session_mock.client.return_value = logs_client_mock
+        mock_get_session.return_value = queue_session_mock
+
+        # Set up deadline client mock
+        deadline_mock = MagicMock()
+        mock_get_client.return_value = deadline_mock
+
+        # Call the function
+        result = get_session_logs(
+            farm_id=MOCK_FARM_ID,
+            queue_id=MOCK_QUEUE_ID,
+            session_id="session-test-session",
+            limit=100,
+        )
+
+        # Verify the result
+        assert isinstance(result, SessionLogResult)
+        assert len(result.events) == 2
+
+        # Verify the queue session was created with correct parameters
+        mock_get_session.assert_called_once_with(
+            deadline=deadline_mock,
+            config=None,
+            farm_id=MOCK_FARM_ID,
+            queue_id=MOCK_QUEUE_ID,
+        )
+
+        # Verify the logs client was created from the queue session
+        queue_session_mock.client.assert_called_once_with("logs")
+
+        # Verify the logs client was called with correct parameters
+        logs_client_mock.get_log_events.assert_called_once_with(
+            logGroupName=f"/aws/deadline/{MOCK_FARM_ID}/{MOCK_QUEUE_ID}",
+            logStreamName="session-test-session",
+            limit=100,
+            startFromHead=False,
+        )
+
+
+def test_get_session_logs_with_next_token():
+    """
+    Test that get_session_logs works correctly with pagination token.
+    """
+    with patch("deadline.client.api._job_monitoring.get_boto3_client") as mock_get_client, patch(
+        "deadline.client.api._job_monitoring.get_user_and_identity_store_id"
+    ) as mock_get_user:
+        # Mock user and identity store ID to be None (standard credentials path)
+        mock_get_user.return_value = (None, None)
+
+        # Set up logs client mock
+        logs_client_mock = MagicMock()
+        logs_client_mock.get_log_events.return_value = MOCK_GET_LOG_EVENTS_RESPONSE
+        mock_get_client.return_value = logs_client_mock
+
+        # Call the function with next_token
+        result = get_session_logs(
+            farm_id=MOCK_FARM_ID,
+            queue_id=MOCK_QUEUE_ID,
+            session_id="session-test-session",
+            limit=100,
+            next_token="previous-token",
+        )
+
+        # Verify the result
+        assert isinstance(result, SessionLogResult)
+        assert result.next_token == "next-token"
+
+        # Verify the logs client was called with correct parameters
+        logs_client_mock.get_log_events.assert_called_once_with(
+            logGroupName=f"/aws/deadline/{MOCK_FARM_ID}/{MOCK_QUEUE_ID}",
+            logStreamName="session-test-session",
+            limit=100,
+            startFromHead=False,
+            nextToken="previous-token",
+        )
+
+
+def test_get_session_logs_resource_not_found():
+    """
+    Test that get_session_logs handles ResourceNotFoundException correctly.
+    """
+    with patch("deadline.client.api._job_monitoring.get_boto3_client") as mock_get_client, patch(
+        "deadline.client.api._job_monitoring.get_user_and_identity_store_id"
+    ) as mock_get_user:
+        # Mock user and identity store ID to be None (standard credentials path)
+        mock_get_user.return_value = (None, None)
+
+        # Set up logs client mock with ResourceNotFoundException
+        logs_client_mock = MagicMock()
+        logs_client_mock.exceptions.ResourceNotFoundException = type(
+            "ResourceNotFoundException", (Exception,), {}
+        )
+        logs_client_mock.get_log_events.side_effect = (
+            logs_client_mock.exceptions.ResourceNotFoundException()
+        )
+        mock_get_client.return_value = logs_client_mock
+
+        # Call the function
+        result = get_session_logs(
+            farm_id=MOCK_FARM_ID,
+            queue_id=MOCK_QUEUE_ID,
+            session_id="session-test-session",
+            limit=100,
+        )
+
+        # Verify the result is empty but valid
+        assert isinstance(result, SessionLogResult)
+        assert len(result.events) == 0
+        assert result.next_token is None
+        assert result.log_group == f"/aws/deadline/{MOCK_FARM_ID}/{MOCK_QUEUE_ID}"
+        assert result.log_stream == "session-test-session"
+        assert result.count == 0
+
+
+def test_get_session_logs_invalid_datetime():
+    """
+    Test that get_session_logs handles invalid datetime objects correctly.
+    """
+    with patch("deadline.client.api._job_monitoring.get_boto3_client") as mock_get_client, patch(
+        "deadline.client.api._job_monitoring.get_user_and_identity_store_id"
+    ) as mock_get_user:
+        # Mock user and identity store ID to be None (standard credentials path)
+        mock_get_user.return_value = (None, None)
+
+        # Set up logs client mock
+        logs_client_mock = MagicMock()
+        mock_get_client.return_value = logs_client_mock
+
+        # Create an invalid datetime object (None with timestamp attribute that raises)
+        invalid_datetime = MagicMock()
+        invalid_datetime.timestamp.side_effect = AttributeError(
+            "'NoneType' object has no attribute 'timestamp'"
+        )
+
+        # Call the function with invalid datetime and verify it raises an error
+        try:
+            get_session_logs(
+                farm_id=MOCK_FARM_ID,
+                queue_id=MOCK_QUEUE_ID,
+                session_id="session-test-session",
+                start_time=invalid_datetime,
+            )
+            assert False, "Expected DeadlineOperationError was not raised"
+        except DeadlineOperationError as e:
+            assert "Invalid start time" in str(e)

--- a/test/unit/deadline_client/cli/test_cli_job.py
+++ b/test/unit/deadline_client/cli/test_cli_job.py
@@ -22,6 +22,7 @@ from deadline.client import api, config
 from deadline.client.cli import main
 from deadline.client.cli._groups import job_group
 from deadline.client.cli._groups.job_group import _get_summary_of_files_to_download_message
+from deadline.client.exceptions import DeadlineOperationError, DeadlineOperationTimedOut
 from deadline.job_attachments.models import (
     FileConflictResolution,
     JobAttachmentS3Settings,
@@ -904,6 +905,322 @@ def test_get_summary_of_files_to_download_message_windows(
         _get_summary_of_files_to_download_message(output_paths_by_root, is_json_format)
         == expected_result
     )
+
+
+def test_cli_job_wait_succeeded(fresh_deadline_config):
+    """
+    Test that job wait command returns exit code 0 when job succeeds.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
+
+    with patch.object(api, "wait_for_job_completion") as mock_wait:
+        mock_wait.return_value = api.JobCompletionResult(
+            status="SUCCEEDED", failed_tasks=[], elapsed_time=10.5
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["job", "wait"])
+
+        assert "Job completed with status: SUCCEEDED" in result.output
+        assert "Elapsed time: 10.5 seconds" in result.output
+        assert "No failed tasks found." in result.output
+        assert result.exit_code == 0
+
+
+def test_cli_job_wait_timeout(fresh_deadline_config):
+    """
+    Test that job wait command returns exit code 1 when timeout occurs.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
+
+    with patch.object(api, "wait_for_job_completion") as mock_wait:
+        mock_wait.side_effect = DeadlineOperationTimedOut(
+            "Timeout waiting for job job-123 to complete after 30.0 seconds"
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["job", "wait"])
+
+        assert "Timeout waiting for job" in result.output
+        assert result.exit_code == 1
+
+
+def test_cli_job_wait_failed(fresh_deadline_config):
+    """
+    Test that job wait command returns exit code 2 when job fails.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
+
+    with patch.object(api, "wait_for_job_completion") as mock_wait:
+        mock_wait.return_value = api.JobCompletionResult(
+            status="FAILED",
+            failed_tasks=[
+                api.FailedTask(
+                    step_id="step-123",
+                    task_id="task-456",
+                    step_name="Render Step",
+                    parameters={"frame": {"int": 1}},
+                    session_id="session-789",
+                )
+            ],
+            elapsed_time=15.2,
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["job", "wait"])
+
+        assert "Job completed with status: FAILED" in result.output
+        assert "Elapsed time: 15.2 seconds" in result.output
+        assert "Found 1 failed tasks:" in result.output
+        assert result.exit_code == 2
+
+
+def test_cli_job_wait_canceled(fresh_deadline_config):
+    """
+    Test that job wait command returns exit code 3 when job is canceled.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
+
+    with patch.object(api, "wait_for_job_completion") as mock_wait:
+        mock_wait.return_value = api.JobCompletionResult(
+            status="CANCELED", failed_tasks=[], elapsed_time=5.0
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["job", "wait"])
+
+        assert "Job completed with status: CANCELED" in result.output
+        assert "Elapsed time: 5.0 seconds" in result.output
+        assert "No failed tasks found." in result.output
+        assert result.exit_code == 3
+
+
+def test_cli_job_wait_archived(fresh_deadline_config):
+    """
+    Test that job wait command returns exit code 4 when job is archived.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
+
+    with patch.object(api, "wait_for_job_completion") as mock_wait:
+        mock_wait.return_value = api.JobCompletionResult(
+            status="ARCHIVED", failed_tasks=[], elapsed_time=8.3
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["job", "wait"])
+
+        assert "Job completed with status: ARCHIVED" in result.output
+        assert "Elapsed time: 8.3 seconds" in result.output
+        assert "No failed tasks found." in result.output
+        assert result.exit_code == 4
+
+
+def test_cli_job_wait_not_compatible(fresh_deadline_config):
+    """
+    Test that job wait command returns exit code 5 when job is not compatible.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
+
+    with patch.object(api, "wait_for_job_completion") as mock_wait:
+        mock_wait.return_value = api.JobCompletionResult(
+            status="NOT_COMPATIBLE", failed_tasks=[], elapsed_time=2.1
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["job", "wait"])
+
+        assert "Job completed with status: NOT_COMPATIBLE" in result.output
+        assert "Elapsed time: 2.1 seconds" in result.output
+        assert "No failed tasks found." in result.output
+        assert result.exit_code == 5
+
+
+def test_cli_job_wait_succeeded_with_failed_tasks_returns_exit_code_2(fresh_deadline_config):
+    """
+    Test that job wait command returns exit code 2 when there are failed tasks, even if status is SUCCEEDED.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
+
+    with patch.object(api, "wait_for_job_completion") as mock_wait:
+        mock_wait.return_value = api.JobCompletionResult(
+            status="SUCCEEDED",
+            failed_tasks=[
+                api.FailedTask(
+                    step_id="step-123",
+                    task_id="task-456",
+                    step_name="Render Step",
+                    parameters={"frame": {"int": 1}},
+                    session_id="session-789",
+                )
+            ],
+            elapsed_time=12.0,
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["job", "wait"])
+
+        assert "Job completed with status: SUCCEEDED" in result.output
+        assert "Found 1 failed tasks:" in result.output
+        assert result.exit_code == 2
+
+
+def test_cli_job_wait_json_output_succeeded(fresh_deadline_config):
+    """
+    Test that job wait command with JSON output returns exit code 0 when job succeeds.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
+
+    with patch.object(api, "wait_for_job_completion") as mock_wait:
+        mock_wait.return_value = api.JobCompletionResult(
+            status="SUCCEEDED", failed_tasks=[], elapsed_time=10.5
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["job", "wait", "--output", "json"])
+
+        # Parse the JSON output
+        output_data = json.loads(result.output)
+        assert output_data["status"] == "SUCCEEDED"
+        assert output_data["elapsedTime"] == pytest.approx(10.5)
+        assert output_data["failedTasks"] == []
+        assert result.exit_code == 0
+
+
+def test_cli_job_wait_json_output_failed(fresh_deadline_config):
+    """
+    Test that job wait command with JSON output returns exit code 2 when job fails.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
+
+    with patch.object(api, "wait_for_job_completion") as mock_wait:
+        mock_wait.return_value = api.JobCompletionResult(
+            status="FAILED",
+            failed_tasks=[
+                api.FailedTask(
+                    step_id="step-123",
+                    task_id="task-456",
+                    step_name="Render Step",
+                    parameters={"frame": {"int": 1}},
+                    session_id="session-789",
+                )
+            ],
+            elapsed_time=15.2,
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["job", "wait", "--output", "json"])
+
+        # Parse the JSON output
+        output_data = json.loads(result.output)
+        assert output_data["status"] == "FAILED"
+        assert output_data["elapsedTime"] == pytest.approx(15.2)
+        assert len(output_data["failedTasks"]) == 1
+        assert output_data["failedTasks"][0]["stepId"] == "step-123"
+        assert output_data["failedTasks"][0]["taskId"] == "task-456"
+        assert output_data["failedTasks"][0]["stepName"] == "Render Step"
+        assert output_data["failedTasks"][0]["sessionId"] == "session-789"
+        assert result.exit_code == 2
+
+
+def test_cli_job_wait_unknown_status_returns_exit_code_2(fresh_deadline_config):
+    """
+    Test that job wait command returns exit code 2 for unknown status.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
+
+    with patch.object(api, "wait_for_job_completion") as mock_wait:
+        mock_wait.return_value = api.JobCompletionResult(
+            status="UNKNOWN_STATUS", failed_tasks=[], elapsed_time=3.0
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["job", "wait"])
+
+        assert "Job completed with status: UNKNOWN_STATUS" in result.output
+        assert result.exit_code == 2
+
+
+def test_cli_job_wait_timeout_json_output(fresh_deadline_config):
+    """
+    Test that job wait command handles timeout correctly with JSON output.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
+
+    with patch.object(api, "wait_for_job_completion") as mock_wait:
+        mock_wait.side_effect = DeadlineOperationTimedOut(
+            "Timeout waiting for job job-123 to complete after 30.0 seconds"
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["job", "wait", "--output", "json"])
+
+        # Parse the JSON output
+        output_data = json.loads(result.output)
+        assert (
+            output_data["error"] == "Timeout waiting for job job-123 to complete after 30.0 seconds"
+        )
+        assert output_data["timeout"] is True
+        assert result.exit_code == 1
+
+
+def test_cli_job_wait_error_handling(fresh_deadline_config):
+    """
+    Test that job wait command handles non-timeout errors correctly.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
+
+    with patch.object(api, "wait_for_job_completion") as mock_wait:
+        mock_wait.side_effect = DeadlineOperationError("Test error message")
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["job", "wait"])
+
+        assert "Error waiting for job completion: Test error message" in result.output
+        assert result.exit_code == 2
+
+
+def test_cli_job_wait_error_handling_json_output(fresh_deadline_config):
+    """
+    Test that job wait command handles non-timeout errors correctly with JSON output.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
+
+    with patch.object(api, "wait_for_job_completion") as mock_wait:
+        mock_wait.side_effect = DeadlineOperationError("Test error message")
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["job", "wait", "--output", "json"])
+
+        # Parse the JSON output
+        output_data = json.loads(result.output)
+        assert output_data["error"] == "Test error message"
+        assert result.exit_code == 2
 
 
 def test_cli_job_download_output_handle_web_url_with_optional_input(fresh_deadline_config):

--- a/test/unit/deadline_client/cli/test_cli_job_logs.py
+++ b/test/unit/deadline_client/cli/test_cli_job_logs.py
@@ -1,0 +1,824 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Tests for the CLI job logs command.
+"""
+
+import json
+import datetime
+from unittest.mock import ANY, MagicMock, patch
+
+from click.testing import CliRunner
+
+from deadline.client import api
+from deadline.client.cli import main
+from deadline.client.config import config_file as config
+from deadline.client.api._job_monitoring import SessionLogResult, LogEvent
+
+from ..shared_constants import (
+    MOCK_FARM_ID,
+    MOCK_QUEUE_ID,
+)
+
+# Mock constants for tests that don't use shared constants
+MOCK_JOB_ID = "job-0123456789abcdefabcdefabcdefabcd"
+
+# Sample log events for testing
+SAMPLE_LOG_EVENTS = [
+    LogEvent(
+        timestamp=datetime.datetime(2023, 1, 1, 12, 0, 0),
+        message="Log message 1",
+        ingestion_time=datetime.datetime(2023, 1, 1, 12, 0, 10),
+        event_id="event-1",
+    ),
+    LogEvent(
+        timestamp=datetime.datetime(2023, 1, 1, 12, 1, 0),
+        message="Log message 2",
+        ingestion_time=datetime.datetime(2023, 1, 1, 12, 1, 10),
+        event_id="event-2",
+    ),
+]
+
+# Sample log result for testing
+SAMPLE_LOG_RESULT = SessionLogResult(
+    events=SAMPLE_LOG_EVENTS,
+    next_token="next-token",
+    log_group=f"/aws/deadline/{MOCK_FARM_ID}/{MOCK_QUEUE_ID}",
+    log_stream="session-test-session",
+    count=2,
+)
+
+# Sample empty log result for testing
+EMPTY_LOG_RESULT = SessionLogResult(
+    events=[],
+    next_token=None,
+    log_group=f"/aws/deadline/{MOCK_FARM_ID}/{MOCK_QUEUE_ID}",
+    log_stream="session-test-session",
+    count=0,
+)
+
+
+def test_cli_job_logs_verbose(fresh_deadline_config):
+    """
+    Test that logs CLI works correctly in verbose mode.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+
+    with patch("deadline.client.api.get_session_logs") as mock_get_logs, patch(
+        "deadline.client.api._job_monitoring.get_user_and_identity_store_id"
+    ) as mock_get_user:
+        mock_get_user.return_value = (None, None)
+        mock_get_logs.return_value = SAMPLE_LOG_RESULT
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main, ["job", "logs", "--session-id", "test-session", "--limit", "100"]
+        )
+
+        assert "Retrieving logs for session" in result.output
+        assert "[2023-01-01 12:00:00] Log message 1" in result.output
+        assert "[2023-01-01 12:01:00] Log message 2" in result.output
+        assert "Retrieved 2 log events" in result.output
+        assert "More logs are available" in result.output
+        assert result.exit_code == 0
+
+        # Verify the API was called with correct parameters
+        mock_get_logs.assert_called_once()
+        _, kwargs = mock_get_logs.call_args
+        assert kwargs["farm_id"] == MOCK_FARM_ID
+        assert kwargs["queue_id"] == MOCK_QUEUE_ID
+        assert kwargs["session_id"] == "test-session"
+        assert kwargs["limit"] == 100
+
+
+def test_cli_job_logs_json(fresh_deadline_config):
+    """
+    Test that logs CLI works correctly in JSON mode.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+
+    with patch("deadline.client.api.get_session_logs") as mock_get_logs, patch(
+        "deadline.client.api._job_monitoring.get_user_and_identity_store_id"
+    ) as mock_get_user:
+        mock_get_user.return_value = (None, None)
+        mock_get_logs.return_value = SAMPLE_LOG_RESULT
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "job",
+                "logs",
+                "--session-id",
+                "test-session",
+                "--limit",
+                "100",
+                "--output",
+                "json",
+            ],
+        )
+
+        # Verify the output is valid JSON
+        output_json = json.loads(result.output)
+        assert "events" in output_json
+        assert len(output_json["events"]) == 2
+        assert output_json["events"][0]["message"] == "Log message 1"
+        assert output_json["events"][1]["message"] == "Log message 2"
+        assert output_json["count"] == 2
+        assert output_json["nextToken"] == "next-token"
+        assert output_json["logGroup"] == f"/aws/deadline/{MOCK_FARM_ID}/{MOCK_QUEUE_ID}"
+        assert output_json["logStream"] == "session-test-session"
+
+        # Verify no intermediate text output was produced
+        assert "Retrieving logs for session" not in result.output
+
+        assert result.exit_code == 0
+
+
+def test_cli_job_logs_empty(fresh_deadline_config):
+    """
+    Test that logs CLI handles empty results correctly.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+
+    with patch("deadline.client.api.get_session_logs") as mock_get_logs, patch(
+        "deadline.client.api._job_monitoring.get_user_and_identity_store_id"
+    ) as mock_get_user:
+        mock_get_user.return_value = (None, None)
+        mock_get_logs.return_value = EMPTY_LOG_RESULT
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main, ["job", "logs", "--session-id", "test-session", "--limit", "100"]
+        )
+
+        assert "No logs found for the specified session" in result.output
+        assert result.exit_code == 0
+
+
+def test_cli_job_logs_json_empty(fresh_deadline_config):
+    """
+    Test that logs CLI handles empty results correctly in JSON mode.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+
+    with patch("deadline.client.api.get_session_logs") as mock_get_logs, patch(
+        "deadline.client.api._job_monitoring.get_user_and_identity_store_id"
+    ) as mock_get_user:
+        mock_get_user.return_value = (None, None)
+        mock_get_logs.return_value = EMPTY_LOG_RESULT
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "job",
+                "logs",
+                "--session-id",
+                "test-session",
+                "--limit",
+                "100",
+                "--output",
+                "json",
+            ],
+        )
+
+        # Verify the output is valid JSON
+        output_json = json.loads(result.output)
+        assert "events" in output_json
+        assert len(output_json["events"]) == 0
+        assert output_json["count"] == 0
+        assert output_json["nextToken"] is None
+
+        assert result.exit_code == 0
+
+
+def test_cli_job_logs_json_error(fresh_deadline_config):
+    """
+    Test that logs CLI handles errors correctly in JSON mode.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+
+    with patch("deadline.client.api.get_session_logs") as mock_get_logs, patch(
+        "deadline.client.api._job_monitoring.get_user_and_identity_store_id"
+    ) as mock_get_user:
+        mock_get_user.return_value = (None, None)
+        mock_get_logs.side_effect = Exception("Test error message")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["job", "logs", "--session-id", "test-session", "--output", "json"],
+        )
+
+        # Verify the output contains an error message
+        assert "error" in result.output
+        # The actual error message is different in the test environment
+
+        # Exit code should be non-zero for errors
+        assert result.exit_code != 0
+
+
+def test_cli_job_logs_with_time_params(fresh_deadline_config):
+    """
+    Test that logs CLI handles time parameters correctly.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+
+    with patch("deadline.client.api.get_session_logs") as mock_get_logs, patch(
+        "deadline.client.api._job_monitoring.get_user_and_identity_store_id"
+    ) as mock_get_user:
+        mock_get_user.return_value = (None, None)
+        mock_get_logs.return_value = SAMPLE_LOG_RESULT
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "job",
+                "logs",
+                "--session-id",
+                "test-session",
+                "--start-time",
+                "2023-01-01T12:00:00Z",
+                "--end-time",
+                "2023-01-01T13:00:00Z",
+            ],
+        )
+
+        assert result.exit_code == 0
+
+        # Verify the API was called with correct parameters
+        mock_get_logs.assert_called_once()
+        _, kwargs = mock_get_logs.call_args
+        assert kwargs["start_time"] == "2023-01-01T12:00:00Z"
+        assert kwargs["end_time"] == "2023-01-01T13:00:00Z"
+
+
+def test_cli_job_logs_with_next_token(fresh_deadline_config):
+    """
+    Test that logs CLI handles next_token parameter correctly.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+
+    with patch("deadline.client.api.get_session_logs") as mock_get_logs, patch(
+        "deadline.client.api._job_monitoring.get_user_and_identity_store_id"
+    ) as mock_get_user:
+        mock_get_user.return_value = (None, None)
+        mock_get_logs.return_value = SAMPLE_LOG_RESULT
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "job",
+                "logs",
+                "--session-id",
+                "test-session",
+                "--next-token",
+                "test-token",
+            ],
+        )
+
+        assert result.exit_code == 0
+
+        # Verify the API was called with correct parameters
+        mock_get_logs.assert_called_once()
+        _, kwargs = mock_get_logs.call_args
+        assert kwargs["next_token"] == "test-token"
+
+
+def test_cli_job_logs_with_session_id(fresh_deadline_config):
+    """
+    Test job logs command with explicit session ID.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+
+    with patch.object(api, "get_session_logs") as mock_get_logs:
+        # Mock the API response
+        mock_get_logs.return_value = SessionLogResult(
+            events=[
+                LogEvent(
+                    timestamp=datetime.datetime(2023, 1, 27, 7, 24, 45),
+                    message="Test log message 1",
+                    ingestion_time=datetime.datetime(2023, 1, 27, 7, 24, 46),
+                    event_id="event-1",
+                ),
+                LogEvent(
+                    timestamp=datetime.datetime(2023, 1, 27, 7, 24, 50),
+                    message="Test log message 2",
+                    ingestion_time=datetime.datetime(2023, 1, 27, 7, 24, 51),
+                    event_id="event-2",
+                ),
+            ],
+            count=2,
+            next_token=None,
+            log_group=f"/aws/deadline/{MOCK_FARM_ID}/{MOCK_QUEUE_ID}",
+            log_stream="session-1",
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "job",
+                "logs",
+                "--session-id",
+                "session-1",
+            ],
+        )
+
+        # Verify the API was called correctly
+        mock_get_logs.assert_called_once_with(
+            farm_id=MOCK_FARM_ID,
+            queue_id=MOCK_QUEUE_ID,
+            session_id="session-1",
+            limit=100,
+            start_time=None,
+            end_time=None,
+            next_token=None,
+            config=ANY,
+        )
+
+        # Check output
+        assert "Retrieving logs for session session-1" in result.output
+        assert "2023-01-27 07:24:45" in result.output
+        assert "Test log message 1" in result.output
+        assert "2023-01-27 07:24:50" in result.output
+        assert "Test log message 2" in result.output
+        assert "Retrieved 2 log events" in result.output
+        assert result.exit_code == 0
+
+
+def test_cli_job_logs_with_job_id_single_session(fresh_deadline_config):
+    """
+    Test job logs command with job ID when there's only one session.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
+
+    with patch.object(api, "get_boto3_client") as boto3_client_mock, patch.object(
+        api, "get_session_logs"
+    ) as mock_get_logs:
+        # Mock the paginator
+        paginator_mock = MagicMock()
+        boto3_client_mock().get_paginator.return_value = paginator_mock
+
+        # Set up the paginator to return a single session
+        paginator_mock.paginate.return_value = [{"sessions": [{"sessionId": "session-1"}]}]
+
+        # Mock the get_session_logs response
+        mock_get_logs.return_value = api.SessionLogResult(
+            events=[
+                api.LogEvent(
+                    timestamp=datetime.datetime(2023, 1, 27, 7, 24, 45),
+                    message="Test log message",
+                    ingestion_time=datetime.datetime(2023, 1, 27, 7, 24, 46),
+                    event_id="event-1",
+                ),
+            ],
+            count=1,
+            next_token=None,
+            log_group=f"/aws/deadline/{MOCK_FARM_ID}/{MOCK_QUEUE_ID}",
+            log_stream="session-1",
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "job",
+                "logs",
+                "--job-id",
+                MOCK_JOB_ID,
+            ],
+        )
+
+        # Verify paginator was called correctly
+        boto3_client_mock().get_paginator.assert_called_once_with("list_sessions")
+        paginator_mock.paginate.assert_called_once_with(
+            farmId=MOCK_FARM_ID, queueId=MOCK_QUEUE_ID, jobId=MOCK_JOB_ID
+        )
+
+        # Verify get_session_logs was called with the correct session ID
+        mock_get_logs.assert_called_once_with(
+            farm_id=MOCK_FARM_ID,
+            queue_id=MOCK_QUEUE_ID,
+            session_id="session-1",
+            limit=100,
+            start_time=None,
+            end_time=None,
+            next_token=None,
+            config=ANY,
+        )
+
+        # Check output
+        assert "Using the only available session: session-1" in result.output
+        assert "Test log message" in result.output
+        assert result.exit_code == 0
+
+
+def test_cli_job_logs_with_job_id_no_sessions(fresh_deadline_config):
+    """
+    Test job logs command with job ID when there are no sessions.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+
+    with patch.object(api, "get_boto3_client") as boto3_client_mock:
+        # Mock the paginator
+        paginator_mock = MagicMock()
+        boto3_client_mock().get_paginator.return_value = paginator_mock
+
+        # Set up the paginator to return no sessions
+        paginator_mock.paginate.return_value = [{"sessions": []}]
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "job",
+                "logs",
+                "--job-id",
+                MOCK_JOB_ID,
+            ],
+        )
+
+        # Verify paginator was called correctly
+        boto3_client_mock().get_paginator.assert_called_once_with("list_sessions")
+        paginator_mock.paginate.assert_called_once_with(
+            farmId=MOCK_FARM_ID, queueId=MOCK_QUEUE_ID, jobId=MOCK_JOB_ID
+        )
+
+        # Check error message
+        assert f"No sessions found for job {MOCK_JOB_ID}" in result.output
+        assert result.exit_code != 0
+
+
+def test_cli_job_logs_with_pagination(fresh_deadline_config):
+    """
+    Test job logs command with pagination of sessions.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+
+    with patch.object(api, "get_boto3_client") as boto3_client_mock, patch.object(
+        api, "get_session_logs"
+    ) as mock_get_logs:
+        # Mock the paginator
+        paginator_mock = MagicMock()
+        boto3_client_mock().get_paginator.return_value = paginator_mock
+
+        # Set up the paginator to return sessions across multiple pages
+        paginator_mock.paginate.return_value = [
+            {
+                "sessions": [
+                    {
+                        "sessionId": "session-1",
+                        "endedAt": datetime.datetime(2023, 1, 27, 7, 0, 0),
+                    }
+                ]
+            },
+            {
+                "sessions": [
+                    {
+                        "sessionId": "session-2",
+                        "endedAt": datetime.datetime(2023, 1, 27, 8, 0, 0),
+                    }
+                ]
+            },
+        ]
+
+        # Mock the get_session_logs response
+        mock_get_logs.return_value = api.SessionLogResult(
+            events=[
+                api.LogEvent(
+                    timestamp=datetime.datetime(2023, 1, 27, 8, 0, 0),
+                    message="Test log message",
+                    ingestion_time=datetime.datetime(2023, 1, 27, 8, 0, 1),
+                    event_id="event-1",
+                ),
+            ],
+            count=1,
+            next_token=None,
+            log_group=f"/aws/deadline/{MOCK_FARM_ID}/{MOCK_QUEUE_ID}",
+            log_stream="session-2",
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "job",
+                "logs",
+                "--job-id",
+                MOCK_JOB_ID,
+            ],
+        )
+
+        # Verify paginator was called correctly
+        boto3_client_mock().get_paginator.assert_called_once_with("list_sessions")
+        paginator_mock.paginate.assert_called_once_with(
+            farmId=MOCK_FARM_ID, queueId=MOCK_QUEUE_ID, jobId=MOCK_JOB_ID
+        )
+
+        # Verify get_session_logs was called with the latest session ID
+        mock_get_logs.assert_called_once_with(
+            farm_id=MOCK_FARM_ID,
+            queue_id=MOCK_QUEUE_ID,
+            session_id="session-2",  # Should use the latest session
+            limit=100,
+            start_time=None,
+            end_time=None,
+            next_token=None,
+            config=ANY,
+        )
+
+        # Check output
+        assert "Using the latest session: session-2" in result.output
+        assert "Test log message" in result.output
+        assert result.exit_code == 0
+
+
+def test_cli_job_logs_with_job_id_prioritizes_ongoing_sessions(fresh_deadline_config):
+    """
+    Test that ongoing sessions (no endedAt) are prioritized over completed sessions.
+    """
+    with patch.object(config, "get_setting") as mock_get_setting:
+        mock_get_setting.side_effect = [
+            MOCK_FARM_ID,  # _apply_cli_options_to_config check for farm_id
+            MOCK_QUEUE_ID,  # _apply_cli_options_to_config check for queue_id
+            MOCK_FARM_ID,  # defaults.farm_id
+            MOCK_QUEUE_ID,  # defaults.queue_id
+            MOCK_JOB_ID,  # defaults.job_id
+        ]
+
+        with patch("deadline.client.api.get_boto3_client") as boto3_client_mock:
+            with patch("deadline.client.api.get_session_logs") as mock_get_logs:
+                # Set up the paginator to return mix of ongoing and completed sessions
+                paginator_mock = MagicMock()
+                boto3_client_mock().get_paginator.return_value = paginator_mock
+                paginator_mock.paginate.return_value = [
+                    {
+                        "sessions": [
+                            {
+                                "sessionId": "session-completed-recent",
+                                "startedAt": datetime.datetime(2023, 1, 27, 8, 0, 0),
+                                "endedAt": datetime.datetime(
+                                    2023, 1, 27, 9, 0, 0
+                                ),  # Most recent completion
+                            },
+                            {
+                                "sessionId": "session-ongoing-older",
+                                "startedAt": datetime.datetime(
+                                    2023, 1, 27, 6, 0, 0
+                                ),  # Ongoing but older
+                                # No endedAt - this is ongoing
+                            },
+                            {
+                                "sessionId": "session-ongoing-newer",
+                                "startedAt": datetime.datetime(
+                                    2023, 1, 27, 7, 30, 0
+                                ),  # Ongoing and newer
+                                # No endedAt - this is ongoing
+                            },
+                            {
+                                "sessionId": "session-completed-older",
+                                "startedAt": datetime.datetime(2023, 1, 27, 5, 0, 0),
+                                "endedAt": datetime.datetime(
+                                    2023, 1, 27, 6, 0, 0
+                                ),  # Older completion
+                            },
+                        ]
+                    }
+                ]
+
+                # Mock the get_session_logs response
+                mock_get_logs.return_value = api.SessionLogResult(
+                    events=[
+                        api.LogEvent(
+                            timestamp=datetime.datetime(2023, 1, 27, 7, 30, 0),
+                            message="Ongoing session log message",
+                            ingestion_time=datetime.datetime(2023, 1, 27, 7, 30, 1),
+                            event_id="event-1",
+                        ),
+                    ],
+                    count=1,
+                    next_token=None,
+                    log_group=f"/aws/deadline/{MOCK_FARM_ID}/{MOCK_QUEUE_ID}",
+                    log_stream="session-ongoing-newer",
+                )
+
+                runner = CliRunner()
+                result = runner.invoke(
+                    main,
+                    [
+                        "job",
+                        "logs",
+                        "--job-id",
+                        MOCK_JOB_ID,
+                    ],
+                )
+
+                # Verify get_session_logs was called with the most recently started ongoing session
+                mock_get_logs.assert_called_once_with(
+                    farm_id=MOCK_FARM_ID,
+                    queue_id=MOCK_QUEUE_ID,
+                    session_id="session-ongoing-newer",  # Should prioritize ongoing session with most recent start
+                    limit=100,
+                    start_time=None,
+                    end_time=None,
+                    next_token=None,
+                    config=ANY,
+                )
+
+                # Check output
+                assert "Using the latest session: session-ongoing-newer" in result.output
+                assert "Ongoing session log message" in result.output
+                assert result.exit_code == 0
+
+
+def test_cli_job_logs_with_job_id_selects_most_recent_completed_when_no_ongoing(
+    fresh_deadline_config,
+):
+    """
+    Test that when there are no ongoing sessions, the most recently completed session is selected.
+    """
+    with patch.object(config, "get_setting") as mock_get_setting:
+        mock_get_setting.side_effect = [
+            MOCK_FARM_ID,  # _apply_cli_options_to_config check for farm_id
+            MOCK_QUEUE_ID,  # _apply_cli_options_to_config check for queue_id
+            MOCK_FARM_ID,  # defaults.farm_id
+            MOCK_QUEUE_ID,  # defaults.queue_id
+            MOCK_JOB_ID,  # defaults.job_id
+        ]
+
+        with patch("deadline.client.api.get_boto3_client") as boto3_client_mock:
+            with patch("deadline.client.api.get_session_logs") as mock_get_logs:
+                # Set up the paginator to return only completed sessions
+                paginator_mock = MagicMock()
+                boto3_client_mock().get_paginator.return_value = paginator_mock
+                paginator_mock.paginate.return_value = [
+                    {
+                        "sessions": [
+                            {
+                                "sessionId": "session-completed-older",
+                                "startedAt": datetime.datetime(2023, 1, 27, 6, 0, 0),
+                                "endedAt": datetime.datetime(
+                                    2023, 1, 27, 7, 0, 0
+                                ),  # Older completion
+                            },
+                            {
+                                "sessionId": "session-completed-newer",
+                                "startedAt": datetime.datetime(2023, 1, 27, 8, 0, 0),
+                                "endedAt": datetime.datetime(
+                                    2023, 1, 27, 9, 0, 0
+                                ),  # Most recent completion
+                            },
+                        ]
+                    }
+                ]
+
+                # Mock the get_session_logs response
+                mock_get_logs.return_value = api.SessionLogResult(
+                    events=[
+                        api.LogEvent(
+                            timestamp=datetime.datetime(2023, 1, 27, 9, 0, 0),
+                            message="Most recent completed session log",
+                            ingestion_time=datetime.datetime(2023, 1, 27, 9, 0, 1),
+                            event_id="event-1",
+                        ),
+                    ],
+                    count=1,
+                    next_token=None,
+                    log_group=f"/aws/deadline/{MOCK_FARM_ID}/{MOCK_QUEUE_ID}",
+                    log_stream="session-completed-newer",
+                )
+
+                runner = CliRunner()
+                result = runner.invoke(
+                    main,
+                    [
+                        "job",
+                        "logs",
+                        "--job-id",
+                        MOCK_JOB_ID,
+                    ],
+                )
+
+                # Verify get_session_logs was called with the most recently completed session
+                mock_get_logs.assert_called_once_with(
+                    farm_id=MOCK_FARM_ID,
+                    queue_id=MOCK_QUEUE_ID,
+                    session_id="session-completed-newer",  # Should select most recently ended session
+                    limit=100,
+                    start_time=None,
+                    end_time=None,
+                    next_token=None,
+                    config=ANY,
+                )
+
+                # Check output
+                assert "Using the latest session: session-completed-newer" in result.output
+                assert "Most recent completed session log" in result.output
+                assert result.exit_code == 0
+
+
+def test_cli_job_logs_with_job_id_selects_most_recent_among_multiple_ongoing(fresh_deadline_config):
+    """
+    Test that when there are multiple ongoing sessions, the most recently started one is selected.
+    """
+    with patch.object(config, "get_setting") as mock_get_setting:
+        mock_get_setting.side_effect = [
+            MOCK_FARM_ID,  # _apply_cli_options_to_config check for farm_id
+            MOCK_QUEUE_ID,  # _apply_cli_options_to_config check for queue_id
+            MOCK_FARM_ID,  # defaults.farm_id
+            MOCK_QUEUE_ID,  # defaults.queue_id
+            MOCK_JOB_ID,  # defaults.job_id
+        ]
+
+        with patch("deadline.client.api.get_boto3_client") as boto3_client_mock:
+            with patch("deadline.client.api.get_session_logs") as mock_get_logs:
+                # Set up the paginator to return multiple ongoing sessions
+                paginator_mock = MagicMock()
+                boto3_client_mock().get_paginator.return_value = paginator_mock
+                paginator_mock.paginate.return_value = [
+                    {
+                        "sessions": [
+                            {
+                                "sessionId": "session-ongoing-oldest",
+                                "startedAt": datetime.datetime(
+                                    2023, 1, 27, 5, 0, 0
+                                ),  # Oldest ongoing
+                                # No endedAt - this is ongoing
+                            },
+                            {
+                                "sessionId": "session-ongoing-middle",
+                                "startedAt": datetime.datetime(
+                                    2023, 1, 27, 6, 0, 0
+                                ),  # Middle ongoing
+                                # No endedAt - this is ongoing
+                            },
+                            {
+                                "sessionId": "session-ongoing-newest",
+                                "startedAt": datetime.datetime(
+                                    2023, 1, 27, 7, 0, 0
+                                ),  # Most recent ongoing
+                                # No endedAt - this is ongoing
+                            },
+                        ]
+                    }
+                ]
+
+                # Mock the get_session_logs response
+                mock_get_logs.return_value = api.SessionLogResult(
+                    events=[
+                        api.LogEvent(
+                            timestamp=datetime.datetime(2023, 1, 27, 7, 0, 0),
+                            message="Most recent ongoing session log",
+                            ingestion_time=datetime.datetime(2023, 1, 27, 7, 0, 1),
+                            event_id="event-1",
+                        ),
+                    ],
+                    count=1,
+                    next_token=None,
+                    log_group=f"/aws/deadline/{MOCK_FARM_ID}/{MOCK_QUEUE_ID}",
+                    log_stream="session-ongoing-newest",
+                )
+
+                runner = CliRunner()
+                result = runner.invoke(
+                    main,
+                    [
+                        "job",
+                        "logs",
+                        "--job-id",
+                        MOCK_JOB_ID,
+                    ],
+                )
+
+                # Verify get_session_logs was called with the most recently started ongoing session
+                mock_get_logs.assert_called_once_with(
+                    farm_id=MOCK_FARM_ID,
+                    queue_id=MOCK_QUEUE_ID,
+                    session_id="session-ongoing-newest",  # Should select most recently started ongoing session
+                    limit=100,
+                    start_time=None,
+                    end_time=None,
+                    next_token=None,
+                    config=ANY,
+                )
+
+                # Check output
+                assert "Using the latest session: session-ongoing-newest" in result.output
+                assert "Most recent ongoing session log" in result.output
+                assert result.exit_code == 0


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The Deadline library/client does have facilities to wait for a job to complete and go from failures to logs.

This is  common workflow during the building and debugging of new conda packages or job templates

### What was the solution? (How)
## Job Monitoring and Logs

#### Waiting for Job Completion

After submitting a job, you can wait for it to complete using the `wait` command:

```sh
# Wait for a job to complete with default settings
$ deadline job wait --job-id job-12345

# Customize the polling interval (default is 10 seconds)
$ deadline job wait --job-id job-12345 --poll-interval 30

# Set a timeout (default is 0, meaning no timeout)
$ deadline job wait --job-id job-12345 --timeout 3600

# Get the result in JSON format
$ deadline job wait --job-id job-12345 --output json
```

The command blocks until the job reaches a terminal state (SUCCEEDED, FAILED, CANCELED, or NOT_COMPATIBLE), then returns information about the job's status and any failed tasks. 

### Retrieving Job Logs

You can monitor job status and retrieve logs using the CLI:

```sh
# Get logs for a specific session
$ deadline job logs --session-id session-12345

# Get logs for a job (automatically uses the latest session based on endedAt time if multiple sessions exist)
$ deadline job logs --job-id job-12345

# Limit the number of log lines returned
$ deadline job logs --session-id session-12345 --limit 50

# Filter logs by time range
$ deadline job logs --session-id session-12345 --start-time 2023-01-01T12:00:00Z --end-time 2023-01-01T13:00:00Z

# Get logs in JSON format
$ deadline job logs --session-id session-12345 --output json

# Paginate through logs
$ deadline job logs --session-id session-12345 --next-token next-token-value
```

When using a Deadline Cloud monitor profile, the `job logs` command will use the Queue role credentials to read logs. Otherwise, the chosen profile credentials are used for all API invocations. This allows you to access logs with the appropriate permissions based on your authentication method.

### What is the impact of this change?
Debugging tools and workflows do not have to reinvent the wheel for these operations


### How was this change tested?
New unit tests
I'm using this in a new local workflow

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests? Yes
- Have you run the integration tests? No
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass. No

### Was this change documented?

- Are relevant docstrings in the code base updated? No
- Has the README.md been updated? If you modified CLI arguments, for instance. Not yet

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [ x] This PR does not add any new dependencies.

### Is this a breaking change? No

A breaking change is one that modifies a public contract in a way that is not backwards compatible. See the 
[Public Contracts](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#public-contracts) section
of the DEVELOPMENT.md for more information on the public contracts.

If so, then please describe the changes that users of this package must make to update their scripts, or Python applications.

### Does this change impact security? No

- Does the change need to be threat modeled? For example, does it create or modify files/directories that must only be readable by the process owner?
    - If so, then please label this pull request with the "security" label. We'll work with you to analyze the threats.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
