### PR TITLE
feat: Adding a helper to initialize the lru_cached get_s3_client meth…

### DIFF
--- a/src/deadline/client/api/__init__.py
+++ b/src/deadline/client/api/__init__.py
@@ -13,6 +13,7 @@ __all__ = [
     "check_authentication_status",
     "check_deadline_api_available",
     "get_credentials_source",
+    "precache_clients",
     "list_farms",
     "list_queues",
     "list_jobs",
@@ -50,6 +51,7 @@ from ._loginout import login, logout
 from ._session import (
     AwsAuthenticationStatus,
     AwsCredentialsSource,
+    precache_clients,
     get_queue_user_boto3_session,
     check_authentication_status,
     get_boto3_client,

--- a/src/deadline/client/api/_session.py
+++ b/src/deadline/client/api/_session.py
@@ -12,7 +12,7 @@ from configparser import ConfigParser
 from contextlib import contextmanager
 from enum import Enum
 from functools import lru_cache
-from typing import Optional
+from typing import Optional, Tuple
 
 import boto3  # type: ignore[import]
 import botocore
@@ -27,6 +27,7 @@ from botocore.session import get_session as get_botocore_session
 from .. import version
 from ..config import get_setting
 from ..exceptions import DeadlineOperationError
+from ...job_attachments._aws.aws_clients import get_s3_client
 
 
 class AwsCredentialsSource(Enum):
@@ -117,6 +118,25 @@ def get_default_client_config() -> botocore.config.Config:
     return session_config
 
 
+@lru_cache
+def get_session_client(session: boto3.Session, service_name: str):
+    """
+    Create and cache a boto3 client for the given session and service name.
+
+    This function is decorated with @lru_cache to ensure that repeated calls
+    with the same session and service name return the cached client to avoid
+    repeating initialization where possible.
+
+    Args:
+        session: The boto3 Session to use for creating the client
+        service_name: The name of the AWS service (e.g., 's3', 'sts', 'ec2')
+
+    Returns:
+        A boto3 client for the specified service
+    """
+    return session.client(service_name, config=get_default_client_config())
+
+
 def get_boto3_client(service_name: str, config: Optional[ConfigParser] = None) -> BaseClient:
     """
     Gets a client from the boto3 session returned by `get_boto3_session`.
@@ -129,7 +149,7 @@ def get_boto3_client(service_name: str, config: Optional[ConfigParser] = None) -
     """
 
     session = get_boto3_session(config=config)
-    return session.client(service_name, config=get_default_client_config())
+    return get_session_client(session=session, service_name=service_name)
 
 
 def get_credentials_source(config: Optional[ConfigParser] = None) -> AwsCredentialsSource:
@@ -278,6 +298,66 @@ def check_authentication_status(config: Optional[ConfigParser] = None) -> AwsAut
             if get_credentials_source(config) == AwsCredentialsSource.DEADLINE_CLOUD_MONITOR_LOGIN:
                 return AwsAuthenticationStatus.NEEDS_LOGIN
             return AwsAuthenticationStatus.CONFIGURATION_ERROR
+
+
+def precache_clients(
+    deadline: BaseClient = None,
+    config: Optional[ConfigParser] = None,
+    farm_id: Optional[str] = None,
+    queue_id: Optional[str] = None,
+    queue_display_name: Optional[str] = None,
+) -> Tuple[BaseClient, BaseClient]:
+    """
+    Initialize an S3 client (and optionally a Deadline client) with queue user credentials
+    to pre-warm the client cache.
+
+    This function creates an S3 client using queue user credentials, which triggers
+    the expensive service discovery process once. Subsequent client creations using
+    the same session object should then use the cached client, improving performance.
+    This function is designed to be called in a background thread at application startup.
+
+    Args:
+        deadline: An existing deadline client. If None, one will be created.
+        config: Optional configuration parser. If None, the default configuration will be used.
+        farm_id: The farm ID. If None, it will be retrieved from settings.
+        queue_id: The queue ID. If None, it will be retrieved from settings.
+        queue_display_name: The queue display name. If None, it will be retrieved from the queue.
+
+    Returns:
+        Created (or current) s3 client for the given queue_role_session
+
+    Example:
+        # Fire and forget initialization in a background thread
+        import threading
+        threading.Thread(
+            target=initialize_queue_user_s3_client,
+            daemon=True,
+            name="S3ClientInit"
+        ).start()
+    """
+    if not deadline:
+        deadline = get_boto3_client("deadline", config=config)
+    if not queue_id:
+        queue_id = get_setting("defaults.queue_id", config=config)
+    if not farm_id:
+        farm_id = get_setting("defaults.farm_id", config=config)
+
+    if not queue_display_name:
+        queue = deadline.get_queue(
+            farmId=farm_id,
+            queueId=queue_id,
+        )
+        queue_display_name = queue["displayName"]
+
+    queue_role_session = get_queue_user_boto3_session(
+        deadline=deadline,
+        config=config,
+        farm_id=farm_id,
+        queue_id=queue_id,
+        queue_display_name=queue_display_name,
+    )
+    # Initialize the S3 client to populate the cache
+    return deadline, get_s3_client(queue_role_session)
 
 
 class QueueUserCredentialProvider(CredentialProvider):

--- a/test/unit/deadline_client/api/test_api_session.py
+++ b/test/unit/deadline_client/api/test_api_session.py
@@ -9,6 +9,7 @@ from unittest.mock import call, patch, MagicMock, ANY
 
 import boto3  # type: ignore[import]
 from deadline.client import api, config
+from deadline.client.api._session import get_session_client, precache_clients
 
 
 def test_get_boto3_session(fresh_deadline_config):
@@ -139,3 +140,127 @@ def test_check_deadline_api_available_fails(fresh_deadline_config):
         assert result is False
         # It should have called list_farms with to check the API
         session_mock().client("deadline").list_farms.assert_called_once_with(maxResults=1)
+
+
+def test_get_session_client_caching():
+    """Test that get_session_client properly caches clients."""
+    # Create a real boto3 session for testing the cache
+    session = boto3.Session()
+
+    # First call should create a new client
+    client1 = get_session_client(session, "s3")
+
+    # Second call with same session should return the same client
+    client2 = get_session_client(session, "s3")
+
+    # Verify they're the same object
+    assert client1 is client2
+
+    # Different service should create a new client
+    client3 = get_session_client(session, "sts")
+    assert client1 is not client3
+
+    # Create a new session with the same parameters
+    # This should create a new client since it's a different object
+    new_session = boto3.Session()
+    client4 = get_session_client(new_session, "s3")
+    assert client1 is not client4
+
+
+@patch("deadline.client.api._session.get_s3_client")
+@patch("deadline.client.api._session.get_queue_user_boto3_session")
+@patch("deadline.client.api._session.get_boto3_client")
+def test_precache_clients(mock_get_boto3_client, mock_get_queue_user_session, mock_get_s3_client):
+    """Test that precache_clients calls the right functions."""
+    # Setup mocks
+    mock_deadline_client = MagicMock()
+    mock_deadline_client.get_queue.return_value = {"displayName": "test-queue"}
+    mock_get_boto3_client.return_value = mock_deadline_client
+
+    mock_session = MagicMock()
+    mock_get_queue_user_session.return_value = mock_session
+
+    # Call the function
+    precache_clients()
+
+    # Verify the right calls were made
+    mock_get_boto3_client.assert_called_once_with("deadline", config=None)
+    mock_deadline_client.get_queue.assert_called_once()
+    mock_get_queue_user_session.assert_called_once()
+    mock_get_s3_client.assert_called_once_with(mock_session)
+
+
+@patch("deadline.client.api._session.get_s3_client")
+@patch("deadline.client.api._session.get_queue_user_boto3_session")
+@patch("deadline.client.api._session.get_boto3_client")
+def test_precache_clients_with_params(
+    mock_get_boto3_client, mock_get_queue_user_session, mock_get_s3_client
+):
+    """Test that precache_clients uses provided parameters correctly."""
+    # Setup mocks
+    mock_deadline_client = MagicMock()
+    mock_session = MagicMock()
+    mock_config = MagicMock()
+    mock_get_queue_user_session.return_value = mock_session
+
+    # Call the function with all parameters specified
+    precache_clients(
+        deadline=mock_deadline_client,
+        config=mock_config,
+        farm_id="test-farm",
+        queue_id="test-queue",
+        queue_display_name="Test Queue",
+    )
+
+    # Verify the right calls were made
+    mock_get_boto3_client.assert_not_called()  # Should not be called since we provided a client
+    mock_deadline_client.get_queue.assert_not_called()  # Should not be called since we provided queue_display_name
+
+    # Verify queue user session was created with correct parameters
+    mock_get_queue_user_session.assert_called_once_with(
+        deadline=mock_deadline_client,
+        config=mock_config,
+        farm_id="test-farm",
+        queue_id="test-queue",
+        queue_display_name="Test Queue",
+    )
+
+    # Verify S3 client was initialized with the session
+    mock_get_s3_client.assert_called_once_with(mock_session)
+
+
+def test_precache_clients_warms_asset_uploader_client(fresh_deadline_config):
+    """
+    Test that initializing the deadline and S3 client with precache_clients
+    properly pre-warms the cache for subsequent job submissions.
+    """
+    # Setup mocks
+    mock_deadline_client = MagicMock()
+    mock_deadline_client.get_queue.return_value = {
+        "displayName": "test-queue",
+        "jobAttachmentSettings": {"s3BucketName": "test-bucket", "rootPrefix": "test-prefix"},
+    }
+
+    # Use a real boto3 session for proper hashability
+    real_session = boto3.Session()
+
+    # First, initialize the S3 client
+    with patch(
+        "deadline.client.api._session.get_boto3_client", return_value=mock_deadline_client
+    ), patch(
+        "deadline.client.api._session.get_queue_user_boto3_session", return_value=real_session
+    ):
+        # Get the client from initialization
+        _, s3_client1 = precache_clients(farm_id="test-farm", queue_id="test-queue")
+
+    # Now create an S3AssetUploader with the same session
+    from deadline.job_attachments.upload import S3AssetUploader
+
+    # Create the uploader with the same session
+    uploader = S3AssetUploader(session=real_session)
+
+    # Get the client from the uploader
+    s3_client2 = uploader._s3
+
+    # Verify that both clients are the same object (cached)
+    assert s3_client1 is s3_client2


### PR DESCRIPTION
Adding a helper to initialize the lru_cached get_s3_client method.  

Adding a cached get_session_client method to allow get_boto3_client calls which end up using the same session and same service name to use cached clients.

### What was the problem/requirement? (What/Why)
While investigating slowness at job submission time in the unreal integration it was discovered that in create_job_from_job_bundle we were creating a new deadline client each time so our subsequent call to get_queue_user_boto3_session would then create a new session, causing our S3AssetUploader to create a new s3 client.  

Additionally from the unreal side we wanted to "pre cache" the s3 client which we'd later reuse with the above changes.

### What was the solution? (How)
Modify the get_boto3_client method which can't directly use lru_caching due to the ConfigParser parameter to internally retrieve the client from a new get_session_client option which does use lru_caching.  In the case where the same session is used to retrieve a client from the same service, the same client should be returned.

### What is the impact of this change?
Much faster job submission in the unreal integration pre hashing (~30 seconds -> 1-2 seconds) and likely improved performance from other integrations.

### How was this change tested?
All unit tests pass, new unit tests added which pass, manual testing in the unreal integration (Follow on PR to use this feature coming to the unreal integration once a new release is out)

### Was this change documented?
Yes

### Does this PR introduce new dependencies?
No

### Is this a breaking change?
No

### Does this change impact security?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
