### PR TITLE
feat: Add job name/id to job waitoutput and improve timestamp output for 'logs' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ The command blocks until the job reaches a terminal state (SUCCEEDED, FAILED, CA
 
 ### Retrieving Job Logs
 
-You can monitor job status and retrieve logs using the CLI. The logs lines are returned starting from the most recent log event.:
+You can monitor job status and retrieve logs using the CLI. The logs lines are returned starting from the most recent log event with timestamps in ISO 8601 format:
 
 ```sh
 # Get logs for a specific session
@@ -237,9 +237,26 @@ $ deadline job logs --session-id session-12345 --start-time 2023-01-01T12:00:00Z
 # Get logs in JSON format
 $ deadline job logs --session-id session-12345 --output json
 
+# Get logs with timestamps in local timezone (default is UTC)
+$ deadline job logs --session-id session-12345 --timezone local
+
+# Get logs with explicit UTC timestamps (default behavior)
+$ deadline job logs --session-id session-12345 --timezone utc
+
+# Combine timezone option with JSON output
+$ deadline job logs --session-id session-12345 --timezone local --output json
+
 # Paginate through logs
 $ deadline job logs --session-id session-12345 --next-token next-token-value
 ```
+
+**Timestamp Format**: All timestamps are displayed in ISO 8601 format with full microsecond precision and timezone information:
+- UTC format: `2025-07-03T10:49:33.821306+00:00`
+- Local format: `2025-07-03T03:49:33.821306-07:00` (example for PST)
+
+**Timezone Options**:
+- `--timezone utc` (default): Display timestamps in UTC with `+00:00` offset
+- `--timezone local`: Display timestamps converted to your local system timezone
 
 When using a Deadline Cloud monitor profile, the `job logs` command will use the Queue role credentials to read logs. Otherwise, the chosen profile credentials are used for all API invocations. This allows you to access logs with the appropriate permissions based on your authentication method.
 

--- a/src/deadline/client/cli/_groups/job_group.py
+++ b/src/deadline/client/cli/_groups/job_group.py
@@ -57,6 +57,31 @@ JSON_MSG_TYPE_ERROR = "error"
 JSON_MSG_TYPE_WARNING = "warning"
 
 
+def _format_timestamp(timestamp: datetime.datetime, use_local_time: bool = False) -> str:
+    """
+    Format a timestamp in ISO 8601 format with timezone information.
+
+    Args:
+        timestamp: The datetime object to format
+        use_local_time: If True, convert to local time; if False, keep as UTC
+
+    Returns:
+        Formatted timestamp string in ISO 8601 format with timezone
+    """
+    if use_local_time and timestamp.tzinfo is not None:
+        # Convert to local time
+        local_timestamp = timestamp.astimezone()
+        return local_timestamp.isoformat()
+    else:
+        # Keep as UTC - ensure it has timezone info
+        if timestamp.tzinfo is None:
+            # Assume naive datetime is UTC
+            utc_timestamp = timestamp.replace(tzinfo=datetime.timezone.utc)
+        else:
+            utc_timestamp = timestamp
+        return utc_timestamp.isoformat()
+
+
 # Set up the signal handler for handling Ctrl + C interruptions.
 sigint_handler = SigIntHandler()
 
@@ -767,6 +792,11 @@ def job_wait_for_completion(max_poll_interval, timeout, output, **args):
 
     is_json_output = output.lower() == "json"
 
+    # Get job name for output
+    deadline = api.get_boto3_client("deadline", config=config)
+    job = deadline.get_job(farmId=farm_id, queueId=queue_id, jobId=job_id)
+    job_name = job["name"]
+
     # Define a status callback for verbose output
     def status_callback(status, elapsed_time=0, total_timeout=0):
         if not is_json_output:
@@ -800,6 +830,8 @@ def job_wait_for_completion(max_poll_interval, timeout, output, **args):
         if is_json_output:
             # Return everything as JSON
             response = {
+                "jobId": job_id,
+                "jobName": job_name,
                 "status": result.status,
                 "elapsedTime": result.elapsed_time,
                 "failedTasks": [
@@ -815,6 +847,8 @@ def job_wait_for_completion(max_poll_interval, timeout, output, **args):
             click.echo(json.dumps(response, indent=2))
         else:
             # Use verbose output with YAML formatting
+            click.echo(f"Job ID: {job_id}")
+            click.echo(f"Job Name: {job_name}")
             click.echo(f"Job completed with status: {result.status}")
             click.echo(f"Elapsed time: {result.elapsed_time:.1f} seconds")
 
@@ -855,16 +889,29 @@ def job_wait_for_completion(max_poll_interval, timeout, output, **args):
 
     except DeadlineOperationTimedOut as e:
         if is_json_output:
-            error_response = {"error": str(e), "timeout": True}
+            error_response = {
+                "error": str(e),
+                "timeout": True,
+                "jobId": job_id,
+                "jobName": job_name,
+            }
             click.echo(json.dumps(error_response, indent=2))
         else:
+            click.echo(f"Job ID: {job_id}")
+            click.echo(f"Job Name: {job_name}")
             click.echo(f"Error waiting for job completion: {e}")
         sys.exit(1)
     except DeadlineOperationError as e:
         if is_json_output:
-            error_response = {"error": str(e)}
+            error_response = {
+                "error": str(e),
+                "jobId": job_id,
+                "jobName": job_name,
+            }
             click.echo(json.dumps(error_response, indent=2))
         else:
+            click.echo(f"Job ID: {job_id}")
+            click.echo(f"Job Name: {job_name}")
             click.echo(f"Error waiting for job completion: {e}")
         sys.exit(2)
 
@@ -891,8 +938,14 @@ def job_wait_for_completion(max_poll_interval, timeout, output, **args):
     default="verbose",
     help="Output format (verbose or json).",
 )
+@click.option(
+    "--timezone",
+    type=click.Choice(["utc", "local"], case_sensitive=False),
+    default="utc",
+    help="Timezone for timestamps (utc or local). Default is utc.",
+)
 @_handle_error
-def job_logs(session_id, limit, start_time, end_time, next_token, output, **args):
+def job_logs(session_id, limit, start_time, end_time, next_token, output, timezone, **args):
     """
     Get CloudWatch logs for a specific session.
 
@@ -917,9 +970,15 @@ def job_logs(session_id, limit, start_time, end_time, next_token, output, **args
 
     is_json_output = output.lower() == "json"
 
+    # Get job name if job_id is available
+    deadline = api.get_boto3_client("deadline", config=config)
+    job = deadline.get_job(farmId=farm_id, queueId=queue_id, jobId=job_id)
+    job_name = job["name"]
+
+    use_local_time = timezone.lower() == "local"
+
     # If session_id is not provided but job_id is, try to find the session
     if not session_id and job_id:
-        deadline = api.get_boto3_client("deadline", config=config)
         try:
             # Use paginator to get all sessions
             paginator = deadline.get_paginator("list_sessions")
@@ -993,12 +1052,14 @@ def job_logs(session_id, limit, start_time, end_time, next_token, output, **args
         if is_json_output:
             # Return everything as JSON
             response = {
+                "jobId": job_id,
+                "jobName": job_name,
                 "events": [
                     {
-                        "timestamp": event.timestamp.strftime("%Y-%m-%d %H:%M:%S"),
+                        "timestamp": _format_timestamp(event.timestamp, use_local_time),
                         "message": event.message,
                         "ingestionTime": (
-                            event.ingestion_time.strftime("%Y-%m-%d %H:%M:%S")
+                            _format_timestamp(event.ingestion_time, use_local_time)
                             if event.ingestion_time
                             else None
                         ),
@@ -1018,8 +1079,12 @@ def job_logs(session_id, limit, start_time, end_time, next_token, output, **args
                 click.echo("No logs found for the specified session.")
                 return
 
+            # Display job information if available
+            click.echo(f"Job ID: {job_id}")
+            click.echo(f"Job Name: {job_name}")
+
             for event in result.events:
-                timestamp = event.timestamp.strftime("%Y-%m-%d %H:%M:%S")
+                timestamp = _format_timestamp(event.timestamp, use_local_time)
                 click.echo(f"[{timestamp}] {event.message}")
 
             click.echo(f"\nRetrieved {result.count} log events.")

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -46,5 +46,28 @@ def fresh_deadline_config():
         temp_dir.cleanup()
 
 
+@pytest.fixture(scope="function", autouse=True)
+def aws_config(monkeypatch):
+    """
+    Fixture to set the AWS_CONFIG_FILE environment variable to a temporary file.
+
+    This fixture sanitizes the environment, otherwise it's easy to write a test that only works when
+    a AWS config file exists(even if it isn't used) that then fails on machines where no such config file exists
+
+    This fixture yields the AWS config file path, so that tests can write to this file if necessary for testing
+    """
+    try:
+        temp_dir = tempfile.TemporaryDirectory()
+        temp_dir_path = Path(temp_dir.name)
+        temp_file_path = temp_dir_path / "aws_config"
+        monkeypatch.setenv("AWS_CONFIG_FILE", temp_file_path)
+
+        yield temp_file_path
+
+    finally:
+        temp_dir.cleanup()
+        monkeypatch.delenv("AWS_CONFIG_FILE", raising=False)
+
+
 def is_windows_non_admin():
     return sys.platform == "win32" and getpass.getuser() != "Administrator"

--- a/test/unit/deadline_client/cli/test_cli_job.py
+++ b/test/unit/deadline_client/cli/test_cli_job.py
@@ -915,14 +915,26 @@ def test_cli_job_wait_succeeded(fresh_deadline_config):
     config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
     config.set_setting("defaults.job_id", MOCK_JOB_ID)
 
-    with patch.object(api, "wait_for_job_completion") as mock_wait:
+    with patch.object(api, "wait_for_job_completion") as mock_wait, patch.object(
+        api, "get_boto3_client"
+    ) as boto3_client_mock:
         mock_wait.return_value = api.JobCompletionResult(
             status="SUCCEEDED", failed_tasks=[], elapsed_time=10.5
         )
 
+        # Mock get_job to return job name
+        boto3_client_mock().get_job.return_value = {"name": "Test Job Name"}
+
         runner = CliRunner()
         result = runner.invoke(main, ["job", "wait"])
 
+        # Verify get_job was called to get job name
+        boto3_client_mock().get_job.assert_called_once_with(
+            farmId=MOCK_FARM_ID, queueId=MOCK_QUEUE_ID, jobId=MOCK_JOB_ID
+        )
+
+        assert "Job ID: " + MOCK_JOB_ID in result.output
+        assert "Job Name: Test Job Name" in result.output
         assert "Job completed with status: SUCCEEDED" in result.output
         assert "Elapsed time: 10.5 seconds" in result.output
         assert "No failed tasks found." in result.output
@@ -937,10 +949,15 @@ def test_cli_job_wait_timeout(fresh_deadline_config):
     config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
     config.set_setting("defaults.job_id", MOCK_JOB_ID)
 
-    with patch.object(api, "wait_for_job_completion") as mock_wait:
+    with patch.object(api, "wait_for_job_completion") as mock_wait, patch.object(
+        api, "get_boto3_client"
+    ) as boto3_client_mock:
         mock_wait.side_effect = DeadlineOperationTimedOut(
             "Timeout waiting for job job-123 to complete after 30.0 seconds"
         )
+
+        # Mock get_job to return job name
+        boto3_client_mock().get_job.return_value = {"name": "Test Job Name"}
 
         runner = CliRunner()
         result = runner.invoke(main, ["job", "wait"])
@@ -957,7 +974,9 @@ def test_cli_job_wait_failed(fresh_deadline_config):
     config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
     config.set_setting("defaults.job_id", MOCK_JOB_ID)
 
-    with patch.object(api, "wait_for_job_completion") as mock_wait:
+    with patch.object(api, "wait_for_job_completion") as mock_wait, patch.object(
+        api, "get_boto3_client"
+    ) as boto3_client_mock:
         mock_wait.return_value = api.JobCompletionResult(
             status="FAILED",
             failed_tasks=[
@@ -972,9 +991,14 @@ def test_cli_job_wait_failed(fresh_deadline_config):
             elapsed_time=15.2,
         )
 
+        # Mock get_job to return job name
+        boto3_client_mock().get_job.return_value = {"name": "Test Job Name"}
+
         runner = CliRunner()
         result = runner.invoke(main, ["job", "wait"])
 
+        assert "Job ID: " + MOCK_JOB_ID in result.output
+        assert "Job Name: Test Job Name" in result.output
         assert "Job completed with status: FAILED" in result.output
         assert "Elapsed time: 15.2 seconds" in result.output
         assert "Found 1 failed tasks:" in result.output
@@ -989,14 +1013,21 @@ def test_cli_job_wait_canceled(fresh_deadline_config):
     config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
     config.set_setting("defaults.job_id", MOCK_JOB_ID)
 
-    with patch.object(api, "wait_for_job_completion") as mock_wait:
+    with patch.object(api, "wait_for_job_completion") as mock_wait, patch.object(
+        api, "get_boto3_client"
+    ) as boto3_client_mock:
         mock_wait.return_value = api.JobCompletionResult(
             status="CANCELED", failed_tasks=[], elapsed_time=5.0
         )
 
+        # Mock get_job to return job name
+        boto3_client_mock().get_job.return_value = {"name": "Test Job Name"}
+
         runner = CliRunner()
         result = runner.invoke(main, ["job", "wait"])
 
+        assert "Job ID: " + MOCK_JOB_ID in result.output
+        assert "Job Name: Test Job Name" in result.output
         assert "Job completed with status: CANCELED" in result.output
         assert "Elapsed time: 5.0 seconds" in result.output
         assert "No failed tasks found." in result.output
@@ -1011,14 +1042,21 @@ def test_cli_job_wait_archived(fresh_deadline_config):
     config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
     config.set_setting("defaults.job_id", MOCK_JOB_ID)
 
-    with patch.object(api, "wait_for_job_completion") as mock_wait:
+    with patch.object(api, "wait_for_job_completion") as mock_wait, patch.object(
+        api, "get_boto3_client"
+    ) as boto3_client_mock:
         mock_wait.return_value = api.JobCompletionResult(
             status="ARCHIVED", failed_tasks=[], elapsed_time=8.3
         )
 
+        # Mock get_job to return job name
+        boto3_client_mock().get_job.return_value = {"name": "Test Job Name"}
+
         runner = CliRunner()
         result = runner.invoke(main, ["job", "wait"])
 
+        assert "Job ID: " + MOCK_JOB_ID in result.output
+        assert "Job Name: Test Job Name" in result.output
         assert "Job completed with status: ARCHIVED" in result.output
         assert "Elapsed time: 8.3 seconds" in result.output
         assert "No failed tasks found." in result.output
@@ -1033,14 +1071,21 @@ def test_cli_job_wait_not_compatible(fresh_deadline_config):
     config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
     config.set_setting("defaults.job_id", MOCK_JOB_ID)
 
-    with patch.object(api, "wait_for_job_completion") as mock_wait:
+    with patch.object(api, "wait_for_job_completion") as mock_wait, patch.object(
+        api, "get_boto3_client"
+    ) as boto3_client_mock:
         mock_wait.return_value = api.JobCompletionResult(
             status="NOT_COMPATIBLE", failed_tasks=[], elapsed_time=2.1
         )
 
+        # Mock get_job to return job name
+        boto3_client_mock().get_job.return_value = {"name": "Test Job Name"}
+
         runner = CliRunner()
         result = runner.invoke(main, ["job", "wait"])
 
+        assert "Job ID: " + MOCK_JOB_ID in result.output
+        assert "Job Name: Test Job Name" in result.output
         assert "Job completed with status: NOT_COMPATIBLE" in result.output
         assert "Elapsed time: 2.1 seconds" in result.output
         assert "No failed tasks found." in result.output
@@ -1055,7 +1100,9 @@ def test_cli_job_wait_succeeded_with_failed_tasks_returns_exit_code_2(fresh_dead
     config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
     config.set_setting("defaults.job_id", MOCK_JOB_ID)
 
-    with patch.object(api, "wait_for_job_completion") as mock_wait:
+    with patch.object(api, "wait_for_job_completion") as mock_wait, patch.object(
+        api, "get_boto3_client"
+    ) as boto3_client_mock:
         mock_wait.return_value = api.JobCompletionResult(
             status="SUCCEEDED",
             failed_tasks=[
@@ -1070,9 +1117,14 @@ def test_cli_job_wait_succeeded_with_failed_tasks_returns_exit_code_2(fresh_dead
             elapsed_time=12.0,
         )
 
+        # Mock get_job to return job name
+        boto3_client_mock().get_job.return_value = {"name": "Test Job Name"}
+
         runner = CliRunner()
         result = runner.invoke(main, ["job", "wait"])
 
+        assert "Job ID: " + MOCK_JOB_ID in result.output
+        assert "Job Name: Test Job Name" in result.output
         assert "Job completed with status: SUCCEEDED" in result.output
         assert "Found 1 failed tasks:" in result.output
         assert result.exit_code == 2
@@ -1086,16 +1138,23 @@ def test_cli_job_wait_json_output_succeeded(fresh_deadline_config):
     config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
     config.set_setting("defaults.job_id", MOCK_JOB_ID)
 
-    with patch.object(api, "wait_for_job_completion") as mock_wait:
+    with patch.object(api, "wait_for_job_completion") as mock_wait, patch.object(
+        api, "get_boto3_client"
+    ) as boto3_client_mock:
         mock_wait.return_value = api.JobCompletionResult(
             status="SUCCEEDED", failed_tasks=[], elapsed_time=10.5
         )
+
+        # Mock get_job to return job name
+        boto3_client_mock().get_job.return_value = {"name": "Test Job Name"}
 
         runner = CliRunner()
         result = runner.invoke(main, ["job", "wait", "--output", "json"])
 
         # Parse the JSON output
         output_data = json.loads(result.output)
+        assert output_data["jobId"] == MOCK_JOB_ID
+        assert output_data["jobName"] == "Test Job Name"
         assert output_data["status"] == "SUCCEEDED"
         assert output_data["elapsedTime"] == pytest.approx(10.5)
         assert output_data["failedTasks"] == []
@@ -1110,7 +1169,9 @@ def test_cli_job_wait_json_output_failed(fresh_deadline_config):
     config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
     config.set_setting("defaults.job_id", MOCK_JOB_ID)
 
-    with patch.object(api, "wait_for_job_completion") as mock_wait:
+    with patch.object(api, "wait_for_job_completion") as mock_wait, patch.object(
+        api, "get_boto3_client"
+    ) as boto3_client_mock:
         mock_wait.return_value = api.JobCompletionResult(
             status="FAILED",
             failed_tasks=[
@@ -1125,11 +1186,16 @@ def test_cli_job_wait_json_output_failed(fresh_deadline_config):
             elapsed_time=15.2,
         )
 
+        # Mock get_job to return job name
+        boto3_client_mock().get_job.return_value = {"name": "Test Job Name"}
+
         runner = CliRunner()
         result = runner.invoke(main, ["job", "wait", "--output", "json"])
 
         # Parse the JSON output
         output_data = json.loads(result.output)
+        assert output_data["jobId"] == MOCK_JOB_ID
+        assert output_data["jobName"] == "Test Job Name"
         assert output_data["status"] == "FAILED"
         assert output_data["elapsedTime"] == pytest.approx(15.2)
         assert len(output_data["failedTasks"]) == 1
@@ -1148,7 +1214,12 @@ def test_cli_job_wait_unknown_status_returns_exit_code_2(fresh_deadline_config):
     config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
     config.set_setting("defaults.job_id", MOCK_JOB_ID)
 
-    with patch.object(api, "wait_for_job_completion") as mock_wait:
+    with patch.object(api, "wait_for_job_completion") as mock_wait, patch.object(
+        api, "get_boto3_client"
+    ) as mock_get_client:
+        mock_client = mock_get_client.return_value
+        mock_client.get_job.return_value = {"jobId": MOCK_JOB_ID, "name": "Test Job"}
+
         mock_wait.return_value = api.JobCompletionResult(
             status="UNKNOWN_STATUS", failed_tasks=[], elapsed_time=3.0
         )
@@ -1156,6 +1227,8 @@ def test_cli_job_wait_unknown_status_returns_exit_code_2(fresh_deadline_config):
         runner = CliRunner()
         result = runner.invoke(main, ["job", "wait"])
 
+        assert "Job ID: " + MOCK_JOB_ID in result.output
+        assert "Job Name: Test Job" in result.output
         assert "Job completed with status: UNKNOWN_STATUS" in result.output
         assert result.exit_code == 2
 
@@ -1168,7 +1241,12 @@ def test_cli_job_wait_timeout_json_output(fresh_deadline_config):
     config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
     config.set_setting("defaults.job_id", MOCK_JOB_ID)
 
-    with patch.object(api, "wait_for_job_completion") as mock_wait:
+    with patch.object(api, "wait_for_job_completion") as mock_wait, patch.object(
+        api, "get_boto3_client"
+    ) as mock_get_client:
+        mock_client = mock_get_client.return_value
+        mock_client.get_job.return_value = {"jobId": MOCK_JOB_ID, "name": "Test Job"}
+
         mock_wait.side_effect = DeadlineOperationTimedOut(
             "Timeout waiting for job job-123 to complete after 30.0 seconds"
         )
@@ -1182,6 +1260,8 @@ def test_cli_job_wait_timeout_json_output(fresh_deadline_config):
             output_data["error"] == "Timeout waiting for job job-123 to complete after 30.0 seconds"
         )
         assert output_data["timeout"] is True
+        assert output_data["jobId"] == MOCK_JOB_ID
+        assert output_data["jobName"] == "Test Job"
         assert result.exit_code == 1
 
 
@@ -1193,12 +1273,19 @@ def test_cli_job_wait_error_handling(fresh_deadline_config):
     config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
     config.set_setting("defaults.job_id", MOCK_JOB_ID)
 
-    with patch.object(api, "wait_for_job_completion") as mock_wait:
+    with patch.object(api, "wait_for_job_completion") as mock_wait, patch.object(
+        api, "get_boto3_client"
+    ) as mock_get_client:
+        mock_client = mock_get_client.return_value
+        mock_client.get_job.return_value = {"jobId": MOCK_JOB_ID, "name": "Test Job"}
+
         mock_wait.side_effect = DeadlineOperationError("Test error message")
 
         runner = CliRunner()
         result = runner.invoke(main, ["job", "wait"])
 
+        assert "Job ID: " + MOCK_JOB_ID in result.output
+        assert "Job Name: Test Job" in result.output
         assert "Error waiting for job completion: Test error message" in result.output
         assert result.exit_code == 2
 
@@ -1211,7 +1298,12 @@ def test_cli_job_wait_error_handling_json_output(fresh_deadline_config):
     config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
     config.set_setting("defaults.job_id", MOCK_JOB_ID)
 
-    with patch.object(api, "wait_for_job_completion") as mock_wait:
+    with patch.object(api, "wait_for_job_completion") as mock_wait, patch.object(
+        api, "get_boto3_client"
+    ) as mock_get_client:
+        mock_client = mock_get_client.return_value
+        mock_client.get_job.return_value = {"jobId": MOCK_JOB_ID, "name": "Test Job"}
+
         mock_wait.side_effect = DeadlineOperationError("Test error message")
 
         runner = CliRunner()
@@ -1220,6 +1312,8 @@ def test_cli_job_wait_error_handling_json_output(fresh_deadline_config):
         # Parse the JSON output
         output_data = json.loads(result.output)
         assert output_data["error"] == "Test error message"
+        assert output_data["jobId"] == MOCK_JOB_ID
+        assert output_data["jobName"] == "Test Job"
         assert result.exit_code == 2
 
 

--- a/test/unit/deadline_client/cli/test_cli_job_logs.py
+++ b/test/unit/deadline_client/cli/test_cli_job_logs.py
@@ -26,15 +26,19 @@ MOCK_JOB_ID = "job-0123456789abcdefabcdefabcdefabcd"
 # Sample log events for testing
 SAMPLE_LOG_EVENTS = [
     LogEvent(
-        timestamp=datetime.datetime(2023, 1, 1, 12, 0, 0),
+        timestamp=datetime.datetime(2023, 1, 1, 12, 0, 0, 123456, tzinfo=datetime.timezone.utc),
         message="Log message 1",
-        ingestion_time=datetime.datetime(2023, 1, 1, 12, 0, 10),
+        ingestion_time=datetime.datetime(
+            2023, 1, 1, 12, 0, 10, 654321, tzinfo=datetime.timezone.utc
+        ),
         event_id="event-1",
     ),
     LogEvent(
-        timestamp=datetime.datetime(2023, 1, 1, 12, 1, 0),
+        timestamp=datetime.datetime(2023, 1, 1, 12, 1, 0, 789012, tzinfo=datetime.timezone.utc),
         message="Log message 2",
-        ingestion_time=datetime.datetime(2023, 1, 1, 12, 1, 10),
+        ingestion_time=datetime.datetime(
+            2023, 1, 1, 12, 1, 10, 345678, tzinfo=datetime.timezone.utc
+        ),
         event_id="event-2",
     ),
 ]
@@ -64,12 +68,16 @@ def test_cli_job_logs_verbose(fresh_deadline_config):
     """
     config.set_setting("defaults.farm_id", MOCK_FARM_ID)
     config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
 
     with patch("deadline.client.api.get_session_logs") as mock_get_logs, patch(
         "deadline.client.api._job_monitoring.get_user_and_identity_store_id"
-    ) as mock_get_user:
+    ) as mock_get_user, patch("deadline.client.api.get_boto3_client") as boto3_client_mock:
         mock_get_user.return_value = (None, None)
         mock_get_logs.return_value = SAMPLE_LOG_RESULT
+
+        # Mock get_job to return job name
+        boto3_client_mock().get_job.return_value = {"name": "Test Job Name"}
 
         runner = CliRunner()
         result = runner.invoke(
@@ -77,8 +85,10 @@ def test_cli_job_logs_verbose(fresh_deadline_config):
         )
 
         assert "Retrieving logs for session" in result.output
-        assert "[2023-01-01 12:00:00] Log message 1" in result.output
-        assert "[2023-01-01 12:01:00] Log message 2" in result.output
+        assert "Job ID: " + MOCK_JOB_ID in result.output
+        assert "Job Name: Test Job Name" in result.output
+        assert "[2023-01-01T12:00:00.123456+00:00] Log message 1" in result.output
+        assert "[2023-01-01T12:01:00.789012+00:00] Log message 2" in result.output
         assert "Retrieved 2 log events" in result.output
         assert "More logs are available" in result.output
         assert result.exit_code == 0
@@ -98,12 +108,16 @@ def test_cli_job_logs_json(fresh_deadline_config):
     """
     config.set_setting("defaults.farm_id", MOCK_FARM_ID)
     config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
 
     with patch("deadline.client.api.get_session_logs") as mock_get_logs, patch(
         "deadline.client.api._job_monitoring.get_user_and_identity_store_id"
-    ) as mock_get_user:
+    ) as mock_get_user, patch("deadline.client.api.get_boto3_client") as boto3_client_mock:
         mock_get_user.return_value = (None, None)
         mock_get_logs.return_value = SAMPLE_LOG_RESULT
+
+        # Mock get_job to return job name
+        boto3_client_mock().get_job.return_value = {"name": "Test Job Name"}
 
         runner = CliRunner()
         result = runner.invoke(
@@ -125,11 +139,19 @@ def test_cli_job_logs_json(fresh_deadline_config):
         assert "events" in output_json
         assert len(output_json["events"]) == 2
         assert output_json["events"][0]["message"] == "Log message 1"
+        assert output_json["events"][0]["timestamp"] == "2023-01-01T12:00:00.123456+00:00"
+        assert output_json["events"][0]["ingestionTime"] == "2023-01-01T12:00:10.654321+00:00"
         assert output_json["events"][1]["message"] == "Log message 2"
+        assert output_json["events"][1]["timestamp"] == "2023-01-01T12:01:00.789012+00:00"
+        assert output_json["events"][1]["ingestionTime"] == "2023-01-01T12:01:10.345678+00:00"
         assert output_json["count"] == 2
         assert output_json["nextToken"] == "next-token"
         assert output_json["logGroup"] == f"/aws/deadline/{MOCK_FARM_ID}/{MOCK_QUEUE_ID}"
         assert output_json["logStream"] == "session-test-session"
+
+        # Verify job information is included
+        assert output_json["jobId"] == MOCK_JOB_ID
+        assert output_json["jobName"] == "Test Job Name"
 
         # Verify no intermediate text output was produced
         assert "Retrieving logs for session" not in result.output
@@ -143,12 +165,16 @@ def test_cli_job_logs_empty(fresh_deadline_config):
     """
     config.set_setting("defaults.farm_id", MOCK_FARM_ID)
     config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
 
     with patch("deadline.client.api.get_session_logs") as mock_get_logs, patch(
         "deadline.client.api._job_monitoring.get_user_and_identity_store_id"
-    ) as mock_get_user:
+    ) as mock_get_user, patch("deadline.client.api.get_boto3_client") as boto3_client_mock:
         mock_get_user.return_value = (None, None)
         mock_get_logs.return_value = EMPTY_LOG_RESULT
+
+        # Mock get_job to return job name
+        boto3_client_mock().get_job.return_value = {"name": "Test Job Name"}
 
         runner = CliRunner()
         result = runner.invoke(
@@ -165,12 +191,16 @@ def test_cli_job_logs_json_empty(fresh_deadline_config):
     """
     config.set_setting("defaults.farm_id", MOCK_FARM_ID)
     config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
 
     with patch("deadline.client.api.get_session_logs") as mock_get_logs, patch(
         "deadline.client.api._job_monitoring.get_user_and_identity_store_id"
-    ) as mock_get_user:
+    ) as mock_get_user, patch("deadline.client.api.get_boto3_client") as boto3_client_mock:
         mock_get_user.return_value = (None, None)
         mock_get_logs.return_value = EMPTY_LOG_RESULT
+
+        # Mock get_job to return job name
+        boto3_client_mock().get_job.return_value = {"name": "Test Job Name"}
 
         runner = CliRunner()
         result = runner.invoke(
@@ -194,6 +224,10 @@ def test_cli_job_logs_json_empty(fresh_deadline_config):
         assert output_json["count"] == 0
         assert output_json["nextToken"] is None
 
+        # Verify job information is included
+        assert output_json["jobId"] == MOCK_JOB_ID
+        assert output_json["jobName"] == "Test Job Name"
+
         assert result.exit_code == 0
 
 
@@ -206,9 +240,12 @@ def test_cli_job_logs_json_error(fresh_deadline_config):
 
     with patch("deadline.client.api.get_session_logs") as mock_get_logs, patch(
         "deadline.client.api._job_monitoring.get_user_and_identity_store_id"
-    ) as mock_get_user:
+    ) as mock_get_user, patch("deadline.client.api.get_boto3_client") as boto3_client_mock:
         mock_get_user.return_value = (None, None)
         mock_get_logs.side_effect = Exception("Test error message")
+
+        # Mock boto3 client to prevent AWS SDK calls
+        boto3_client_mock.return_value = MagicMock()
 
         runner = CliRunner()
         result = runner.invoke(
@@ -230,12 +267,16 @@ def test_cli_job_logs_with_time_params(fresh_deadline_config):
     """
     config.set_setting("defaults.farm_id", MOCK_FARM_ID)
     config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
 
     with patch("deadline.client.api.get_session_logs") as mock_get_logs, patch(
         "deadline.client.api._job_monitoring.get_user_and_identity_store_id"
-    ) as mock_get_user:
+    ) as mock_get_user, patch("deadline.client.api.get_boto3_client") as boto3_client_mock:
         mock_get_user.return_value = (None, None)
         mock_get_logs.return_value = SAMPLE_LOG_RESULT
+
+        # Mock get_job to return job name
+        boto3_client_mock().get_job.return_value = {"name": "Test Job Name"}
 
         runner = CliRunner()
         result = runner.invoke(
@@ -267,12 +308,16 @@ def test_cli_job_logs_with_next_token(fresh_deadline_config):
     """
     config.set_setting("defaults.farm_id", MOCK_FARM_ID)
     config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
 
     with patch("deadline.client.api.get_session_logs") as mock_get_logs, patch(
         "deadline.client.api._job_monitoring.get_user_and_identity_store_id"
-    ) as mock_get_user:
+    ) as mock_get_user, patch("deadline.client.api.get_boto3_client") as boto3_client_mock:
         mock_get_user.return_value = (None, None)
         mock_get_logs.return_value = SAMPLE_LOG_RESULT
+
+        # Mock get_job to return job name
+        boto3_client_mock().get_job.return_value = {"name": "Test Job Name"}
 
         runner = CliRunner()
         result = runner.invoke(
@@ -301,21 +346,32 @@ def test_cli_job_logs_with_session_id(fresh_deadline_config):
     """
     config.set_setting("defaults.farm_id", MOCK_FARM_ID)
     config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
 
-    with patch.object(api, "get_session_logs") as mock_get_logs:
+    with patch.object(api, "get_session_logs") as mock_get_logs, patch.object(
+        api, "get_boto3_client"
+    ) as boto3_client_mock:
         # Mock the API response
         mock_get_logs.return_value = SessionLogResult(
             events=[
                 LogEvent(
-                    timestamp=datetime.datetime(2023, 1, 27, 7, 24, 45),
+                    timestamp=datetime.datetime(
+                        2023, 1, 27, 7, 24, 45, tzinfo=datetime.timezone.utc
+                    ),
                     message="Test log message 1",
-                    ingestion_time=datetime.datetime(2023, 1, 27, 7, 24, 46),
+                    ingestion_time=datetime.datetime(
+                        2023, 1, 27, 7, 24, 46, tzinfo=datetime.timezone.utc
+                    ),
                     event_id="event-1",
                 ),
                 LogEvent(
-                    timestamp=datetime.datetime(2023, 1, 27, 7, 24, 50),
+                    timestamp=datetime.datetime(
+                        2023, 1, 27, 7, 24, 50, tzinfo=datetime.timezone.utc
+                    ),
                     message="Test log message 2",
-                    ingestion_time=datetime.datetime(2023, 1, 27, 7, 24, 51),
+                    ingestion_time=datetime.datetime(
+                        2023, 1, 27, 7, 24, 51, tzinfo=datetime.timezone.utc
+                    ),
                     event_id="event-2",
                 ),
             ],
@@ -324,6 +380,9 @@ def test_cli_job_logs_with_session_id(fresh_deadline_config):
             log_group=f"/aws/deadline/{MOCK_FARM_ID}/{MOCK_QUEUE_ID}",
             log_stream="session-1",
         )
+
+        # Mock get_job to return job name
+        boto3_client_mock().get_job.return_value = {"name": "Test Job Name"}
 
         runner = CliRunner()
         result = runner.invoke(
@@ -350,9 +409,11 @@ def test_cli_job_logs_with_session_id(fresh_deadline_config):
 
         # Check output
         assert "Retrieving logs for session session-1" in result.output
-        assert "2023-01-27 07:24:45" in result.output
+        assert "Job ID: " + MOCK_JOB_ID in result.output
+        assert "Job Name: Test Job Name" in result.output
+        assert "2023-01-27T07:24:45+00:00" in result.output
         assert "Test log message 1" in result.output
-        assert "2023-01-27 07:24:50" in result.output
+        assert "2023-01-27T07:24:50+00:00" in result.output
         assert "Test log message 2" in result.output
         assert "Retrieved 2 log events" in result.output
         assert result.exit_code == 0
@@ -375,6 +436,9 @@ def test_cli_job_logs_with_job_id_single_session(fresh_deadline_config):
 
         # Set up the paginator to return a single session
         paginator_mock.paginate.return_value = [{"sessions": [{"sessionId": "session-1"}]}]
+
+        # Mock get_job to return job name
+        boto3_client_mock().get_job.return_value = {"name": "Test Job Name"}
 
         # Mock the get_session_logs response
         mock_get_logs.return_value = api.SessionLogResult(
@@ -409,6 +473,11 @@ def test_cli_job_logs_with_job_id_single_session(fresh_deadline_config):
             farmId=MOCK_FARM_ID, queueId=MOCK_QUEUE_ID, jobId=MOCK_JOB_ID
         )
 
+        # Verify get_job was called to get job name
+        boto3_client_mock().get_job.assert_called_once_with(
+            farmId=MOCK_FARM_ID, queueId=MOCK_QUEUE_ID, jobId=MOCK_JOB_ID
+        )
+
         # Verify get_session_logs was called with the correct session ID
         mock_get_logs.assert_called_once_with(
             farm_id=MOCK_FARM_ID,
@@ -421,8 +490,10 @@ def test_cli_job_logs_with_job_id_single_session(fresh_deadline_config):
             config=ANY,
         )
 
-        # Check output
+        # Check output includes job information
         assert "Using the only available session: session-1" in result.output
+        assert "Job ID: " + MOCK_JOB_ID in result.output
+        assert "Job Name: Test Job Name" in result.output
         assert "Test log message" in result.output
         assert result.exit_code == 0
 
@@ -779,6 +850,9 @@ def test_cli_job_logs_with_job_id_selects_most_recent_among_multiple_ongoing(fre
                     }
                 ]
 
+                # Mock get_job to return job name
+                boto3_client_mock().get_job.return_value = {"name": "Test Job Name"}
+
                 # Mock the get_session_logs response
                 mock_get_logs.return_value = api.SessionLogResult(
                     events=[
@@ -806,6 +880,11 @@ def test_cli_job_logs_with_job_id_selects_most_recent_among_multiple_ongoing(fre
                     ],
                 )
 
+                # Verify get_job was called to get job name
+                boto3_client_mock().get_job.assert_called_once_with(
+                    farmId=MOCK_FARM_ID, queueId=MOCK_QUEUE_ID, jobId=MOCK_JOB_ID
+                )
+
                 # Verify get_session_logs was called with the most recently started ongoing session
                 mock_get_logs.assert_called_once_with(
                     farm_id=MOCK_FARM_ID,
@@ -818,7 +897,248 @@ def test_cli_job_logs_with_job_id_selects_most_recent_among_multiple_ongoing(fre
                     config=ANY,
                 )
 
-                # Check output
+                # Check output includes job information
                 assert "Using the latest session: session-ongoing-newest" in result.output
+                assert "Job ID: " + MOCK_JOB_ID in result.output
+                assert "Job Name: Test Job Name" in result.output
                 assert "Most recent ongoing session log" in result.output
                 assert result.exit_code == 0
+
+
+def test_cli_job_logs_json_with_job_info(fresh_deadline_config):
+    """
+    Test that logs CLI includes job information in JSON mode when job-id is provided.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
+
+    with patch.object(api, "get_boto3_client") as boto3_client_mock, patch.object(
+        api, "get_session_logs"
+    ) as mock_get_logs:
+        # Mock the paginator
+        paginator_mock = MagicMock()
+        boto3_client_mock().get_paginator.return_value = paginator_mock
+
+        # Set up the paginator to return a single session
+        paginator_mock.paginate.return_value = [{"sessions": [{"sessionId": "session-1"}]}]
+
+        # Mock get_job to return job name
+        boto3_client_mock().get_job.return_value = {"name": "Test Job Name"}
+
+        # Mock the get_session_logs response
+        mock_get_logs.return_value = SAMPLE_LOG_RESULT
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "job",
+                "logs",
+                "--job-id",
+                MOCK_JOB_ID,
+                "--output",
+                "json",
+            ],
+        )
+
+        # Verify the output is valid JSON
+        output_json = json.loads(result.output)
+        assert "events" in output_json
+        assert len(output_json["events"]) == 2
+        assert output_json["events"][0]["message"] == "Log message 1"
+        assert output_json["events"][1]["message"] == "Log message 2"
+        assert output_json["count"] == 2
+        assert output_json["nextToken"] == "next-token"
+        assert output_json["logGroup"] == f"/aws/deadline/{MOCK_FARM_ID}/{MOCK_QUEUE_ID}"
+        assert output_json["logStream"] == "session-test-session"
+
+        # Verify job information is included
+        assert output_json["jobId"] == MOCK_JOB_ID
+        assert output_json["jobName"] == "Test Job Name"
+
+        # Verify no intermediate text output was produced
+        assert "Retrieving logs for session" not in result.output
+        assert "Using the only available session" not in result.output
+
+        assert result.exit_code == 0
+
+
+def test_cli_job_logs_timezone_utc(fresh_deadline_config):
+    """
+    Test that logs CLI works correctly with UTC timezone (default).
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
+
+    with patch("deadline.client.api.get_session_logs") as mock_get_logs, patch(
+        "deadline.client.api._job_monitoring.get_user_and_identity_store_id"
+    ) as mock_get_user, patch("deadline.client.api.get_boto3_client") as boto3_client_mock:
+        mock_get_user.return_value = (None, None)
+        mock_get_logs.return_value = SAMPLE_LOG_RESULT
+
+        # Mock get_job to return job name
+        boto3_client_mock().get_job.return_value = {"name": "Test Job Name"}
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main, ["job", "logs", "--session-id", "test-session", "--timezone", "utc"]
+        )
+
+        # Verify UTC timestamps are displayed
+        assert "[2023-01-01T12:00:00.123456+00:00] Log message 1" in result.output
+        assert "[2023-01-01T12:01:00.789012+00:00] Log message 2" in result.output
+        assert result.exit_code == 0
+
+
+def test_cli_job_logs_timezone_local_verbose(fresh_deadline_config):
+    """
+    Test that logs CLI works correctly with local timezone in verbose mode.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
+
+    # Create timezone-aware datetime objects for testing
+    import datetime
+
+    utc_time1 = datetime.datetime(2023, 1, 1, 12, 0, 0, 123456, tzinfo=datetime.timezone.utc)
+    utc_time2 = datetime.datetime(2023, 1, 1, 12, 1, 0, 789012, tzinfo=datetime.timezone.utc)
+
+    timezone_aware_events = [
+        LogEvent(
+            timestamp=utc_time1,
+            message="Log message 1",
+            ingestion_time=datetime.datetime(
+                2023, 1, 1, 12, 0, 10, 654321, tzinfo=datetime.timezone.utc
+            ),
+            event_id="event-1",
+        ),
+        LogEvent(
+            timestamp=utc_time2,
+            message="Log message 2",
+            ingestion_time=datetime.datetime(
+                2023, 1, 1, 12, 1, 10, 345678, tzinfo=datetime.timezone.utc
+            ),
+            event_id="event-2",
+        ),
+    ]
+
+    timezone_aware_result = SessionLogResult(
+        events=timezone_aware_events,
+        next_token="next-token",
+        log_group=f"/aws/deadline/{MOCK_FARM_ID}/{MOCK_QUEUE_ID}",
+        log_stream="session-test-session",
+        count=2,
+    )
+
+    with patch("deadline.client.api.get_session_logs") as mock_get_logs, patch(
+        "deadline.client.api._job_monitoring.get_user_and_identity_store_id"
+    ) as mock_get_user, patch("deadline.client.api.get_boto3_client") as boto3_client_mock:
+        mock_get_user.return_value = (None, None)
+        mock_get_logs.return_value = timezone_aware_result
+
+        # Mock get_job to return job name
+        boto3_client_mock().get_job.return_value = {"name": "Test Job Name"}
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main, ["job", "logs", "--session-id", "test-session", "--timezone", "local"]
+        )
+
+        # The exact local time will depend on the system timezone, but we can verify
+        # that the format is ISO 8601 and that the command succeeds
+        assert "Log message 1" in result.output
+        assert "Log message 2" in result.output
+        # Check that timestamps contain 'T' (ISO format) and timezone offset
+        assert "T" in result.output
+        assert "+" in result.output or "-" in result.output  # timezone offset
+        assert result.exit_code == 0
+
+
+def test_cli_job_logs_timezone_local_json(fresh_deadline_config):
+    """
+    Test that logs CLI works correctly with local timezone in JSON mode.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
+
+    # Create timezone-aware datetime objects for testing
+    import datetime
+
+    utc_time1 = datetime.datetime(2023, 1, 1, 12, 0, 0, 123456, tzinfo=datetime.timezone.utc)
+    utc_time2 = datetime.datetime(2023, 1, 1, 12, 1, 0, 789012, tzinfo=datetime.timezone.utc)
+
+    timezone_aware_events = [
+        LogEvent(
+            timestamp=utc_time1,
+            message="Log message 1",
+            ingestion_time=datetime.datetime(
+                2023, 1, 1, 12, 0, 10, 654321, tzinfo=datetime.timezone.utc
+            ),
+            event_id="event-1",
+        ),
+        LogEvent(
+            timestamp=utc_time2,
+            message="Log message 2",
+            ingestion_time=datetime.datetime(
+                2023, 1, 1, 12, 1, 10, 345678, tzinfo=datetime.timezone.utc
+            ),
+            event_id="event-2",
+        ),
+    ]
+
+    timezone_aware_result = SessionLogResult(
+        events=timezone_aware_events,
+        next_token="next-token",
+        log_group=f"/aws/deadline/{MOCK_FARM_ID}/{MOCK_QUEUE_ID}",
+        log_stream="session-test-session",
+        count=2,
+    )
+
+    with patch("deadline.client.api.get_session_logs") as mock_get_logs, patch(
+        "deadline.client.api._job_monitoring.get_user_and_identity_store_id"
+    ) as mock_get_user, patch("deadline.client.api.get_boto3_client") as boto3_client_mock:
+        mock_get_user.return_value = (None, None)
+        mock_get_logs.return_value = timezone_aware_result
+
+        # Mock get_job to return job name
+        boto3_client_mock().get_job.return_value = {"name": "Test Job Name"}
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "job",
+                "logs",
+                "--session-id",
+                "test-session",
+                "--timezone",
+                "local",
+                "--output",
+                "json",
+            ],
+        )
+
+        # Verify the output is valid JSON
+        output_json = json.loads(result.output)
+        assert "events" in output_json
+        assert len(output_json["events"]) == 2
+        assert output_json["events"][0]["message"] == "Log message 1"
+        assert output_json["events"][1]["message"] == "Log message 2"
+
+        # Verify timestamps are in ISO 8601 format with timezone info
+        timestamp1 = output_json["events"][0]["timestamp"]
+        timestamp2 = output_json["events"][1]["timestamp"]
+        ingestion1 = output_json["events"][0]["ingestionTime"]
+        ingestion2 = output_json["events"][1]["ingestionTime"]
+
+        # Check ISO 8601 format (contains 'T' and timezone offset)
+        assert "T" in timestamp1 and ("+" in timestamp1 or "-" in timestamp1)
+        assert "T" in timestamp2 and ("+" in timestamp2 or "-" in timestamp2)
+        assert "T" in ingestion1 and ("+" in ingestion1 or "-" in ingestion1)
+        assert "T" in ingestion2 and ("+" in ingestion2 or "-" in ingestion2)
+
+        assert result.exit_code == 0

--- a/test/unit/deadline_job_attachments/api/test_manifest_upload.py
+++ b/test/unit/deadline_job_attachments/api/test_manifest_upload.py
@@ -6,8 +6,6 @@ import tempfile
 from unittest.mock import ANY, MagicMock, patch
 import pytest
 
-from deadline.client import api
-
 from deadline.job_attachments.api.manifest import _manifest_upload
 
 
@@ -35,19 +33,26 @@ class TestManifestUpload:
         return path
 
     @patch("deadline.job_attachments.api.manifest.S3AssetUploader")
-    def test_upload(self, mock_upload_assets: MagicMock, mock_manifest_file: str) -> None:
+    @patch("deadline.client.api.get_boto3_session")
+    def test_upload(
+        self,
+        mock_get_boto3_session: MagicMock,
+        mock_upload_assets: MagicMock,
+        mock_manifest_file: str,
+    ) -> None:
         """
         Upload is really simple. It is a pass through to S3AssetUploader. Make sure it is called correctly.
         """
         # Given
-        boto_session = api.get_boto3_session()
+        mock_boto_session = MagicMock()
+        mock_get_boto3_session.return_value = mock_boto_session
 
         # When the API is called....
         _manifest_upload(
             manifest_file=mock_manifest_file,
             s3_bucket_name=TEST_BUCKET_NAME,
             s3_cas_prefix=TEST_CAS_PREFIX,
-            boto_session=boto_session,
+            boto_session=mock_boto_session,
         )
 
         # Then
@@ -60,14 +65,19 @@ class TestManifestUpload:
         )
 
     @patch("deadline.job_attachments.api.manifest.S3AssetUploader")
