### PR TITLE
chore: remove json schemas from pyinstaller

### DIFF
--- a/scripts/pyinstaller/deadline_cli.spec
+++ b/scripts/pyinstaller/deadline_cli.spec
@@ -19,8 +19,6 @@ datas, binaries, hiddenimports = collect_all('deadline')
 # The 'datas' parameter adds data files to the bundle.
 # Each entry is a pair (local_filename, destination_path).
 datas += [
-    (b_module_path + '/job_attachments/asset_manifests/schemas/*.json',
-     'deadline_job_attachments/asset_manifests/schemas'),
     (b_module_path + '/../../THIRD_PARTY_LICENSES',
      '.')
 ]


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

One additional section had to be updated with the json schema removal.

```
Unable to find "src/deadline/job_attachments/asset_manifests/schemas/*.json" when adding binary and data files.
Traceback (most recent call last):
  File "scripts/pyinstaller/make_exe.py", line 117, in <module>
    main()
  File "scripts/pyinstaller/make_exe.py", line 113, in main
    make_exe(output, cleanup=args.cleanup)
  File "scripts/pyinstaller/make_exe.py", line 44, in make_exe
    pyinstaller(str(DEADLINE_CLI_SPEC_PATH))
  File "scripts/pyinstaller/make_exe.py", line 80, in pyinstaller
    subprocess.run(["pyinstaller", *args], cwd=PYINSTALLER_DIR, check=True)
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['pyinstaller', 'scripts/pyinstaller/deadline_cli.spec']' returned non-zero exit status 1.
```

### What was the solution? (How)

Remove it!

### What is the impact of this change?

It builds!

### How was this change tested?

```
hatch env prune && hatch run installer:build_installer_local
hatch run test_installer
```

```
test/installer/test_installer.py::TestUserInstall::test_uninstall 
test/installer/test_installer.py::TestWindows::test_user_permissions 
test/installer/test_installer.py::test_default_location 
test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions 
test/installer/test_installer.py::TestSystemInstall::test_install 
[gw8] [  7%] SKIPPED test/installer/test_installer.py::TestSystemInstall::test_install 
test/installer/test_installer.py::test_did_not_build_with_evaluation_mode 
[gw1] [ 15%] SKIPPED test/installer/test_installer.py::test_did_not_build_with_evaluation_mode 
test/installer/test_installer.py::TestSystemInstall::test_uninstall 
[gw9] [ 23%] SKIPPED test/installer/test_installer.py::TestSystemInstall::test_uninstall 
test/installer/test_installer.py::TestLinuxAndMacOS::test_system_permissions 
[gw3] [ 30%] SKIPPED test/installer/test_installer.py::TestLinuxAndMacOS::test_system_permissions 
test/installer/test_installer.py::TestWindows::test_system_permissions 
[gw5] [ 38%] SKIPPED test/installer/test_installer.py::TestWindows::test_system_permissions 
[gw4] [ 46%] SKIPPED test/installer/test_installer.py::TestWindows::test_user_permissions 
test/installer/test_installer.py::TestVerifySigning::test_linux_signing 
[gw1] [ 53%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_linux_signing 
test/installer/test_installer.py::TestUserInstall::test_install 
[gw0] [ 61%] PASSED test/installer/test_installer.py::test_default_location 
test/installer/test_installer.py::TestVerifySigning::test_windows_signing 
[gw0] [ 69%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_windows_signing 
[gw6] [ 76%] PASSED test/installer/test_installer.py::TestUserInstall::test_install 
[gw2] [ 84%] PASSED test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions 
test/installer/test_installer.py::TestVerifySigning::test_macos_signing 
[gw2] [ 92%] SKIPPED test/installer/test_installer.py::TestVerifySigning::test_macos_signing 
[gw7] [100%] PASSED test/installer/test_installer.py::TestUserInstall::test_uninstall 

================================================================= slowest 5 durations =================================================================
30.13s setup    test/installer/test_installer.py::TestLinuxAndMacOS::test_user_permissions
29.78s setup    test/installer/test_installer.py::TestUserInstall::test_uninstall
29.22s setup    test/installer/test_installer.py::TestUserInstall::test_install
3.82s call     test/installer/test_installer.py::TestUserInstall::test_uninstall
3.21s call     test/installer/test_installer.py::test_default_location
============================================================ 4 passed, 9 skipped in 34.89s ============================================================
```

Successfully builds and tests the installer.

Launching gui-submit, I'm able to successfully submit jobs.

### Was this change documented?

N/A

### Does this PR introduce new dependencies?

*   [X] This PR does not add any new dependencies.

### Is this a breaking change?

N/A

### Does this change impact security?

N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
