### PR TITLE
ci: update pypi publish to tag based release

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -107,7 +107,7 @@ jobs:
   # PyPI does not support reusable workflows yet
   # # See https://github.com/pypi/warehouse/issues/11096
   PublishToPyPI:
-    needs: Publish
+    needs: [TagRelease, Publish]
     runs-on: ubuntu-latest
     environment: release
     permissions:
@@ -116,7 +116,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.Publish.outputs.tag }}
+          ref: ${{ needs.TagRelease.outputs.tag }}
           fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The PyPI publish job is referencing the Publish jobs output, we should update to to reference the TagRelease job.

### What was the solution? (How)
Update the PyPI publish reference the tag output from the TagRelease job

### What is the impact of this change?
Code reads better and matches other repositories implementation.

### How was this change tested?
n/a

### Was this change documented?
n/a

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*