### PR TITLE
feat(experimental): Add client library API to list recently updated jobs

### DIFF
--- a/src/deadline/client/api/_list_jobs_recent_by_timestamp_field.py
+++ b/src/deadline/client/api/_list_jobs_recent_by_timestamp_field.py
@@ -1,0 +1,212 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from __future__ import annotations
+
+__all__ = ["_list_jobs_recent_by_timestamp_field"]
+
+from typing import Any, Optional
+import boto3
+
+from deadline.client.api._session import get_default_client_config
+from botocore.exceptions import ClientError
+from datetime import datetime, timedelta, timezone
+from deadline.client.exceptions import DeadlineOperationError
+
+
+class JobFetchFailure(RuntimeError):
+    """
+    Failure fetching jobs updated since timestamp
+    """
+
+
+def _list_jobs_recent_by_timestamp_field(
+    boto3_session: boto3.Session,
+    farm_id: str,
+    queue_id: str,
+    timestamp_field_name: str,
+    *,
+    timestamp: Optional[datetime] = None,
+    look_back_duration: Optional[timedelta] = None,
+) -> list[dict[str, Any]]:
+    """
+    This function retrieves jobs that have a value for `timestamp_field_name` timestamp equal or newer than
+    the provided timestamp. It returns a list of jobs in the form returned by the deadline:SearchJobs API.
+
+    CAUTION:
+        Eventual consistency in the deadline:SearchJobs API means that the result set can be missing jobs
+        with a timestamp close to the current time. If you are repeatedly calling this function to collect
+        all jobs over time, use a sufficiently large overlap window to account for this eventual consistency.
+
+    TODO: This is an experimental function under development, and is exposed under the internal-only name
+          deadline.client.api._list_jobs_recent_by_timestamp_field._list_jobs_recent_by_timestamp_field.
+          If it proves useful, deadline.client.api.list_jobs_recent_by_timestamp_field is the likely public function.
+
+    NOTE:
+        There's an edge case where 100 jobs with identical timestamps will cause the function to raise
+        a JobFetchFailure exception. Because this would require all 100 jobs be created/updated with
+        identical timestamp recorded at millisecond precision, we do not expect this to occur in practice.
+
+    Example:
+        boto3_session = boto3.Session()
+        farm_id = ...
+        queue_id = ...
+        saved_timestamp = ...
+
+        # Get the jobs created in the last 5 minutes
+        since_5minutes = _list_jobs_recent_by_timestamp_field(
+            boto3_session,
+            farm_id,
+            queue_id,
+            "createdAt",
+            look_back_duration=timedelta(minutes=5)
+        )
+
+        # Continuously get jobs created, querying every 5 minutes
+        job_ids = set()
+        timestamp = <starting_timestamp>
+        while True:
+            # Determine the next threshold timestamp before calling the function
+            # using a 90 second overlap to account for eventual consistency.
+            next_timestamp = datetime.now(timezone.utc) - timedelta(seconds=90)
+
+            jobs = _list_jobs_recent_by_timestamp_field(
+                boto3_session,
+                farm_id,
+                queue_id,
+                "endedAt",
+                timestamp=timestamp
+            )
+            # Jobs can be seen more than once, so add them to a set
+            job_ids.update(job["jobId"] for job in jobs)
+
+            # Sleep for 5 minutes
+            time.sleep(5*60)
+
+
+    Args:
+      boto3_session (boto3.Session): The boto3 Session for AWS API access.
+      farm_id (str): The Farm ID.
+      queue_id (str): The Queue ID.
+      timestamp_field_name (str): The name of the job timestamp field to use. Can be
+            "createdAt", "endedAt", "startedAt", or "updatedAt". See
+            https://docs.aws.amazon.com/deadline-cloud/latest/APIReference/API_GetJob.html#API_GetJob_ResponseSyntax
+      timestamp (Optional[datetime]): The timestamp from which to retrieve jobs. Either timestamp
+            or look_back_duration must be provided.
+      look_back_duration (Optional[timedelta]): A timedelta subtracted from the current time to
+            get the timestamp from which to retrieve jobs. Either timestamp or look_back_duration
+            must be provided.
+
+    Returns:
+      The list of all jobs in the queue whose timestamp field is equal or greater than the provided
+      timestamp. Each job is as returned by the deadline:SearchJobs API.
+    """
+    # This function gets the full set of jobs whose timestamp field is newer than the threshold timestamp,
+    # except potentially jobs whose timestamp is near datetime.now(), due to eventual consistency.
+    # It uses deadline:SearchJobs as a primitive, unioning subsets of up to 100 jobs at a time,
+    # designed to guarantee we end up with the full correct set.
+    #
+    # Let J = {j ∈ queue | j["timestamp_field_name"] >= threshold_timestamp} be the set we want
+    #     J' = union {J_i | i ∈ range(search_count)} be the set the algorithm produces,
+    #            where J_i = {j ∈ queue | j["timestamp_field_name"] >= timestamp_i} [limit 100, ordered by timestamp_field_name asc]
+    #                  timestamp_0 = input_timestamp
+    #                  timestamp_i = max {j["timestamp_field_name"]: j in J_{i-1}}
+    #
+    # To prove these sets are equal, we show they are each a subset of the other.
+    #
+    # J' is a subset of J, because each J_i is from a deadline:SearchJobs that filters to a subset of J.
+    #
+    # Consider a job j ∈ J. A property of the system is that if the timestamp field is updated, it will be updated to the current time.
+    #    1. If the timestamp field of j is not updated during the algorithm, and is visible to deadline:SearchJobs, it will be
+    #       in one of the sets J_i because by construction the union of the query time intervals
+    #       cover the time interval for J. If it is not visible to deadline:SearchJobs, its timestamp is in the eventual
+    #       consistency window close to datetime.now().
+    #    2. If j has the timestamp field created or modified during the algorithm, its timestamp will be set to the current time.
+    #       and depending on how quickly the deadline:SearchJobs API updates, it may appear in a later set J_n. Eventual
+    #       consistency of deadline:SearchJobs means it may not end up in J.
+    #
+    # These are all the possibilities, so therefore j is in J' and J is a subset of J' except for some jobs whose timestamps
+    # are within the eventual consistency window close to datetime.now().
+
+    # This holds {job_id: job_from_search_jobs_call, ...}
+    result_jobs = {}
+
+    # Initialize threshold timestamp with the input timestamp/timedelta
+    if timestamp is not None and look_back_duration is not None:
+        raise ValueError("Only one of timestamp and look_back_duration may be provided.")
+    elif timestamp is not None:
+        if timestamp.tzinfo is None:
+            raise ValueError(f"The input timestamp {timestamp} is missing a required time zone.")
+        threshold_timestamp = timestamp
+    elif look_back_duration is not None:
+        threshold_timestamp = datetime.now(timezone.utc) - look_back_duration
+    else:
+        raise ValueError("One of timestamp or look_back_duration must be provided.")
+
+    permitted_field_names = ["createdAt", "endedAt", "startedAt", "updatedAt"]
+    if timestamp_field_name not in permitted_field_names:
+        raise ValueError(
+            f"The provided timestamp field name {timestamp_field_name!r} is not one of {permitted_field_names}"
+        )
+
+    deadline = boto3_session.client("deadline", config=get_default_client_config())
+
+    # The endedAt field is called ENDED_AT in sort and filter expressions
+    expression_field_name = timestamp_field_name.replace("At", "_at").upper()
+
+    # Sort jobs in ascending order of the timestamp field
+    sort_expressions = [{"fieldSort": {"name": expression_field_name, "sortOrder": "ASCENDING"}}]
+
+    # Continue until we've processed all jobs
+    while True:
+        # Filter jobs to have job[timestamp_field_name] >= threshold_timestamp
+        filter_expressions = {
+            "filters": [
+                {
+                    "dateTimeFilter": {
+                        "name": expression_field_name,
+                        "dateTime": threshold_timestamp,
+                        "operator": "GREATER_THAN_EQUAL_TO",
+                    }
+                },
+            ],
+            "operator": "AND",
+        }
+
+        try:
+            # The pageSize defaults to its maximum, 100, so we leave it out of the call.
+            response = deadline.search_jobs(
+                farmId=farm_id,
+                queueIds=[queue_id],
+                itemOffset=0,
+                filterExpressions=filter_expressions,
+                sortExpressions=sort_expressions,
+            )
+        except ClientError as exc:
+            raise DeadlineOperationError(f"Failed to get Jobs from Deadline:\n{exc}") from exc
+
+        # This is up to the first 100 of jobs that satisfy the query
+        jobs = response.get("jobs", [])
+        # This is the total number of jobs that satisfied the query
+        total_results = response.get("totalResults", 0)
+
+        # Some jobs may not have the requested time stamp field.
+        jobs = [job for job in jobs if timestamp_field_name in job]
+
+        result_jobs.update({job["jobId"]: job for job in jobs})
+
+        if len(jobs) == total_results:
+            # If the jobs we got are the total results, result_jobs is now the full set
+            break
+        elif jobs[0][timestamp_field_name] == jobs[-1][timestamp_field_name]:
+            # Rare edge case where the timestamp field is the same for all 100 jobs in the page, that
+            # we expect to never see in practice. The timestamp value is stored with
+            # millisecond precision, and jobs are scheduled independently from each other,
+            # with updates of running jobs generally being multiple seconds apart.
+            raise JobFetchFailure(
+                f"Failure fetching recent jobs based on the {timestamp_field_name} field as more then 100 jobs have the exact same timestamp value."
+            )
+        else:
+            # Continue processing from the largest timestamp value we saw so far
+            threshold_timestamp = jobs[-1][timestamp_field_name]
+
+    return list(result_jobs.values())

