### PR TITLE
fix: normalize paths in windows so relative_to works properly

### DIFF
--- a/scripted_tests/set_file_permission_for_windows.py
+++ b/scripted_tests/set_file_permission_for_windows.py
@@ -31,7 +31,8 @@ python ./scripted_tests/set_file_permission_for_windows.py \
     -f <file_permission> \
     -d <directory_permission> \
     -u <target_user_name> \
-    -du <disjoint_user_name>
+    -du <disjoint_user_name> \
+    -ex <use_extended_paths> 
 
 Note: The `-f` and `-d` flags are optional.
 
@@ -64,6 +65,12 @@ def run_test():
     parser.add_argument("-d", "--dir_permission", required=False, type=str, default="FULL_CONTROL")
     parser.add_argument("-u", "--target_user", required=True, type=str)
     parser.add_argument("-du", "--disjoint_user", required=True, type=str)
+    parser.add_argument(
+        "-ex",
+        "--use_extended_paths",
+        action="store_true",
+        help="Use extended-length file paths (\\\\?\\)",
+    )
 
     args = parser.parse_args()
 
@@ -86,7 +93,11 @@ def run_test():
             if not os.path.exists(file_path):
                 with file_path.open("w", encoding="utf-8") as f:
                     f.write(f"test: {i}")
-            files.append(str(file_path))
+
+            file_path_str = (
+                _to_extended_path(file_path) if args.use_extended_paths else str(file_path)
+            )
+            files.append(str(file_path_str))
 
         print("Temporary files created.")
         print("Running test: Setting file permissions...")
@@ -136,6 +147,11 @@ def check_file_permission(file_path, username) -> Tuple[bool, bool]:
 
     # Return a tuple of (has read access, has write access)
     return (bool(result & con.FILE_GENERIC_READ), bool(result & con.FILE_GENERIC_WRITE))
+
+
+def _to_extended_path(path: Path) -> str:
+    # Convert to absolute and apply extended-length prefix
+    return f"\\\\?\\{path.resolve()}"
 
 
 if __name__ == "__main__":

--- a/src/deadline/job_attachments/_utils.py
+++ b/src/deadline/job_attachments/_utils.py
@@ -71,14 +71,14 @@ def _get_bucket_and_object_key(s3_path: str) -> Tuple[str, str]:
     return bucket, key
 
 
-def _normalize_windows_path(path: Path) -> Path:
+def _normalize_windows_path(path: Union[Path, str]) -> Path:
     """
     Strips \\\\?\\ prefix from Windows paths.
     """
     p_str = str(path)
     if p_str.startswith("\\\\?\\"):
         return Path(p_str[4:])
-    return path
+    return Path(path)
 
 
 def _is_relative_to(path1: Union[Path, str], path2: Union[Path, str]) -> bool:

--- a/src/deadline/job_attachments/os_file_permission.py
+++ b/src/deadline/job_attachments/os_file_permission.py
@@ -9,7 +9,7 @@ from enum import Enum
 from typing import List, Set, Union
 
 from .exceptions import AssetSyncError, PathOutsideDirectoryError
-from ._utils import _is_relative_to
+from ._utils import _is_relative_to, _normalize_windows_path
 
 
 @dataclass
@@ -127,7 +127,11 @@ def _set_fs_permission_for_windows(
 
         # Add the parent directories of each file to the set of directories whose
         # permissions will be changed.
-        path_components = Path(file_path_str).relative_to(local_root).parents
+        path_components = (
+            _normalize_windows_path(file_path_str)
+            .relative_to(_normalize_windows_path(local_root))
+            .parents
+        )
         for path_component in path_components:
             path_to_change = Path(local_root).joinpath(path_component)
             dir_paths_to_change_fs_group.add(path_to_change)


### PR DESCRIPTION
Fixes: #689 

### What was the problem/requirement? (What/Why)
Long paths on windows cause the `relative_to` function to operate unexpectedly.

### What was the solution? (How)
normalizing the path

### What is the impact of this change?
Users should be able to submit jobs that have the MAX_PATH //?/ flag prepended to them

### How was this change tested?
`hatch build`
`python -m pip install *.whl`
`python .\scripted_tests\set_file_permission_for_windows.py -n 5 -u razen -du TestDummyUser -ex`
`python .\scripted_tests\set_file_permission_for_windows.py -n 5 -u razen -du TestDummyUser`
![image](https://github.com/user-attachments/assets/63c4824a-1333-4c96-9c5e-1c1be80b5e6a)

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests? Yes
- Have you run the integration tests? No
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass.

### Was this change documented?

- Are relevant docstrings in the code base updated? Yes
- Has the README.md been updated? If you modified CLI arguments, for instance. Yes

### Does this PR introduce new dependencies?
No
This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?
No
A breaking change is one that modifies a public contract in a way that is not backwards compatible. See the 
[Public Contracts](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#public-contracts) section
of the DEVELOPMENT.md for more information on the public contracts.

If so, then please describe the changes that users of this package must make to update their scripts, or Python applications.

### Does this change impact security?

- Does the change need to be threat modeled? For example, does it create or modify files/directories that must only be readable by the process owner?
    - If so, then please label this pull request with the "security" label. We'll work with you to analyze the threats.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
