### PR TITLE
chore: Allow zero version in Semantic Release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,6 +185,7 @@ fail_under = 80
 # Can be removed or set to true once we are v1
 major_on_zero = false
 tag_format = "{version}"
+allow_zero_version = true
 
 [tool.semantic_release.commit_parser_options]
 allowed_tags = [


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Bump actions automatically go to 1.0.0 due to a change in Semantic Release.

### What was the solution? (How)
Add a flag to `pyproject.toml` to retain 0 version.

### What is the impact of this change?
No unwanted version bumps :)

### How was this change tested?
n/a

#### Please run the integration tests and paste the results below
didn't change source behaviour

#### If `installer/` was modified or a file was added/removed from `src/`, then update the installer tests and post the test results below
n/a

### Was this change documented?
n/a

### Is this a breaking change?
nop

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*