### PR TITLE
refactor!: Refactor uploading job output to s3 to use the same parallelized upload as on job submission

### DIFF
--- a/src/deadline/job_attachments/asset_sync.py
+++ b/src/deadline/job_attachments/asset_sync.py
@@ -56,7 +56,7 @@ from .models import (
     JobAttachmentsFileSystem,
     JobAttachmentS3Settings,
     ManifestProperties,
-    OutputFile,
+    FileUploadInfo,
     PathFormat,
     PathMappingRule,
 )
@@ -487,7 +487,7 @@ class AssetSync:
     def _upload_output_files_to_s3(
         self,
         s3_settings: JobAttachmentS3Settings,
-        output_files: List[OutputFile],
+        files: List[FileUploadInfo],
         on_uploading_files: Optional[Callable[[ProgressReportMetadata], bool]],
     ) -> SummaryStatistics:
         """
@@ -495,10 +495,10 @@ class AssetSync:
         Sets up `progress_tracker` to report upload progress back to the caller (i.e. worker.)
         """
         # Sets up progress tracker to report upload progress back to the caller.
-        total_file_size = sum([file.file_size for file in output_files])
+        total_file_size = sum([file.size for file in files])
         progress_tracker = ProgressTracker(
             status=ProgressStatus.UPLOAD_IN_PROGRESS,
-            total_files=len(output_files),
+            total_files=len(files),
             total_bytes=total_file_size,
             on_progress_callback=on_uploading_files,
             logger=self.logger,
@@ -506,18 +506,12 @@ class AssetSync:
 
         start_time = time.perf_counter()
 
-        for file in output_files:
-            if file.in_s3:
-                progress_tracker.increase_skipped(1, file.file_size)
-                continue
-
-            self.s3_uploader.upload_file_to_s3(
-                local_path=Path(file.full_path),
-                s3_bucket=s3_settings.s3BucketName,
-                s3_upload_key=file.s3_key,
-                progress_tracker=progress_tracker,
-                base_dir_path=Path(file.base_dir) if file.base_dir else None,
-            )
+        self.s3_uploader.upload_files(
+            files=files,
+            s3_bucket=s3_settings.s3BucketName,
+            s3_cas_prefix=s3_settings.full_cas_prefix(),
+            progress_tracker=progress_tracker,
+        )
 
         progress_tracker.total_time = time.perf_counter() - start_time
         return progress_tracker.get_summary_statistics()
@@ -562,24 +556,22 @@ class AssetSync:
             extra_args=metadata,
         )
 
-    def _generate_output_manifest(self, outputs: List[OutputFile]) -> BaseAssetManifest:
+    def _generate_output_manifest(self, outputs: List[FileUploadInfo]) -> BaseAssetManifest:
         paths: list[RelativeFilePath] = []
         for output in outputs:
             path_args: dict[str, Any] = {
-                "hash": output.file_hash,
+                "hash": output.hash,
                 "path": output.rel_path,
             }
-            path_args["size"] = output.file_size
-            # stat().st_mtime_ns returns an int that represents the time in nanoseconds since the epoch.
-            # The asset manifest spec requires the mtime to be represented as an integer in microseconds.
-            path_args["mtime"] = trunc(Path(output.full_path).stat().st_mtime_ns // 1000)
+            path_args["size"] = output.size
+            path_args["mtime"] = output.mtime
             paths.append(self.manifest_model.Path(**path_args))
 
         asset_manifest_args: dict[str, Any] = {
             "paths": paths,
             "hash_alg": self.hash_alg,
         }
-        asset_manifest_args["total_size"] = sum([output.file_size for output in outputs])
+        asset_manifest_args["total_size"] = sum([output.size for output in outputs])
 
         return self.manifest_model.AssetManifest(**asset_manifest_args)  # type: ignore[call-arg]
 
@@ -589,12 +581,12 @@ class AssetSync:
         s3_settings: JobAttachmentS3Settings,
         local_root: Path,
         session_dir: Path,
-    ) -> List[OutputFile]:
+    ) -> List[FileUploadInfo]:
         """
         Walks the output directories for this asset root for any output files that have been created or modified
         since the start time provided. Hashes and checks if the output files already exist in the CAS.
         """
