### PR TITLE
feat: make _launch_vfs return a boolean indicating VFS launch success

### DIFF
--- a/src/deadline/job_attachments/asset_sync.py
+++ b/src/deadline/job_attachments/asset_sync.py
@@ -252,7 +252,7 @@ class AssetSync:
         fs_permission_settings: Optional[FileSystemPermissionSettings] = None,
         merged_manifests_by_root: dict[str, BaseAssetManifest] = dict(),
         os_env_vars: dict[str, str] | None = None,
-    ) -> None:
+    ) -> bool:
         """
         Args:
             s3_settings: S3-specific Job Attachment settings.
@@ -261,8 +261,7 @@ class AssetSync:
                                     to be set on the downloaded (synchronized) input files and directories.
             merged_manifests_by_root: Merged manifests produced by
                                     _aggregate_asset_root_manifests()
-        Returns: None
-        Raises: VFSExecutableMissingError If VFS is not startable.
+        Returns: bool indicating if VFS was able to be launched. True if VFS launched successfully.
         """
 
         try:
@@ -276,11 +275,12 @@ class AssetSync:
                 os_env_vars=os_env_vars,  # type: ignore[arg-type]
                 cas_prefix=s3_settings.full_cas_prefix(),
             )
-
+            return True
         except VFSExecutableMissingError:
             logger.error(
                 f"Virtual File System not found, falling back to {JobAttachmentsFileSystem.COPIED} for JobAttachmentsFileSystem."
             )
+            return False
 
     def copied_download(
         self,


### PR DESCRIPTION


### What was the problem/requirement? (What/Why)
When calling the `_launch_vfs` function, the caller has no way of knowing whether VFS was able to be launched successfully. This may cause issues when trying to fallback to copied workflow, as the caller does not know if VFS was successfully launched.

### What was the solution? (How)
Make `_launch_vfs()` return a boolean indicating whether VFS was able to be successfully launched
### What is the impact of this change?

Callers of this function will be able to fallback or do behaviours correctly  according to whether VFS is able to be launched 
### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests? yes
- Have you run the integration tests? yes
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass. yes

### Was this change documented?
No
- Are relevant docstrings in the code base updated? No
- Has the README.md been updated? If you modified CLI arguments, for instance. No

### Does this PR introduce new dependencies?
No
This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x ] This PR does not add any new dependencies.

### Is this a breaking change?
No, this is an internal function
A breaking change is one that modifies a public contract in a way that is not backwards compatible. See the 
[Public Contracts](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#public-contracts) section
of the DEVELOPMENT.md for more information on the public contracts.

If so, then please describe the changes that users of this package must make to update their scripts, or Python applications.

### Does this change impact security?
No
- Does the change need to be threat modeled? For example, does it create or modify files/directories that must only be readable by the process owner? No
    - If so, then please label this pull request with the "security" label. We'll work with you to analyze the threats.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
