### PR TITLE
feat(experimental): Download outputs for the auto download feature

### DIFF
--- a/src/deadline/client/cli/_groups/queue_group.py
+++ b/src/deadline/client/cli/_groups/queue_group.py
@@ -250,12 +250,19 @@ def queue_get(**args):
     "OVERWRITE (default): Download and replace the existing file.\n"
     "Default behaviour is to OVERWRITE.",
 )
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Perform a dry run of the operation, don't actually download the output files.",
+    default=False,
+)
 @_handle_error
 def incremental_output_download(
     json: bool,
     bootstrap_lookback_minutes: float,
     checkpoint_dir: str,
     force_bootstrap: bool,
+    dry_run: bool,
     **args,
 ):
     """
@@ -303,8 +310,13 @@ def incremental_output_download(
     checkpoint_file_path: str = os.path.join(checkpoint_dir, download_checkpoint_file_name)
 
     deadline = boto3_session.client("deadline")
-    response = deadline.get_queue(farmId=farm_id, queueId=queue_id)
-    logger.echo(f"Started incremental download for queue: {response['displayName']}")
+    queue = deadline.get_queue(farmId=farm_id, queueId=queue_id)
+    if "jobAttachmentSettings" not in queue:
+        raise DeadlineOperationError(
+            f"Queue '{queue['displayName']}' does not have job attachments configured."
+        )
+
+    logger.echo(f"Started incremental download for queue: {queue['displayName']}")
     logger.echo(f"Checkpoint: {checkpoint_file_path}")
     logger.echo()
 
@@ -350,10 +362,15 @@ def incremental_output_download(
         updated_download_state: IncrementalDownloadState = _incremental_output_download(
             boto3_session=boto3_session,
             farm_id=farm_id,
-            queue_id=queue_id,
-            download_state=current_download_state,
+            queue=queue,
+            checkpoint=current_download_state,
             print_function_callback=logger.echo,
+            dry_run=dry_run,
         )
 
-        # Save the checkpoint file
-        updated_download_state.save_file(checkpoint_file_path)
+        # Save the checkpoint file if it's not a dry run
+        if not dry_run:
+            updated_download_state.save_file(checkpoint_file_path)
+            logger.echo("Checkpoint saved")
+        else:
+            logger.echo("This is a DRY RUN so the checkpoint was not saved")

--- a/src/deadline/client/cli/_incremental_download.py
+++ b/src/deadline/client/cli/_incremental_download.py
@@ -5,19 +5,46 @@ __all__ = ["_incremental_output_download"]
 
 from datetime import datetime, timedelta, timezone
 import difflib
-import textwrap
 from typing import Optional
+from configparser import ConfigParser
+from typing import Any, Callable
+import time
+import concurrent.futures
 
 from .. import api
-from typing import Any, Callable
 import boto3
+from botocore.client import BaseClient  # type: ignore[import]
 from ..api._list_jobs_by_filter_expression import _list_jobs_by_filter_expression
+from ...job_attachments.api import summarize_path_list
 from ...job_attachments._incremental_downloads.incremental_download_state import (
     IncrementalDownloadState,
     IncrementalDownloadJob,
     _datetimes_to_str,
 )
-from ._common import _cli_object_repr
+from ...job_attachments._incremental_downloads._manifest_s3_downloads import (
+    _add_output_manifests_from_s3,
+    _download_all_manifests_with_absolute_paths,
+    _merge_absolute_path_manifest_list,
+    _download_manifest_paths,
+)
+from ...job_attachments.asset_manifests import (
+    BaseAssetManifest,
+    BaseManifestPath,
+)
+from ...job_attachments.asset_manifests import (
+    HashAlgorithm,
+)
+from ...job_attachments.models import (
+    FileConflictResolution,
+)
+from ...job_attachments.progress_tracker import (
+    ProgressReportMetadata,
+)
+from ._common import _cli_object_repr, sigint_handler
+from ...job_attachments._path_summarization import human_readable_file_size
+
+
+SESSIONS_API_MAX_CONCURRENCY = 3
 
 
 def _get_download_candidate_jobs(
@@ -33,10 +60,11 @@ def _get_download_candidate_jobs(
     the provided starting_timestamp.
 
     Args:
-        boto3_session: The boto3 session for calling AWS APIs.
-        farm_id: The farm ID.
-        queue_id: The queue ID in the farm.
+        boto3_session: The boto3.Session for accessing AWS.
+        farm_id: The farm id for the operation.
+        queue_id: The queue id for the operation.
         starting_timestamp: The point in time from which to look for new download outputs.
+        print_function_callback: Callback for printing output to the terminal or log.
 
     Returns:
         A dictionary mapping job id to the job as returned by the deadline.search_jobs API.
@@ -180,14 +208,24 @@ class CategorizedJobIds:
     """
     Takes jobs loaded from a loaded checkpoint and a query to get download candidate jobs,
     analyzes all the jobs by looking at fields like task run status counds to categorize them.
+
+    Job categories:
+        added: The job was created or requeued so it now can produce new downloads.
+        updated: The job changed since the previous incremental download operation.
+        unchanged: The job did not change since the previous incremental download operation.
+        completed: The job finished running so all output is available for download.
+        inactive: The job can no longer have any new downloads unless it is requeued. Minimal
+            metadata is tracked to detect if it is requeued.
+        attachments_free: The job has no job attachments associated that can produce
+            outputs for download.
     """
 
-    inactive: set[str] = set()
-    updated: set[str] = set()
     added: set[str] = set()
+    updated: set[str] = set()
     unchanged: set[str] = set()
-    attachments_free: set[str] = set()
     completed: set[str] = set()
+    inactive: set[str] = set()
+    attachments_free: set[str] = set()
 
 
 def _categorize_jobs_in_checkpoint(
@@ -203,7 +241,18 @@ def _categorize_jobs_in_checkpoint(
     Categorizes the provided download candidate jobs by id into a CategorizedJobIds object,
     updating the jobs within download_candidate_jobs where necessary.
 
-    * Calls deadline:GetJob to get job attachments manifest information if it is not stored yet.
+    * Calls boto3 deadline.get_job() to get job attachments manifest information if it is not stored yet.
+
+    Args:
+        boto3_session: The boto3.Session for accessing AWS.
+        farm_id: The farm id for the operation.
+        queue_id: The queue id for the operation.
+        checkpoint: The checkpoint for the incremental download.
+        download_candidate_jobs: The result of a _get_download_candidate_jobs call, {job_id: job} where
+            job is a result from a deadline.search_jobs() or deadline.get_job() call.
+        new_completed_timestamp: This is the timestamp value that will be placed in
+            checkpoint.downloads_completed_timestamp when saving the checkpoint.
+        print_function_callback: Callback for printing output to the terminal or log.
     """
     deadline = boto3_session.client("deadline")
     checkpoint_jobs = {job.job_id: job.job for job in checkpoint.jobs}
