### PR TITLE
feat(experimental): Retrieve sessions/session actions for auto download

### DIFF
--- a/src/deadline/client/cli/_incremental_download.py
+++ b/src/deadline/client/cli/_incremental_download.py
@@ -6,6 +6,7 @@ __all__ = ["_incremental_output_download"]
 from datetime import datetime, timedelta, timezone
 import difflib
 import textwrap
+from typing import Optional
 
 from .. import api
 from typing import Any, Callable
@@ -20,7 +21,11 @@ from ._common import _cli_object_repr
 
 
 def _get_download_candidate_jobs(
-    boto3_session: boto3.Session, farm_id: str, queue_id: str, starting_timestamp: datetime
+    boto3_session: boto3.Session,
+    farm_id: str,
+    queue_id: str,
+    starting_timestamp: datetime,
+    print_function_callback: Callable[[str], None] = lambda msg: None,
 ) -> dict[str, dict[str, Any]]:
     """
     Uses deadline:SearchJobs queries to get a dict {job_id: job} of download candidates for the queue.
@@ -36,10 +41,13 @@ def _get_download_candidate_jobs(
     Returns:
         A dictionary mapping job id to the job as returned by the deadline.search_jobs API.
     """
+    print_function_callback("Retrieving updated data from Deadline Cloud...")
+    start_time = datetime.now(tz=timezone.utc)
+
     # Construct the full set of jobs that may have new available downloads.
     # - Any active job (job with taskRunStatus in READY, ASSIGNED,
     #   STARTING, SCHEDULED, or RUNNING), that has at least one SUCCEEDED task.