-        output_files: List[OutputFile] = []
+        output_files: List[FileUploadInfo] = []
 
         source_path_format = manifest_properties.rootPathFormat
         current_path_format = PathFormat.get_host_path_format()
@@ -652,24 +644,20 @@ class AssetSync:
                 ):
                     file_size = file_real_path.resolve().lstat().st_size
                     file_hash = hash_file(str(file_real_path), self.hash_alg)
-                    s3_key = f"{file_hash}.{self.hash_alg.value}"
-
-                    if s3_settings.full_cas_prefix():
-                        s3_key = _join_s3_paths(s3_settings.full_cas_prefix(), s3_key)
-                    in_s3 = self.s3_uploader.file_already_uploaded(s3_settings.s3BucketName, s3_key)
 
                     total_file_count += 1
                     total_file_size += file_size
 
                     output_files.append(
-                        OutputFile(
-                            file_size=file_size,
-                            file_hash=file_hash,
+                        FileUploadInfo(
+                            size=file_size,
+                            hash=file_hash,
+                            hash_alg=self.hash_alg,
+                            # stat().st_mtime_ns returns an int that represents the time in nanoseconds since the epoch.
+                            # The asset manifest spec requires the mtime to be represented as an integer in microseconds.
+                            mtime=trunc(file_mtime // 1000),
                             rel_path=str(PurePosixPath(*file_path.relative_to(local_root).parts)),
-                            full_path=str(file_real_path),
-                            s3_key=s3_key,
-                            in_s3=in_s3,
-                            base_dir=str(session_dir),
+                            full_path=file_real_path,
                         )
                     )
 
@@ -946,7 +934,7 @@ class AssetSync:
             self.logger.info(f"No attachments configured for Job {job_id}, no outputs to sync.")
             return SummaryStatistics()
 
-        all_output_files: List[OutputFile] = []
+        all_output_files: List[FileUploadInfo] = []
 
         storage_profiles_source_paths = list(storage_profiles_path_mapping_rules.keys())
 
@@ -974,7 +962,7 @@ class AssetSync:
                 dir_name: str = _get_unique_dest_dir_name(manifest_properties.rootPath)
                 local_root = session_dir.joinpath(dir_name)
 
-            output_files: List[OutputFile] = self._get_output_files(
+            output_files: List[FileUploadInfo] = self._get_output_files(
                 manifest_properties,
                 s3_settings,
                 local_root,
@@ -1009,7 +997,9 @@ class AssetSync:
                 f" to S3: {s3_settings.s3BucketName}/{s3_settings.full_cas_prefix()}"
             )
             summary_stats: SummaryStatistics = self._upload_output_files_to_s3(
-                s3_settings, all_output_files, on_uploading_files
+                s3_settings,
+                all_output_files,
+                on_uploading_files,
             )
         else:
             summary_stats = SummaryStatistics()

--- a/src/deadline/job_attachments/models.py
+++ b/src/deadline/job_attachments/models.py
@@ -104,19 +104,16 @@ class ManifestPathGroup:
 
 
 @dataclass
-class OutputFile:
-    """Files for output"""
+class FileUploadInfo:
+    """Information for uploading a file to content-addressable storage"""
 
     # File size in Bytes
-    file_size: int
-    file_hash: str
+    size: int
+    hash: str
+    hash_alg: HashAlgorithm
+    mtime: int
     rel_path: str
-    full_path: str
-    s3_key: str
-    # If the file already exists in the CAS
-    in_s3: bool
-    # The base directory path against which file paths are containment-checked
-    base_dir: Optional[str]
+    full_path: Path
 
 
 class StorageProfileOperatingSystemFamily(str, Enum):

--- a/src/deadline/job_attachments/upload.py
+++ b/src/deadline/job_attachments/upload.py
@@ -59,6 +59,7 @@ from .models import (
     AssetRootManifest,
     AssetUploadGroup,
     Attachments,
+    FileUploadInfo,
     FileStatus,
     FileSystemLocationType,
     JobAttachmentS3Settings,
@@ -337,51 +338,81 @@ class S3AssetUploader:
         can save the S3 API calls.
         """
 
+        files: List[FileUploadInfo] = [
+            FileUploadInfo(
+                size=path.size,
+                hash=path.hash,
+                hash_alg=manifest.hashAlg,
+                mtime=path.mtime,
+                rel_path=path.path,
+                full_path=source_root.joinpath(path.path),
+            )
+            for path in manifest.paths
+        ]
+
+        with S3CheckCache(s3_check_cache_dir) as s3_cache:
+            self.upload_files(
+                files,
+                s3_bucket=s3_bucket,
+                s3_cas_prefix=s3_cas_prefix,
+                progress_tracker=progress_tracker,
+                s3_cache=s3_cache,
+            )
+
+    def upload_files(
+        self,
+        files: List[FileUploadInfo],
+        s3_bucket: str,
+        s3_cas_prefix: str,
+        progress_tracker: Optional[ProgressTracker] = None,
+        s3_cache: Optional[S3CheckCache] = None,
+    ) -> None:
+        """
+        Uploads all of the files listed in the given manifest to S3 if they don't exist in the
+        given S3 prefix already.
+
+        The local 'S3 check cache' is used to note if we've seen an object in S3 before so we
+        can save the S3 API calls.
+        """
+
         # Split into a separate 'large file' and 'small file' queues.
         # Separate 'large' files from 'small' files so that we can process 'large' files serially.
         # This wastes less bandwidth if uploads are cancelled, as it's better to use the multi-threaded
         # multi-part upload for a single large file than multiple large files at the same time.
         (small_file_queue, large_file_queue) = self._separate_files_by_size(
-            manifest.paths, self.small_file_threshold
+            files, self.small_file_threshold
         )
 
-        with S3CheckCache(s3_check_cache_dir) as s3_cache:
-            # First, process the whole 'small file' queue with parallel object uploads.
-            with concurrent.futures.ThreadPoolExecutor(
-                max_workers=self.num_upload_workers
-            ) as executor:
-                futures = {
-                    executor.submit(
-                        self.upload_object_to_cas,
-                        file,
-                        manifest.hashAlg,
-                        s3_bucket,
-                        source_root,
-                        s3_cas_prefix,
-                        s3_cache,
-                        progress_tracker,
-                    ): file
-                    for file in small_file_queue
-                }
-                # surfaces any exceptions in the thread
-                for future in concurrent.futures.as_completed(futures):
-                    (is_uploaded, file_size) = future.result()
-                    if progress_tracker and not is_uploaded:
-                        progress_tracker.increase_skipped(1, file_size)
-
-            # Now process the whole 'large file' queue with serial object uploads (but still parallel multi-part upload.)
-            for file in large_file_queue:
-                (is_uploaded, file_size) = self.upload_object_to_cas(
+        # First, process the whole 'small file' queue with parallel object uploads.
+        with concurrent.futures.ThreadPoolExecutor(max_workers=self.num_upload_workers) as executor:
+            futures = {
+                executor.submit(
+                    self.upload_file_to_cas,
                     file,
-                    manifest.hashAlg,
                     s3_bucket,
-                    source_root,
                     s3_cas_prefix,
                     s3_cache,
                     progress_tracker,
-                )
+                ): file
+                for file in small_file_queue
+            }
+            # surfaces any exceptions in the thread
+            for future in concurrent.futures.as_completed(futures):
+                (is_uploaded, file_size) = future.result()
                 if progress_tracker and not is_uploaded:
                     progress_tracker.increase_skipped(1, file_size)
+
+        # Now process the whole 'large file' queue with serial object uploads (but still parallel multi-part upload.)
+        for file in large_file_queue:
+            (is_uploaded, file_size) = self.upload_file_to_cas(
+                file,
+                s3_bucket,
+                s3_cas_prefix,
+                s3_cache,
+                progress_tracker,
+            )
+            if progress_tracker and not is_uploaded:
+                progress_tracker.increase_skipped(1, file_size)
 
         # to report progress 100% at the end, and
         # to check if the job submission was canceled in the middle of processing the last batch of files.
@@ -450,7 +481,7 @@ class S3AssetUploader:
 
         # Find the list of s3 upload keys that have been cached
         s3_upload_keys: List[str] = [
-            self._generate_s3_upload_key(file, manifest.hashAlg, s3_cas_prefix)
+            self._generate_s3_upload_key(file.hash, manifest.hashAlg, s3_cas_prefix)
             for file in manifest.paths
         ]
         with S3CheckCache(s3_check_cache_dir) as s3_cache:
@@ -466,14 +497,14 @@ class S3AssetUploader:
 
     def _separate_files_by_size(
         self,
-        files_to_upload: list[base_manifest.BaseManifestPath],
+        files_to_upload: list[FileUploadInfo],
         size_threshold: int,
-    ) -> Tuple[list[base_manifest.BaseManifestPath], list[base_manifest.BaseManifestPath]]:
+    ) -> Tuple[list[FileUploadInfo], list[FileUploadInfo]]:
         """
         Splits the given list of files into two queues: one for small files and one for large files.
         """
-        small_file_queue: list[base_manifest.BaseManifestPath] = []
-        large_file_queue: list[base_manifest.BaseManifestPath] = []
+        small_file_queue: list[FileUploadInfo] = []
+        large_file_queue: list[FileUploadInfo] = []
         for file in files_to_upload:
             if file.size <= size_threshold:
                 small_file_queue.append(file)
@@ -486,11 +517,11 @@ class S3AssetUploader:
 
     def _generate_s3_upload_key(
         self,
-        file: base_manifest.BaseManifestPath,
-        hash_algorithm: HashAlgorithm,
+        file_hash: str,
+        hash_alg: HashAlgorithm,
         s3_cas_prefix: str,
     ) -> str:
-        s3_upload_key = f"{file.hash}.{hash_algorithm.value}"
+        s3_upload_key = f"{file_hash}.{hash_alg.value}"
         if s3_cas_prefix:
             s3_upload_key = _join_s3_paths(s3_cas_prefix, s3_upload_key)
         return s3_upload_key
@@ -510,38 +541,69 @@ class S3AssetUploader:
         does a head-object check and only uploads the file if it doesn't exist in S3 already.
         Returns a tuple (whether it has been uploaded, the file size).
         """
-        local_path = source_root.joinpath(file.path)
-        s3_upload_key = self._generate_s3_upload_key(file, hash_algorithm, s3_cas_prefix)
-        is_uploaded = False
-        file_size = local_path.resolve().stat().st_size
+        file_upload_info = FileUploadInfo(
+            size=file.size,
+            hash=file.hash,
+            hash_alg=hash_algorithm,
+            mtime=file.mtime,
+            rel_path=file.path,
+            full_path=source_root.joinpath(file.path),
+        )
 
-        if s3_check_cache.get_entry(s3_key=f"{s3_bucket}/{s3_upload_key}"):
+        return self.upload_file_to_cas(
+            file=file_upload_info,
+            s3_bucket=s3_bucket,
+            s3_cas_prefix=s3_cas_prefix,
+            s3_check_cache=s3_check_cache,
+            progress_tracker=progress_tracker,
+        )
+
+    def upload_file_to_cas(
+        self,
+        file: FileUploadInfo,
+        s3_bucket: str,
+        s3_cas_prefix: str,
+        s3_check_cache: Optional[S3CheckCache] = None,
+        progress_tracker: Optional[ProgressTracker] = None,
+    ) -> Tuple[bool, int]:
+        """
+        Uploads an object to the S3 content-addressable storage (CAS) prefix. Optionally,
+        does a head-object check and only uploads the file if it doesn't exist in S3 already.
+        Returns a tuple (whether it has been uploaded, the file size).
+        """
+        s3_upload_key = self._generate_s3_upload_key(file.hash, file.hash_alg, s3_cas_prefix)
+        is_uploaded = False
+
+        if s3_check_cache is not None and s3_check_cache.get_entry(
+            s3_key=f"{s3_bucket}/{s3_upload_key}"
+        ):
             logger.debug(
-                f"skipping {local_path} because {s3_bucket}/{s3_upload_key} exists in the cache"
+                f"skipping {file.full_path} because {s3_bucket}/{s3_upload_key} exists in the cache"
             )
-            return (is_uploaded, file_size)
+            return (is_uploaded, file.size)
 
         if self.file_already_uploaded(s3_bucket, s3_upload_key):
             logger.debug(
-                f"skipping {local_path} because it has already been uploaded to s3://{s3_bucket}/{s3_upload_key}"
+                f"skipping {file.full_path} because it has already been uploaded to s3://{s3_bucket}/{s3_upload_key}"
             )
         else:
             self.upload_file_to_s3(
-                local_path=local_path,
+                local_path=Path(file.full_path),
                 s3_bucket=s3_bucket,
                 s3_upload_key=s3_upload_key,
                 progress_tracker=progress_tracker,
             )
             is_uploaded = True
 
-        s3_check_cache.put_entry(
-            S3CheckCacheEntry(
-                s3_key=f"{s3_bucket}/{s3_upload_key}",
-                last_seen_time=self._get_current_timestamp(),
+        if s3_check_cache is not None:
+            s3_check_cache.put_entry(
+                S3CheckCacheEntry(
+                    s3_key=f"{s3_bucket}/{s3_upload_key}",
+                    last_seen_time=self._get_current_timestamp(),
+                )
             )
-        )
 
-        return (is_uploaded, file_size)
+        return (is_uploaded, file.size)
 
     def upload_file_to_s3(
         self,

--- a/src/deadline/job_attachments/upload.py
+++ b/src/deadline/job_attachments/upload.py
@@ -368,11 +368,12 @@ class S3AssetUploader:
         s3_cache: Optional[S3CheckCache] = None,
     ) -> None:
         """
-        Uploads all of the files listed in the given manifest to S3 if they don't exist in the
+        Uploads all the provided files to S3 if they don't exist in the
         given S3 prefix already.
 
-        The local 'S3 check cache' is used to note if we've seen an object in S3 before so we
-        can save the S3 API calls.
+        The optional local 'S3 check cache' is used to note if we've seen an object in S3 before so we
+        can save the S3 API calls. This is used when submitting jobs, but not when uploading output on
+        the worker.
         """
 
         # Split into a separate 'large file' and 'small file' queues.
@@ -567,7 +568,7 @@ class S3AssetUploader:
         progress_tracker: Optional[ProgressTracker] = None,
     ) -> Tuple[bool, int]:
         """
-        Uploads an object to the S3 content-addressable storage (CAS) prefix. Optionally,
+        Uploads a local file to the S3 content-addressable storage (CAS) prefix. Optionally,
         does a head-object check and only uploads the file if it doesn't exist in S3 already.
         Returns a tuple (whether it has been uploaded, the file size).
         """

--- a/test/integ/deadline_job_attachments/test_job_attachments.py
+++ b/test/integ/deadline_job_attachments/test_job_attachments.py
@@ -27,7 +27,7 @@ from deadline.job_attachments.asset_manifests import (
     hash_file,
 )
 from deadline.job_attachments._aws.deadline import get_queue
-from deadline.job_attachments.exceptions import AssetSyncError, JobAttachmentsS3ClientError
+from deadline.job_attachments.exceptions import JobAttachmentsS3ClientError
 from deadline.job_attachments.models import (
     Attachments,
     ManifestProperties,
@@ -1453,7 +1453,11 @@ def test_sync_outputs_bucket_wrong_account(
 
     # WHEN
     with pytest.raises(
-        AssetSyncError, match=f"Error checking if object exists in bucket '{external_bucket}'"
+        # Note: This error is raised in this case when the s3:PutObject operation is denied
+        # due to the ExpectedBucketOwner check on our s3 operation. If the bucket is in the expected
+        # account, then the error is a different access denied error.
+        JobAttachmentsS3ClientError,
+        match=".*when calling the PutObject operation: Access Denied",
     ):
         sync_inputs.asset_syncer.sync_outputs(
             s3_settings=job_attachment_settings,

--- a/test/unit/deadline_job_attachments/test_upload.py
+++ b/test/unit/deadline_job_attachments/test_upload.py
@@ -42,6 +42,7 @@ from deadline.job_attachments.models import (
     Attachments,
     FileSystemLocation,
     FileSystemLocationType,
+    FileUploadInfo,
     ManifestProperties,
     JobAttachmentS3Settings,
     StorageProfileOperatingSystemFamily,
@@ -2431,31 +2432,101 @@ class TestUpload:
             ),
             (
                 [
-                    BaseManifestPath(path="", hash="", size=10 * (1024**2), mtime=1),
-                    BaseManifestPath(path="", hash="", size=100 * (1024**2), mtime=1),
-                    BaseManifestPath(path="", hash="", size=1000 * (1024**2), mtime=1),
+                    FileUploadInfo(
+                        rel_path="",
+                        full_path="",
+                        hash="",
+                        hash_alg=HashAlgorithm.XXH128,
+                        size=10 * (1024**2),
+                        mtime=1,
+                    ),
+                    FileUploadInfo(
+                        rel_path="",
+                        full_path="",
+                        hash="",
+                        hash_alg=HashAlgorithm.XXH128,
+                        size=100 * (1024**2),
+                        mtime=1,
+                    ),
+                    FileUploadInfo(
+                        rel_path="",
+                        full_path="",
+                        hash="",
+                        hash_alg=HashAlgorithm.XXH128,
+                        size=1000 * (1024**2),
+                        mtime=1,
+                    ),
                 ],
                 100 * (1024**2),  # 100 MB
                 (
                     [
-                        BaseManifestPath(path="", hash="", size=10 * (1024**2), mtime=1),
-                        BaseManifestPath(path="", hash="", size=100 * (1024**2), mtime=1),
+                        FileUploadInfo(
+                            rel_path="",
+                            full_path="",
+                            hash="",
+                            hash_alg=HashAlgorithm.XXH128,
+                            size=10 * (1024**2),
+                            mtime=1,
+                        ),
+                        FileUploadInfo(
+                            rel_path="",
+                            full_path="",
+                            hash="",
+                            hash_alg=HashAlgorithm.XXH128,
+                            size=100 * (1024**2),
+                            mtime=1,
+                        ),
                     ],
                     [
-                        BaseManifestPath(path="", hash="", size=1000 * (1024**2), mtime=1),
+                        FileUploadInfo(
+                            rel_path="",
+                            full_path="",
+                            hash="",
+                            hash_alg=HashAlgorithm.XXH128,
+                            size=1000 * (1024**2),
+                            mtime=1,
+                        ),
                     ],
                 ),
             ),
             (
                 [
-                    BaseManifestPath(path="", hash="", size=10 * (1024**2), mtime=1),
-                    BaseManifestPath(path="", hash="", size=100 * (1024**2), mtime=1),
+                    FileUploadInfo(
+                        rel_path="",
+                        full_path="",
+                        hash="",
+                        hash_alg=HashAlgorithm.XXH128,
+                        size=10 * (1024**2),
+                        mtime=1,
+                    ),
+                    FileUploadInfo(
+                        rel_path="",
+                        full_path="",
+                        hash="",
+                        hash_alg=HashAlgorithm.XXH128,
+                        size=100 * (1024**2),
+                        mtime=1,
+                    ),
                 ],
                 800 * (1024**2),  # 800 MB
                 (
                     [
-                        BaseManifestPath(path="", hash="", size=10 * (1024**2), mtime=1),
-                        BaseManifestPath(path="", hash="", size=100 * (1024**2), mtime=1),
+                        FileUploadInfo(
+                            rel_path="",
+                            full_path="",
+                            hash="",
+                            hash_alg=HashAlgorithm.XXH128,
+                            size=10 * (1024**2),
+                            mtime=1,
+                        ),
+                        FileUploadInfo(
+                            rel_path="",
+                            full_path="",
+                            hash="",
+                            hash_alg=HashAlgorithm.XXH128,
+                            size=100 * (1024**2),
+                            mtime=1,
+                        ),
                     ],
                     [],
                 ),
@@ -2464,9 +2535,9 @@ class TestUpload:
     )
     def test_separate_files_by_size(
         self,
-        input_files: List[BaseManifestPath],
+        input_files: List[FileUploadInfo],
         size_threshold: int,
-        expected_queues: Tuple[List[BaseManifestPath], List[BaseManifestPath]],
+        expected_queues: Tuple[List[FileUploadInfo], List[FileUploadInfo]],
     ):
         """
         Tests that a helper method `_separate_files_by_size` is working as expected.


### PR DESCRIPTION
Fixes: *<insert link to GitHub issue here>*

### What was the problem/requirement? (What/Why)
I noticed that uploading job output for many small files was very slow. This seemed to be due to us performing head object requests and then put object requests in serial in sync_output.

### What was the solution? (How)
Refactor S3AssetUploader so that we can use the same parallelized s3 upload that we use for job submission for uploading job output.

### What is the impact of this change?
uploading job output is much faster than it was before. Tested with a job that creates 60,000 101 byte files in a single task. With the mainline implementation, identifying all the modified files took ~12 minutes (due to serial head object requests per each file), and uploading took 20 minutes.

```
2025/06/06 17:08:09-07:00 ----------------------------------------------
2025/06/06 17:08:09-07:00 Uploading output files to Job Attachments
2025/06/06 17:08:09-07:00 ----------------------------------------------
2025/06/06 17:08:09-07:00 Started syncing outputs using Job Attachments
2025/06/06 17:20:04-07:00 Found 60000 files totaling 6.06 MB in output directory: /sessions/session-da2b9cc31a5c4b0b9b341699080837553u7tvoqv/assetroot-71511d6763c17b7d7ce8
2025/06/06 17:20:05-07:00 Uploading output manifest to DeadlineData/Manifests/farm-e6bcb4ffe1dc427a8aceaeeffedb43af/queue-f771d8a7e01c4943baf20ccc0b23a624/job-67921f4e17c440f98c863c5156d95fe0/step-4fac2183ff2247d3a3b42af8d275bede/task-4fac2183ff2247d3a3b42af8d275bede-0/2025-06-07T00:08:07.231663Z_sessionaction-da2b9cc31a5c4b0b9b34169908083755-3/826efb47307aebda2b1b036908d477a0_output
2025/06/06 17:20:05-07:00 Uploading 60000 output files to S3: deadline-vfscmf-ja-529920871242/DeadlineData/Data
2025/06/06 17:22:15-07:00 Uploaded 606.0 KB / 6.06 MB of 60000 files (Transfer rate: 4.43 KB/s)
2025/06/06 17:24:25-07:00 Uploaded 1.21 MB / 6.06 MB of 60000 files (Transfer rate: 3.37 KB/s)
2025/06/06 17:26:36-07:00 Uploaded 1.82 MB / 6.06 MB of 60000 files (Transfer rate: 5.05 KB/s)
2025/06/06 17:28:47-07:00 Uploaded 2.42 MB / 6.06 MB of 60000 files (Transfer rate: 3.03 KB/s)
2025/06/06 17:30:57-07:00 Uploaded 3.03 MB / 6.06 MB of 60000 files (Transfer rate: 3.86 KB/s)
2025/06/06 17:33:06-07:00 Uploaded 3.64 MB / 6.06 MB of 60000 files (Transfer rate: 4.69 KB/s)
2025/06/06 17:35:15-07:00 Uploaded 4.24 MB / 6.06 MB of 60000 files (Transfer rate: 4.41 KB/s)
2025/06/06 17:37:28-07:00 Uploaded 4.85 MB / 6.06 MB of 60000 files (Transfer rate: 1.84 KB/s)
2025/06/06 17:39:40-07:00 Uploaded 5.45 MB / 6.06 MB of 60000 files (Transfer rate: 4.31 KB/s)
2025/06/06 17:41:52-07:00 Uploaded 6.06 MB / 6.06 MB of 60000 files (Transfer rate: 4.64 KB/s)
2025/06/06 17:41:52-07:00 Summary Statistics for file uploads:
Processed 60000 files totaling 6.06 MB.
Skipped re-processing 0 files totaling 0 B.
Total processing time of 1307.3415 seconds at 4.63 KB/s.

2025/06/06 17:41:52-07:00 Finished syncing outputs using Job Attachments
```

Testing with a worker using the changes in this PR, identifying the modified files took 7 seconds, and uploading them took ~7 minutes:

```
2025/06/06 16:59:07-07:00 ----------------------------------------------
2025/06/06 16:59:07-07:00 Uploading output files to Job Attachments
2025/06/06 16:59:07-07:00 ----------------------------------------------
2025/06/06 16:59:07-07:00 Started syncing outputs using Job Attachments
2025/06/06 16:59:14-07:00 Found 60000 files totaling 6.06 MB in output directory: /sessions/session-6c2477ddb87f44eb8ba894d1670c1ef358r45zu7/assetroot-71511d6763c17b7d7ce8
2025/06/06 16:59:15-07:00 Uploading output manifest to DeadlineData/Manifests/farm-e6bcb4ffe1dc427a8aceaeeffedb43af/queue-f771d8a7e01c4943baf20ccc0b23a624/job-d16894b6da764f79816679e2ab06b72e/step-18356d9a3c194e649631ddb4538a4b23/task-18356d9a3c194e649631ddb4538a4b23-0/2025-06-06T23:59:05.972532Z_sessionaction-6c2477ddb87f44eb8ba894d1670c1ef3-3/826efb47307aebda2b1b036908d477a0_output
2025/06/06 16:59:15-07:00 this is the modified worker! :)
2025/06/06 16:59:15-07:00 Uploading 60000 output files to S3: deadline-vfscmf-ja-529920871242/DeadlineData/Data
2025/06/06 16:59:59-07:00 Uploaded 606.0 KB / 6.06 MB of 60000 files (Transfer rate: 14.93 KB/s)
2025/06/06 17:00:43-07:00 Uploaded 1.21 MB / 6.06 MB of 60000 files (Transfer rate: 14.35 KB/s)
2025/06/06 17:01:25-07:00 Uploaded 1.82 MB / 6.06 MB of 60000 files (Transfer rate: 16.32 KB/s)
2025/06/06 17:02:07-07:00 Uploaded 2.42 MB / 6.06 MB of 60000 files (Transfer rate: 13.47 KB/s)
2025/06/06 17:02:49-07:00 Uploaded 3.03 MB / 6.06 MB of 60000 files (Transfer rate: 12.98 KB/s)
2025/06/06 17:03:31-07:00 Uploaded 3.64 MB / 6.06 MB of 60000 files (Transfer rate: 13.47 KB/s)
2025/06/06 17:04:13-07:00 Uploaded 4.24 MB / 6.06 MB of 60000 files (Transfer rate: 20.2 KB/s)
2025/06/06 17:04:54-07:00 Uploaded 4.85 MB / 6.06 MB of 60000 files (Transfer rate: 13.85 KB/s)
2025/06/06 17:05:37-07:00 Uploaded 5.45 MB / 6.06 MB of 60000 files (Transfer rate: 14.66 KB/s)
2025/06/06 17:06:18-07:00 Uploaded 6.06 MB / 6.06 MB of 60000 files (Transfer rate: 14.79 KB/s)
2025/06/06 17:06:18-07:00 Summary Statistics for file uploads:
Processed 60000 files totaling 6.06 MB.
Skipped re-processing 0 files totaling 0 B.
Total processing time of 423.18597 seconds at 14.32 KB/s.

2025/06/06 17:06:18-07:00 Finished syncing outputs using Job Attachments
```

15 KB/s still seems a bit slow though, maybe adjusting the worker count on the threadpool might yield better results.
### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests? yes, all passed
- Have you run the integration tests? yes, all passed
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass.

Created a worker using the changes in the PR and tested performance (see "What is the impact of this change?"). Also tested correctness of output with the dep_data_flow bundle.

### Was this change documented?

- Are relevant docstrings in the code base updated? Yes.
- Has the README.md been updated? If you modified CLI arguments, for instance. No changes to CLI or external interface.

### Does this PR introduce new dependencies?
This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [X] This PR does not add any new dependencies.

### Is this a breaking change?

A breaking change is one that modifies a public contract in a way that is not backwards compatible. See the 
[Public Contracts](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#public-contracts) section
of the DEVELOPMENT.md for more information on the public contracts.

If so, then please describe the changes that users of this package must make to update their scripts, or Python applications.

BREAKING CHANGE: Removed OutputFile data structure and replaced it with FileUploadInfo. OutputFile would be unused within the repository as a result of these changes. OutputFile has an attribute `in_s3` which doesn't make sense anymore- the head object request has been moved to right before we actually try to upload the file. This data class is only created and consumed by private functions (which have the _ prefix), so it seemed appropriate to remove the object.

### Does this change impact security?

No.

- Does the change need to be threat modeled? For example, does it create or modify files/directories that must only be readable by the process owner?
    - If so, then please label this pull request with the "security" label. We'll work with you to analyze the threats.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