--- a/test/unit/deadline_client/api/test_list_jobs_recent_by_timestamp_field.py
+++ b/test/unit/deadline_client/api/test_list_jobs_recent_by_timestamp_field.py
@@ -1,0 +1,335 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from __future__ import annotations
+
+import uuid
+from copy import deepcopy
+from datetime import datetime, timedelta, timezone
+from random import randrange
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from deadline.client.api._list_jobs_recent_by_timestamp_field import (
+    JobFetchFailure,
+    _list_jobs_recent_by_timestamp_field,
+)
+
+# Constants for testing
+from ..shared_constants import MOCK_FARM_ID, MOCK_QUEUE_ID
+
+MOCK_TIMESTAMP = datetime(2023, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def mock_boto3_session():
+    """Create a mock boto3 session for tests."""
+    session = MagicMock()
+    session.client.return_value = MagicMock()
+    return session
+
+
+def fake_search_jobs_for_set(farmIdForJobs, queueIdForJobs, jobs):
+    """Returns a fake "search_jobs" API that emulates a subset of Deadline Cloud's
+    SearchJobs on the provided set of jobs.
+
+    These fake jobs only have the timestamp fields. If we decide to generalize this
+    function for more cases, we could move this to a conftest.py and extend it.
+
+    See https://docs.aws.amazon.com/deadline-cloud/latest/APIReference/API_SearchJobs.html
+    """
+
+    def _fake_search_jobs(
+        farmId, queueIds, itemOffset, pageSize=100, filterExpressions={}, sortExpressions=[]
+    ):
+        # Make deep copies of these parameters so we can destructively assert about them
+        filterExpressions = deepcopy(filterExpressions)
+        sortExpressions = deepcopy(sortExpressions)
+
+        assert farmId == farmIdForJobs
+        assert queueIdForJobs in queueIds
+        # We're only implementing ascending order by one of the timestamp fields
+        field_sort_name = sortExpressions[0]["fieldSort"].pop("name")
+        assert field_sort_name in ["CREATED_AT", "ENDED_AT", "STARTED_AT", "UPDATED_AT"]
+        assert sortExpressions == [{"fieldSort": {"sortOrder": "ASCENDING"}}]
+        # Only implementing a filter that is "<timestamp field> >= threshold"
+        threshold = filterExpressions["filters"][0]["dateTimeFilter"].pop("dateTime")
+        assert isinstance(threshold, datetime)
+        field_filter_name = filterExpressions["filters"][0]["dateTimeFilter"].pop("name")
+        assert field_filter_name in ["CREATED_AT", "ENDED_AT", "STARTED_AT", "UPDATED_AT"]
+        assert filterExpressions == {
+            "filters": [
+                {
+                    "dateTimeFilter": {
+                        "operator": "GREATER_THAN_EQUAL_TO",
+                    }
+                }
+            ],
+            "operator": "AND",
+        }
+
+        # Sort the jobs
+        result_jobs = sorted(jobs, key=lambda j: j[field_sort_name.lower().replace("_a", "A")])
+        # Filter the jobs
+        result_jobs = [
+            j for j in result_jobs if j[field_filter_name.lower().replace("_a", "A")] >= threshold
+        ]
+        # Construct the API response
+        nextItemOffset = min(len(result_jobs), itemOffset + pageSize)
+        response = {
+            "jobs": deepcopy(result_jobs[itemOffset:nextItemOffset]),
+            "totalResults": len(result_jobs),
+        }
+        if nextItemOffset < len(result_jobs):
+            response["nextItemOffset"] = nextItemOffset
+
+        return response
+
+    return _fake_search_jobs
+
+
+def create_fake_job_list(job_count, updated_at_min: datetime, updated_at_max: datetime):
+    """See https://docs.aws.amazon.com/deadline-cloud/latest/APIReference/API_JobSearchSummary.html
+    The list_jobs_recently_updated function only uses jobId and timestamps, so we're only populating
+    those values.
+    """
+    jobs: list[dict[str, Any]] = [
+        {"jobId": f"job-{str(uuid.uuid4()).replace('-', '')}"} for _ in range(job_count)
+    ]
+
+    updated_at_micros_range = int((updated_at_max - updated_at_min).total_seconds() * 1000000)
+
+    # Populate all the various timestamp fields
+    for timestamp_field_name in ["createdAt", "endedAt", "startedAt", "updatedAt"]:
+        for job in jobs:
+            random_micros = (
+                randrange(0, updated_at_micros_range) if updated_at_micros_range > 0 else 0
+            )
+            job[timestamp_field_name] = updated_at_min + timedelta(microseconds=random_micros)
+
+        if job_count >= 2:
+            # Ensure two randomly-selected jobs have the min and max values
+            jobs[randrange(0, job_count // 2)][timestamp_field_name] = updated_at_min
+            jobs[randrange(job_count // 2, job_count)][timestamp_field_name] = updated_at_max
+
+    return jobs
+
+
+def test_list_jobs_recent_timestamp_param_error(mock_boto3_session):
+    """Test parameter validation of the timestamp"""
+    # Mock SearchJobs to assert it wasn't called
+    mock_boto3_session.client().search_jobs.return_value = {}
+
+    # Test when both timestamp and look_back_duration are missing
+    with pytest.raises(ValueError) as excinfo:
+        _list_jobs_recent_by_timestamp_field(
+            boto3_session=mock_boto3_session,
+            farm_id=MOCK_FARM_ID,
+            queue_id=MOCK_QUEUE_ID,
+            timestamp_field_name="createdAt",
+        )
+    assert "One of timestamp or look_back_duration must be provided" in str(excinfo.value)
+
+    # Test when both timestamp and look_back_duration are provided
+    with pytest.raises(ValueError) as excinfo:
+        _list_jobs_recent_by_timestamp_field(
+            boto3_session=mock_boto3_session,
+            farm_id=MOCK_FARM_ID,
+            queue_id=MOCK_QUEUE_ID,
+            timestamp_field_name="createdAt",
+            timestamp=datetime.now(timezone.utc),
+            look_back_duration=timedelta(minutes=5),
+        )
+    assert "Only one of timestamp and look_back_duration may be provided" in str(excinfo.value)
+
+    # Test when timestamp is missing a timezone
+    with pytest.raises(ValueError) as excinfo:
+        _list_jobs_recent_by_timestamp_field(
+            boto3_session=mock_boto3_session,
+            farm_id=MOCK_FARM_ID,
+            queue_id=MOCK_QUEUE_ID,
+            timestamp_field_name="createdAt",
+            timestamp=datetime.now(),
+        )
+    assert "is missing a required time zone" in str(excinfo.value)
+
+    # Test when timestamp is missing a timezone
+    with pytest.raises(ValueError) as excinfo:
+        _list_jobs_recent_by_timestamp_field(
+            boto3_session=mock_boto3_session,
+            farm_id=MOCK_FARM_ID,
+            queue_id=MOCK_QUEUE_ID,
+            timestamp_field_name="introducedAt",
+            timestamp=datetime.now(timezone.utc),
+        )
+    assert "The provided timestamp field name" in str(excinfo.value)
+    assert "is not one of" in str(excinfo.value)
+
+    # Every case should have raised before calling SearchJobs
+    assert mock_boto3_session.client().search_jobs.call_count == 0
+
+
+@pytest.mark.parametrize("use_look_back", [True, False])
+@pytest.mark.parametrize("timestamp_field_name", ["createdAt", "endedAt", "startedAt", "updatedAt"])
+@pytest.mark.parametrize(
+    "job_count, expected_call_count",
+    [
+        (0, 1),
+        (1, 1),
+        (10, 1),
+        (70, 1),
+        (99, 1),
+        (100, 1),
+        (101, 2),
+        (199, 2),
+        (200, 3),
+        (201, 3),
+        (298, 3),
+        (299, 4),
+        (300, 4),
+    ],
+)
+def test_list_jobs_recent_jobs_timestamp(
+    fresh_deadline_config,
+    mock_boto3_session,
+    use_look_back,
+    timestamp_field_name,
+    job_count,
+    expected_call_count,
+):
+    """Test cases calling with with a matrix of variations"""
+    updated_at_min = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    updated_at_max = datetime(2025, 1, 1, 23, tzinfo=timezone.utc)
+    jobs = create_fake_job_list(job_count, updated_at_min, updated_at_max)
+
+    # Create the fake deadline:SearchJobs API, wrapped in a mock we can inspect
+    mock_search_jobs = MagicMock(wraps=fake_search_jobs_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, jobs))
+    mock_boto3_session.client().search_jobs = mock_search_jobs
+
+    if use_look_back:
+        # This lookback time is the duration since the first job, plus 5 minutes to account for testing variance
+        look_back_duration = (datetime.now(timezone.utc) - updated_at_min) + timedelta(minutes=5)
+        timestamp = None
+    else:
+        look_back_duration = None
+        timestamp = updated_at_min
+
+    # The function under test
+    result = _list_jobs_recent_by_timestamp_field(
+        boto3_session=mock_boto3_session,
+        farm_id=MOCK_FARM_ID,
+        queue_id=MOCK_QUEUE_ID,
+        timestamp_field_name=timestamp_field_name,
+        timestamp=timestamp,
+        look_back_duration=look_back_duration,
+    )
+
+    assert mock_search_jobs.call_count == expected_call_count
+    assert (
+        mock_search_jobs.call_args_list[0].kwargs["filterExpressions"]["filters"][0][
+            "dateTimeFilter"
+        ]["dateTime"]
+        <= updated_at_min
+    )
+    assert sorted(result, key=lambda v: v[timestamp_field_name]) == sorted(
+        jobs, key=lambda v: v[timestamp_field_name]
+    )
+
+
+def test_list_jobs_recent_jobs_timestamp_partial_jobs_return(
+    fresh_deadline_config, mock_boto3_session
+):
+    """Test cases calling with timestamp parameter, where it's somewhere in the middle of the timestamp range"""
+    updated_at_min = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    updated_at_max = datetime(2025, 1, 1, 23, tzinfo=timezone.utc)
+    updated_at_micros_range = int((updated_at_max - updated_at_min).total_seconds() * 1000000)
+    jobs = create_fake_job_list(1000, updated_at_min, updated_at_max)
+
+    # Create the fake deadline:SearchJobs API, wrapped in a mock we can inspect
+    mock_search_jobs = MagicMock(wraps=fake_search_jobs_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, jobs))
+    mock_boto3_session.client().search_jobs = mock_search_jobs
+
+    # Run a few random cases
+    for _ in range(10):
+        mock_search_jobs.reset_mock()
+        # Create a random value for the filter
+        random_micros = randrange(0, updated_at_micros_range) if updated_at_micros_range > 0 else 0
+        updated_at_filter = updated_at_min + timedelta(microseconds=random_micros)
+
+        # The function under test
+        result = _list_jobs_recent_by_timestamp_field(
+            boto3_session=mock_boto3_session,
+            farm_id=MOCK_FARM_ID,
+            queue_id=MOCK_QUEUE_ID,
+            timestamp_field_name="createdAt",
+            timestamp=updated_at_filter,
+        )
+
+        # The first SearchJobs call should be at the provided filter
+        assert (
+            mock_search_jobs.call_args_list[0].kwargs["filterExpressions"]["filters"][0][
+                "dateTimeFilter"
+            ]["dateTime"]
+            == updated_at_filter
+        )
+        # Each subsequent SearchJobs call should be with a greater timestamp
+        for i in range(1, mock_search_jobs.call_count):
+            cur_datetime = mock_search_jobs.call_args_list[i].kwargs["filterExpressions"][
+                "filters"
+            ][0]["dateTimeFilter"]["dateTime"]
+            prev_datetime = mock_search_jobs.call_args_list[i - 1].kwargs["filterExpressions"][
+                "filters"
+            ][0]["dateTimeFilter"]["dateTime"]
+            assert cur_datetime > prev_datetime
+        filtered_jobs = (job for job in jobs if job["createdAt"] >= updated_at_filter)
+        assert sorted(result, key=lambda v: v["createdAt"]) == sorted(
+            filtered_jobs, key=lambda v: v["createdAt"]
+        )
+
+
+def test_list_jobs_recent_edge_case_many_equal_timestamps(
+    fresh_deadline_config, mock_boto3_session
+):
+    """Test edge case when there are > 100 exactly equal timestamps."""
+    updated_at_min = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    updated_at_max = datetime(2025, 1, 1, 23, tzinfo=timezone.utc)
+    # Repeat the midpoint a bunch of times
+    updated_at_repeated = updated_at_min + 0.5 * (updated_at_max - updated_at_min)
+    jobs = create_fake_job_list(100, updated_at_min, updated_at_max)
+    jobs.extend(create_fake_job_list(101, updated_at_repeated, updated_at_repeated))
+
+    # Sorted by timestamp, the jobs dataset has ~50 jobs with random timestamps, 101 jobs with repeated timestamp,
+    # and then ~50 more jobs with random timestamps again. The first SearchJobs call returns about half of its
+    # jobs with repeated timestamps, and then the second call returns the first 100 jobs with repeated timestamp and
+    # so misses the 101st.
+
+    # Create the fake deadline:SearchJobs API, wrapped in a mock we can inspect
+    mock_search_jobs = MagicMock(wraps=fake_search_jobs_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, jobs))
+    mock_boto3_session.client().search_jobs = mock_search_jobs
+
+    with pytest.raises(JobFetchFailure) as excinfo:
+        _list_jobs_recent_by_timestamp_field(
+            boto3_session=mock_boto3_session,
+            farm_id=MOCK_FARM_ID,
+            queue_id=MOCK_QUEUE_ID,
+            timestamp_field_name="updatedAt",
+            timestamp=updated_at_min,
+        )
+    assert "more then 100 jobs have the exact same timestamp value" in str(excinfo.value)
+
+    assert mock_search_jobs.call_count == 2
+    # The way the algorithm and test data set are structured, the first call will filter from the provided parameter
+    # timestamp, and the second call will filter from the repeated timestamp
+    assert (
+        mock_search_jobs.call_args_list[0].kwargs["filterExpressions"]["filters"][0][
+            "dateTimeFilter"
+        ]["dateTime"]
+        == updated_at_min
+    )
+    assert (
+        mock_search_jobs.call_args_list[1].kwargs["filterExpressions"]["filters"][0][
+            "dateTimeFilter"
+        ]["dateTime"]
+        == updated_at_repeated
+    )


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

For the incremental downloads CLI command in development, we need a robust way to get
all jobs that are new, or have had tasks requeued, since a specified timestamp.

### What was the solution? (How)

* Added experimental candidate API function in deadline.client.api._list_jobs_recent_by_timestamp_field
  * It returns all jobs in a queue whose selected timestamp field is >= a provided timestamp, or since a provided timedelta ago.
  * The name starts with list_jobs_, so that someone using tab-complete or browsing the list of functions sees it alphabetically adjacent to the straight list_jobs function.
* The purpose of this function is to support the new incremental downloads CLI command. We expect it to be a useful primitive, but are marking it internal-only for now.

### What is the impact of this change?

We can build the rest of the CLI command using this function.

### How was this change tested?

Added unit tests that cover the function by generating random fake job datasets, and a mocked SearchJobs implementation that implements the subset of that API used by the function.

Tested the function on a Deadline Cloud queue.

### Was this change documented?

No.

### Does this PR introduce new dependencies?

No.

### Is this a breaking change?

No.

### Does this change impact security?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