-    download_candidate_jobs_dict = {
+    download_candidate_jobs = {
         job["jobId"]: job
         for job in _list_jobs_by_filter_expression(
             boto3_session,
@@ -61,7 +69,7 @@ def _get_download_candidate_jobs(
             },
         )
     }
-    download_candidate_jobs_dict.update(
+    download_candidate_jobs.update(
         {
             job["jobId"]: job
             for job in _list_jobs_by_filter_expression(
@@ -84,21 +92,21 @@ def _get_download_candidate_jobs(
             )
         }
     )
-    print(f"DEBUG: Got {len(download_candidate_jobs_dict)} active jobs")
-    download_candidate_jobs_dict = {
+    print(f"DEBUG: Got {len(download_candidate_jobs)} active jobs")
+    download_candidate_jobs = {
         job_id: _datetimes_to_str(job)
-        for job_id, job in download_candidate_jobs_dict.items()
+        for job_id, job in download_candidate_jobs.items()
         if job["taskRunStatusCounts"]["SUCCEEDED"] > 0
     }
     print(
-        f"DEBUG: Filtered down to {len(download_candidate_jobs_dict)} active jobs based on SUCCEEDED task filter"
+        f"DEBUG: Filtered down to {len(download_candidate_jobs)} active jobs based on SUCCEEDED task filter"
     )
 
     # - Any recently ended job (job went from active to terminal with a taskRunStatus
     #   in SUSPENDED, CANCELED, FAILED, SUCCEEDED, NOT_COMPATIBLE), that has at least
     #   one SUCCEEDED task. The endedAt timestamp field gets updated when that occurs.
     # TODO: Enable this when filtering by ENDED_AT works.
-    # download_candidate_jobs_dict.update(
+    # download_candidate_jobs.update(
     #     {
     #         job["jobId"]: job
     #         for job in _list_jobs_by_filter_expression(
@@ -120,9 +128,9 @@ def _get_download_candidate_jobs(
     #         )
     #     }
     # )
-    # WORKAROUND: Get all jobs with a SUCCEEDED or SUSPENDED task run status, and filter by endedAt client-side.
-    #             We want to download everything that is succeeded or suspended, but not
-    #             FAILED, CANCELED, or NOT_COMPATIBLE.
+    # WORKAROUND: Get all jobs with a SUCCEEDED, SUSPENDED, or FAILED task run status, and filter by endedAt client-side.
+    #             We want to download all parts of these jobs that succeeded, even when the whole did not.
+    #             We do not download anything more for a job that was CANCELED or is NOT_COMPATIBLE.
     recently_ended_jobs = _list_jobs_by_filter_expression(
         boto3_session,
         farm_id,
@@ -136,12 +144,13 @@ def _get_download_candidate_jobs(
                         "value": status_value,
                     },
                 }
-                for status_value in ["SUCCEEDED", "SUSPENDED"]
+                for status_value in ["SUCCEEDED", "SUSPENDED", "FAILED"]
             ],
             "operator": "OR",
         },
     )
     print(f"DEBUG: Got {len(recently_ended_jobs)} succeeded/suspended jobs")
+    print(f"DEBUG: Filtering to job[endedAt] >= {starting_timestamp.astimezone().isoformat()}")
     # Jobs that are submitted with a SUSPENDED status will have no "endedAt" field
     # Filter to jobs that:
     # 1. Have an endedAt field. (jobs submitted as SUSPENDED will not have one)
@@ -157,11 +166,405 @@ def _get_download_candidate_jobs(
     print(
         f"DEBUG: Filtered down to {len(recently_ended_jobs)} succeeded/suspended jobs based on endedAt timestamp threshold and SUCCEEDED task filter"
     )
-    download_candidate_jobs_dict.update(
+    download_candidate_jobs.update(
         {job["jobId"]: _datetimes_to_str(job) for job in recently_ended_jobs}
     )
 
-    return download_candidate_jobs_dict
+    duration = datetime.now(tz=timezone.utc) - start_time
+    print_function_callback(f"...retrieval completed in {duration}")
+
+    return download_candidate_jobs
+
+
+class CategorizedJobIds:
+    """
+    Takes jobs loaded from a loaded checkpoint and a query to get download candidate jobs,
+    analyzes all the jobs by looking at fields like task run status counds to categorize them.
+    """
+
+    inactive: set[str] = set()
+    updated: set[str] = set()
+    added: set[str] = set()
+    unchanged: set[str] = set()
+    attachments_free: set[str] = set()
+    completed: set[str] = set()
+
+
+def _categorize_jobs_in_checkpoint(
+    boto3_session: boto3.Session,
+    farm_id: str,
+    queue_id: str,
+    checkpoint: IncrementalDownloadState,
+    download_candidate_jobs: dict[str, dict[str, Any]],
+    new_completed_timestamp: datetime,
+    print_function_callback: Callable[[str], None] = lambda msg: None,
+) -> CategorizedJobIds:
+    """
+    Categorizes the provided download candidate jobs by id into a CategorizedJobIds object,
+    updating the jobs within download_candidate_jobs where necessary.
+
+    * Calls deadline:GetJob to get job attachments manifest information if it is not stored yet.
+    """
+    deadline = boto3_session.client("deadline")
+    checkpoint_jobs = {job.job_id: job.job for job in checkpoint.jobs}
+    checkpoint_job_ids = set(checkpoint_jobs.keys())
+
+    download_candidate_job_ids = set(download_candidate_jobs.keys())
+
+    print_function_callback(
+        f"Categorizing {len(checkpoint_jobs)} checkpoint jobs against {len(download_candidate_jobs)} download candidate jobs..."
+    )
+    start_time = datetime.now(tz=timezone.utc)
+
+    became_inactive_job_ids = checkpoint_job_ids.difference(download_candidate_job_ids)
+    updated_job_ids = checkpoint_job_ids.intersection(download_candidate_job_ids)
+    new_job_ids = download_candidate_job_ids.difference(checkpoint_job_ids)
+    # The following sets get populated while analyzing the jobs
+    unchanged_job_ids = set()
+    attachments_free_job_ids = set()
+    completed_job_ids = set()
+
+    # Copy the job attachments manifest data from the checkpoint to the new job objects. This data is not returned
+    # by deadline:SearchJobs, so we need to call deadline:GetJob on every job to retrieve it. The manifests on a job
+    # don't change, so after the call to deadline:GetJob we can cache it indefinitely.
+    for job_id in updated_job_ids:
+        ip_job = checkpoint_jobs[job_id]
+        dc_job = download_candidate_jobs[job_id]
+
+        if set(ip_job.keys()) == {"jobId"}:
+            # If the job has a minimal placeholder, move the job id to the new job ids
+            new_job_ids.add(job_id)
+        elif ip_job["attachments"] is None:
+            # Carry over the minimal placeholder identifying the job as not using job attachments
+            download_candidate_jobs[job_id] = ip_job
+            attachments_free_job_ids.add(job_id)
+        else:
+            # Copy the attachments manifest metadata as it is not returned by deadline:SearchJobs
+            dc_job["attachments"] = ip_job["attachments"]
+    updated_job_ids.difference_update(attachments_free_job_ids)
+    updated_job_ids.difference_update(new_job_ids)
+
+    # Prune jobs that we are (almost) certain have no changes by looking at its task status counts. We treat a job as unchanged if its
+    # value job["taskRunStatusCounts"]["SUCCEEDED"] stayed the same and its timestamp job["endedAt"] stayed the same.
+    #
+    # The case this misses (and causes a delay in task output download) is the following sequence: 1/ User requeues one or more steps/tasks.
+    # 2/ Tasks succeed in the correct number to equal the previous value 3/ The incremental output download command sees an equal count
+    # and miscategorizes it as unchanged. If that count is all the tasks, the job["endedAt"] timestamp will catch it, and if the count
+    # is less, the next time a task completes the succeeded count will be different.
+    #
+    # Because of this potential delay, the checkpoint needs to keep tracking all of the sessions it has seen, and cannot assume
+    # that a session ending before the downloads completed timestamp was already processed.
+    for job_id in updated_job_ids:
+        ip_job = checkpoint_jobs[job_id]
+        dc_job = download_candidate_jobs[job_id]
+
+        if ip_job["taskRunStatusCounts"]["SUCCEEDED"] == dc_job["taskRunStatusCounts"][
+            "SUCCEEDED"
+        ] and ip_job.get("endedAt") == dc_job.get("endedAt"):
+            print_function_callback(f"UNCHANGED Job: {dc_job['name']} ({job_id})")
+            unchanged_job_ids.add(job_id)
+    updated_job_ids.difference_update(unchanged_job_ids)
+
+    # First make note of any jobs that were dropped, for example if they were canceled or they failed
+    for job_id in became_inactive_job_ids:
+        ip_job = checkpoint_jobs[job_id]
+        if "taskRunStatusCounts" in ip_job:
+            ip_succeeded_task_count = ip_job["taskRunStatusCounts"]["SUCCEEDED"]
+            ip_total_task_count = sum(value for _, value in ip_job["taskRunStatusCounts"].items())
+        else:
+            ip_succeeded_task_count = 0
+            ip_total_task_count = -1
+
+        # Print something only if the job is more than a minimal "jobId" tracker
+        if set(ip_job.keys()) != {"jobId"}:
+            print_function_callback(f"DROPPED Job: {ip_job['name']} ({job_id})")
+            if ip_job["attachments"] is None:
+                print_function_callback("  Job without job attachments is no longer active")
+            elif ip_succeeded_task_count == ip_total_task_count:
+                print_function_callback("   Job succeeded")
+            else:
+                print_function_callback(
+                    "   Job is not a download candidate anymore (likely suspended, canceled or failed)"
+                )
+
+    # Process all the jobs that have updates
+    for job_id in updated_job_ids:
+        ip_job = checkpoint_jobs[job_id]
+        dc_job = download_candidate_jobs[job_id]
+        ip_succeeded_task_count = ip_job["taskRunStatusCounts"]["SUCCEEDED"]
+        ip_total_task_count = sum(value for _, value in ip_job["taskRunStatusCounts"].items())
+        dc_succeeded_task_count = dc_job["taskRunStatusCounts"]["SUCCEEDED"]
+        dc_total_task_count = sum(value for _, value in dc_job["taskRunStatusCounts"].items())
+
+        print_function_callback(f"EXISTING Job: {ip_job['name']} ({job_id})")
+        print_function_callback(
+            f"  Succeeded tasks (before): {ip_succeeded_task_count} / {ip_total_task_count}"
+        )
+        print_function_callback(
+            f"  Succeeded tasks (now)   : {dc_succeeded_task_count} / {dc_total_task_count}"
+        )
+
+        # Use the CLI output format to produce a diff of the changes
+        ip_job_repr: list[str] = _cli_object_repr(ip_job).splitlines()
+        dc_job_repr: list[str] = _cli_object_repr(dc_job).splitlines()
+
+        for line in difflib.unified_diff(
+            ip_job_repr,
+            dc_job_repr,
+            fromfile="Previous update",
+            tofile="Current update",
+            lineterm="",
+        ):
+            print_function_callback(f"  {line}")
+
+        if (
+            dc_succeeded_task_count == dc_total_task_count
+            and "endedAt" in dc_job
+            and datetime.fromisoformat(dc_job["endedAt"]) < new_completed_timestamp
+        ):
+            completed_job_ids.add(job_id)
+    updated_job_ids.difference_update(completed_job_ids)
+
+    # Process all the jobs that are new
+    for job_id in new_job_ids:
+        dc_job = download_candidate_jobs[job_id]
+
+        # Call deadline:GetJob to retrieve attachments manifest information
+        job = deadline.get_job(jobId=job_id, queueId=queue_id, farmId=farm_id)
+        dc_job["attachments"] = job.get("attachments")
+        dc_succeeded_task_count = dc_job["taskRunStatusCounts"]["SUCCEEDED"]
+        dc_total_task_count = sum(value for _, value in dc_job["taskRunStatusCounts"].items())
+
+        print_function_callback(f"NEW Job: {dc_job['name']} ({job_id})")
+
+        print_function_callback(
+            f"  Succeeded tasks: {dc_succeeded_task_count} / {dc_total_task_count}"
+        )
+        if dc_job["attachments"] is None:
+            # If the job does not use job attachments, save a minimal placeholder to avoid
+            # repeatedly calling deadline:GetJob.
+            download_candidate_jobs[job_id] = dc_job = {
+                "jobId": job_id,
+                "name": dc_job["name"],
+                "attachments": None,
+            }
+            attachments_free_job_ids.add(job_id)
+            print_function_callback("  Job does not use job attachments.")
+        else:
+            print_function_callback(textwrap.indent(_cli_object_repr(dc_job["attachments"]), "  "))
+
+        if (
+            dc_succeeded_task_count == dc_total_task_count
+            and "endedAt" in dc_job
+            and datetime.fromisoformat(dc_job["endedAt"]) < new_completed_timestamp
+        ):
+            completed_job_ids.add(job_id)
+    new_job_ids.difference_update(attachments_free_job_ids)
+    new_job_ids.difference_update(completed_job_ids)
+
+    result = CategorizedJobIds()
+    result.attachments_free = attachments_free_job_ids
+    result.completed = completed_job_ids
+    result.inactive = became_inactive_job_ids
+    result.added = new_job_ids
+    result.unchanged = unchanged_job_ids
+    result.updated = updated_job_ids
+
+    duration = datetime.now(tz=timezone.utc) - start_time
+    print_function_callback(f"...categorization completed in {duration}")
+
+    return result
+
+
+def _get_job_sessions(
+    boto3_session: boto3.Session,
+    farm_id: str,
+    queue_id: str,
+    checkpoint_job_session_completed_indexes: dict[str, dict[str, int]],
+    categorized_job_ids: CategorizedJobIds,
+    checkpoint: IncrementalDownloadState,
+    print_function_callback: Callable[[str], None] = lambda msg: None,
+) -> dict[str, list]:
+    """
+    This function gets all the job sessions and session actions from the completed, added, and updated jobs.
+    It uses the checkpoint's session_completed_indexes to filter out older session actions that are already downloaded.
+    """
+    job_ids = categorized_job_ids.completed.union(categorized_job_ids.added).union(
+        categorized_job_ids.updated
+    )
+    print_function_callback(f"Retrieving session actions for {len(job_ids)} jobs...")
+    start_time = datetime.now(tz=timezone.utc)
+
+    # The max timestamp of a downloaded session's endedAt provides a lower bound to filter sessions by.
+    # This is tracked in the checkpoint.
+    job_session_ended_timestamp: dict[str, datetime] = {
+        job.job_id: job.session_ended_timestamp
+        for job in checkpoint.jobs
+        if job.session_ended_timestamp is not None
+    }
+
+    deadline = boto3_session.client("deadline")
+    job_sessions: dict[str, list] = {}
+    sessions_paginator = deadline.get_paginator("list_sessions")
+    for job_id in job_ids:
+        # Use the greater of the bootstrap command timestamp and the session ended timestamps
+        # recorded in the checkpoint.
+        session_ended_timestamp = job_session_ended_timestamp.get(job_id)
+        if session_ended_timestamp is None:
+            session_ended_timestamp = checkpoint.downloads_started_timestamp
+
+        session_list: list[dict[str, Any]] = []
+        for sessions_page in sessions_paginator.paginate(
+            farmId=farm_id, queueId=queue_id, jobId=job_id
+        ):
+            # Filter out older sessions by endedAt timestamp, using an eventual consistency window to accept a little extra
+            session_ended_timestamp = session_ended_timestamp - timedelta(
+                seconds=checkpoint.eventual_consistency_max_seconds
+            )
+            session_list.extend(
+                session
+                for session in sessions_page.get("sessions", [])
+                if "endedAt" not in session or session["endedAt"] >= session_ended_timestamp
+            )
+        if session_list:
+            job_sessions[job_id] = session_list
+
+    # Retrieve the session actions for all the sessions that we found
+    session_actions_paginator = deadline.get_paginator("list_session_actions")
+    for job_id, session_list in job_sessions.items():
+        for session in session_list:
+            session_action_list: list[dict[str, Any]] = []
+            for session_actions_page in session_actions_paginator.paginate(
+                farmId=farm_id, queueId=queue_id, jobId=job_id, sessionId=session["sessionId"]
+            ):
+                # Include only succeeded taskRun actions, and filter out any actions that ended before the
+                # start of the update time interval
+                session_action_list.extend(
+                    session_action
+                    for session_action in session_actions_page.get("sessionActions", [])
+                    if session_action.get("status") == "SUCCEEDED"
+                    and "taskRun" in session_action.get("definition", {})
+                    and not (
+                        "endedAt" in session_action
+                        and session_action["endedAt"] < checkpoint.downloads_completed_timestamp
+                    )
+                )
+            if session_action_list:
+                # Extract the session action indexes from the ids
+                for session_action in session_action_list:
+                    # Session action IDs look like "sessionaction-abc123-12" for index 12
+                    session_action_index = int(session_action["sessionActionId"].rsplit("-", 1)[-1])
+                    session_action["sessionActionIndex"] = session_action_index
+                # Include only session action indexes newer than latest downloaded ones from the checkpoint
+                session_completed_index: Optional[int] = (
+                    checkpoint_job_session_completed_indexes.get(job_id, {}).get(
+                        session["sessionId"]
+                    )
+                )
+                if session_completed_index is not None:
+                    # Filter out older session actions that were already downloaded
+                    session_action_list = [
+                        session_action
+                        for session_action in session_action_list
+                        if session_action["sessionActionIndex"] > session_completed_index
+                    ]
+                if session_action_list:
+                    session["sessionActions"] = session_action_list
+
+    duration = datetime.now(tz=timezone.utc) - start_time
+    print_function_callback(f"...retrieval completed in {duration}")
+
+    return job_sessions
+
+
+def _update_checkpoint_jobs_list(
+    checkpoint: IncrementalDownloadState,
+    download_candidate_jobs: dict[str, dict[str, Any]],
+    categorized_job_ids: CategorizedJobIds,
+    job_sessions: dict[str, list],
+):
+    """
+    Update the jobs list in the checkpoint object.
+    """
+    updated_jobs: list[IncrementalDownloadJob] = []
+
+    # Produce the session_ended_timestamp for all the job ids. Start
+    # with the values from the previous checkpoint, and then overwrite
+    # them from job_sessions
+    job_session_ended_timestamps: dict[str, Optional[datetime]] = {
+        job.job_id: job.session_ended_timestamp
+        for job in checkpoint.jobs
+        if job.session_ended_timestamp is not None
+    }
+    for job_id, session_list in job_sessions.items():
+        max_session_ended_timestamp = None
+        for session in session_list:
+            if "endedAt" in session:
+                if max_session_ended_timestamp is None:
+                    max_session_ended_timestamp = session["endedAt"]
+                else:
+                    max_session_ended_timestamp = max(
+                        max_session_ended_timestamp, session["endedAt"]
+                    )
+        job_session_ended_timestamps[job_id] = max_session_ended_timestamp
+
+    # Produce the session_completed_indexes for all the job ids. Start
+    # with the values from the previous checkpoint, then overwrite
+    # them from job_sessions.
+    job_session_completed_indexes: dict[str, dict[str, int]] = {
+        job.job_id: job.session_completed_indexes for job in checkpoint.jobs
+    }
+    for job_id, session_list in job_sessions.items():
+        for session in session_list:
+            session_actions = session.get("sessionActions", [])
+            if session_actions:
+                job_session_completed_indexes.setdefault(job_id, {})[session["sessionId"]] = max(
+                    session_action["sessionActionIndex"] for session_action in session_actions
+                )
+        job_session_ended_timestamps[job_id] = max_session_ended_timestamp
+
+    # These categories keep the download_candidate_jobs job as is.
+    for job_id in (
+        categorized_job_ids.added | categorized_job_ids.updated | categorized_job_ids.unchanged
+    ):
+        updated_jobs.append(
+            IncrementalDownloadJob(
+                download_candidate_jobs[job_id],
+                job_session_ended_timestamps.get(job_id),
+                job_session_completed_indexes.get(job_id, {}),
+            )
+        )
+    # This category keeps a signal that it has no job attachments to process by having an attachments field with None in it
+    for job_id in categorized_job_ids.attachments_free:
+        updated_jobs.append(
+            IncrementalDownloadJob(
+                {
+                    "jobId": job_id,
+                    "name": download_candidate_jobs[job_id]["name"],
+                    "attachments": None,
+                },
+                None,
+                {},
+            )
+        )
+    # Keep completed jobs around until they become inactive
+    for job_id in categorized_job_ids.completed:
+        updated_jobs.append(
+            IncrementalDownloadJob(
+                download_candidate_jobs[job_id],
+                job_session_ended_timestamps.get(job_id),
+                job_session_completed_indexes.get(job_id, {}),
+            )
+        )
+    # When a job becomes inactive, keep it around in minimal form when it has a session_ended_timestamp
+    for job_id in categorized_job_ids.inactive:
+        session_ended_timestamp = job_session_ended_timestamps.get(job_id)
+        if session_ended_timestamp is not None:
+            updated_jobs.append(
+                IncrementalDownloadJob({"jobId": job_id}, session_ended_timestamp, {})
+            )
+
+    checkpoint.jobs = updated_jobs
 
 
 @api.record_function_latency_telemetry_event()
@@ -186,161 +589,97 @@ def _incremental_output_download(
     :return: updated downloaded state
     """
     # When this function is done, we will be confident that downloads are complete up to
-    # this timestamp. We subtract a duration from now() that gives a generous amount of
+    # new_completed_timestamp. We subtract a duration from now() that gives a generous amount of
     # time for the deadline:SearchJobs API's eventual consistency to converge.
-    new_completed_timestamp = datetime.now(timezone.utc) - timedelta(
-        seconds=download_state.eventual_consistency_max_seconds
+    current_timestamp = datetime.now(timezone.utc)
+    new_completed_timestamp = max(
+        download_state.downloads_started_timestamp,
+        current_timestamp - timedelta(seconds=download_state.eventual_consistency_max_seconds),
     )
 
+    print_function_callback("Updating download state across time interval:")
     print_function_callback(
-        f"Checkpoint state tracks {len(download_state.jobs)} jobs. Retrieving updated data from Deadline Cloud..."
+        f"    From: {download_state.downloads_completed_timestamp.astimezone().isoformat()}"
     )
+    print_function_callback(f"      To: {current_timestamp.astimezone().isoformat()}")
+    update_length = current_timestamp - download_state.downloads_completed_timestamp
+    eventual_consistency_delta = timedelta(seconds=download_state.eventual_consistency_max_seconds)
+    if update_length > eventual_consistency_delta:
+        print_function_callback(
+            f"  Length: {update_length - eventual_consistency_delta} + {eventual_consistency_delta} (eventual consistency allowance)"
+        )
+    else:
+        # Immediately after bootstrapping, this length will be shorter than the eventual consistency window
+        print_function_callback(f"  Length: {update_length}")
+    print_function_callback("")
 
-    deadline = boto3_session.client("deadline")
+    # Save all the jobs' session action indexes from the checkpoint, before we update the checkpoint's jobs list
+    checkpoint_job_session_completed_indexes: dict[str, dict[str, int]] = {
+        job.job_id: job.session_completed_indexes for job in download_state.jobs
+    }
 
-    download_candidate_jobs = _get_download_candidate_jobs(
-        boto3_session, farm_id, queue_id, download_state.downloads_completed_timestamp
+    # Call deadline:SearchJobs to get a set of jobs that includes every job with downloads available.
+    download_candidate_jobs: dict[str, dict[str, Any]] = _get_download_candidate_jobs(
+        boto3_session,
+        farm_id,
+        queue_id,
+        download_state.downloads_completed_timestamp,
+        print_function_callback,
     )
-    download_candidate_job_ids = set(download_candidate_jobs.keys())
-
-    in_progress_jobs = {job.job_id: job.job for job in download_state.jobs}
-    in_progress_job_ids = set(in_progress_jobs.keys())
-
-    print_function_callback(
-        f"Comparing with {len(download_candidate_jobs)} download candidate jobs..."
-    )
-
-    updated_in_progress_jobs = []
-
-    dropped_job_ids = in_progress_job_ids.difference(download_candidate_job_ids)
-    updated_job_ids = in_progress_job_ids.intersection(download_candidate_job_ids)
-    new_job_ids = download_candidate_job_ids.difference(in_progress_job_ids)
-    # The following sets get populated while analyzing the jobs
-    unchanged_job_ids = set()
-    attachments_free_job_ids = set()
-
-    # Copy the job attachments manifest data from the checkpoint to the new job objects. This data is not returned
-    # by deadline:SearchJobs, so we need to call deadline:GetJob on every job to retrieve it. The manifests on a job
-    # don't change, so after the call to deadline:GetJob we can cache it indefinitely.
-    for job_id in updated_job_ids:
-        ip_job = in_progress_jobs[job_id]
-        dc_job = download_candidate_jobs[job_id]
-
-        if ip_job["attachments"] is None:
-            # Carry over the minimal placeholder identifying the job as not using job attachments
-            download_candidate_jobs[job_id] = ip_job
-            attachments_free_job_ids.add(job_id)
-            updated_in_progress_jobs.append(ip_job)
-        else:
-            # Carry over the attachments manifest metadata
-            dc_job["attachments"] = ip_job["attachments"]
-    updated_job_ids.difference_update(attachments_free_job_ids)
-
-    # Prune jobs that we are certain have no changes by looking at its task status counts. A job is unchanged if both of these are true:
-    # 1. job["taskRunStatusCounts"]["SUCCEEDED"] stayed the same. Except for when a task is requeued, this count will always increase
-    #    when new output is available to download. If a task is requeued, this value could drop and then return to the same value
-    #    when new output is generated.
-    # 2. job["updatedAt"] stayed the same. If a task is requeued, this timestamp will be updated, so this catches anything missed
-    #    by the first check. This timestamp can also change for other reasons, and the later checks that look at session actions
-    #    directly will find those cases.
-    for job_id in updated_job_ids:
-        ip_job = in_progress_jobs[job_id]
-        dc_job = download_candidate_jobs[job_id]
-
-        if ip_job["taskRunStatusCounts"]["SUCCEEDED"] == dc_job["taskRunStatusCounts"][
-            "SUCCEEDED"
-        ] and ip_job.get("updatedAt") == dc_job.get("updatedAt"):
-            print_function_callback(f"UNCHANGED Job: {dc_job['name']} ({job_id})")
-            unchanged_job_ids.add(job_id)
-            updated_in_progress_jobs.append(dc_job)
-    updated_job_ids.difference_update(unchanged_job_ids)
-
-    # First make note of any jobs that were dropped, for example if they were canceled or they failed
-    for job_id in dropped_job_ids:
-        ip_job = in_progress_jobs[job_id]
-
-        print_function_callback(f"DROPPED Job: {ip_job['name']} ({job_id})")
-        if ip_job["attachments"] is None:
-            print_function_callback("  Job without job attachments no longer needs tracking")
-        else:
-            print_function_callback(
-                "   Job is not a download candidate anymore (likely canceled or failed)"
-            )
-
-    # Process all the jobs that have updates
-    for job_id in updated_job_ids:
-        ip_job = in_progress_jobs[job_id]
-        dc_job = download_candidate_jobs[job_id]
-
-        print_function_callback(f"EXISTING Job: {ip_job['name']} ({job_id})")
-        print_function_callback(
-            f"  Succeeded tasks (before): {ip_job['taskRunStatusCounts']['SUCCEEDED']} / {sum(value for _, value in ip_job['taskRunStatusCounts'].items())}"
-        )
-        print_function_callback(
-            f"  Succeeded tasks (now)   : {dc_job['taskRunStatusCounts']['SUCCEEDED']} / {sum(value for _, value in dc_job['taskRunStatusCounts'].items())}"
-        )
-
-        # Use the CLI output format to produce a diff of the changes
-        ip_job_repr: list[str] = _cli_object_repr(ip_job).splitlines()
-        dc_job_repr: list[str] = _cli_object_repr(dc_job).splitlines()
-
-        for line in difflib.unified_diff(
-            ip_job_repr,
-            dc_job_repr,
-            fromfile="Previous update",
-            tofile="Current update",
-            lineterm="",
-        ):
-            print_function_callback(f"  {line}")
-
-        updated_in_progress_jobs.append(dc_job)
-
-    # Process all the jobs that are new
-    for job_id in new_job_ids:
-        dc_job = download_candidate_jobs[job_id]
-
-        # Call deadline:GetJob to retrieve attachments manifest information
-        job = deadline.get_job(jobId=job_id, queueId=queue_id, farmId=farm_id)
-        dc_job["attachments"] = job.get("attachments")
-
-        print_function_callback(f"NEW Job: {dc_job['name']} ({job_id})")
-        print_function_callback(
-            f"  Succeeded tasks: {dc_job['taskRunStatusCounts']['SUCCEEDED']} / {sum(value for _, value in dc_job['taskRunStatusCounts'].items())}"
-        )
-        if dc_job["attachments"] is None:
-            # If the job does not use job attachments, save a minimal placeholder to avoid
-            # repeatedly calling deadline:GetJob.
-            download_candidate_jobs[job_id] = dc_job = {
-                "jobId": job_id,
-                "name": dc_job["name"],
-                "attachments": None,
-            }
-            attachments_free_job_ids.add(job_id)
-            print_function_callback("  Job does not use job attachments.")
-        else:
-            print_function_callback(textwrap.indent(_cli_object_repr(dc_job["attachments"]), "  "))
-
-        updated_in_progress_jobs.append(dc_job)
-    new_job_ids.difference_update(attachments_free_job_ids)
-
-    download_state.jobs = [IncrementalDownloadJob(job) for job in updated_in_progress_jobs]
 
     print_function_callback("")
-    print_function_callback(f"Identified {len(download_state.jobs)}")
+
+    # Compare the download candidates with the previously saved checkpoint state to categorize the jobs
+    categorized_job_ids: CategorizedJobIds = _categorize_jobs_in_checkpoint(
+        boto3_session,
+        farm_id,
+        queue_id,
+        download_state,
+        download_candidate_jobs,
+        new_completed_timestamp,
+        print_function_callback,
+    )
+
+    print_function_callback("")
+
+    # All the completed, added, and updated jobs might have downloads available. Retrieve the sessions for these jobs.
+    job_sessions: dict[str, list] = _get_job_sessions(
+        boto3_session,
+        farm_id,
+        queue_id,
+        checkpoint_job_session_completed_indexes,
+        categorized_job_ids,
+        download_state,
+        print_function_callback,
+    )
+
+    # Use the information collected so far to update the jobs list in download_state
+    _update_checkpoint_jobs_list(
+        download_state, download_candidate_jobs, categorized_job_ids, job_sessions
+    )
+
+    print("Job session + session actions:")
+    print_function_callback(_cli_object_repr(job_sessions))
 
     # TODO the rest of the incremental output download
 
     # Update the timestamp in the state object to reflect the downloads that were completed
-    download_state.downloads_completed_timestamp = max(
-        download_state.downloads_started_timestamp, new_completed_timestamp
-    )
+    download_state.downloads_completed_timestamp = new_completed_timestamp
 
     print_function_callback("")
     print_function_callback("Summary of incremental output download:")
-    print_function_callback(f"  Jobs without job attachments: {len(attachments_free_job_ids)}")
-    print_function_callback(f"  Jobs unchanged: {len(unchanged_job_ids)}")
-    print_function_callback(f"  Jobs added: {len(new_job_ids)}")
-    print_function_callback(f"  Jobs updated: {len(updated_job_ids)}")
-    print_function_callback(f"  Jobs dropped: {len(dropped_job_ids)}")
+    print_function_callback(
+        f"  Downloaded session actions: {sum(len(session.get('sessionActions', [])) for session_list in job_sessions.values() for session in session_list)}"
+    )
+    print_function_callback("  Jobs with downloads:")
+    print_function_callback(f"    completed: {len(categorized_job_ids.completed)}")
+    print_function_callback(f"    added: {len(categorized_job_ids.added)}")
+    print_function_callback(f"    updated: {len(categorized_job_ids.updated)}")
+    print_function_callback("  Jobs without downloads:")
+    print_function_callback(
+        f"    not using job attachments: {len(categorized_job_ids.attachments_free)}"
+    )
+    print_function_callback(f"    unchanged: {len(categorized_job_ids.unchanged)}")
+    print_function_callback(f"    inactive: {len(categorized_job_ids.inactive)}")
 
     return download_state

--- a/src/deadline/job_attachments/incremental_downloads/incremental_download_state.py
+++ b/src/deadline/job_attachments/incremental_downloads/incremental_download_state.py
@@ -31,25 +31,37 @@ class IncrementalDownloadJob:
     Model representing a job in the download progress state.
     """
 
-    _required_dict_fields = ["jobId", "job", "sessions"]
+    _required_dict_fields = ["job", "sessionEndedTimestamp", "sessionCompletedIndexes"]
 
-    job_id: str
     job: dict[str, Any]
-    sessions: list
+    session_ended_timestamp: Optional[datetime]
+    session_completed_indexes: dict[str, int]
 
-    def __init__(self, job: dict[str, Any], sessions: Optional[list] = None):
+    def __init__(
+        self,
+        job: dict[str, Any],
+        session_ended_timestamp: Optional[datetime],
+        session_completed_indexes: Optional[dict[str, int]],
+    ):
         """
         Initialize a Job instance.
         Args:
             job (dict[str, Any]): The job as returned by boto3 from deadline:SearchJobs.
-            sessions (list): List of JobSession objects
+            session_ended_timestamp (Optional[datetime]): The largest endedAt timestamp for a session
+                whose output has been downloaded. This can be None only when the job lacks job attachments.
+            session_completed_index (dict[str, int]): A mapping from session id to the index
+                of the latest completed session action download.
         """
-        self.job_id = job["jobId"]
         self.job = _datetimes_to_str(job)
-        self.sessions = sessions or []
+        self.session_ended_timestamp = session_ended_timestamp
+        self.session_completed_indexes = session_completed_indexes or {}
+
+    @property
+    def job_id(self) -> str:
+        return self.job["jobId"]
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]):
+    def from_dict(cls, data: dict[str, Any]) -> "IncrementalDownloadJob":
         """
         Create a Job instance from a dictionary.
         Args:
@@ -63,8 +75,18 @@ class IncrementalDownloadJob:
         if missing_fields:
             raise ValueError(f"Input is missing required fields: {missing_fields}")
 
-        sessions = data["sessions"]
-        return cls(job=data["job"], sessions=sessions)
+        job = data["job"]
+        session_completed_indexes = data["sessionCompletedIndexes"]
+        session_ended_timestamp = (
+            datetime.fromisoformat(data["sessionEndedTimestamp"])
+            if data["sessionEndedTimestamp"] is not None
+            else None
+        )
+        return cls(
+            job=job,
+            session_ended_timestamp=session_ended_timestamp,
+            session_completed_indexes=session_completed_indexes,
+        )
 
     def to_dict(self) -> dict[str, Any]:
         """
@@ -72,7 +94,13 @@ class IncrementalDownloadJob:
         Returns:
             dict: Dictionary representation of the job
         """
-        return {"jobId": self.job_id, "job": self.job, "sessions": self.sessions}
+        return {
+            "job": self.job,
+            "sessionEndedTimestamp": self.session_ended_timestamp
+            if self.session_ended_timestamp is None
+            else self.session_ended_timestamp.isoformat(),
+            "sessionCompletedIndexes": self.session_completed_indexes,
+        }
 
 
 class IncrementalDownloadState:
@@ -90,46 +118,12 @@ class IncrementalDownloadState:
     a stream by tracking state at three levels. Where possible, we use the resource state at one level to prune queries at lower levels:
 
     1. Job - The jobs list contains every job that is active and that we have downloaded output from in a previous incremental download command.
-    2. Session - Each session of a job represents a single worker running a sequence of tasks from the job. The sessions list in
-            a job contains all the sessions that are active and from which we have downloaded some output.
-    3. SessionAction - Session actions have sequential IDs, so for each session we track the highest index of session action
-            for which we have performed the download.
-
-
-
-    Model representing the download progress state file structure.
-    Incremental download state file structure:
-    {
-        "lastLookbackTime": "2025-04-04T05:30:00",
-        "jobs":
-        [
-            {
-                "jobId": "job-1234353453443",
-                "sessions": [
-                {
-                    "sessionId": "session-1324324354354",
-                    "sessionLifecycleStatus": "SUCCESSFUL",
-                    "lastDownloadedSessActionId": 3
-                },
-                {
-                    "sessionId": "session-3423435435454",
-                    "sessionLifecycleStatus": "RUNNING",
-                    "lastDownloadedSessActionId": 6
-                }
-                ]
-            },
-            {
-                "jobId": "job-3234324354345",
-                "sessions": [
-                {
-                    "sessionId": "session-4235435434345",
-                    "sessionLifecycleStatus": "FAILED",
-                    "lastDownloadedSessActionId": 3
-                }
-                ]
-            }
-        ]
-    }
+    2. Session - Each session of a job represents a single worker running a sequence of tasks from the job. The sessionCompletedIndexes
+            member of the IncrementalDownloadJob contains an entry for every session that is either still running, or whose
+            endedAt field is >= the downloadsCompletedTimestamp.
+    3. SessionAction - Session actions have sequential IDs, so for each session we store the highest index of session action
+            for which we have completed the download. A session action ID looks like "sessionaction-abc123-12" for session action
+            index 12.
     """
 
     _required_dict_fields = [

--- a/test/unit/deadline_client/cli/test_cli_queue_incremental_download.py
+++ b/test/unit/deadline_client/cli/test_cli_queue_incremental_download.py
@@ -7,7 +7,7 @@ Tests for the CLI queue incremental output download command.
 import os
 import pytest
 from unittest.mock import patch, MagicMock
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import boto3
 from freezegun import freeze_time
@@ -22,12 +22,21 @@ from ..mock_deadline_job_apis import (
     create_fake_job_list,
     mock_get_job_for_set,
 )
+from deadline.job_attachments.incremental_downloads.incremental_download_state import (
+    EVENTUAL_CONSISTENCY_MAX_SECONDS,
+)
 
+ISO_FREEZE_TIME_MINUS_5MIN = "2025-05-26 11:55:00+00:00"
+ISO_FREEZE_TIME_MINUS_1MIN = "2025-05-26 11:59:00+00:00"
 ISO_FREEZE_TIME = "2025-05-26 12:00:00+00:00"
+ISO_FREEZE_TIME_PLUS_1MIN = "2025-05-26 12:01:00+00:00"
+ISO_FREEZE_TIME_PLUS_3MIN = "2025-05-26 12:03:00+00:00"
+ISO_FREEZE_TIME_PLUS_5MIN = "2025-05-26 12:05:00+00:00"
+ISO_FREEZE_TIME_PLUS_7MIN = "2025-05-26 12:07:00+00:00"
 
 
 # Fixtures for shared resources
-@pytest.fixture(scope="module")
+@pytest.fixture()
 def checkpoint_dir(tmp_path_factory):
     """Create a checkpoint directory for all tests to use."""
     checkpoint_dir = tmp_path_factory.mktemp("checkpoint")
@@ -64,7 +73,13 @@ def with_incremental_download_enabled():
     del os.environ["ENABLE_INCREMENTAL_OUTPUT_DOWNLOAD"]
 
 
-def test_incremental_output_download_requires_beta_acknowledgement(boto3_session, checkpoint_dir):
+def test_incremental_output_download_requires_beta_acknowledgement(
+    fresh_deadline_config, boto3_session, checkpoint_dir
+):
+    # Make sure the acknowledgement env var is not defined
+    if "ENABLE_INCREMENTAL_OUTPUT_DOWNLOAD" in os.environ:
+        del os.environ["ENABLE_INCREMENTAL_OUTPUT_DOWNLOAD"]
+
     # Run the CLI command once to bootstrap the operation
     runner = CliRunner()
     with freeze_time(ISO_FREEZE_TIME):
@@ -91,113 +106,12 @@ def test_incremental_output_download_requires_beta_acknowledgement(boto3_session
     ), result.output
 
 
-def test_incremental_output_download_simple_success(
-    with_incremental_download_enabled, boto3_session, checkpoint_dir
-):
-    """Test successful execution of incremental_output_download"""
-    mock_jobs = create_fake_job_list(1)
-    mock_jobs[0]["name"] = "Mock Job"
-    mock_jobs[0]["jobId"] = MOCK_JOB_ID
-    mock_jobs[0]["taskRunStatus"] = "READY"
-    mock_jobs[0]["taskRunStatusCounts"] = {
-        "SUCCEEDED": 1,
-        "READY": 1,
-    }
-    mock_jobs[0]["attachments"] = {
-        "manifests": [
-            {"rootPath": "/", "rootPathFormat": "posix", "outputRelativeDirectories": ["."]}
-        ],
-        "fileSystem": "VIRTUAL",
-    }
-    del mock_jobs[0]["endedAt"]
-    boto3_session.client().search_jobs = mock_search_jobs_for_set(
-        MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs
-    )
-    boto3_session.client().get_job = mock_get_job_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
-
-    # Run the CLI command once to bootstrap the operation
-    runner = CliRunner()
-    with freeze_time(ISO_FREEZE_TIME):
-        result = runner.invoke(
-            main,
-            [
-                "queue",
-                "incremental-output-download",
-                "--farm-id",
-                MOCK_FARM_ID,
-                "--queue-id",
-                MOCK_QUEUE_ID,
-                "--checkpoint-dir",
-                checkpoint_dir,
-            ],
-        )
-
-    # Assert the command executed successfully
-    assert result.exit_code == 0, result.output
-
-    # Assert that the output contained information about the bootstrapping and the mocked resources
-    assert "Started incremental download for queue: Mock Queue" in result.output, result.output
-    assert (
-        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_download_checkpoint.json')}"
-        in result.output
-    ), result.output
-    assert "Checkpoint not found, lookback is 0.0 minutes" in result.output, result.output
-    # Need to convert the freeze time to the local time zone for this print assertion
-    assert (
-        f"Initializing from: {datetime.fromisoformat(ISO_FREEZE_TIME).astimezone().isoformat()}"
-        in result.output
-    ), result.output
-    assert f"NEW Job: Mock Job ({MOCK_JOB_ID})" in result.output, result.output
-    assert "Succeeded tasks: 1 / 2" in result.output, result.output
-    assert "Jobs added: 1" in result.output, result.output
-
-    # Edit the mock job to complete the task
-    mock_jobs[0]["taskRunStatus"] = "SUCCEEDED"
-    mock_jobs[0]["taskRunStatusCounts"] = {
-        "SUCCEEDED": 2,
-        "READY": 0,
-    }
-    mock_jobs[0]["endedAt"] = datetime.fromisoformat(ISO_FREEZE_TIME)
-
-    # Run the CLI command again to "complete" the download that was started
-    with freeze_time(ISO_FREEZE_TIME):
-        result = runner.invoke(
-            main,
-            [
-                "queue",
-                "incremental-output-download",
-                "--farm-id",
-                MOCK_FARM_ID,
-                "--queue-id",
-                MOCK_QUEUE_ID,
-                "--checkpoint-dir",
-                checkpoint_dir,
-            ],
-        )
-
-    # Assert the command executed successfully
-    assert result.exit_code == 0, result.output
-
-    # Assert that the output contained information about loading the checkpoint and the mocked resources
-    assert "Started incremental download for queue: Mock Queue" in result.output, result.output
-    assert (
-        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_download_checkpoint.json')}"
-        in result.output
-    ), result.output
-    assert "Checkpoint found" in result.output, result.output
-    # Need to convert the freeze time to the local time zone for this print assertion
-    assert (
-        f"Continuing from: {datetime.fromisoformat(ISO_FREEZE_TIME).astimezone().isoformat()}"
-        in result.output
-    ), result.output
-    assert f"EXISTING Job: Mock Job ({MOCK_JOB_ID})" in result.output, result.output
-    assert "Succeeded tasks (before): 1 / 2" in result.output, result.output
-    assert "Succeeded tasks (now)   : 2 / 2" in result.output, result.output
-    assert "Jobs updated: 1" in result.output, result.output
-
-
 def test_incremental_output_download_pid_lock_already_held_error(
-    with_incremental_download_enabled, boto3_session, checkpoint_dir, pid_lock_file
+    fresh_deadline_config,
+    with_incremental_download_enabled,
+    boto3_session,
+    checkpoint_dir,
+    pid_lock_file,
 ):
     """Test incremental_output_download when PidLockAlreadyHeld is raised"""
     # Write a fake PID to the file
@@ -232,3 +146,651 @@ def test_incremental_output_download_pid_lock_already_held_error(
 
     # Verify the PID file still exists since we're simulating another process holding the lock
     assert os.path.exists(pid_lock_file)
+
+
+def test_incremental_output_download_bootstrap_and_completion(
+    fresh_deadline_config, with_incremental_download_enabled, boto3_session, checkpoint_dir
+):
+    """Test a new job through bootstrap, completion, and retirement."""
+    mock_jobs = create_fake_job_list(1)
+    mock_jobs[0]["name"] = "Mock Job"
+    mock_jobs[0]["jobId"] = MOCK_JOB_ID
+    mock_jobs[0]["taskRunStatus"] = "READY"
+    mock_jobs[0]["taskRunStatusCounts"] = {
+        "SUCCEEDED": 1,
+        "READY": 1,
+    }
+    mock_jobs[0]["attachments"] = {
+        "manifests": [
+            {"rootPath": "/", "rootPathFormat": "posix", "outputRelativeDirectories": ["."]}
+        ],
+        "fileSystem": "VIRTUAL",
+    }
+    del mock_jobs[0]["endedAt"]
+    boto3_session.client().search_jobs = mock_search_jobs_for_set(
+        MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs
+    )
+    boto3_session.client().get_job = mock_get_job_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+
+    # RUN 1: Run the CLI command once to bootstrap the operation
+    runner = CliRunner()
+    with freeze_time(ISO_FREEZE_TIME):
+        result = runner.invoke(
+            main,
+            [
+                "queue",
+                "incremental-output-download",
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--checkpoint-dir",
+                checkpoint_dir,
+            ],
+        )
+
+    # Assert the command executed successfully
+    assert result.exit_code == 0, result.output
+
+    # Assert that the output contained information about the bootstrapping and the mocked resources
+    assert "Started incremental download for queue: Mock Queue" in result.output, result.output
+    assert (
+        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_download_checkpoint.json')}"
+        in result.output
+    ), result.output
+    assert "Checkpoint not found, lookback is 0.0 minutes" in result.output, result.output
+    # Need to convert the freeze time to the local time zone for this print assertion
+    assert (
+        f"Initializing from: {datetime.fromisoformat(ISO_FREEZE_TIME).astimezone().isoformat()}"
+        in result.output
+    ), result.output
+    assert f"NEW Job: Mock Job ({MOCK_JOB_ID})" in result.output, result.output
+    assert "Succeeded tasks: 1 / 2" in result.output, result.output
+    assert "added: 1" in result.output, result.output
+
+    # Edit the mock job to complete the task
+    mock_jobs[0]["taskRunStatus"] = "SUCCEEDED"
+    mock_jobs[0]["taskRunStatusCounts"] = {
+        "SUCCEEDED": 2,
+        "READY": 0,
+    }
+    mock_jobs[0]["endedAt"] = datetime.fromisoformat(ISO_FREEZE_TIME)
+
+    # RUN 2: Run the CLI command again to "complete" the download that was started
+    # 3 minutes later is after the consistency window, so that the call after this
+    # sees the job being retired.
+    with freeze_time(ISO_FREEZE_TIME_PLUS_3MIN):
+        result = runner.invoke(
+            main,
+            [
+                "queue",
+                "incremental-output-download",
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--checkpoint-dir",
+                checkpoint_dir,
+            ],
+        )
+
+    # Assert the command executed successfully
+    assert result.exit_code == 0, result.output
+
+    # Assert that the output contained information about loading the checkpoint and the mocked resources
+    assert "Started incremental download for queue: Mock Queue" in result.output, result.output
+    assert (
+        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_download_checkpoint.json')}"
+        in result.output
+    ), result.output
+    assert "Checkpoint found" in result.output, result.output
+    # Need to convert the freeze time to the local time zone for this print assertion
+    assert (
+        f"Continuing from: {datetime.fromisoformat(ISO_FREEZE_TIME).astimezone().isoformat()}"
+        in result.output
+    ), result.output
+    assert f"EXISTING Job: Mock Job ({MOCK_JOB_ID})" in result.output, result.output
+    assert "Succeeded tasks (before): 1 / 2" in result.output, result.output
+    assert "Succeeded tasks (now)   : 2 / 2" in result.output, result.output
+    assert "completed: 1" in result.output, result.output
+
+    # RUN 3: Run the CLI command again with a later timestamp to retire the job from the checkpoint
+    # 5 minutes later is outside the eventual consistency window.
+    with freeze_time(ISO_FREEZE_TIME_PLUS_5MIN):
+        result = runner.invoke(
+            main,
+            [
+                "queue",
+                "incremental-output-download",
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--checkpoint-dir",
+                checkpoint_dir,
+            ],
+        )
+
+    # Assert the command executed successfully
+    assert result.exit_code == 0, result.output
+
+    # Assert that the output contained information about loading the checkpoint and the mocked resources
+    assert "Started incremental download for queue: Mock Queue" in result.output, result.output
+    assert (
+        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_download_checkpoint.json')}"
+        in result.output
+    ), result.output
+    assert "Checkpoint found" in result.output, result.output
+    # Need to convert the freeze time to the local time zone for this print assertion
+    assert (
+        f"Continuing from: {(datetime.fromisoformat(ISO_FREEZE_TIME_PLUS_3MIN) - timedelta(seconds=EVENTUAL_CONSISTENCY_MAX_SECONDS)).astimezone().isoformat()}"
+        in result.output
+    ), result.output
+    assert f"DROPPED Job: Mock Job ({MOCK_JOB_ID})" in result.output, result.output
+    assert "Job succeeded" in result.output, result.output
+    assert "inactive: 1" in result.output, result.output
+
+    # RUN 4: Run the CLI command again with a later timestamp to see the job stay inactive
+    with freeze_time(ISO_FREEZE_TIME_PLUS_7MIN):
+        result = runner.invoke(
+            main,
+            [
+                "queue",
+                "incremental-output-download",
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--checkpoint-dir",
+                checkpoint_dir,
+            ],
+        )
+
+    # Assert the command executed successfully
+    assert result.exit_code == 0, result.output
+
+    # Assert that the output contained information about loading the checkpoint and the mocked resources
+    assert "Started incremental download for queue: Mock Queue" in result.output, result.output
+    assert (
+        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_download_checkpoint.json')}"
+        in result.output
+    ), result.output
+    assert "Checkpoint found" in result.output, result.output
+    # Need to convert the freeze time to the local time zone for this print assertion
+    assert (
+        f"Continuing from: {(datetime.fromisoformat(ISO_FREEZE_TIME_PLUS_5MIN) - timedelta(seconds=EVENTUAL_CONSISTENCY_MAX_SECONDS)).astimezone().isoformat()}"
+        in result.output
+    ), result.output
+    # Because this test didn't model any sessions and session actions, there is no session endedAt
+    # timestamp, so no job needs to be further tracked as inactive in this case.
+    assert "inactive: 0" in result.output, result.output
+
+
+def test_incremental_output_download_bootstrap_retire_job_without_attachments(
+    fresh_deadline_config, with_incremental_download_enabled, boto3_session, checkpoint_dir
+):
+    """Test a new job through bootstrap and completion over two incremental download commands."""
+    mock_jobs = create_fake_job_list(1)
+    mock_jobs[0]["name"] = "Mock Job"
+    mock_jobs[0]["jobId"] = MOCK_JOB_ID
+    mock_jobs[0]["taskRunStatus"] = "READY"
+    mock_jobs[0]["taskRunStatusCounts"] = {
+        "SUCCEEDED": 1,
+        "READY": 1,
+    }
+    del mock_jobs[0]["endedAt"]
+    boto3_session.client().search_jobs = mock_search_jobs_for_set(
+        MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs
+    )
+    boto3_session.client().get_job = mock_get_job_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+
+    # RUN 1: Run the CLI command once to bootstrap the operation
+    runner = CliRunner()
+    with freeze_time(ISO_FREEZE_TIME):
+        result = runner.invoke(
+            main,
+            [
+                "queue",
+                "incremental-output-download",
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--checkpoint-dir",
+                checkpoint_dir,
+            ],
+        )
+
+    # Assert the command executed successfully
+    assert result.exit_code == 0, result.output
+
+    # Assert that the output contained information about the bootstrapping and the mocked resources
+    assert "Started incremental download for queue: Mock Queue" in result.output, result.output
+    assert (
+        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_download_checkpoint.json')}"
+        in result.output
+    ), result.output
+    assert "Checkpoint not found, lookback is 0.0 minutes" in result.output, result.output
+    # Need to convert the freeze time to the local time zone for this print assertion
+    assert (
+        f"Initializing from: {datetime.fromisoformat(ISO_FREEZE_TIME).astimezone().isoformat()}"
+        in result.output
+    ), result.output
+    assert f"NEW Job: Mock Job ({MOCK_JOB_ID})" in result.output, result.output
+    assert "Succeeded tasks: 1 / 2" in result.output, result.output
+    assert "not using job attachments: 1" in result.output, result.output
+
+    # Edit the mock job to complete the task
+    mock_jobs[0]["taskRunStatus"] = "SUCCEEDED"
+    mock_jobs[0]["taskRunStatusCounts"] = {
+        "SUCCEEDED": 2,
+        "READY": 0,
+    }
+    mock_jobs[0]["endedAt"] = datetime.fromisoformat(ISO_FREEZE_TIME)
+
+    # RUN 2: Run the CLI command again after the job has all tasks completed
+    # 3 minutes later is after the consistency window, so that the call after this
+    # sees the job being retired.
+    with freeze_time(ISO_FREEZE_TIME_PLUS_3MIN):
+        result = runner.invoke(
+            main,
+            [
+                "queue",
+                "incremental-output-download",
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--checkpoint-dir",
+                checkpoint_dir,
+            ],
+        )
+
+    # Assert the command executed successfully
+    assert result.exit_code == 0, result.output
+
+    # Assert that the output contained information about loading the checkpoint and the mocked resources
+    assert "Started incremental download for queue: Mock Queue" in result.output, result.output
+    assert (
+        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_download_checkpoint.json')}"
+        in result.output
+    ), result.output
+    assert "Checkpoint found" in result.output, result.output
+    # Need to convert the freeze time to the local time zone for this print assertion
+    assert (
+        f"Continuing from: {datetime.fromisoformat(ISO_FREEZE_TIME).astimezone().isoformat()}"
+        in result.output
+    ), result.output
+    assert "not using job attachments: 1" in result.output, result.output
+
+    # RUN 3: Run the CLI command again with a later timestamp to retire the job from the checkpoint
+    # 5 minutes later is outside the eventual consistency window.
+    with freeze_time(ISO_FREEZE_TIME_PLUS_5MIN):
+        result = runner.invoke(
+            main,
+            [
+                "queue",
+                "incremental-output-download",
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--checkpoint-dir",
+                checkpoint_dir,
+            ],
+        )
+
+    # Assert the command executed successfully
+    assert result.exit_code == 0, result.output
+
+    # Assert that the output contained information about loading the checkpoint and the mocked resources
+    assert "Started incremental download for queue: Mock Queue" in result.output, result.output
+    assert (
+        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_download_checkpoint.json')}"
+        in result.output
+    ), result.output
+    assert "Checkpoint found" in result.output, result.output
+    # Need to convert the freeze time to the local time zone for this print assertion
+    assert (
+        f"Continuing from: {(datetime.fromisoformat(ISO_FREEZE_TIME_PLUS_3MIN) - timedelta(seconds=EVENTUAL_CONSISTENCY_MAX_SECONDS)).astimezone().isoformat()}"
+        in result.output
+    ), result.output
+    assert "inactive: 1" in result.output, result.output
+
+
+def test_incremental_output_download_job_unchanged(
+    fresh_deadline_config, with_incremental_download_enabled, boto3_session, checkpoint_dir
+):
+    """Test a new job through bootstrap and an 'UNCHANGED' message."""
+    mock_jobs = create_fake_job_list(1)
+    mock_jobs[0]["name"] = "Mock Job"
+    mock_jobs[0]["jobId"] = MOCK_JOB_ID
+    mock_jobs[0]["taskRunStatus"] = "READY"
+    mock_jobs[0]["taskRunStatusCounts"] = {
+        "SUCCEEDED": 1,
+        "READY": 1,
+    }
+    mock_jobs[0]["attachments"] = {
+        "manifests": [
+            {"rootPath": "/", "rootPathFormat": "posix", "outputRelativeDirectories": ["."]}
+        ],
+        "fileSystem": "VIRTUAL",
+    }
+    del mock_jobs[0]["endedAt"]
+    boto3_session.client().search_jobs = mock_search_jobs_for_set(
+        MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs
+    )
+    boto3_session.client().get_job = mock_get_job_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+
+    # RUN 1: Run the CLI command once to bootstrap the operation
+    runner = CliRunner()
+    with freeze_time(ISO_FREEZE_TIME):
+        result = runner.invoke(
+            main,
+            [
+                "queue",
+                "incremental-output-download",
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--checkpoint-dir",
+                checkpoint_dir,
+            ],
+        )
+
+    # Assert the command executed successfully
+    assert result.exit_code == 0, result.output
+
+    # Assert that the output contained information about the bootstrapping and the mocked resources
+    assert "Started incremental download for queue: Mock Queue" in result.output, result.output
+    assert (
+        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_download_checkpoint.json')}"
+        in result.output
+    ), result.output
+    assert "Checkpoint not found, lookback is 0.0 minutes" in result.output, result.output
+    # Need to convert the freeze time to the local time zone for this print assertion
+    assert (
+        f"Initializing from: {datetime.fromisoformat(ISO_FREEZE_TIME).astimezone().isoformat()}"
+        in result.output
+    ), result.output
+    assert f"NEW Job: Mock Job ({MOCK_JOB_ID})" in result.output, result.output
+    assert "Succeeded tasks: 1 / 2" in result.output, result.output
+    assert "added: 1" in result.output, result.output
+
+    # RUN 2: Run the CLI command again to see that the job is unchanged
+    with freeze_time(ISO_FREEZE_TIME_PLUS_3MIN):
+        result = runner.invoke(
+            main,
+            [
+                "queue",
+                "incremental-output-download",
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--checkpoint-dir",
+                checkpoint_dir,
+            ],
+        )
+
+    # Assert the command executed successfully
+    assert result.exit_code == 0, result.output
+
+    # Assert that the output contained information about loading the checkpoint and the mocked resources
+    assert "Started incremental download for queue: Mock Queue" in result.output, result.output
+    assert (
+        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_download_checkpoint.json')}"
+        in result.output
+    ), result.output
+    assert "Checkpoint found" in result.output, result.output
+    # Need to convert the freeze time to the local time zone for this print assertion
+    assert (
+        f"Continuing from: {datetime.fromisoformat(ISO_FREEZE_TIME).astimezone().isoformat()}"
+        in result.output
+    ), result.output
+    assert f"UNCHANGED Job: Mock Job ({MOCK_JOB_ID})" in result.output, result.output
+    assert "unchanged: 1" in result.output, result.output
+
+
+def test_incremental_output_download_job_canceled(
+    fresh_deadline_config, with_incremental_download_enabled, boto3_session, checkpoint_dir
+):
+    """Test a new job through bootstrap and cancelation before it's complete"""
+    mock_jobs = create_fake_job_list(1)
+    mock_jobs[0]["name"] = "Mock Job"
+    mock_jobs[0]["jobId"] = MOCK_JOB_ID
+    mock_jobs[0]["taskRunStatus"] = "READY"
+    mock_jobs[0]["taskRunStatusCounts"] = {
+        "SUCCEEDED": 1,
+        "READY": 1,
+    }
+    mock_jobs[0]["attachments"] = {
+        "manifests": [
+            {"rootPath": "/", "rootPathFormat": "posix", "outputRelativeDirectories": ["."]}
+        ],
+        "fileSystem": "VIRTUAL",
+    }
+    del mock_jobs[0]["endedAt"]
+    boto3_session.client().search_jobs = mock_search_jobs_for_set(
+        MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs
+    )
+    boto3_session.client().get_job = mock_get_job_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+
+    # RUN 1: Run the CLI command once to bootstrap the operation
+    runner = CliRunner()
+    with freeze_time(ISO_FREEZE_TIME):
+        result = runner.invoke(
+            main,
+            [
+                "queue",
+                "incremental-output-download",
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--checkpoint-dir",
+                checkpoint_dir,
+            ],
+        )
+
+    # Assert the command executed successfully
+    assert result.exit_code == 0, result.output
+
+    # Assert that the output contained information about the bootstrapping and the mocked resources
+    assert "Started incremental download for queue: Mock Queue" in result.output, result.output
+    assert (
+        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_download_checkpoint.json')}"
+        in result.output
+    ), result.output
+    assert "Checkpoint not found, lookback is 0.0 minutes" in result.output, result.output
+    # Need to convert the freeze time to the local time zone for this print assertion
+    assert (
+        f"Initializing from: {datetime.fromisoformat(ISO_FREEZE_TIME).astimezone().isoformat()}"
+        in result.output
+    ), result.output
+    assert f"NEW Job: Mock Job ({MOCK_JOB_ID})" in result.output, result.output
+    assert "Succeeded tasks: 1 / 2" in result.output, result.output
+    assert "added: 1" in result.output, result.output
+
+    # RUN 2: Run the CLI command again to see that the job is canceled
+    mock_jobs[0]["taskRunStatus"] = "CANCELED"
+    mock_jobs[0]["taskRunStatusCounts"] = {
+        "SUCCEEDED": 1,
+        "CANCELED": 1,
+    }
+    with freeze_time(ISO_FREEZE_TIME_PLUS_3MIN):
+        result = runner.invoke(
+            main,
+            [
+                "queue",
+                "incremental-output-download",
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--checkpoint-dir",
+                checkpoint_dir,
+            ],
+        )
+
+    # Assert the command executed successfully
+    assert result.exit_code == 0, result.output
+
+    # Assert that the output contained information about loading the checkpoint and the mocked resources
+    assert "Started incremental download for queue: Mock Queue" in result.output, result.output
+    assert (
+        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_download_checkpoint.json')}"
+        in result.output
+    ), result.output
+    assert "Checkpoint found" in result.output, result.output
+    # Need to convert the freeze time to the local time zone for this print assertion
+    assert (
+        f"Continuing from: {datetime.fromisoformat(ISO_FREEZE_TIME).astimezone().isoformat()}"
+        in result.output
+    ), result.output
+    assert f"DROPPED Job: Mock Job ({MOCK_JOB_ID})" in result.output, result.output
+    assert (
+        "Job is not a download candidate anymore (likely suspended, canceled or failed)"
+        in result.output
+    ), result.output
+    assert "inactive: 1" in result.output, result.output
+
+
+def test_incremental_output_download_job_completed_then_requeued(
+    fresh_deadline_config, with_incremental_download_enabled, boto3_session, checkpoint_dir
+):
+    """Test a new job through bootstrap, retirement, then requeue."""
+    iso_freeze_time = datetime.fromisoformat(ISO_FREEZE_TIME)
+    mock_jobs = create_fake_job_list(1, iso_freeze_time - timedelta(minutes=5), iso_freeze_time)
+    mock_jobs[0]["name"] = "Mock Job"
+    mock_jobs[0]["jobId"] = MOCK_JOB_ID
+    mock_jobs[0]["taskRunStatus"] = "SUCCEEDED"
+    mock_jobs[0]["taskRunStatusCounts"] = {
+        "SUCCEEDED": 2,
+        "READY": 0,
+    }
+    mock_jobs[0]["attachments"] = {
+        "manifests": [
+            {"rootPath": "/", "rootPathFormat": "posix", "outputRelativeDirectories": ["."]}
+        ],
+        "fileSystem": "VIRTUAL",
+    }
+    mock_jobs[0]["endedAt"] = iso_freeze_time - timedelta(minutes=3)
+    boto3_session.client().search_jobs = mock_search_jobs_for_set(
+        MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs
+    )
+    boto3_session.client().get_job = mock_get_job_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+
+    # RUN 1: Run the CLI command once to bootstrap the operation
+    # We've set up the job and timestamps so it bootstraps as completed
+    runner = CliRunner()
+    with freeze_time(ISO_FREEZE_TIME):
+        result = runner.invoke(
+            main,
+            [
+                "queue",
+                "incremental-output-download",
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--checkpoint-dir",
+                checkpoint_dir,
+                "--bootstrap-lookback-minutes",
+                "4.5",
+            ],
+        )
+
+    # Assert the command executed successfully
+    assert result.exit_code == 0, result.output
+
+    # Assert that the output contained information about the bootstrapping and the mocked resources
+    assert "Started incremental download for queue: Mock Queue" in result.output, result.output
+    assert (
+        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_download_checkpoint.json')}"
+        in result.output
+    ), result.output
+    assert "Checkpoint not found, lookback is 4.5 minutes" in result.output, result.output
+    # Need to convert the freeze time to the local time zone for this print assertion
+    assert (
+        f"Initializing from: {(iso_freeze_time - timedelta(minutes=4.5)).astimezone().isoformat()}"
+        in result.output
+    ), result.output
+    assert f"NEW Job: Mock Job ({MOCK_JOB_ID})" in result.output, result.output
+    assert "Succeeded tasks: 2 / 2" in result.output, result.output
+    assert "completed: 1" in result.output, result.output
+
+    # RUN 2: Run the CLI command again to see that the job becomes inactive
+    with freeze_time(ISO_FREEZE_TIME_PLUS_5MIN):
+        result = runner.invoke(
+            main,
+            [
+                "queue",
+                "incremental-output-download",
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--checkpoint-dir",
+                checkpoint_dir,
+            ],
+        )
+
+    # Assert the command executed successfully
+    assert result.exit_code == 0, result.output
+
+    # Assert that the output contained information about loading the checkpoint and the mocked resources
+    assert "Started incremental download for queue: Mock Queue" in result.output, result.output
+    assert (
+        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_download_checkpoint.json')}"
+        in result.output
+    ), result.output
+    assert "Checkpoint found" in result.output, result.output
+    # Need to convert the freeze time to the local time zone for this print assertion
+    assert (
+        f"Continuing from: {(iso_freeze_time - timedelta(seconds=EVENTUAL_CONSISTENCY_MAX_SECONDS)).astimezone().isoformat()}"
+        in result.output
+    ), result.output
+    assert "inactive: 1" in result.output, result.output
+
+    # RUN 3: Run the CLI command again after requeuing tasks
+    mock_jobs[0]["taskRunStatus"] = "READY"
+    mock_jobs[0]["taskRunStatusCounts"] = {
+        "SUCCEEDED": 1,
+        "READY": 1,
+    }
+    del mock_jobs[0]["endedAt"]
+    with freeze_time(ISO_FREEZE_TIME_PLUS_5MIN):
+        result = runner.invoke(
+            main,
+            [
+                "queue",
+                "incremental-output-download",
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--checkpoint-dir",
+                checkpoint_dir,
+            ],
+        )
+
+    # Assert the command executed successfully
+    assert result.exit_code == 0, result.output
+
+    # Assert that the output contained information about loading the checkpoint and the mocked resources
+    assert "Started incremental download for queue: Mock Queue" in result.output, result.output
+    assert (
+        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_download_checkpoint.json')}"
+        in result.output
+    ), result.output
+    assert "Checkpoint found" in result.output, result.output
+    # Need to convert the freeze time to the local time zone for this print assertion
+    assert (
+        f"Continuing from: {(datetime.fromisoformat(ISO_FREEZE_TIME_PLUS_5MIN) - timedelta(seconds=EVENTUAL_CONSISTENCY_MAX_SECONDS)).astimezone().isoformat()}"
+        in result.output
+    ), result.output
+    assert f"NEW Job: Mock Job ({MOCK_JOB_ID})" in result.output, result.output
+    assert "Succeeded tasks: 1 / 2" in result.output, result.output
+    assert "added: 1" in result.output, result.output

--- a/test/unit/deadline_job_attachments/incremental_downloads/test_incremental_download_state.py
+++ b/test/unit/deadline_job_attachments/incremental_downloads/test_incremental_download_state.py
@@ -73,8 +73,12 @@ class TestIncrementalDownloadState:
             downloads_started_timestamp=datetime.fromisoformat("2023-01-01T00:00:00+00:00"),
             downloads_completed_timestamp=datetime.fromisoformat("2023-01-02T00:00:00+00:00"),
             jobs=[
-                IncrementalDownloadJob({"jobId": "job-123", "name": "Job 1"}),
-                IncrementalDownloadJob({"jobId": "job-124", "name": "Job 2"}),
+                IncrementalDownloadJob({"jobId": "job-123", "name": "Job 1"}, None, {}),
+                IncrementalDownloadJob(
+                    {"jobId": "job-124", "name": "Job 2"},
+                    datetime.fromisoformat("2023-01-02T00:00:00+00:00"),
+                    {},
+                ),
             ],
         )
 
@@ -93,7 +97,7 @@ class TestIncrementalDownloadState:
         assert state.jobs == []
 
         # Test with provided values
-        jobs = [IncrementalDownloadJob({"jobId": "job-123"}, [])]
+        jobs = [IncrementalDownloadJob({"jobId": "job-123"}, None, {})]
         state = IncrementalDownloadState(
             downloads_started_timestamp=bootstrap_time,
             downloads_completed_timestamp=completed_time,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The auto download feature needs to determine all the sessions and session actions that change across an incremental update. The session actions will later be used to determine which downloads to perform.

### What was the solution? (How)

* Move the code to categorize and update the jobs from the checkpoint into a _categorize_jobs_in_checkpoint function
* Update the storage about sessions in IncrementalDownloadJob to be a dict from session ID to the latest session action index that is finished downloading. When a session's endedAt is before the downloadsCompletedTimestamp, we no longer have to track the session, and remove it from the checkpoint file.
* Add a field to IncrementalDownloadJob that contains the maximum endedAt timestamp of a session for the job that has been downloaded.
* Implement a function _get_job_sessions that uses deadline:ListSessions and deadline:ListSessionActions to retrieve all the new session actions to download for the job. It uses the maximum endedAt timestamp stored in the IncrementalDownloadJob as a threshold to filter out old sessions, and populates the sessionActionIndex in the session action objects by extracting it from the sessionActionId.
* Implement a function _update_checkpoint_jobs_list to take the categorized job ids and other data collected, and produce an updated list of IncrementalDownloadJob objects to put in the checkpoint.

### What is the impact of this change?

Progress towards an auto downloads feature.

### How was this change tested?

Some unit tests, but will add more later. Mostly testing in a farm with random job submissions being done periodically.

### Was this change documented?

No

### Does this PR introduce new dependencies?

No

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
