### PR TITLE
fix: installer_version.txt was not uninstalled

### DIFF
--- a/installer/DeadlineCloudClient.xml
+++ b/installer/DeadlineCloudClient.xml
@@ -455,6 +455,9 @@ ${_fnAddEnvironmentVariable_list}
             <path>${installdir}/DeadlineClient/installer_version.txt</path>
             <text>${project.version}</text>
         </writeFile>
+        <addFilesToUninstaller>
+            <files>${installdir}/DeadlineClient/installer_version.txt</files>
+        </addFilesToUninstaller>
         <changePermissions permissions="0644" files="${installdir}/DeadlineClient/installer_version.txt"/>
         <addDirectoriesToUninstaller>
           <files>${installdir}/DeadlineClient</files>


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

```
=== short test summary info ===
FAILED test/installer/test_installer.py::TestUserInstall::test_uninstall - AssertionError: assert not True
 +  where True = exists()
 +    where exists = PosixPath('/private/var/folders/j_/kh9hgnt51jn_4rk3z3dz6m_h0000gr/T/pytest/pytest-2/popen-gw7/test_uninstall0/dne').exists
=== 1 failed, 3 passed, 9 skipped in 36.83s ===
```

When you inspect the folder, we see that the DeadlineClient folder is left behind with installer_version.txt in it, preventing the full uninstallation.

```
$ (cd /private/var/folders/j_/kh9hgnt51jn_4rk3z3dz6m_h0000gr/T/pytest/pytest-2/popen-gw7/test_uninstall0 && tree dne)
dne
└── DeadlineClient
    └── installer_version.txt

2 directories, 1 file
```

### What was the solution? (How)

Add installer_verison.txt to the files to uninstall list. Not sure how it was passing previously 🤔 but it consistently fails now.

### What is the impact of this change?

Tests pass!

```
test/installer/test_installer.py::test_default_location 
test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions 
test/installer/test_installer.py::TestLinuxAndMacOS::test_system_permissions 
test/installer/test_installer.py::TestUserInstall::test_install 
test/installer/test_installer.py::TestSystemInstall::test_uninstall 
[gw9] [  7%] SKIPPED test/installer/test_installer.py::TestSystemInstall::test_uninstall 
test/installer/test_installer.py::TestUserInstall::test_uninstall 
test/installer/test_installer.py::TestSystemInstall::test_install 
[gw3] [ 15%] SKIPPED test/installer/test_installer.py::TestLinuxAndMacOS::test_system_permissions 
test/installer/test_installer.py::TestWindows::test_system_permissions 
[gw5] [ 23%] SKIPPED test/installer/test_installer.py::TestWindows::test_system_permissions 
test/installer/test_installer.py::test_did_not_build_with_evaluation_mode 
[gw1] [ 30%] SKIPPED test/installer/test_installer.py::test_did_not_build_with_evaluation_mode 
test/installer/test_installer.py::TestWindows::test_user_permissions 
[gw4] [ 38%] SKIPPED test/installer/test_installer.py::TestWindows::test_user_permissions 
[gw8] [ 46%] SKIPPED test/installer/test_installer.py::TestSystemInstall::test_install 
test/installer/test_installer.py::TestVerifySigning::test_linux_signing 
[gw1] [ 53%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_linux_signing 
[gw0] [ 61%] PASSED test/installer/test_installer.py::test_default_location 
test/installer/test_installer.py::TestVerifySigning::test_windows_signing 
[gw0] [ 69%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_windows_signing 
[gw2] [ 76%] PASSED test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions 
test/installer/test_installer.py::TestVerifySigning::test_macos_signing 
[gw2] [ 84%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_macos_signing 
[gw6] [ 92%] PASSED test/installer/test_installer.py::TestUserInstall::test_install 
[gw7] [100%] PASSED test/installer/test_installer.py::TestUserInstall::test_uninstall 

=== 4 passed, 9 skipped in 39.02s ===

```

### How was this change tested?

```
hatch run test_installer
```

results posted above

### Was this change documented?

N/A

### Does this PR introduce new dependencies?

N/A

### Is this a breaking change?

N/A
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