+    @patch("deadline.client.api.get_boto3_session")
     def test_upload_with_prefix(
-        self, mock_upload_assets: MagicMock, mock_manifest_file: str
+        self,
+        mock_get_boto3_session: MagicMock,
+        mock_upload_assets: MagicMock,
+        mock_manifest_file: str,
     ) -> None:
         """
         Upload is really simple. It is a pass through to S3AssetUploader. Make sure it is called correctly with prefix
         """
         # Given
-        boto_session = api.get_boto3_session()
+        mock_boto_session = MagicMock()
+        mock_get_boto3_session.return_value = mock_boto_session
 
         # When the API is called....
         _manifest_upload(
@@ -75,7 +85,7 @@ class TestManifestUpload:
             s3_bucket_name=TEST_BUCKET_NAME,
             s3_cas_prefix=TEST_CAS_PREFIX,
             s3_key_prefix=TEST_KEY_PREFIX,
-            boto_session=boto_session,
+            boto_session=mock_boto_session,
         )
 
         # Then


### PR DESCRIPTION

I received some offline feedback for the previous change adding these commands.

I have added job name/id to the output of the 'wait' command, as if you use the default job there is no indication of which job you are waiting on.

I've improved the timestamp handling in the logs command, it now returns ISO8601 and there is a '--timezone local' switch which will print out in local timezone:

Fixes: *<insert link to GitHub issue here>*

### What was the problem/requirement? (What/Why)
`deadline job wait` had no output indicting which job was being waited on
`deadline job logs` output no precision timestamps with ambiguous timezones


### What was the solution? (How)
`deadline job wait` now prints the job id and name
`deadline job logs` now prints iso8601 timestamps, and has a `--timezone local` switch to use the system timezone.


### What is the impact of this change?
More precise information for users of these commands
 

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests? yes
- Have you run the integration tests? no
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass. no

### Was this change documented?

- Are relevant docstrings in the code base updated? yes
- Has the README.md been updated? If you modified CLI arguments, for instance. yes

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x ] This PR does not add any new dependencies.

### Is this a breaking change?

A breaking change is one that modifies a public contract in a way that is not backwards compatible. See the 
[Public Contracts](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#public-contracts) section
of the DEVELOPMENT.md for more information on the public contracts.

If so, then please describe the changes that users of this package must make to update their scripts, or Python applications.


Technically I guess? but the base change was merged just a few hours ago

### Does this change impact security?

No

- Does the change need to be threat modeled? For example, does it create or modify files/directories that must only be readable by the process owner?
    - If so, then please label this pull request with the "security" label. We'll work with you to analyze the threats.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
