### PR TITLE
fix: handle normalizing windows paths when they are larger than MAX_PATH

### DIFF
--- a/src/deadline/job_attachments/_utils.py
+++ b/src/deadline/job_attachments/_utils.py
@@ -71,13 +71,25 @@ def _get_bucket_and_object_key(s3_path: str) -> Tuple[str, str]:
     return bucket, key
 
 
+def _normalize_windows_path(path: Path) -> Path:
+    """
+    Strips \\\\?\\ prefix from Windows paths.
+    """
+    p_str = str(path)
+    if p_str.startswith("\\\\?\\"):
+        return Path(p_str[4:])
+    return path
+
+
 def _is_relative_to(path1: Union[Path, str], path2: Union[Path, str]) -> bool:
     """
     Determines if path1 is relative to path2. This function is to support
     Python versions (3.7 and 3.8) that do not have the built-in `Path.is_relative_to()` method.
     """
     try:
-        Path(path1).relative_to(Path(path2))
+        p1 = _normalize_windows_path(Path(path1).resolve())
+        p2 = _normalize_windows_path(Path(path2).resolve())
+        p1.relative_to(p2)
         return True
     except ValueError:
         return False

--- a/test/unit/deadline_job_attachments/test_utils.py
+++ b/test/unit/deadline_job_attachments/test_utils.py
@@ -6,12 +6,33 @@ import sys
 import pytest
 
 from deadline.job_attachments._utils import (
+    _normalize_windows_path,
     _is_relative_to,
     _retry,
 )
 
 
 class TestUtils:
+    @pytest.mark.skipif(
+        sys.platform != "win32",
+        reason="This test is for paths in Windows format and will be skipped on non-Windows systems.",
+    )
+    @pytest.mark.parametrize(
+        ("input_path", "expected"),
+        [
+            (r"\\?\C:\path\to\file.txt", Path(r"C:\path\to\file.txt")),
+            (r"\\?\D:\another\long\path", Path(r"D:\another\long\path")),
+            (r"C:\normal\path.txt", Path(r"C:\normal\path.txt")),
+            (r"Z:\already\normal\path", Path(r"Z:\already\normal\path")),
+        ],
+    )
+    def test_normalize_windows_path(self, input_path, expected):
+        """
+        Tests if _normalize_windows_path correctly strips the \\?\\ prefix
+        from Windows extended-length paths.
+        """
+        assert _normalize_windows_path(Path(input_path)) == expected
+
     @pytest.mark.skipif(
         sys.platform == "win32",
         reason="This test is for paths in POSIX path format and will be skipped on Windows.",
@@ -54,6 +75,16 @@ class TestUtils:
             ("C:/a/b/c", "C:/d", False),
             ("a/b/c", "b", False),
             ("a/b/c", "d", False),
+            (
+                "\\\\?\\C:\\path\\to\\a\\very\\long\\file\\path\\that\\exceeds\\the\\windows\\max\\path\\length\\for\\testing\\max\\file\\path\\error\\handling\\when\\comparing\\path\\relativity\\using\\job\\attachments",
+                "C:\\path\\to\\",
+                True,
+            ),
+            (
+                "\\\\?\\C:\\path\\to\\a\\very\\long\\file\\path\\that\\exceeds\\the\\windows\\max\\path\\length\\for\\testing\\max\\file\\path\\error\\handling\\when\\comparing\\path\\relativity\\using\\job\\attachments",
+                "C:\\path\\doesnt\\exist\\",
+                False,
+            ),
         ],
     )
     def test_is_relative_to_on_windows(self, path1, path2, expected):


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud/issues/689

### What was the problem/requirement? (What/Why)
Attempting to upload a job with additional assets to my 3ds Max CMF and assets were being prepended with `"\\?\"`
I assume this is due to the maximum file path limitation below.
https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry

### What was the solution? (How)
I tried to use `pathlib` but wasn't able to get any of the functions to normalize the path.
I check each path to see if it starts with `//?/` and then remove it from the string.

### What is the impact of this change?
Users will be able to upload assets if the filepath exceeds Windows Maximum File path limitation

### How was this change tested?
`hatch run test:all`
`hatch run integ:test`

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests? **Yes**
- Have you run the integration tests? **Yes**
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass. **No, this is the job_attachments.**

### Was this change documented?
**No**

- Are relevant docstrings in the code base updated? **Yes**
- Has the README.md been updated? If you modified CLI arguments, for instance.

### Does this PR introduce new dependencies?
This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?
**No**
A breaking change is one that modifies a public contract in a way that is not backwards compatible. See the 
[Public Contracts](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#public-contracts) section
of the DEVELOPMENT.md for more information on the public contracts.

If so, then please describe the changes that users of this package must make to update their scripts, or Python applications.

### Does this change impact security?
**No**
- Does the change need to be threat modeled? For example, does it create or modify files/directories that must only be readable by the process owner?
    - If so, then please label this pull request with the "security" label. We'll work with you to analyze the threats.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