@@ -351,7 +400,11 @@ def _categorize_jobs_in_checkpoint(
             attachments_free_job_ids.add(job_id)
             print_function_callback("  Job does not use job attachments.")
         else:
-            print_function_callback(textwrap.indent(_cli_object_repr(dc_job["attachments"]), "  "))
+            print_function_callback("  Manifest file system paths:")
+            for manifest in dc_job["attachments"]["manifests"]:
+                print_function_callback(
+                    f"    - {manifest['rootPath']} ({manifest['rootPathFormat']})"
+                )
 
         if (
             dc_succeeded_task_count == dc_total_task_count
@@ -376,23 +429,158 @@ def _categorize_jobs_in_checkpoint(
     return result
 
 
-def _get_job_sessions(
-    boto3_session: boto3.Session,
+def _retrieve_sessions_for_job(
+    deadline_client: BaseClient,
+    checkpoint: IncrementalDownloadState,
     farm_id: str,
     queue_id: str,
+    job_id: str,
+    session_ended_threshold: datetime,
+    output_job_sessions: dict[str, list],
+):
+    """
+    Uses deadline.list_sessions to get all sessions of the specified job that are still running or
+    that ended after session_ended_threshold.
+
+    Places the output into output_job_sessions[job_id]
+
+    Args:
+        deadline_client: A boto3 client for accessing Deadline.
+        checkpoint: The checkpoint for the incremental download.
+        farm_id: The farm id for the operation.
+        queue_id: The queue id for the operation.
+        job_id: The job id to process.
+        session_ended_threshold: The timestamp threshold to filter out older sessions based on the endedAt field.
+        output_job_sessions: A dictionary {job_id: session_list} to populate for the provided job id.
+    """
+    sessions_paginator = deadline_client.get_paginator("list_sessions")
+    # Filter out older sessions by endedAt timestamp, using an eventual consistency window to accept a little extra
+    session_ended_threshold = session_ended_threshold - timedelta(
+        seconds=checkpoint.eventual_consistency_max_seconds
+    )
+
+    session_list: list[dict[str, Any]] = []
+    for sessions_page in sessions_paginator.paginate(
+        farmId=farm_id, queueId=queue_id, jobId=job_id
+    ):
+        for session in sessions_page.get("sessions", []):
+            if "endedAt" not in session or session["endedAt"] >= session_ended_threshold:
+                session_list.append(session)
+    if session_list:
+        output_job_sessions[job_id] = session_list
+
+
+def _retrieve_session_actions_for_session(
+    deadline_client: BaseClient,
+    checkpoint_job_session_completed_indexes: dict[str, dict[str, int]],
+    farm_id: str,
+    queue_id: str,
+    job_id: str,
+    output_session: dict[str, Any],
+):
+    """
+    Args:
+        deadline_client: A boto3 client for accessing Deadline.
+        checkpoint_job_session_completed_indexes: All the jobs' session action indexes loaded from the checkpoint.
+            The value checkpoint_job_session_completed_indexes[job_id][session_id] is the session action index of
+            the latest session action that is completed download.
+        farm_id: The farm id for the operation.
+        queue_id: The queue id for the operation.
+        job_id: The job id to process.
+        output_session: The session to populate with a sessionActions field.
+    """
+    session_actions_paginator = deadline_client.get_paginator("list_session_actions")
+
+    session_action_list: list[dict[str, Any]] = []
+    for session_actions_page in session_actions_paginator.paginate(
+        farmId=farm_id,
+        queueId=queue_id,
+        jobId=job_id,
+        sessionId=output_session["sessionId"],
+    ):
+        # Include only succeeded taskRun actions.
+        for session_action in session_actions_page.get("sessionActions", []):
+            succeeded = session_action.get("status") == "SUCCEEDED"
+            is_task_run = "taskRun" in session_action.get("definition", {})
+            if succeeded and is_task_run:
+                session_action_list.append(session_action)
+
+    if session_action_list:
+        # Extract the session action indexes from the ids
+        for session_action in session_action_list:
+            # Session action IDs look like "sessionaction-abc123-12" for index 12
+            session_action_index = int(session_action["sessionActionId"].rsplit("-", 1)[-1])
+            session_action["sessionActionIndex"] = session_action_index
+        # Include only session action indexes newer than latest downloaded ones from the checkpoint
+        session_completed_index: Optional[int] = checkpoint_job_session_completed_indexes.get(
+            job_id, {}
+        ).get(output_session["sessionId"])
+        if session_completed_index is not None:
+            # Filter out older session actions that were already downloaded
+            session_action_list = [
+                session_action
+                for session_action in session_action_list
+                if session_action["sessionActionIndex"] > session_completed_index
+            ]
+        if session_action_list:
+            output_session["sessionActions"] = session_action_list
+
+
+def _get_job_sessions(
+    boto3_session: boto3.Session,
+    boto3_session_for_s3: boto3.Session,
+    farm_id: str,
+    queue: dict[str, Any],
     checkpoint_job_session_completed_indexes: dict[str, dict[str, int]],
     categorized_job_ids: CategorizedJobIds,
     checkpoint: IncrementalDownloadState,
+    download_candidate_jobs: dict[str, dict[str, Any]],
     print_function_callback: Callable[[str], None] = lambda msg: None,
 ) -> dict[str, list]:
     """
     This function gets all the job sessions and session actions from the completed, added, and updated jobs.
     It uses the checkpoint's session_completed_indexes to filter out older session actions that are already downloaded.
+
+    Args:
+        boto3_session: The boto3.Session for accessing AWS.
+        boto3_session_for_s3: The boto3.Session to use for accessing S3.
+        farm_id: The farm id for the operation.
+        queue: The queue as returned by boto3 deadline.get_queue().
+        checkpoint_job_session_completed_indexes: All the jobs' session action indexes loaded from the checkpoint.
+            The value checkpoint_job_session_completed_indexes[job_id][session_id] is the session action index of
+            the latest session action that is completed download.
+        categorized_job_ids: The categorized job ids as returned by _categorize_jobs_in_checkpoint().
+        checkpoint: The checkpoint for the incremental download.
+        download_candidate_jobs: The result of a _get_download_candidate_jobs call, {job_id: job} where
+            job is a result from a deadline.search_jobs() or deadline.get_job() call.
+        print_function_callback: Callback for printing output to the terminal or log.
+
+    Returns:
+        Access a session action in the returned job_sessions with
+            job_sessions[job_id][session_index]["sessionActions"][session_action_index]
+        The returned structure looks like this:
+        {
+            "<job_id>": [
+                {
+                    "sessionId": "<session_id>",
+                    ...,
+                    "sessionActions": [
+                        {
+                            "sessionActionId": "<session_action_id>",
+                            ...
+                        },
+                        ...
+                    ]
+                },
+                ...
+            ],
+            ...
+        }
     """
     job_ids = categorized_job_ids.completed.union(categorized_job_ids.added).union(
         categorized_job_ids.updated
     )
-    print_function_callback(f"Retrieving session actions for {len(job_ids)} jobs...")
+    print_function_callback(f"Retrieving sessions for {len(job_ids)} jobs...")
     start_time = datetime.now(tz=timezone.utc)
 
     # The max timestamp of a downloaded session's endedAt provides a lower bound to filter sessions by.
@@ -405,76 +593,157 @@ def _get_job_sessions(
 
     deadline = boto3_session.client("deadline")
     job_sessions: dict[str, list] = {}
-    sessions_paginator = deadline.get_paginator("list_sessions")
-    for job_id in job_ids:
-        # Use the greater of the bootstrap command timestamp and the session ended timestamps
-        # recorded in the checkpoint.
-        session_ended_timestamp = job_session_ended_timestamp.get(job_id)
-        if session_ended_timestamp is None:
-            session_ended_timestamp = checkpoint.downloads_started_timestamp
 
-        session_list: list[dict[str, Any]] = []
-        for sessions_page in sessions_paginator.paginate(
-            farmId=farm_id, queueId=queue_id, jobId=job_id
-        ):
-            # Filter out older sessions by endedAt timestamp, using an eventual consistency window to accept a little extra
-            session_ended_timestamp = session_ended_timestamp - timedelta(
-                seconds=checkpoint.eventual_consistency_max_seconds
-            )
-            session_list.extend(
-                session
-                for session in sessions_page.get("sessions", [])
-                if "endedAt" not in session or session["endedAt"] >= session_ended_timestamp
-            )
-        if session_list:
-            job_sessions[job_id] = session_list
+    # Retrieve all the sessions with some parallelism
+    max_workers = SESSIONS_API_MAX_CONCURRENCY
+    print_function_callback(f"Using {max_workers} threads")
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = []
+        for job_id in job_ids:
+            # Use the greater of the bootstrap command timestamp and the session ended timestamps
+            # recorded in the checkpoint.
+            session_ended_threshold = job_session_ended_timestamp.get(job_id)
+            if session_ended_threshold is None:
+                session_ended_threshold = checkpoint.downloads_started_timestamp
 
-    # Retrieve the session actions for all the sessions that we found
-    session_actions_paginator = deadline.get_paginator("list_session_actions")
-    for job_id, session_list in job_sessions.items():
-        for session in session_list:
-            session_action_list: list[dict[str, Any]] = []
-            for session_actions_page in session_actions_paginator.paginate(
-                farmId=farm_id, queueId=queue_id, jobId=job_id, sessionId=session["sessionId"]
-            ):
-                # Include only succeeded taskRun actions, and filter out any actions that ended before the
-                # start of the update time interval
-                session_action_list.extend(
-                    session_action
-                    for session_action in session_actions_page.get("sessionActions", [])
-                    if session_action.get("status") == "SUCCEEDED"
-                    and "taskRun" in session_action.get("definition", {})
-                    and not (
-                        "endedAt" in session_action
-                        and session_action["endedAt"] < checkpoint.downloads_completed_timestamp
-                    )
+            futures.append(
+                executor.submit(
+                    _retrieve_sessions_for_job,
+                    deadline,
+                    checkpoint,
+                    farm_id,
+                    queue["queueId"],
+                    job_id,
+                    session_ended_threshold,
+                    job_sessions,
                 )
-            if session_action_list:
-                # Extract the session action indexes from the ids
-                for session_action in session_action_list:
-                    # Session action IDs look like "sessionaction-abc123-12" for index 12
-                    session_action_index = int(session_action["sessionActionId"].rsplit("-", 1)[-1])
-                    session_action["sessionActionIndex"] = session_action_index
-                # Include only session action indexes newer than latest downloaded ones from the checkpoint
-                session_completed_index: Optional[int] = (
-                    checkpoint_job_session_completed_indexes.get(job_id, {}).get(
-                        session["sessionId"]
-                    )
-                )
-                if session_completed_index is not None:
-                    # Filter out older session actions that were already downloaded
-                    session_action_list = [
-                        session_action
-                        for session_action in session_action_list
-                        if session_action["sessionActionIndex"] > session_completed_index
-                    ]
-                if session_action_list:
-                    session["sessionActions"] = session_action_list
+            )
+
+        # surfaces any exceptions in the thread
+        for future in concurrent.futures.as_completed(futures):
+            future.result()
 
     duration = datetime.now(tz=timezone.utc) - start_time
     print_function_callback(f"...retrieval completed in {duration}")
 
+    print_function_callback("")
+    print_function_callback(
+        f"Retrieving session actions for {sum(len(session_list) for session_list in job_sessions.values())} sessions..."
+    )
+    start_time = datetime.now(tz=timezone.utc)
+
+    # Retrieve all the session actions with some parallelism
+    max_workers = SESSIONS_API_MAX_CONCURRENCY
+    print_function_callback(f"Using {max_workers} threads")
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = []
+        for job_id, session_list in job_sessions.items():
+            for session in session_list:
+                futures.append(
+                    executor.submit(
+                        _retrieve_session_actions_for_session,
+                        deadline,
+                        checkpoint_job_session_completed_indexes,
+                        farm_id,
+                        queue["queueId"],
+                        job_id,
+                        session,
+                    )
+                )
+        # surfaces any exceptions in the thread
+        for future in concurrent.futures.as_completed(futures):
+            future.result()
+
+    duration = datetime.now(tz=timezone.utc) - start_time
+    print_function_callback(f"...retrieval completed in {duration}")
+
+    print_function_callback("")
+    print_function_callback("Populating missing manifest S3 keys...")
+    start_time = datetime.now(tz=timezone.utc)
+
+    _add_missing_output_manifests_to_job_sessions(
+        boto3_session_for_s3, farm_id, queue, job_sessions, download_candidate_jobs
+    )
+
+    _filter_session_actions_without_manifests_from_job_sessions(
+        job_sessions,
+        download_candidate_jobs,
+        print_function_callback,
+    )
+
+    duration = datetime.now(tz=timezone.utc) - start_time
+    print_function_callback(f"...populated in {duration}")
+
     return job_sessions
+
+
+def _add_missing_output_manifests_to_job_sessions(
+    boto3_session_for_s3: boto3.Session,
+    farm_id: str,
+    queue: dict[str, Any],
+    job_sessions: dict[str, list],
+    download_candidate_jobs: dict[str, dict[str, Any]],
+):
+    """
+    Args:
+        boto3_session_for_s3: The boto3.Session to use for accessing S3.
+        farm_id: The farm id for the operation.
+        queue: The queue as returned by boto3 deadline.get_queue().
+        job_sessions: Contains each job's sessions and session actions, structured as job_sessions[job_id][session_index]["sessionActions"][session_action_index].
+                      See the function _get_job_sessions for more details.
+        download_candidate_jobs: The result of a _get_download_candidate_jobs call, {job_id: job} where
+            job is a result from a deadline.search_jobs() or deadline.get_job() call.
+    """
+    for job_id, session_list in job_sessions.items():
+        job = download_candidate_jobs[job_id]
+        session_action_list = [
+            session_action
+            for session in session_list
+            for session_action in session.get("sessionActions", [])
+        ]
+        _add_output_manifests_from_s3(
+            farm_id, queue, job, boto3_session_for_s3, session_action_list
+        )
+
+
+def _filter_session_actions_without_manifests_from_job_sessions(
+    job_sessions: dict[str, list],
+    download_candidate_jobs: dict[str, dict[str, Any]],
+    print_function_callback: Callable[[str], None] = lambda msg: None,
+):
+    """
+    Modify job_sessions in place to filter out any session actions that lack any output manifests.
+    Print a warning message for any job that had a session action like this.
+
+    Args:
+        job_sessions: Contains each job's sessions and session actions, structured as job_sessions[job_id][session_index]["sessionActions"][session_action_index].
+                      See the function _get_job_sessions for more details.
+        download_candidate_jobs: The result of a _get_download_candidate_jobs call, {job_id: job} where
+            job is a result from a deadline.search_jobs() or deadline.get_job() call.
+        print_function_callback: Callback for printing output to the terminal or log.
+    """
+    for job_id, session_list in job_sessions.items():
+        job = download_candidate_jobs[job_id]
+        total_count = 0
+        filtered_count = 0
+        for session in session_list:
+            total_count += len(session.get("sessionActions", []))
+            # Filter out session actions with no manifest files
+            filtered_session_action_list = [
+                session_action
+                for session_action in session.get("sessionActions", [])
+                if any(item != {} for item in session_action["manifests"])
+            ]
+            filtered_count += len(filtered_session_action_list)
+            if total_count != filtered_count:
+                session["sessionActions"] = filtered_session_action_list
+        if total_count != filtered_count:
+            print_function_callback(
+                f"WARNING: Job {job['name']} ({job_id}) ran {total_count - filtered_count} / {total_count} session actions with no output."
+            )
+            print_function_callback(
+                "         This may indicate steps in the job that strictly perform validation or save results elsewhere like a shared file system or S3."
+            )
 
 
 def _update_checkpoint_jobs_list(
@@ -485,6 +754,14 @@ def _update_checkpoint_jobs_list(
 ):
     """
     Update the jobs list in the checkpoint object.
+
+    Args:
+        checkpoint: The checkpoint for the incremental download.
+        download_candidate_jobs: The result of a _get_download_candidate_jobs call, {job_id: job} where
+            job is a result from a deadline.search_jobs() or deadline.get_job() call.
+        categorized_job_ids: The categorized job ids as returned by _categorize_jobs_in_checkpoint().
+        job_sessions: Contains each job's sessions and session actions, structured as job_sessions[job_id][session_index]["sessionActions"][session_action_index].
+                      See the function _get_job_sessions for more details.
     """
     updated_jobs: list[IncrementalDownloadJob] = []
 
@@ -556,7 +833,9 @@ def _update_checkpoint_jobs_list(
                 job_session_completed_indexes.get(job_id, {}),
             )
         )
-    # When a job becomes inactive, keep it around in minimal form when it has a session_ended_timestamp
+    # When a job becomes inactive, keep it around in minimal form when it has a session_ended_timestamp.
+    # This is necessary for the case where a completed job gets requeued later. We can't tell
+    # that it was requeued from the deadline.search_jobs query, so we hold this metadata in the checkpoint.
     for job_id in categorized_job_ids.inactive:
         session_ended_timestamp = job_session_ended_timestamps.get(job_id)
         if session_ended_timestamp is not None:
@@ -570,40 +849,66 @@ def _update_checkpoint_jobs_list(
 @api.record_function_latency_telemetry_event()
 def _incremental_output_download(
     farm_id: str,
-    queue_id: str,
+    queue: dict[str, Any],
     boto3_session: boto3.Session,
-    download_state: IncrementalDownloadState,
+    checkpoint: IncrementalDownloadState,
+    config: Optional[ConfigParser] = None,
     print_function_callback: Callable[[str], None] = lambda msg: None,
+    *,
+    dry_run: bool = False,
 ) -> IncrementalDownloadState:
     """
     This function downloads all the task run outputs from the specified queue, that have become
-    available since the last time the function was called. The download_state object
+    available since the last time the function was called. The checkpoint object
     keeps track of all state needed to keep track of what needs to be downloaded.
 
-    :param farm_id: farm id for the output download
-    :param queue_id: queue for scoping output download
-    :param download_state: Download state for starting the incremental download
-    :param boto3_session: boto3 session
-    :param print_function_callback: Callback to print messages produced in this function.
-                Used in the CLI to print to stdout using click.echo. By default, ignores messages.
-    :return: updated downloaded state
+    Pre-condition: The input checkpoint holds all information needed to understand the state of downloads
+        completed up to the timestamp checkpoint.downloads_completed_timestamp. See the documentation
+        in the IncrementalDownloadState to understand the invariants of the checkpoint.
+
+    Post-condition: The output checkpoint has an updated checkpoint.downloads_completed_timestamp,
+        all downloads were performed up to at least this timestamp, and the checkpoint data
+        is updated to satisfy the next call's pre-condition.
+
+    Args:
+        farm_id: The farm id for the operation.
+        queue: The queue as returned by boto3 deadline.get_queue().
+        boto3_session: The boto3.Session for accessing AWS.
+        checkpoint: The checkpoint for the incremental download.
+        config: Optional, a Deadline Cloud configuration as loaded from config_file.read_config().
+        print_function_callback: Callback for printing output to the terminal or log.
+        dry_run: If True, the operation will print out information but not perform any data downloads.
+
+    Returns:
+        An updated checkpoint object.
     """
+    deadline = boto3_session.client("deadline")
+
     # When this function is done, we will be confident that downloads are complete up to
     # new_completed_timestamp. We subtract a duration from now() that gives a generous amount of
     # time for the deadline:SearchJobs API's eventual consistency to converge.
     current_timestamp = datetime.now(timezone.utc)
     new_completed_timestamp = max(
-        download_state.downloads_started_timestamp,
-        current_timestamp - timedelta(seconds=download_state.eventual_consistency_max_seconds),
+        checkpoint.downloads_started_timestamp,
+        current_timestamp - timedelta(seconds=checkpoint.eventual_consistency_max_seconds),
+    )
+
+    # The queue role is used for accessing S3
+    boto3_session_for_s3 = api.get_queue_user_boto3_session(
+        deadline=deadline,
+        config=config,
+        farm_id=farm_id,
+        queue_id=queue["queueId"],
+        queue_display_name=queue["displayName"],
     )
 
     print_function_callback("Updating download state across time interval:")
     print_function_callback(
-        f"    From: {download_state.downloads_completed_timestamp.astimezone().isoformat()}"
+        f"    From: {checkpoint.downloads_completed_timestamp.astimezone().isoformat()}"
     )
     print_function_callback(f"      To: {current_timestamp.astimezone().isoformat()}")
-    update_length = current_timestamp - download_state.downloads_completed_timestamp
-    eventual_consistency_delta = timedelta(seconds=download_state.eventual_consistency_max_seconds)
+    update_length = current_timestamp - checkpoint.downloads_completed_timestamp
+    eventual_consistency_delta = timedelta(seconds=checkpoint.eventual_consistency_max_seconds)
     if update_length > eventual_consistency_delta:
         print_function_callback(
             f"  Length: {update_length - eventual_consistency_delta} + {eventual_consistency_delta} (eventual consistency allowance)"
@@ -615,15 +920,15 @@ def _incremental_output_download(
 
     # Save all the jobs' session action indexes from the checkpoint, before we update the checkpoint's jobs list
     checkpoint_job_session_completed_indexes: dict[str, dict[str, int]] = {
-        job.job_id: job.session_completed_indexes for job in download_state.jobs
+        job.job_id: job.session_completed_indexes for job in checkpoint.jobs
     }
 
     # Call deadline:SearchJobs to get a set of jobs that includes every job with downloads available.
     download_candidate_jobs: dict[str, dict[str, Any]] = _get_download_candidate_jobs(
         boto3_session,
         farm_id,
-        queue_id,
-        download_state.downloads_completed_timestamp,
+        queue["queueId"],
+        checkpoint.downloads_completed_timestamp,
         print_function_callback,
     )
 
@@ -633,8 +938,8 @@ def _incremental_output_download(
     categorized_job_ids: CategorizedJobIds = _categorize_jobs_in_checkpoint(
         boto3_session,
         farm_id,
-        queue_id,
-        download_state,
+        queue["queueId"],
+        checkpoint,
         download_candidate_jobs,
         new_completed_timestamp,
         print_function_callback,
@@ -645,31 +950,106 @@ def _incremental_output_download(
     # All the completed, added, and updated jobs might have downloads available. Retrieve the sessions for these jobs.
     job_sessions: dict[str, list] = _get_job_sessions(
         boto3_session,
+        boto3_session_for_s3,
         farm_id,
-        queue_id,
+        queue,
         checkpoint_job_session_completed_indexes,
         categorized_job_ids,
-        download_state,
+        checkpoint,
+        download_candidate_jobs,
         print_function_callback,
     )
 
-    # Use the information collected so far to update the jobs list in download_state
+    # Use the information collected so far to update the jobs list in checkpoint
     _update_checkpoint_jobs_list(
-        download_state, download_candidate_jobs, categorized_job_ids, job_sessions
+        checkpoint, download_candidate_jobs, categorized_job_ids, job_sessions
     )
 
-    print("Job session + session actions:")
-    print_function_callback(_cli_object_repr(job_sessions))
+    downloaded_manifests: list[tuple[datetime, BaseAssetManifest]] = (
+        _download_all_manifests_with_absolute_paths(
+            queue,
+            download_candidate_jobs,
+            job_sessions,
+            boto3_session_for_s3,
+            print_function_callback,
+        )
+    )
 
-    # TODO the rest of the incremental output download
+    # Merge the manifests ordered by the last modified timestamp
+    manifest_paths_to_download: list[BaseManifestPath] = _merge_absolute_path_manifest_list(
+        downloaded_manifests
+    )
+
+    # Print a summary of all the paths before starting the download
+    local_path_list = [manifest_path.path for manifest_path in manifest_paths_to_download]
+    file_size_by_path = {
+        manifest_path.path: manifest_path.size for manifest_path in manifest_paths_to_download
+    }
+    print_function_callback("")
+    print_function_callback("Summary of paths to download:")
+    print_function_callback(
+        summarize_path_list(local_path_list, total_size_by_path=file_size_by_path, max_entries=30)
+    )
+    print_function_callback("")
+
+    if not dry_run:
+        print_function_callback(f"Downloading {len(manifest_paths_to_download)} files from S3...")
+        start_time = datetime.now(tz=timezone.utc)
+
+        # Incremental download is mostly a background thing, so don't print status too often while downloading
+        MIN_DELAY_BETWEEN_PRINTOUTS = 20
+        last_call_time = time.time() - MIN_DELAY_BETWEEN_PRINTOUTS
+        printed_100_percent = False
+
+        def _update_download_progress(
+            download_metadata: ProgressReportMetadata,
+        ) -> bool:
+            nonlocal last_call_time, printed_100_percent
+
+            if not printed_100_percent and download_metadata.progress == 100:
+                print_function_callback(f"{download_metadata.progressMessage}")
+                last_call_time = time.time()
+                printed_100_percent = True
+            elif (
+                not printed_100_percent
+                and time.time() - last_call_time > MIN_DELAY_BETWEEN_PRINTOUTS
+            ):
+                print_function_callback(f"{download_metadata.progressMessage}")
+                last_call_time = time.time()
+
+            return sigint_handler.continue_operation
+
+        _download_manifest_paths(
+            manifest_paths_to_download,
+            HashAlgorithm.XXH128,
+            queue,
+            boto3_session_for_s3,
+            FileConflictResolution.OVERWRITE,
+            on_downloading_files=_update_download_progress,
+            print_function_callback=print_function_callback,
+        )
+
+        duration = datetime.now(tz=timezone.utc) - start_time
+        print_function_callback(f"...downloaded in {duration}")
+    else:
+        print_function_callback("Skipping downloads due to DRY RUN")
 
     # Update the timestamp in the state object to reflect the downloads that were completed
-    download_state.downloads_completed_timestamp = new_completed_timestamp
+    checkpoint.downloads_completed_timestamp = new_completed_timestamp
 
     print_function_callback("")
-    print_function_callback("Summary of incremental output download:")
+    if dry_run:
+        print_function_callback(
+            "Summary of DRY RUN for incremental output download (no files were downloaded to the file system):"
+        )
+    else:
+        print_function_callback("Summary of incremental output download:")
     print_function_callback(
         f"  Downloaded session actions: {sum(len(session.get('sessionActions', [])) for session_list in job_sessions.values() for session in session_list)}"
+    )
+    print_function_callback(f"  Downloaded files: {len(manifest_paths_to_download)}")
+    print_function_callback(
+        f"  Downloaded bytes: {human_readable_file_size(sum(path.size for path in manifest_paths_to_download))}"
     )
     print_function_callback("  Jobs with downloads:")
     print_function_callback(f"    completed: {len(categorized_job_ids.completed)}")
@@ -682,4 +1062,4 @@ def _incremental_output_download(
     print_function_callback(f"    unchanged: {len(categorized_job_ids.unchanged)}")
     print_function_callback(f"    inactive: {len(categorized_job_ids.inactive)}")
 
-    return download_state
+    return checkpoint

--- a/src/deadline/job_attachments/README.md
+++ b/src/deadline/job_attachments/README.md
@@ -1,8 +1,8 @@
 # Job attachments
 
-[Job attachments][job-attachments] enable you to transfer files back and forth between your workstation and [AWS Deadline Cloud][deadline-cloud], using an Amazon S3 bucket in your AWS account associated with your [AWS Deadline Cloud queues][queue]. 
+[Job attachments][job-attachments] enable you to transfer files back and forth between your workstation and [AWS Deadline Cloud][deadline-cloud], using an Amazon S3 bucket in your AWS account associated with your [AWS Deadline Cloud queues][queue].
 
-Job attachments uses your configured S3 bucket as a [content-addressable storage](https://en.wikipedia.org/wiki/Content-addressable_storage), which creates a snapshot of the files used in your job submission in [asset manifests](#asset-manifests), only uploading files that aren't already in S3. This saves you time and bandwidth when iterating on jobs. When an [AWS Deadline Cloud worker agent][worker-agent] starts working on a job with job attachments, it recreates the file system snapshot in the worker agent session directory, and uploads any outputs back to your S3 bucket. 
+Job attachments uses your configured S3 bucket as a [content-addressable storage](https://en.wikipedia.org/wiki/Content-addressable_storage), which creates a snapshot of the files used in your job submission in [asset manifests](#asset-manifests), only uploading files that aren't already in S3. This saves you time and bandwidth when iterating on jobs. When an [AWS Deadline Cloud worker agent][worker-agent] starts working on a job with job attachments, it recreates the file system snapshot in the worker agent session directory, and uploads any outputs back to your S3 bucket.
 
 You can then easily download your outputs with the [deadline cli](../client/) `deadline job download-output` command, or using the [protocol handler](#protocol-handler) to download from a click of a button in the [AWS Deadline Cloud monitor][monitor].
 
@@ -68,14 +68,14 @@ Output manifests for tasks are stored under:
 Where:
 - `<root_prefix>` is the prefix configured in the queue's job attachment settings
 - `<farm_id>`, `<queue_id>`, `<job_id>`, `<step_id>`, `<task_id>`, and `<session_action_id>` are the respective identifiers (e.g., farm-1234567890abcdefg)
-- `<manifest_hash>` is a hash derived from the source root path
+- `<manifest_hash>` is a hash of the concatenation of `fileSystemLocationName` (if set) and `rootPath` fields in the job's `manifests` list.
 - `<timestamp>` is the time that the task started. It is formatted as an ISO8601 timestamp with microsecond precision and in the UTC timezone (e.g. `2025-04-01T17:27:28.044179Z`)
 
 Each manifest file also has an asset root which defines the local root path where files should be placed when downloaded. The asset root is stored in the user-defined metadata of the manifest S3 object. If the asset root can be encoded in ASCII, it is stored directly under the `asset-root` userdata property. If not, it is stored as a JSON-encoded string under `asset-root-json`.
 
 ## Asset Manifests
 
-When making a job submission, the job attachments library makes a snapshot of all of the files included in the submission. The contents of each file are hashed, and the files are uploaded to the S3 bucket associated with the queue you are submitting to. This way, if the files haven't changed since a previous submission, the hash will be the same and the files will not be re-uploaded. 
+When making a job submission, the job attachments library makes a snapshot of all of the files included in the submission. The contents of each file are hashed, and the files are uploaded to the S3 bucket associated with the queue you are submitting to. This way, if the files haven't changed since a previous submission, the hash will be the same and the files will not be re-uploaded.
 
 These snapshots are encapsulated in one or more [`asset_manifests`](asset_manifests). Asset manifests include the local file path and associated hash of every file included in the submission, plus some metadata such as the file size and last modified time. Asset manifests are uploaded to your job attachments S3 bucket alongside your files.
 
@@ -138,7 +138,7 @@ In order to further improve submission time, there are currently two local [`cac
 
 ## Protocol Handler
 
-On Windows and Linux operating systems, you can choose to install the [Deadline client](../client/) protocol handler in order to run AWS Deadline Cloud commands sent from a web browser. Of note is the ability to download job attachments outputs from your jobs through the [AWS Deadline Cloud monitor][downloading-output]. 
+On Windows and Linux operating systems, you can choose to install the [Deadline client](../client/) protocol handler in order to run AWS Deadline Cloud commands sent from a web browser. Of note is the ability to download job attachments outputs from your jobs through the [AWS Deadline Cloud monitor][downloading-output].
 
 You can install the protocol handler by running the command: `deadline handle-web-url --install`
 

--- a/src/deadline/job_attachments/_incremental_downloads/_manifest_s3_downloads.py
+++ b/src/deadline/job_attachments/_incremental_downloads/_manifest_s3_downloads.py
@@ -1,0 +1,604 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+from __future__ import annotations
+
+__all__ = [
+    "_add_output_manifests_from_s3",
+    "_download_all_manifests_with_absolute_paths",
+    "_merge_absolute_path_manifest_list",
+    "_download_manifest_paths",
+]
+
+from typing import Any, Callable, DefaultDict, Optional
+from datetime import datetime, timezone
+import re
+import os
+import concurrent.futures
+from threading import Lock
+from pathlib import Path
+
+import boto3
+from boto3.s3.transfer import ProgressCallbackInvoker
+from botocore.client import BaseClient
+from botocore.exceptions import BotoCoreError, ClientError
+
+from ..download import (
+    _get_output_manifest_prefix,
+    _get_tasks_manifests_keys_from_s3,
+    _get_asset_root_and_manifest_from_s3_with_last_modified,
+    _get_num_download_workers,
+    _get_new_copy_file_path,
+    S3_DOWNLOAD_MAX_CONCURRENCY,
+)
+from ..asset_manifests import (
+    hash_data as ja_hash_data,
+    BaseAssetManifest,
+    BaseManifestPath,
+    HashAlgorithm,
+)
+from ..asset_manifests.v2023_03_03.asset_manifest import DEFAULT_HASH_ALG
+from ..models import (
+    FileConflictResolution,
+    JobAttachmentS3Settings,
+    S3_MANIFEST_FOLDER_NAME,
+)
+from ..exceptions import (
+    COMMON_ERROR_GUIDANCE_FOR_S3,
+    AssetSyncError,
+    AssetSyncCancelledError,
+    JobAttachmentS3BotoCoreError,
+    JobAttachmentsS3ClientError,
+    JobAttachmentsError,
+)
+from .._aws.aws_clients import (
+    get_account_id,
+    get_s3_client,
+    get_s3_transfer_manager,
+)
+from ..progress_tracker import (
+    ProgressTracker,
+    ProgressStatus,
+    ProgressReportMetadata,
+)
+from .._utils import _get_long_path_compatible_path
+
+
+"""
+This file contains a forked copy of some functionality from deadline.job_attachments.download,
+with its interface refactored to support the incremental download command.
+
+It consists fully of internal-only functionality. We would like to iteratively refine these
+interfaces over time, with the goal that we deprecate the current interfaces
+in deadline.job_attachments.download and replace them with more general and flexible interfaces.
+"""
+
+SESSION_ACTION_ID_FROM_KEY_RE = re.compile(r"(sessionaction-[^/-]+-[^/-]+)/")
+
+
+def _add_output_manifests_from_s3(
+    farm_id: str,
+    queue: dict[str, Any],
+    job: dict[str, Any],
+    boto3_session: boto3.Session,
+    session_action_list: list[dict[str, Any]],
+):
+    """
+    This function takes a list of session actions (as returned by boto3 deadline.list_session_actions),
+    and for any that lack manifest fields, updates them with values retrieved from S3. While the response
+    from Deadline Cloud will always return both outputManifestPath and outputManifestHash, this function
+    only populates the outputManifestPath value. The order of the manifests in the list precisely correspond
+    to the manifests returned by boto3 deadline.get_job, clients of these APIs can zip() the two
+    manifests lists together to get the full set of fields needed for processing.
+
+    * https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/deadline/client/list_session_actions.html
+    * https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/deadline/client/get_job.html
+
+    Args:
+        farm_id: The farm id.
+        queue: The queue as returned by boto3 deadline.get_queue().
+        job: The job as returned by boto3 deadline.search_jobs().
+        boto3_session: The boto3.Session for accessing AWS.
+        session_action_list: A list of session actions to modify by adding the "manifests" field where necessary.
+            Its shape is as returned by boto3 deadline.list_session_actions() or deadline.get_session_action().
+    """
+    # If the job has no job attachments, there's nothing to add
+    if "attachments" not in job:
+        return
+
+    s3_settings = JobAttachmentS3Settings(**queue["jobAttachmentSettings"])
+
+    # Filter the session action list to exclude any that already contain manifests,
+    # then return early if the result is empty.
+    session_action_list = [
+        session_action
+        for session_action in session_action_list
+        if "manifests" not in session_action
+    ]
+    if not session_action_list:
+        return
+
+    # Process the job's attachments list to generate the hashes
+    job_manifests_length = len(job["attachments"]["manifests"])
+    job_indexed_root_path_hash = [
+        (
+            index,
+            ja_hash_data(
+                f"{manifest.get('fileSystemLocationName', '')}{manifest['rootPath']}".encode(),
+                DEFAULT_HASH_ALG,
+            ),
+        )
+        for index, manifest in enumerate(job["attachments"]["manifests"])
+    ]
+    # Initialize to empty "manifests" entries
+    for session_action in session_action_list:
+        session_action["manifests"] = [{}] * job_manifests_length
+
+    # Get all the output manifest keys for all the steps/tasks of the job.
+    # TODO: This is very inefficient if the job has lots of tasks, because
+    #       the incremental download will generally only use a few of them at a time.
+    manifest_prefix: str = _get_output_manifest_prefix(
+        s3_settings, farm_id, queue["queueId"], job["jobId"]
+    )
+    try:
+        manifests_keys: list[str] = _get_tasks_manifests_keys_from_s3(
+            manifest_prefix,
+            s3_settings.s3BucketName,
+            session=boto3_session,
+            select_latest_per_task=False,
+        )
+    except JobAttachmentsError as e:
+        # If there are no manifests, treat as no data.
+        if str(e).startswith("Unable to find asset manifest in"):
+            return
+        else:
+            raise
+
+    # Organize the session actions by session action id, so that we can quickly get
+    # to the correct session action from the manifest object key.
+    session_actions_by_session_action_id: dict[str, dict[str, Any]] = {
+        session_action["sessionActionId"]: session_action for session_action in session_action_list
+    }
+
+    manifest_prefix = f"{queue['jobAttachmentSettings']['rootPrefix']}/{S3_MANIFEST_FOLDER_NAME}/"
+    for key in manifests_keys:
+        # Extract the session action id from the manifest key
+        m = SESSION_ACTION_ID_FROM_KEY_RE.search(key)
+        if m:
+            manifest_session_action_id = m[1]
+        else:
+            raise RuntimeError(
+                f"Job attachments manifest key for job {job['name']} ({job['jobId']}) lacks a session action id"
+            )
+        # Loop through all the manifests to see whether the hash of the rootPath is in the key,
+        # in order to determine which position in the manifests list this key should get set in.
+        manifests_index = None
+        for index, root_path_hash in job_indexed_root_path_hash:
+            if root_path_hash in key:
+                manifests_index = index
+                break
+        if manifests_index is None:
+            root_path_hashes = [hash for _, hash in job_indexed_root_path_hash]
+            raise RuntimeError(
+                f"Job attachments manifest key for job {job['name']} ({job['jobId']}) does not contain any of the rootPath hashes {', '.join(root_path_hashes)}: {key}"
+            )
+        # If this session action is in the list, add this key to it
+        session_action_for_key = session_actions_by_session_action_id.get(
+            manifest_session_action_id
+        )
+        if session_action_for_key is not None:
+            # This is equivalent to "output_manifest_path = key.removeprefix(manifest_prefix)" to
+            # retain support for Python 3.8 which does not support str.removeprefix.
+            output_manifest_path = key
+            if output_manifest_path.startswith(manifest_prefix):
+                output_manifest_path = output_manifest_path[len(manifest_prefix) :]
+            session_action_for_key["manifests"][manifests_index] = {
+                "outputManifestPath": output_manifest_path,
+            }
+
+
+def _download_manifest_and_make_paths_absolute(
+    index: int,
+    queue: dict[str, Any],
+    root_path: str,
+    manifest_s3_key: str,
+    boto3_session_for_s3: boto3.Session,
+    output_manifests: list,
+):
+    """
+    Downloads the specified manifest, makes all its paths absolute using root_path,
+    and then places it in output_manifests[index].
+    """
+    # Download the manifest
+    _, last_modified, manifest = _get_asset_root_and_manifest_from_s3_with_last_modified(
+        manifest_s3_key, queue["jobAttachmentSettings"]["s3BucketName"], boto3_session_for_s3
+    )
+    # Convert all the manifest paths to have absolute normalized local paths
+    for manifest_path in manifest.paths:
+        manifest_path.path = os.path.normpath(os.path.join(root_path, manifest_path.path))
+        # TODO: Apply path mapping rules to manifest_path.path right here
+    output_manifests[index] = (last_modified, manifest)
+
+
+def _get_manifests_to_download(
+    job_attachments_root_prefix: str,
+    download_candidate_jobs: dict[str, dict[str, Any]],
+    job_sessions: dict[str, list],
+) -> list[tuple[str, str]]:
+    """
+    Collect a list of (rootPath, manifest_s3_key) tuples for all the job attachments that need to be downloaded.
+
+    Args:
+        job_attachments_root_prefix: The queue.jobAttachmentSettings.rootPrefix field from the Deadline
+            Cloud queue.
+        download_candidate_jobs: A mapping from job id to jobs as returned by deadline.search_jobs.
+        job_sessions: Contains each job's sessions and session actions, structured as job_sessions[job_id][session_index]["sessionActions"][session_action_index].
+                      See the function _get_job_sessions for more details.
+
+    Returns:
+        A list of (rootPath, manifest_s3_key) tuples for the manifest objects that need to be downloaded.
+    """
+    manifests_to_download: list[tuple[str, str]] = []
+    for job_id, session_list in job_sessions.items():
+        job = download_candidate_jobs[job_id]
+        for session in session_list:
+            for session_action in session.get("sessionActions", []):
+                # The manifests lists from the job and session action correspond, so we can zip them
+                # together to attach the root path with the S3 manifest key
+                for job_manifest, session_action_manifest in zip(
+                    job["attachments"]["manifests"], session_action["manifests"]
+                ):
+                    if "outputManifestPath" in session_action_manifest:
+                        manifests_to_download.append(
+                            (
+                                job_manifest["rootPath"],
+                                "/".join(
+                                    [
+                                        job_attachments_root_prefix,
+                                        S3_MANIFEST_FOLDER_NAME,
+                                        session_action_manifest["outputManifestPath"],
+                                    ]
+                                ),
+                            )
+                        )
+    return manifests_to_download
+
+
+def _download_all_manifests_with_absolute_paths(
+    queue: dict[str, Any],
+    download_candidate_jobs: dict[str, dict[str, Any]],
+    job_sessions: dict[str, list],
+    boto3_session_for_s3: boto3.Session,
+    print_function_callback: Callable[[str], None] = lambda msg: None,
+) -> list[tuple[datetime, BaseAssetManifest]]:
+    """
+    Downloads all the manifest files that are in the session_actions of job_sessions, and uses the rootPath
+    values taken from the job to make all the paths in the manifest absolute.
+
+    Args:
+        queue: The Deadline Cloud queue as returned by deadline.get_queue.
+        download_candidate_jobs: A mapping from job id to jobs as returned by deadline.search_jobs.
+        job_sessions: Contains each job's sessions and session actions, structured as job_sessions[job_id][session_index]["sessionActions"][session_action_index].
+                      See the function _get_job_sessions for more details.
+        boto3_session_for_s3: The boto3.Session to use for accessing S3.
+        print_function_callback: Callback for printing output to the terminal or log.
+
+    Returns:
+        A list of BaseAssetManifest objects containing local absolute file paths sorted by the last_modified timestamp.
+    """
+    # Get the list of (rootPath, manifest_s3_key) tuples to download from S3.
+    manifests_to_download: list[tuple[str, str]] = _get_manifests_to_download(
+        queue["jobAttachmentSettings"]["rootPrefix"], download_candidate_jobs, job_sessions
+    )
+
+    print_function_callback(f"Downloading {len(manifests_to_download)} asset manifests from S3...")
+    start_time = datetime.now(tz=timezone.utc)
+
+    # Download all the manifest files from S3, and make the paths in the manifests absolute local paths
+    # by joining with the root path and normalizing
+    downloaded_manifests: list = [None] * len(manifests_to_download)
+
+    max_workers = S3_DOWNLOAD_MAX_CONCURRENCY
+    print_function_callback(f"Using {max_workers} threads")
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = []
+        for index, (root_path, manifest_s3_key) in enumerate(manifests_to_download):
+            futures.append(
+                executor.submit(
+                    _download_manifest_and_make_paths_absolute,
+                    index,
+                    queue,
+                    root_path,
+                    manifest_s3_key,
+                    boto3_session_for_s3,
+                    downloaded_manifests,
+                )
+            )
+        # surfaces any exceptions in the thread
+        for future in concurrent.futures.as_completed(futures):
+            future.result()
+
+    duration = datetime.now(tz=timezone.utc) - start_time
+    print_function_callback(f"...downloaded manifests in {duration}")
+
+    return downloaded_manifests
+
+
+def _merge_absolute_path_manifest_list(
+    downloaded_manifests: list[tuple[datetime, BaseAssetManifest]],
+) -> list[BaseManifestPath]:
+    """
+    Given a list of manifests that contain absolute paths, uses the provided last modified timestamps
+    to sort them, and merges them all into a single manifest. Returns the list of manifest paths
+    for download.
+
+    Args:
+        downloaded_manifests: A list of (last_modified_timestamp, manifest) tuples, where each last
+            modified timestamp is the LastModified datetime from the S3 object holding the manifest.
+
+    Returns:
+        A list of manifest paths to download, the result of merging the manifests.
+    """
+    # Because the paths in manifests are all absolute and normalized now, we can merge them
+    # in order by inserting them into a dict in order, using the normcased path as the key.
+    # Later files of the same name will overwrite earlier ones.
+
+    # Sort the manifests by last modified, so that we can overlay them
+    # with later manifests overwriting files from earlier ones.
+    downloaded_manifests.sort(key=lambda item: item[0])
+
+    merged_manifest_paths_dict = {}
+    for _, manifest in downloaded_manifests:
+        for manifest_path in manifest.paths:
+            merged_manifest_paths_dict[os.path.normcase(manifest_path.path)] = manifest_path
+    return list(merged_manifest_paths_dict.values())
+
+
+def _download_file_with_transfer_manager(
+    local_file_path: Path,
+    s3_bucket: str,
+    s3_key: str,
+    boto3_session: boto3.Session,
+    s3_client: BaseClient,
+    progress_tracker: ProgressTracker,
+):
+    """
+    Downloads a single file from S3 using S3 transfer manager. This is appropriate for a larger
+    file that benefits from parallel multi-part download.
+    """
+    transfer_manager = get_s3_transfer_manager(s3_client=s3_client)
+
+    future: concurrent.futures.Future
+
+    def handler(bytes_downloaded):
+        nonlocal progress_tracker
+        nonlocal future
+
+        should_continue = progress_tracker.track_progress_callback(bytes_downloaded)
+        if not should_continue:
+            future.cancel()
+
+    subscribers = [ProgressCallbackInvoker(handler)]
+
+    future = transfer_manager.download(
+        bucket=s3_bucket,
+        key=s3_key,
+        fileobj=str(local_file_path),
+        extra_args={"ExpectedBucketOwner": get_account_id(session=boto3_session)},
+        subscribers=subscribers,
+    )
+
+    future.result()
+
+
+def _download_file_with_get_object(
+    local_file_path: Path,
+    s3_bucket: str,
+    s3_key: str,
+    boto3_session: boto3.Session,
+    s3_client: BaseClient,
+    progress_tracker: ProgressTracker,
+):
+    """
+    Downloads a single file from S3 using get_object. This is appropriate for a smaller
+    file that benefits from reduced overhead.
+    """
+    res = s3_client.get_object(
+        Bucket=s3_bucket,
+        Key=s3_key,
+        ExpectedBucketOwner=get_account_id(session=boto3_session),
+    )
+    body = res["Body"]
+    # Copy the data this amount at a time
+    buffer_size = 128 * 1024
+    with open(local_file_path, "wb") as fh:
+        while True:
+            data = body.read(buffer_size)
+            if not data:
+                break
+            should_continue = progress_tracker.track_progress_callback(len(data))
+            if not should_continue:
+                fh.close()
+                os.remove(local_file_path)
+                raise AssetSyncCancelledError("File download cancelled.")
+            fh.write(data)
+
+
+def _download_file(
+    file: BaseManifestPath,
+    hash_algorithm: HashAlgorithm,
+    collision_lock: Lock,
+    collision_file_dict: DefaultDict[str, int],
+    s3_bucket: str,
+    cas_prefix: str,
+    s3_client: BaseClient,
+    boto3_session_for_s3: boto3.Session,
+    progress_tracker: ProgressTracker,
+    file_conflict_resolution: FileConflictResolution,
+) -> None:
+    """
+    Downloads a file from the S3 bucket to the local directory.
+
+    Args:
+        file: A BaseManifestPath whose path is a local absolute path.
+        hash_algorithm: The hash algorithm used for the queue.
+        collision_lock: A lock to ensure only one thread resolves a path name collision at a time.
+        collision_file_dict: Dictionary for tracking path name collisions.
+        s3_bucket: The job attachments S3 bucket.
+        cas_prefix: The prefix for content-addressed data files in the S3 bucket.
+        s3_client: A boto3 client for accessing S3.
+        boto3_session_for_s3: The boto3.Session to use for accessing S3.
+        progress_tracker: Object to update with download progress status.
+        file_conflict_resolution: The strategy to use for file conflict resolution.
+    """
+    local_file_path = _get_long_path_compatible_path(file.path)
+
+    s3_key = f"{cas_prefix}/{file.hash}.{hash_algorithm.value}"
+
+    # If the file name already exists, resolve the conflict based on the file_conflict_resolution
+    if local_file_path.is_file():
+        if file_conflict_resolution == FileConflictResolution.SKIP:
+            return
+        elif file_conflict_resolution == FileConflictResolution.OVERWRITE:
+            pass
+        elif file_conflict_resolution == FileConflictResolution.CREATE_COPY:
+            local_file_path = _get_new_copy_file_path(
+                local_file_path, collision_lock, collision_file_dict
+            )
+        else:
+            raise ValueError(
+                f"Unknown choice for file conflict resolution: {file_conflict_resolution}"
+            )
+
+    local_file_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if file.size > 1024 * 1024:
+        download_file = _download_file_with_transfer_manager
+    else:
+        download_file = _download_file_with_get_object
+
+    try:
+        download_file(
+            local_file_path=local_file_path,
+            s3_bucket=s3_bucket,
+            s3_key=s3_key,
+            boto3_session=boto3_session_for_s3,
+            s3_client=s3_client,
+            progress_tracker=progress_tracker,
+        )
+    except concurrent.futures.CancelledError as ce:
+        if progress_tracker and progress_tracker.continue_reporting is False:
+            raise AssetSyncCancelledError("File download cancelled.")
+        else:
+            raise AssetSyncError("File download failed.", ce) from ce
+    except ClientError as exc:
+        status_code = int(exc.response["ResponseMetadata"]["HTTPStatusCode"])
+        status_code_guidance = {
+            **COMMON_ERROR_GUIDANCE_FOR_S3,
+            403: (
+                (
+                    "Forbidden or Access denied. Please check your AWS credentials, and ensure that "
+                    "your AWS IAM Role or User has the 's3:GetObject' permission for this bucket. "
+                )
+                if "kms:" not in str(exc)
+                else (
+                    "Forbidden or Access denied. Please check your AWS credentials and Job Attachments S3 bucket "
+                    "encryption settings. If a customer-managed KMS key is set, confirm that your AWS IAM Role or "
+                    "User has the 'kms:Decrypt' and 'kms:DescribeKey' permissions for the key used to encrypt the bucket."
+                )
+            ),
+            404: (
+                "Not found. Please check your bucket name and object key, and ensure that they exist in the AWS account."
+            ),
+        }
+        raise JobAttachmentsS3ClientError(
+            action="downloading file",
+            status_code=status_code,
+            bucket_name=s3_bucket,
+            key_or_prefix=s3_key,
+            message=f"{status_code_guidance.get(status_code, '')} {str(exc)} (Failed to download the file to {str(local_file_path)})",
+        ) from exc
+    except BotoCoreError as bce:
+        raise JobAttachmentS3BotoCoreError(
+            action="downloading file",
+            error_details=str(bce),
+        ) from bce
+    except Exception as e:
+        raise AssetSyncError(e) from e
+
+    # The modified time in the manifest is in microseconds, but utime requires the time be expressed in seconds.
+    modified_time_override = file.mtime / 1000000  # type: ignore[attr-defined]
+    os.utime(local_file_path, (modified_time_override, modified_time_override))  # type: ignore[arg-type]
+
+    # Verify that what we downloaded has the correct file size from the manifest.
+    file_size_on_disk = os.path.getsize(local_file_path)
+    if file_size_on_disk != file.size:
+        # TODO: Improve this error message
+        raise JobAttachmentsError(
+            f"File from S3 for {file.path} had incorrect size {file_size_on_disk}. Required size: {file.size}"
+        )
+
+
+def _download_manifest_paths(
+    manifest_paths_to_download: list[BaseManifestPath],
+    hash_algorithm: HashAlgorithm,
+    queue: dict[str, Any],
+    boto3_session_for_s3: boto3.Session,
+    file_conflict_resolution: FileConflictResolution,
+    on_downloading_files: Optional[Callable[[ProgressReportMetadata], bool]],
+    print_function_callback: Callable[[str], None] = lambda msg: None,
+) -> None:
+    """
+    Downloads all files from the S3 bucket in the Job Attachment settings to the specified directory.
+    Returns a list of local paths of downloaded files.
+
+    Args:
+        manifest_paths_to_download: A list of manifest path objects to download, whose path is an absolute file system path.
+        hash_algorithm: The hash algorithm in use by the queue.
+        queue: The queue as returned by boto3 deadline.get_queue().
+        boto3_session_for_s3: The boto3.Session to use for accessing S3.
+        file_conflict_resolution: The strategy to use for file conflict resolution.
+        on_downloading_files: A callback to handle progress messages and cancelation.
+        print_function_callback: Callback for printing output to the terminal or log.
+    """
+    s3_settings = JobAttachmentS3Settings(**queue["jobAttachmentSettings"])
+    s3_client = get_s3_client(session=boto3_session_for_s3)
+    max_workers = _get_num_download_workers()
+
+    collision_lock: Lock = Lock()
+    collision_file_dict: DefaultDict[str, int] = DefaultDict(int)
+    full_cas_prefix: str = s3_settings.full_cas_prefix()
+
+    progress_tracker = ProgressTracker(
+        status=ProgressStatus.DOWNLOAD_IN_PROGRESS,
+        total_files=len(manifest_paths_to_download),
+        total_bytes=sum(manifest_path.size for manifest_path in manifest_paths_to_download),
+        on_progress_callback=on_downloading_files,
+    )
+
+    print_function_callback(f"Using {max_workers} threads")
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = [
+            executor.submit(
+                _download_file,
+                manifest_path,
+                hash_algorithm,
+                collision_lock,
+                collision_file_dict,
+                s3_settings.s3BucketName,
+                full_cas_prefix,
+                s3_client,
+                boto3_session_for_s3,
+                progress_tracker,
+                file_conflict_resolution,
+            )
+            for manifest_path in manifest_paths_to_download
+        ]
+        # surfaces any exceptions in the thread
+        for future in concurrent.futures.as_completed(futures):
+            future.result()
+            if progress_tracker:
+                progress_tracker.increase_processed(1, 0)
+                progress_tracker.report_progress()
+
+    # to report progress 100% at the end
+    if progress_tracker:
+        progress_tracker.report_progress()

--- a/src/deadline/job_attachments/_incremental_downloads/incremental_download_state.py
+++ b/src/deadline/job_attachments/_incremental_downloads/incremental_download_state.py
@@ -31,7 +31,7 @@ class IncrementalDownloadJob:
     Model representing a job in the download progress state.
     """
 
-    _required_dict_fields = ["job", "sessionEndedTimestamp", "sessionCompletedIndexes"]
+    _required_dict_fields = ["job"]
 
     job: dict[str, Any]
     session_ended_timestamp: Optional[datetime]
@@ -76,10 +76,10 @@ class IncrementalDownloadJob:
             raise ValueError(f"Input is missing required fields: {missing_fields}")
 
         job = data["job"]
-        session_completed_indexes = data["sessionCompletedIndexes"]
+        session_completed_indexes = data.get("sessionCompletedIndexes", {})
         session_ended_timestamp = (
             datetime.fromisoformat(data["sessionEndedTimestamp"])
-            if data["sessionEndedTimestamp"] is not None
+            if data.get("sessionEndedTimestamp") is not None
             else None
         )
         return cls(
@@ -94,13 +94,14 @@ class IncrementalDownloadJob:
         Returns:
             dict: Dictionary representation of the job
         """
-        return {
+        result: dict[str, Any] = {
             "job": self.job,
-            "sessionEndedTimestamp": self.session_ended_timestamp
-            if self.session_ended_timestamp is None
-            else self.session_ended_timestamp.isoformat(),
-            "sessionCompletedIndexes": self.session_completed_indexes,
         }
+        if self.session_ended_timestamp is not None:
+            result["sessionEndedTimestamp"] = self.session_ended_timestamp.isoformat()
+        if self.session_completed_indexes != {}:
+            result["sessionCompletedIndexes"] = self.session_completed_indexes
+        return result
 
 
 class IncrementalDownloadState:
@@ -118,9 +119,12 @@ class IncrementalDownloadState:
     a stream by tracking state at three levels. Where possible, we use the resource state at one level to prune queries at lower levels:
 
     1. Job - The jobs list contains every job that is active and that we have downloaded output from in a previous incremental download command.
+            When a job becomes inactive, it tracks a minimal stub including the sessionEndedTimestamp value, to use for detecting
+            requeued jobs later.
     2. Session - Each session of a job represents a single worker running a sequence of tasks from the job. The sessionCompletedIndexes
             member of the IncrementalDownloadJob contains an entry for every session that is either still running, or whose
-            endedAt field is >= the downloadsCompletedTimestamp.
+            endedAt field is >= the downloadsCompletedTimestamp. When a job gets requeued, the sessionEndedTimestamp stored in the minimal
+            stub lets us skip sessions from before the job was requeued.
     3. SessionAction - Session actions have sequential IDs, so for each session we store the highest index of session action
             for which we have completed the download. A session action ID looks like "sessionaction-abc123-12" for session action
             index 12.

--- a/src/deadline/job_attachments/download.py
+++ b/src/deadline/job_attachments/download.py
@@ -204,7 +204,11 @@ def _get_output_manifest_prefix(
 
 
 def _get_tasks_manifests_keys_from_s3(
-    manifest_prefix: str, s3_bucket: str, session: Optional[boto3.Session] = None
+    manifest_prefix: str,
+    s3_bucket: str,
+    session: Optional[boto3.Session] = None,
+    *,
+    select_latest_per_task=True,
 ) -> List[str]:
     """
     Returns the keys of all output manifests from the given s3 prefix.
@@ -262,12 +266,16 @@ def _get_tasks_manifests_keys_from_s3(
     except Exception as e:
         raise AssetSyncError(e) from e
 
-    # 2. Select all files in the last subfolder (alphabetically) under each "task-{any}" folder.
-    for task_folder, files in task_prefixes.items():
-        last_subfolder = sorted(
-            set(f.split("/")[len(task_folder.split("/"))] for f in files), reverse=True
-        )[0]
-        manifests_keys += [f for f in files if f.startswith(f"{task_folder}/{last_subfolder}/")]
+    if select_latest_per_task:
+        # 2. Select all files in the last subfolder (alphabetically) under each "task-{any}" folder.
+        for task_folder, files in task_prefixes.items():
+            last_subfolder = sorted(
+                set(f.split("/")[len(task_folder.split("/"))] for f in files), reverse=True
+            )[0]
+            manifests_keys += [f for f in files if f.startswith(f"{task_folder}/{last_subfolder}/")]
+    else:
+        # Include all the keys, not just the latest per task
+        manifests_keys = [f for _, files in task_prefixes.items() for f in files]
 
     # Now `manifests_keys` is a list of the keys of files in the last folder (alphabetically) under each "task-" folder.
     return manifests_keys

--- a/test/unit/deadline_client/cli/test_cli_queue_incremental_download.py
+++ b/test/unit/deadline_client/cli/test_cli_queue_incremental_download.py
@@ -36,7 +36,7 @@ ISO_FREEZE_TIME_PLUS_7MIN = "2025-05-26 12:07:00+00:00"
 
 
 # Fixtures for shared resources
-@pytest.fixture()
+@pytest.fixture
 def checkpoint_dir(tmp_path_factory):
     """Create a checkpoint directory for all tests to use."""
     checkpoint_dir = tmp_path_factory.mktemp("checkpoint")
@@ -44,11 +44,18 @@ def checkpoint_dir(tmp_path_factory):
     # No cleanup needed here as tmp_path_factory handles it automatically
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def boto3_session():
     """Create a mock boto3 session for all tests to use."""
     mock_session = MagicMock(spec=boto3.Session)
-    mock_session.client().get_queue.return_value = {"displayName": "Mock Queue"}
+    mock_session.client().get_queue.return_value = {
+        "queueId": MOCK_QUEUE_ID,
+        "displayName": "Mock Queue",
+        "jobAttachmentSettings": {
+            "rootPrefix": "MockRootPrefix",
+            "s3BucketName": "mock-s3-bucket",
+        },
+    }
     with patch.object(boto3, "Session", return_value=mock_session), patch.object(
         deadline.client.api, "get_deadline_cloud_library_telemetry_client"
     ):
@@ -104,6 +111,40 @@ def test_incremental_output_download_requires_beta_acknowledgement(
         "The incremental-output-download command is not fully implemented. You must set the environment variable ENABLE_INCREMENTAL_OUTPUT_DOWNLOAD to 1 to acknowledge this."
         in result.output
     ), result.output
+
+
+def test_incremental_output_download_requires_queue_with_job_attachments(
+    fresh_deadline_config, boto3_session, with_incremental_download_enabled, checkpoint_dir
+):
+    # The response does not include the "jobAttachmentSettings" field
+    boto3_session.client().get_queue.return_value = {
+        "queueId": MOCK_QUEUE_ID,
+        "displayName": "Mock Queue",
+    }
+
+    # Run the CLI command once to bootstrap the operation
+    runner = CliRunner()
+    with freeze_time(ISO_FREEZE_TIME):
+        result = runner.invoke(
+            main,
+            [
+                "queue",
+                "incremental-output-download",
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--checkpoint-dir",
+                checkpoint_dir,
+            ],
+        )
+
+    # Assert the command executed successfully
+    assert result.exit_code == 1, result.output
+
+    assert "Queue 'Mock Queue' does not have job attachments configured." in result.output, (
+        result.output
+    )
 
 
 def test_incremental_output_download_pid_lock_already_held_error(
@@ -794,3 +835,69 @@ def test_incremental_output_download_job_completed_then_requeued(
     assert f"NEW Job: Mock Job ({MOCK_JOB_ID})" in result.output, result.output
     assert "Succeeded tasks: 1 / 2" in result.output, result.output
     assert "added: 1" in result.output, result.output
+
+
+def test_incremental_output_download_dry_run(
+    fresh_deadline_config, with_incremental_download_enabled, boto3_session, checkpoint_dir
+):
+    """Test a new job through bootstrap, completion, and retirement."""
+    mock_jobs = create_fake_job_list(1)
+    mock_jobs[0]["name"] = "Mock Job"
+    mock_jobs[0]["jobId"] = MOCK_JOB_ID
+    mock_jobs[0]["taskRunStatus"] = "READY"
+    mock_jobs[0]["taskRunStatusCounts"] = {
+        "SUCCEEDED": 1,
+        "READY": 1,
+    }
+    mock_jobs[0]["attachments"] = {
+        "manifests": [
+            {"rootPath": "/", "rootPathFormat": "posix", "outputRelativeDirectories": ["."]}
+        ],
+        "fileSystem": "VIRTUAL",
+    }
+    del mock_jobs[0]["endedAt"]
+    boto3_session.client().search_jobs = mock_search_jobs_for_set(
+        MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs
+    )
+    boto3_session.client().get_job = mock_get_job_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+
+    # RUN 1: Run the CLI command once to bootstrap the operation
+    runner = CliRunner()
+    with freeze_time(ISO_FREEZE_TIME):
+        result = runner.invoke(
+            main,
+            [
+                "queue",
+                "incremental-output-download",
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--checkpoint-dir",
+                checkpoint_dir,
+                "--dry-run",
+            ],
+        )
+
+    # Assert the command executed successfully
+    assert result.exit_code == 0, result.output
+
+    # Assert that the output contained information about the bootstrapping and the mocked resources
+    assert "Started incremental download for queue: Mock Queue" in result.output, result.output
+    assert (
+        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_download_checkpoint.json')}"
+        in result.output
+    ), result.output
+    assert "Checkpoint not found, lookback is 0.0 minutes" in result.output, result.output
+    # Need to convert the freeze time to the local time zone for this print assertion
+    assert (
+        f"Initializing from: {datetime.fromisoformat(ISO_FREEZE_TIME).astimezone().isoformat()}"
+        in result.output
+    ), result.output
+    assert f"NEW Job: Mock Job ({MOCK_JOB_ID})" in result.output, result.output
+    assert "Skipping downloads due to DRY RUN" in result.output, result.output
+    assert (
+        "Summary of DRY RUN for incremental output download (no files were downloaded to the file system):"
+        in result.output
+    ), result.output
+    assert "This is a DRY RUN so the checkpoint was not saved" in result.output, result.output

--- a/test/unit/deadline_client/config/test_config_file.py
+++ b/test/unit/deadline_client/config/test_config_file.py
@@ -351,15 +351,11 @@ def test_write_config_directory_permission_windows(
         str(path.resolve()), win32security.DACL_SECURITY_INFORMATION
     ).GetSecurityDescriptorDacl()
 
-    assert new_dacl.GetAceCount() == dacl.GetAceCount()
-    for i in range(dacl.GetAceCount()):
-        # Assert the access control entries are identical
-        (acetype, aceflags), access, sid = dacl.GetAce(i)
-        (new_acetype, new_aceflags), new_access, new_sid = new_dacl.GetAce(i)
-        assert acetype == new_acetype
-        assert aceflags == new_aceflags
-        assert access == new_access
-        assert sid == new_sid
+    new_dacl_aces = [new_dacl.GetAce(i) for i in range(new_dacl.GetAceCount())]
+    dacl_aces = [dacl.GetAce(i) for i in range(dacl.GetAceCount())]
+
+    # Assert the access control entries are identical
+    assert new_dacl_aces == dacl_aces
 
 
 @pytest.mark.skipif(

--- a/test/unit/deadline_job_attachments/incremental_downloads/test_incremental_download_state.py
+++ b/test/unit/deadline_job_attachments/incremental_downloads/test_incremental_download_state.py
@@ -39,7 +39,7 @@ class TestIncrementalDownloadState:
         """
         return {
             "location": temp_dir,
-            "progress_file": os.path.join(temp_dir, "download_progress.json"),
+            "progress_file": os.path.join(temp_dir, "download_checkpoint.json"),
         }
 
     @pytest.fixture

--- a/test/unit/deadline_job_attachments/incremental_downloads/test_manifest_s3_downloads.py
+++ b/test/unit/deadline_job_attachments/incremental_downloads/test_manifest_s3_downloads.py
@@ -1,0 +1,515 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Tests for the _add_output_manifests_from_s3 function in the incremental downloads module.
+
+This module contains comprehensive unit tests for the _add_output_manifests_from_s3 function,
+which is responsible for populating missing manifest information in session actions by
+retrieving output manifest paths from S3.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import patch
+
+import boto3
+from moto import mock_aws
+
+from deadline.job_attachments._incremental_downloads._manifest_s3_downloads import (
+    _add_output_manifests_from_s3,
+)
+from deadline.job_attachments.asset_manifests import hash_data as ja_hash_data
+from deadline.job_attachments.asset_manifests.v2023_03_03.asset_manifest import DEFAULT_HASH_ALG
+
+
+# Test data generation utilities
+
+
+def generate_test_job(job_id: str, root_paths: list[str]) -> dict[str, Any]:
+    """Generate a test job with specified root paths for attachment manifests."""
+    return {
+        "jobId": job_id,
+        "name": f"test-job-{job_id}",
+        "attachments": {
+            "manifests": [
+                {
+                    "rootPath": root_path,
+                    "rootPathFormat": "POSIX",
+                    "inputManifestPath": f"input_manifest_{i}",
+                    "inputManifestHash": f"input_hash_{i}",
+                    "outputRelativeDirectories": [f"output_{i}"],
+                }
+                for i, root_path in enumerate(root_paths)
+            ]
+        },
+    }
+
+
+def generate_session_actions(
+    session_action_ids: list[str],
+    farm_id: str = "farm-01234567890123456789012345678901",
+    queue_id: str = "queue-01234567890123456789012345678901",
+    job_id: str = "job-01234567890123456789012345678901",
+    root_path_hashes: list[str] | None = None,
+    *,
+    with_manifests: bool = False,
+) -> list[dict[str, Any]]:
+    """Generate session actions with or without existing manifests following the correct S3 path pattern."""
+    session_actions = []
+
+    # Default root path hashes if not provided
+    if root_path_hashes is None:
+        root_path_hashes = ["hash1", "hash2"]
+
+    for session_action_id in session_action_ids:
+        session_action: dict[str, Any] = {"sessionActionId": session_action_id}
+        if with_manifests:
+            # Generate manifests following the pattern:
+            # <farm_id>/<queue_id>/<job_id>/<step_id>/<task_id>/<timestamp>_<session_action_id>/<manifest_hash>_output
+            step_id = "step-123"
+            task_id = "task-456"
+            timestamp = "2023-01-01T12:00:00.000000Z"
+
+            manifests = []
+            for i, root_path_hash in enumerate(root_path_hashes):
+                manifest_path = (
+                    f"{farm_id}/{queue_id}/{job_id}/{step_id}/{task_id}/"
+                    f"{timestamp}_{session_action_id}/{root_path_hash}_output"
+                )
+                manifests.append({"outputManifestPath": manifest_path})
+            session_action["manifests"] = manifests
+        session_actions.append(session_action)
+    return session_actions
+
+
+def calculate_root_path_hashes(root_paths: list[str]) -> list[str]:
+    """Calculate hashes for root paths using the same algorithm as the function under test."""
+    return [ja_hash_data(root_path.encode(), DEFAULT_HASH_ALG) for root_path in root_paths]
+
+
+class ManifestKeyBuilder:
+    """Utility class to build S3 manifest keys following the documented pattern."""
+
+    def __init__(self, root_prefix: str, farm_id: str, queue_id: str, job_id: str):
+        self.root_prefix = root_prefix
+        self.farm_id = farm_id
+        self.queue_id = queue_id
+        self.job_id = job_id
+
+    def build_key(self, session_action_id: str, root_path_hash: str) -> str:
+        """Build a manifest S3 key for testing.
+
+        Pattern: <root_prefix>/Manifests/<farm_id>/<queue_id>/<job_id>/<step_id>/<task_id>/<timestamp>_<session_action_id>/<manifest_hash>_output
+        """
+        step_id = "step-123"
+        task_id = "task-456"
+        timestamp = "2023-01-01T12:00:00.000000Z"
+        return (
+            f"{self.root_prefix}/Manifests/{self.farm_id}/{self.queue_id}/"
+            f"{self.job_id}/{step_id}/{task_id}/{timestamp}_{session_action_id}/"
+            f"{root_path_hash}_output"
+        )
+
+
+def create_manifest_s3_objects(s3_client, bucket_name: str, manifest_keys: list[str]):
+    """Create S3 objects for manifest keys with minimal valid content."""
+    manifest_content = json.dumps(
+        {"manifestVersion": "2023-03-03", "hashAlg": "xxh128", "paths": [], "totalSize": 0}
+    )
+
+    for key in manifest_keys:
+        s3_client.put_object(Bucket=bucket_name, Key=key, Body=manifest_content.encode("utf-8"))
+
+
+# Validation utility functions
+
+
+def validate_manifest_structure(manifest_entry: dict[str, Any]) -> None:
+    """
+    Validate that a manifest entry has the expected structure with proper "outputManifestPath" field format.
+
+    Requirements: 4.1 - Verify that the populated manifest structure matches the expected format
+    """
+    assert isinstance(manifest_entry, dict), "Manifest entry must be a dictionary"
+    assert "outputManifestPath" in manifest_entry, (
+        "Manifest entry must contain 'outputManifestPath' field"
+    )
+    assert isinstance(manifest_entry["outputManifestPath"], str), (
+        "outputManifestPath must be a string"
+    )
+    assert len(manifest_entry["outputManifestPath"]) > 0, "outputManifestPath cannot be empty"
+
+    # Validate that the path doesn't contain the S3 prefix (should be removed)
+    output_path = manifest_entry["outputManifestPath"]
+    assert not output_path.startswith("test-prefix/Manifests/"), (
+        "S3 prefix should be removed from outputManifestPath"
+    )
+    assert not output_path.startswith("/Manifests/"), (
+        "Manifest prefix should be removed from outputManifestPath"
+    )
+
+
+def validate_root_path_hash_matching(
+    job: dict[str, Any], session_actions: list[dict[str, Any]], expected_root_path_hashes: list[str]
+) -> None:
+    """
+    Validate that manifests are populated at correct indices based on root path hash matching.
+
+    Requirements: 4.2 - Verify that each manifest is populated at the correct index in the manifests array
+    Requirements: 4.4 - Verify that manifest keys are correctly matched to job attachment manifests based on hash
+    """
+    job_manifests = job.get("attachments", {}).get("manifests", [])
+
+    for session_action in session_actions:
+        if "manifests" not in session_action:
+            continue
+
+        manifests = session_action["manifests"]
+        assert len(manifests) == len(job_manifests), (
+            "Number of manifests should match job attachment manifests"
+        )
+
+        for i, manifest in enumerate(manifests):
+            if manifest and "outputManifestPath" in manifest:
+                # Verify this manifest corresponds to the correct root path hash at index i
+                output_path = manifest["outputManifestPath"]
+                expected_hash = expected_root_path_hashes[i]
+
+                # The output path should contain the root path hash for the corresponding job manifest
+                assert expected_hash in output_path, (
+                    f"Manifest at index {i} should contain root path hash {expected_hash} "
+                    f"but path is {output_path}"
+                )
+
+                # Verify the session action ID is in the path
+                session_action_id = session_action["sessionActionId"]
+                assert session_action_id in output_path, (
+                    f"Output path should contain session action ID {session_action_id}"
+                )
+
+
+def validate_existing_session_action_manifests_are_unmodified(
+    original_session_actions: list[dict[str, Any]], processed_session_actions: list[dict[str, Any]]
+) -> None:
+    """
+    Validate that session actions with existing manifests are not modified during processing.
+    """
+    for i, (original, processed) in enumerate(
+        zip(original_session_actions, processed_session_actions)
+    ):
+        if "manifests" in original:
+            # Session actions that already had manifests should remain unchanged
+            assert original == processed, (
+                f"Session action {i} with existing manifests should not be modified. "
+                f"Original: {original}, Processed: {processed}"
+            )
+
+
+def validate_manifest_keys_do_not_have_prefix(
+    session_actions: list[dict[str, Any]], root_prefix: str
+) -> None:
+    """
+    Validate that output manifest paths do not start with the S3 prefix configured on the queue.
+    """
+    manifest_prefix = f"{root_prefix}/Manifests/"
+
+    for session_action in session_actions:
+        for manifest in session_action.get("manifests", []):
+            if manifest and "outputManifestPath" in manifest:
+                output_path = manifest["outputManifestPath"]
+
+                # Verify the S3 prefix has been removed
+                assert not output_path.startswith(manifest_prefix), (
+                    f"Output manifest path should not start with S3 prefix '{manifest_prefix}'. "
+                    f"Found: {output_path}"
+                )
+
+                # Verify it's a relative path (doesn't start with /)
+                assert not output_path.startswith("/"), (
+                    f"Output manifest path should be relative, not absolute. Found: {output_path}"
+                )
+
+
+@mock_aws
+def test_add_output_manifests_from_s3_fill_in_missing_manifests(fresh_deadline_config):
+    """
+    Test that _add_output_manifests_from_s3 correctly fills in missing manifest information from S3.
+
+    This test uses moto to create a mocked S3 bucket structure containing S3 objects with appropriate key names
+    for the test, and a mock list_session_actions response where some manifests are already provided
+    and others are not. It confirms that the list_session_actions response is updated where the manifests are
+    missing, and is not modified where they are.
+    """
+    # Test constants
+    farm_id = "farm-01234567890123456789012345678901"
+    queue_id = "queue-01234567890123456789012345678901"
+    job_id = "job-01234567890123456789012345678901"
+    bucket_name = "test-bucket"
+    root_prefix = "test-prefix"
+
+    # Create S3 client and bucket
+    s3_client = boto3.client("s3", region_name="us-west-2")
+    s3_client.create_bucket(
+        Bucket=bucket_name, CreateBucketConfiguration={"LocationConstraint": "us-west-2"}
+    )
+
+    # Create test job with multiple attachment manifests having different root paths
+    root_paths = ["/tmp/input1", "/tmp/input2"]
+    job = generate_test_job(job_id, root_paths)
+
+    # Create queue structure
+    queue = {
+        "queueId": queue_id,
+        "jobAttachmentSettings": {"s3BucketName": bucket_name, "rootPrefix": root_prefix},
+    }
+
+    # Generate session actions missing "manifests" fields
+    session_action_ids = ["sessionaction-abc123-0", "sessionaction-def456-1"]
+    session_actions = generate_session_actions(session_action_ids, with_manifests=False)
+
+    # Calculate root path hashes for job attachment manifests
+    root_path_hashes = calculate_root_path_hashes(root_paths)
+
+    # Generate S3 manifest keys containing session action IDs and root path hashes
+    key_builder = ManifestKeyBuilder(root_prefix, farm_id, queue_id, job_id)
+    manifest_keys = []
+
+    for session_action_id in session_action_ids:
+        for root_path_hash in root_path_hashes:
+            manifest_key = key_builder.build_key(session_action_id, root_path_hash)
+            manifest_keys.append(manifest_key)
+
+    # Create S3 objects for the manifest keys with minimal valid content
+    create_manifest_s3_objects(s3_client, bucket_name, manifest_keys)
+
+    # Create boto3 session for the function call
+    boto3_session = boto3.Session()
+
+    # Call the function under test
+    _add_output_manifests_from_s3(
+        farm_id=farm_id,
+        queue=queue,
+        job=job,
+        boto3_session=boto3_session,
+        session_action_list=session_actions,
+    )
+
+    # Validate manifest structure for all populated manifests
+    for session_action in session_actions:
+        assert "manifests" in session_action
+        assert len(session_action["manifests"]) == len(root_paths)
+
+        for manifest in session_action["manifests"]:
+            validate_manifest_structure(manifest)
+
+    # Validate root path hash matching
+    validate_root_path_hash_matching(job, session_actions, root_path_hashes)
+
+    # Validate manifest prefix removal
+    validate_manifest_keys_do_not_have_prefix(session_actions, root_prefix)
+
+    # Verify that all expected manifest keys were created and populated correctly
+    expected_manifest_count = len(session_action_ids) * len(root_paths)
+    actual_manifest_count = sum(
+        len([m for m in sa["manifests"] if "outputManifestPath" in m]) for sa in session_actions
+    )
+    assert actual_manifest_count == expected_manifest_count
+
+
+def test_add_output_manifests_from_s3_already_stored(fresh_deadline_config):
+    """
+    Test that _add_output_manifests_from_s3 does not modify session actions with existing manifests.
+
+    This test confirms that no S3 APIs are accessed, and that the manifests already in the mock
+    list_session_actions response are not modified when session actions already contain manifest data.
+    """
+    # Test constants
+    farm_id = "farm-01234567890123456789012345678901"
+    queue_id = "queue-01234567890123456789012345678901"
+    job_id = "job-01234567890123456789012345678901"
+    bucket_name = "test-bucket"
+    root_prefix = "test-prefix"
+
+    # Create test job with multiple attachment manifests having different root paths
+    root_paths = ["/tmp/input1", "/tmp/input2"]
+    job = generate_test_job(job_id, root_paths)
+
+    # Create queue structure
+    queue = {
+        "queueId": queue_id,
+        "jobAttachmentSettings": {"s3BucketName": bucket_name, "rootPrefix": root_prefix},
+    }
+
+    # Calculate root path hashes for the job attachment manifests
+    root_path_hashes = calculate_root_path_hashes(root_paths)
+
+    # Create session actions that already contain "manifests" fields
+    session_action_ids = ["sessionaction-abc123-0", "sessionaction-def456-1"]
+    session_actions = generate_session_actions(
+        session_action_ids,
+        farm_id=farm_id,
+        queue_id=queue_id,
+        job_id=job_id,
+        root_path_hashes=root_path_hashes,
+        with_manifests=True,
+    )
+
+    # Store original manifest data for comparison
+    original_session_actions = json.loads(json.dumps(session_actions))
+
+    # Create boto3 session for the function call
+    boto3_session = boto3.Session()
+
+    # Mock _get_tasks_manifests_keys_from_s3 to track if it's called
+    with patch(
+        "deadline.job_attachments._incremental_downloads._manifest_s3_downloads._get_tasks_manifests_keys_from_s3"
+    ) as mock_get_keys:
+        # Call the function under test
+        _add_output_manifests_from_s3(
+            farm_id=farm_id,
+            queue=queue,
+            job=job,
+            boto3_session=boto3_session,
+            session_action_list=session_actions,
+        )
+
+        # Verify that _get_tasks_manifests_keys_from_s3 was never called
+        mock_get_keys.assert_not_called()
+
+    # Existing manifests should be preserved
+    validate_existing_session_action_manifests_are_unmodified(
+        original_session_actions, session_actions
+    )
+
+    # Validate manifest prefix removal from S3 object keys
+    validate_manifest_keys_do_not_have_prefix(session_actions, root_prefix)
+
+    # Assert that existing manifest data in session actions remains unchanged
+    assert session_actions == original_session_actions
+
+
+@mock_aws
+def test_add_output_manifests_from_s3_edge_cases(fresh_deadline_config):
+    """
+    Test that _add_output_manifests_from_s3 handles edge cases and mixed scenarios correctly.
+
+    This test validates edge cases including empty session action lists and mixed scenarios
+    where some session actions have manifests and others don't, ensuring the function
+    handles various data structures robustly and maintains data integrity.
+    """
+    # Test constants
+    farm_id = "farm-01234567890123456789012345678901"
+    queue_id = "queue-01234567890123456789012345678901"
+    job_id = "job-01234567890123456789012345678901"
+    bucket_name = "test-bucket"
+    root_prefix = "test-prefix"
+
+    # Create S3 client and bucket
+    s3_client = boto3.client("s3", region_name="us-west-2")
+    s3_client.create_bucket(
+        Bucket=bucket_name, CreateBucketConfiguration={"LocationConstraint": "us-west-2"}
+    )
+
+    # Create test job with multiple attachment manifests having different root paths
+    root_paths = ["/tmp/input1", "/tmp/input2"]
+    job = generate_test_job(job_id, root_paths)
+
+    # Create queue structure
+    queue = {
+        "queueId": queue_id,
+        "jobAttachmentSettings": {"s3BucketName": bucket_name, "rootPrefix": root_prefix},
+    }
+
+    # Calculate root path hashes for job attachment manifests
+    root_path_hashes = calculate_root_path_hashes(root_paths)
+
+    # Create boto3 session for the function call
+    boto3_session = boto3.Session()
+
+    # Test Case 1: Empty session action list
+    empty_session_actions: list[dict[str, Any]] = []
+    _add_output_manifests_from_s3(
+        farm_id=farm_id,
+        queue=queue,
+        job=job,
+        boto3_session=boto3_session,
+        session_action_list=empty_session_actions,
+    )
+
+    # List is still empty
+    assert empty_session_actions == []
+
+    # Test Case 2: Mixed scenario - some with manifests, some without
+    session_action_ids_with = ["sessionaction-with-1", "sessionaction-with-2"]
+    session_action_ids_without = ["sessionaction-without-1", "sessionaction-without-2"]
+
+    # Create session actions with existing manifests
+    session_actions_with_manifests = generate_session_actions(
+        session_action_ids_with,
+        farm_id=farm_id,
+        queue_id=queue_id,
+        job_id=job_id,
+        root_path_hashes=root_path_hashes,
+        with_manifests=True,
+    )
+
+    # Create session actions without manifests
+    session_actions_without_manifests = generate_session_actions(
+        session_action_ids_without, with_manifests=False
+    )
+
+    # Combine both types for mixed scenario
+    mixed_session_actions = session_actions_with_manifests + session_actions_without_manifests
+
+    # Store original data for comparison
+    original_mixed_session_actions = json.loads(json.dumps(mixed_session_actions))
+
+    # Create S3 objects for the session actions that need manifests
+    key_builder = ManifestKeyBuilder(root_prefix, farm_id, queue_id, job_id)
+    manifest_keys = []
+
+    for session_action_id in session_action_ids_without:
+        for root_path_hash in root_path_hashes:
+            manifest_key = key_builder.build_key(session_action_id, root_path_hash)
+            manifest_keys.append(manifest_key)
+
+    create_manifest_s3_objects(s3_client, bucket_name, manifest_keys)
+
+    # Call the function under test with mixed scenario
+    _add_output_manifests_from_s3(
+        farm_id=farm_id,
+        queue=queue,
+        job=job,
+        boto3_session=boto3_session,
+        session_action_list=mixed_session_actions,
+    )
+
+    # Validate that session actions with existing manifests were not modified
+    for i, session_action in enumerate(mixed_session_actions):
+        if session_action["sessionActionId"] in session_action_ids_with:
+            # Find corresponding original session action
+            original_sa = next(
+                sa
+                for sa in original_mixed_session_actions
+                if sa["sessionActionId"] == session_action["sessionActionId"]
+            )
+            assert session_action == original_sa, (
+                f"Session action with existing manifests should not be modified: {session_action['sessionActionId']}"
+            )
+
+    # Validate that session actions without manifests were populated
+    for session_action in mixed_session_actions:
+        if session_action["sessionActionId"] in session_action_ids_without:
+            assert "manifests" in session_action, (
+                f"Session action without manifests should be populated: {session_action['sessionActionId']}"
+            )
+            for manifest in session_action["manifests"]:
+                validate_manifest_structure(manifest)
+
+    # Validate manifest prefix removal for all session actions
+    validate_manifest_keys_do_not_have_prefix(mixed_session_actions, root_prefix)
+
+    # Validate root path hash matching for all populated manifests
+    validate_root_path_hash_matching(job, mixed_session_actions, root_path_hashes)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

For the auto/incremental download, it needs to download the output files after it determines which session actions are in scope for processing. This involves downloading all the manifest files, determining the correct order to process them, merging them, then downloading all the files.

### What was the solution? (How)

* Added code that fills in the manifest keys when they're not already available on the session action. The output manifests of session actions can be stored in session actions, see https://docs.aws.amazon.com/deadline-cloud/latest/APIReference/API_ListSessionActions.html, but this was added recently so is not guaranteed to be present.
* Added a --dry-run option to the incremental download command, that prints out information about what would be downloaded but does not perform the download and does not save the checkpoint file.
* Add a new file _incremental_download_s3_access.py to contain all the S3 functionality needed by the incremental operation. Some of this code is copied from the job attachments download.py, to be able to change the interfaces and work on optimization independently of the existing functionality.
* Use thread-based concurrency for the manifest file download, the session and session action retrieval, and the output file download.
* Print a summary of all the download filenames before proceeding to do the download.
* Add statistics about the number of files and total bytes downloaded.
* Modified the multi-threaded download function to download files
      smaller than 1MB with get_object instead of transfer manager. This
      improved performance on a test dataset from 4m50s to 1m30s.
 
### What is the impact of this change?

The feature works in some manual testing end-to-end. This means we can expand testing and evaluation of it.

### How was this change tested?

Performed many downloads with different look-back periods from a test farm. Filling in more of the unit tests is for a later follow-up.

### Was this change documented?

No

### Does this PR introduce new dependencies?

No

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
