### PR TITLE
fix: Fixing a bug where unc paths compared against non unc paths were…

### DIFF
--- a/src/deadline/client/api/_session.py
+++ b/src/deadline/client/api/_session.py
@@ -330,7 +330,7 @@ def precache_clients(
         # Fire and forget initialization in a background thread
         import threading
         threading.Thread(
-            target=initialize_queue_user_s3_client,
+            target=precache_clients,
             daemon=True,
             name="S3ClientInit"
         ).start()

--- a/src/deadline/job_attachments/_utils.py
+++ b/src/deadline/job_attachments/_utils.py
@@ -75,11 +75,36 @@ def _is_relative_to(path1: Union[Path, str], path2: Union[Path, str]) -> bool:
     """
     Determines if path1 is relative to path2. This function is to support
     Python versions (3.7 and 3.8) that do not have the built-in `Path.is_relative_to()` method.
+
+    On Windows, it handles UNC paths by normalizing both paths before comparison.
     """
+    # First try the direct comparison without any string manipulation
     try:
         Path(path1).relative_to(Path(path2))
         return True
     except ValueError:
+        # If we're on Windows and the direct comparison failed, try with UNC path handling
+        if sys.platform == "win32":
+            path1_str = str(path1)
+            path2_str = str(path2)
+
+            # Only proceed if at least one path has the UNC prefix
+            if path1_str.startswith(WINDOWS_UNC_PATH_STRING_PREFIX) or path2_str.startswith(
+                WINDOWS_UNC_PATH_STRING_PREFIX
+            ):
+                # Strip the prefix if it exists
+                if path1_str.startswith(WINDOWS_UNC_PATH_STRING_PREFIX):
+                    path1_str = path1_str[len(WINDOWS_UNC_PATH_STRING_PREFIX) :]
+                if path2_str.startswith(WINDOWS_UNC_PATH_STRING_PREFIX):
+                    path2_str = path2_str[len(WINDOWS_UNC_PATH_STRING_PREFIX) :]
+
+                # Try again with the modified paths
+                try:
+                    Path(path1_str).relative_to(Path(path2_str))
+                    return True
+                except ValueError:
+                    pass
+
         return False
 
 

--- a/test/unit/deadline_job_attachments/test_utils.py
+++ b/test/unit/deadline_job_attachments/test_utils.py
@@ -81,3 +81,43 @@ class TestUtils:
 
         # Then
         assert call_count == 2
+
+    @pytest.mark.skipif(
+        sys.platform != "win32",
+        reason="This test is for Windows UNC paths and will be skipped on non-Windows.",
+    )
+    @pytest.mark.parametrize(
+        ("path1", "path2", "expected"),
+        [
+            # Test UNC path prefix in path1
+            (r"\\?\C:\a\b\c", r"C:\a\b", True),
+            (r"\\?\C:\a\b\c.txt", r"C:\a", True),
+            # Test UNC path prefix in path2
+            (r"C:\a\b\c", r"\\?\C:\a\b", True),
+            (r"C:\a\b\c.txt", r"\\?\C:\a", True),
+            # Test UNC path prefix in both paths
+            (r"\\?\C:\a\b\c", r"\\?\C:\a\b", True),
+            (r"\\?\C:\a\b\c.txt", r"\\?\C:\a", True),
+            # Test UNC path prefix with non-relative paths
+            (r"\\?\C:\a\b\c", r"C:\d", False),
+            (r"C:\a\b\c", r"\\?\C:\d", False),
+            (r"\\?\C:\a\b\c", r"\\?\C:\d", False),
+            # Test with very long paths (simulating the real-world case)
+            (
+                r"\\?\C:\ProgramData\Amazon\OpenJD\session-d25da5617419425c82f8f9bf9f1eb8b1ctnxk60v\assetroot-51bb83f9066635ca31ef\05_Unreal_5_5_v2\Content\Base_Materials\Grass\seamlessT\originals\95_artificial_green_grass_texture-seamless_hr\95_artificial_green_grass_texture-seamless_hr_bump.uasset",
+                r"C:\ProgramData\Amazon\OpenJD\session-d25da5617419425c82f8f9bf9f1eb8b1ctnxk60v\assetroot-51bb83f9066635ca31ef",
+                True,
+            ),
+            # Test with UNC path in root directory
+            (
+                r"C:\ProgramData\Amazon\OpenJD\session-d25da5617419425c82f8f9bf9f1eb8b1ctnxk60v\assetroot-51bb83f9066635ca31ef\05_Unreal_5_5_v2\Content\file.txt",
+                r"\\?\C:\ProgramData\Amazon\OpenJD\session-d25da5617419425c82f8f9bf9f1eb8b1ctnxk60v\assetroot-51bb83f9066635ca31ef",
+                True,
+            ),
+        ],
+    )
+    def test_is_relative_to_with_unc_paths(self, path1, path2, expected):
+        """
+        Tests if the is_relative_to() works correctly when using Windows UNC paths with \\?\ prefix.
+        """
+        assert _is_relative_to(path1, path2) == expected


### PR DESCRIPTION
… failing the _is_relative_to check

Fixes: [Reported in the Unreal Integration Repo here](https://github.com/aws-deadline/deadline-cloud-for-unreal-engine/issues/156)

Also cleaning up a comment.

### What was the problem/requirement? (What/Why)
The _is_relative_to check was failing when comparing UNC to non UNC paths

### What was the solution? (How)
Add a fallback check performed only on Windows for UNC paths

### What is the impact of this change?
Render jobs on windows workers with long paths should pass

### How was this change tested?
New tests added which pass

Existing tests pass

### Was this change documented?
Yes

### Does this PR introduce new dependencies?
No

### Is this a breaking change?
No

### Does this change impact security?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
