### PR TITLE
feat!: refactor the autorization UI dialog

### DIFF
--- a/src/deadline/client/ui/dialogs/deadline_config_dialog.py
+++ b/src/deadline/client/ui/dialogs/deadline_config_dialog.py
@@ -67,13 +67,21 @@ class DeadlineConfigDialog(QDialog):
     """
 
     @staticmethod
-    def configure_settings(parent=None) -> bool:
+    def configure_settings(parent=None, set_profile_focus=False) -> bool:
         """
         Static method that runs the Deadline Config Dialog.
+
+        Args:
+            parent: Parent widget
+            set_profile_focus: Optional boolean to set the initial focus to the profile selector
 
         Returns True if any changes were applied, False otherwise.
         """
         deadline_config = DeadlineConfigDialog(parent=parent)
+
+        if set_profile_focus:
+            deadline_config.config_box.aws_profiles_box.setFocus()
+
         deadline_config.exec_()
         return deadline_config.changes_were_applied
 
@@ -117,7 +125,9 @@ class DeadlineConfigDialog(QDialog):
 
         self.config_box.refreshed.connect(self.on_refresh)
 
-        self.auth_status_box = DeadlineAuthenticationStatusWidget(self)
+        self.auth_status_box = DeadlineAuthenticationStatusWidget(
+            parent=self, show_profile_switch=False
+        )
         self.layout.addWidget(self.auth_status_box)
         self.deadline_authentication_status.deadline_config_changed.connect(self.config_box.refresh)
         self.deadline_authentication_status.api_availability_changed.connect(
@@ -131,12 +141,8 @@ class DeadlineConfigDialog(QDialog):
         self.button_box.accepted.connect(self.accept)
         self.button_box.rejected.connect(self.reject)
         self.button_box.clicked.connect(self.on_button_box_clicked)
-        self.login_button = QPushButton("Login")
-        self.login_button.clicked.connect(self.on_login)
-        self.button_box.addButton(self.login_button, QDialogButtonBox.ResetRole)
-        self.logout_button = QPushButton("Logout")
-        self.logout_button.clicked.connect(self.on_logout)
-        self.button_box.addButton(self.logout_button, QDialogButtonBox.ResetRole)
+        self.auth_status_box.logout_clicked.connect(self.on_logout)
+        self.auth_status_box.login_clicked.connect(self.on_login)
         self.layout.addWidget(self.button_box)
 
         # Refresh the lists so queue/farm show the description instead of the ID
@@ -149,6 +155,10 @@ class DeadlineConfigDialog(QDialog):
     def accept(self):
         if self.config_box.apply():
             super().accept()
+
+    def reject(self):
+        self.deadline_authentication_status.set_config(config_file.read_config())
+        super().reject()
 
     def on_login(self):
         DeadlineLoginDialog.login(parent=self, config=self.config_box.config)

--- a/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
@@ -192,6 +192,9 @@ class SubmitJobToDeadlineDialog(QDialog):
             self._build_host_requirements_tab(host_requirements)
 
         self.auth_status_box = DeadlineAuthenticationStatusWidget(self)
+        self.auth_status_box.switch_profile_clicked.connect(self.on_switch_profile_clicked)
+        self.auth_status_box.logout_clicked.connect(self.on_logout)
+        self.auth_status_box.login_clicked.connect(self.on_login)
         self.lyt.addWidget(self.auth_status_box)
         self.deadline_authentication_status.api_availability_changed.connect(
             self.refresh_deadline_settings
@@ -201,12 +204,6 @@ class SubmitJobToDeadlineDialog(QDialog):
         self.shared_job_settings.valid_parameters.connect(self._set_submit_button_state)
 
         self.button_box = QDialogButtonBox(Qt.Horizontal)
-        self.login_button = QPushButton("Login")
-        self.login_button.clicked.connect(self.on_login)
-        self.button_box.addButton(self.login_button, QDialogButtonBox.ResetRole)
-        self.logout_button = QPushButton("Logout")
-        self.logout_button.clicked.connect(self.on_logout)
-        self.button_box.addButton(self.logout_button, QDialogButtonBox.ResetRole)
         self.settings_button = QPushButton("Settings...")
         self.settings_button.clicked.connect(self.on_settings_button_clicked)
         self.button_box.addButton(self.settings_button, QDialogButtonBox.ResetRole)
@@ -239,17 +236,6 @@ class SubmitJobToDeadlineDialog(QDialog):
             self.submit_button.setToolTip("")
 
     def refresh_deadline_settings(self):
-        # Enable/disable the Login and Logout buttons based on whether
-        # the configured profile is for Deadline Cloud monitor
-        self.login_button.setEnabled(
-            self.deadline_authentication_status.creds_source
-            == api.AwsCredentialsSource.DEADLINE_CLOUD_MONITOR_LOGIN
-        )
-        self.logout_button.setEnabled(
-            self.deadline_authentication_status.creds_source
-            == api.AwsCredentialsSource.DEADLINE_CLOUD_MONITOR_LOGIN
-        )
-
         self._set_submit_button_state()
 
         self.shared_job_settings.deadline_cloud_settings_box.refresh_setting_controls(
@@ -357,6 +343,10 @@ class SubmitJobToDeadlineDialog(QDialog):
         # This widget watches the auth files, but that does
         # not always catch a change so force a refresh here.
         self.deadline_authentication_status.refresh_status()
+
+    def on_switch_profile_clicked(self):
+        if DeadlineConfigDialog.configure_settings(parent=self, set_profile_focus=True):
+            self.refresh_deadline_settings()
 
     def on_settings_button_clicked(self):
         if DeadlineConfigDialog.configure_settings(parent=self):

--- a/src/deadline/client/ui/widgets/deadline_authentication_status_widget.py
+++ b/src/deadline/client/ui/widgets/deadline_authentication_status_widget.py
@@ -2,112 +2,417 @@
 
 """
 Provides a widget to place in AWS Deadline Cloud submitter dialogs, that shows
-the current status of AWS Deadline Cloud authentication and API.
+the current status of AWS Deadline Cloud authentication.
 The current status is handled by DeadlineAuthenticationStatus.
 """
 
-from logging import getLogger
-from typing import Optional
+import enum
 
-from qtpy.QtCore import Qt
+from dataclasses import dataclass
+from logging import getLogger
+from typing import Callable, Union, Dict
+
+from qtpy.QtCore import Signal
 from qtpy.QtWidgets import (  # pylint: disable=import-error; type: ignore
-    QFormLayout,
-    QGroupBox,
     QHBoxLayout,
     QLabel,
     QWidget,
+    QApplication,
+    QStyle,
+    QFrame,
+    QMenu,
+    QPushButton,
+    QMessageBox,
 )
 
 from ... import api
 from ..deadline_authentication_status import DeadlineAuthenticationStatus
+from ...config import config_file
 
 logger = getLogger(__name__)
 
 
+class RightAlignedQMenu(QMenu):
+    """
+    A modified QMenu that positions itself to the right of its parent widget
+    instead of the default left positioning.
+    """
+
+    def showEvent(self, event):
+        """
+        Override showEvent to position the menu to the right of the parent button.
+        """
+        if self.parent():
+            parent_top_right = self.parent().mapToGlobal(self.parent().rect().topRight())
+            self.move(parent_top_right.x(), parent_top_right.y())
+
+        super().showEvent(event)
+        self.adjustSize()  # The menu was displaying incorrectly on Mac until a resize event
+
+
+@dataclass
+class AuthenticationStateConfig:
+    """
+    Configuration dataclass that encapsulates all the visual and behavioral
+    settings needed to display the authentication widget in different states,
+    including which icon to show, what text to display, and which buttons should
+    be visible.
+
+    Attributes:
+        icon (QStyle.StandardPixmap): The standard Qt icon to display for this state.
+        text (Union[str, Callable[[], str]]): The text to display, either as a string
+            or a callable that returns a string for dynamic text.
+        switch_profile_button_visible (bool): Whether the switch profile button should
+            be visible. If the button isn't visible that switch profile menu item will be.
+            Defaults to False.
+        login_visible (bool): Whether the login button should be visible. Defaults to False.
+        logout_visible (Union[bool, Callable[[], bool]]): Whether the logout option should
+            be visible, either as a boolean or callable returning boolean. Defaults to False.
+        more_info_visible (bool): Whether the more info button should be visible.
+            Defaults to False.
+    """
+
+    icon: QStyle.StandardPixmap
+    text: Union[str, Callable[[], str]]
+    switch_profile_button_visible: bool = False
+    login_visible: bool = False
+    logout_visible: Union[bool, Callable[[], bool]] = False
+    more_info_visible: bool = False
+
+
+class AuthenticationState(enum.Enum):
+    """
+    Enum defining all the possible states that the authentication status widget can display,
+    each corresponding to a different combination of authentication status and
+    API availability.
+
+    Values:
+        REFRESHING: Authentication status is being loaded or refreshed.
+        AUTHENTICATED_READY: User is authenticated and has API access to list-farms
+        AUTHENTICATED_NO_API: User is authenticated but lacks API access permissions to list-farms
+        NEEDS_LOGIN: User needs to log in to authenticate with a DCM profile
+        CONFIGURATION_ERROR: There is a configuration issue with the AWS profile.
+        UNEXPECTED_ERROR: An unknown or unexpected error occurred during authentication.
+    """
+
+    REFRESHING = enum.auto()
+    AUTHENTICATED_READY = enum.auto()
+    AUTHENTICATED_NO_API = enum.auto()
+    NEEDS_LOGIN = enum.auto()
+    CONFIGURATION_ERROR = enum.auto()
+    UNEXPECTED_ERROR = enum.auto()
+
+
 class DeadlineAuthenticationStatusWidget(QWidget):
     """
-    A Widget that displays status information about AWS Deadline Cloud
-    authentication from a DeadlineAuthenticationStatus object.
+    A Qt widget that displays the current AWS Deadline Cloud authentication status.
+
+    This widget provides a visual indicator of the authentication status, showing an appropriate
+    icon, profile name, and relevant action buttons based on the current authentication status.
+
+    Signals:
+        switch_profile_clicked: Emitted when the user clicks to switch AWS profiles.
+        login_clicked: Emitted when the user clicks the login button.
+        logout_clicked: Emitted when the user clicks the logout option.
     """
 
-    def __init__(self, parent=None) -> None:
+    switch_profile_clicked = Signal()
+    login_clicked = Signal()
+    logout_clicked = Signal()
+
+    def __init__(self, parent=None, show_profile_switch=True) -> None:
+        """
+        Initialize the authentication status widget.
+
+        Args:
+            parent: The parent Qt widget. Defaults to None.
+            show_profile_switch (bool): Whether to show the switch profile control.
+                Defaults to True.
+        """
         super().__init__(parent=parent)
 
-        layout = QHBoxLayout(self)
+        self._build_ui(show_profile_switch)
 
-        self.creds_source_group = AuthenticationStatusGroup(title="Credential source", parent=self)
-        layout.addWidget(self.creds_source_group)
-        self.auth_status_group = AuthenticationStatusGroup(
-            title="Authentication status", parent=self
-        )
-        layout.addWidget(self.auth_status_group)
-        self.deadline_authorized_group = AuthenticationStatusGroup(
-            title="AWS Deadline Cloud API", parent=self
-        )
-        layout.addWidget(self.deadline_authorized_group)
-
+        # Connect to authentication status
         self._status = DeadlineAuthenticationStatus.getInstance()
-        self._status.creds_source_changed.connect(self._creds_source_changed)
-        self._status.auth_status_changed.connect(self._auth_status_changed)
-        self._status.api_availability_changed.connect(self._api_availability_changed)
+        self._status.creds_source_changed.connect(self._update_ui)
+        self._status.auth_status_changed.connect(self._update_ui)
+        self._status.api_availability_changed.connect(self._update_ui)
 
-        # Update with current values
-        self._creds_source_changed()
-        self._auth_status_changed()
-        self._api_availability_changed()
+        # Initial update
+        self._update_ui()
 
-    def _creds_source_changed(self) -> None:
-        if self._status.creds_source is None:
-            color = "white"
-            text = "&lt;Refreshing&gt;"
-        elif self._status.creds_source == api.AwsCredentialsSource.NOT_VALID:
-            color = "red"
-            text = self._status.creds_source.name
+    def _build_ui(self, show_profile_switch: bool = True) -> None:
+        """
+        Build the user interface components for the authentication status widget.
+
+        Creates a styled frame containing a status icon, profile button with dropdown menu,
+        and various action buttons (switch profile, login, more info) that are shown/hidden
+        based on the current authentication state.
+
+        Args:
+            show_profile_switch (bool): Whether to enable profile switching functionality.
+                Defaults to True.
+        """
+        main_layout = QHBoxLayout(self)
+        main_layout.setContentsMargins(0, 0, 0, 0)
+
+        frame = QFrame(self)
+        frame.setStyleSheet("QFrame {background-color: palette(base); border-radius: 4px;}")
+        frame.setFrameShape(QFrame.StyledPanel)
+        main_layout.addWidget(frame)
+
+        frame_layout = QHBoxLayout(frame)
+        frame_layout.setContentsMargins(5, 5, 5, 5)
+
+        self._status_icon = QLabel()
+        frame_layout.addWidget(self._status_icon)
+
+        self._profile_button = QPushButton()
+        self._profile_button.setStyleSheet("""
+            QPushButton {
+                background-color: transparent;
+                border: none;
+                padding-right: 5px;
+                text-align: left;
+            }
+        """)
+
+        self._auth_menu = RightAlignedQMenu(self._profile_button)
+
+        self._show_profile_switch = show_profile_switch
+        self._switch_profile_menu_action = self._auth_menu.addAction(
+            "Switch profile", self.switch_profile_clicked.emit
+        )
+        self._logout_menu_action = self._auth_menu.addAction("Log out", self.logout_clicked.emit)
+
+        frame_layout.addWidget(self._profile_button)
+
+        frame_layout.addStretch()
+
+        self._switch_profile_button = QPushButton("Switch profile")
+        self._switch_profile_button.clicked.connect(self.switch_profile_clicked.emit)
+        frame_layout.addWidget(self._switch_profile_button)
+
+        self._login_button = QPushButton("Log in")
+        self._login_button.clicked.connect(self.login_clicked.emit)
+        frame_layout.addWidget(self._login_button)
+
+        self._more_info_button = QPushButton("More info")
+        self._more_info_button.clicked.connect(self._show_more_info)
+        frame_layout.addWidget(self._more_info_button)
+
+    def _get_profile_name(self) -> str:
+        """
+        Get the current AWS profile name from the configuration.
+
+        Returns:
+            str: The AWS profile name configured for Deadline Cloud authentication.
+        """
+        return config_file.get_setting("defaults.aws_profile_name", self._status.config)
+
+    def _should_show_logout(self) -> bool:
+        """
+        Determine whether the logout option should be visible based on the credential source.
+
+        The logout option is only shown when using Deadline Cloud Monitor credentials.
+
+        Returns:
+            bool: True if logout should be visible, False otherwise.
+        """
+        return self._status.creds_source == api.AwsCredentialsSource.DEADLINE_CLOUD_MONITOR_LOGIN
+
+    def _get_auth_state_configs(self) -> Dict[AuthenticationState, AuthenticationStateConfig]:
+        """
+        Get the configuration mapping for each authentication state.
+
+        Defines the UI appearance and behavior for each possible authentication state,
+        including which icon to display, what text to show, and which buttons should
+        be visible.
+
+        Returns:
+            Dict[AuthenticationState, AuthenticationStateConfig]: A dictionary mapping
+                each authentication state to its corresponding UI configuration.
+        """
+        return {
+            AuthenticationState.REFRESHING: AuthenticationStateConfig(
+                icon=QStyle.StandardPixmap.SP_BrowserReload,
+                text=self._get_profile_name,
+            ),
+            AuthenticationState.AUTHENTICATED_READY: AuthenticationStateConfig(
+                icon=QStyle.StandardPixmap.SP_DialogApplyButton,
+                text=self._get_profile_name,
+                logout_visible=self._should_show_logout,
+            ),
+            AuthenticationState.AUTHENTICATED_NO_API: AuthenticationStateConfig(
+                icon=QStyle.StandardPixmap.SP_MessageBoxWarning,
+                text=lambda: f"{self._get_profile_name()} doesn't have access permissions to submit a job.",
+                logout_visible=self._should_show_logout,
+                more_info_visible=True,
+            ),
+            AuthenticationState.NEEDS_LOGIN: AuthenticationStateConfig(
+                icon=QStyle.StandardPixmap.SP_MessageBoxWarning,
+                text=f"{self._get_profile_name()}  -  You are logged out.",
+                switch_profile_button_visible=True,
+                login_visible=True,
+            ),
+            AuthenticationState.CONFIGURATION_ERROR: AuthenticationStateConfig(
+                icon=QStyle.StandardPixmap.SP_MessageBoxWarning,
+                text=lambda: f"A configuration error was received while accessing credentials for the profile '{self._get_profile_name()}'.",
+                more_info_visible=True,
+            ),
+            AuthenticationState.UNEXPECTED_ERROR: AuthenticationStateConfig(
+                icon=QStyle.StandardPixmap.SP_MessageBoxWarning,
+                text="There was an error with authentication",
+                more_info_visible=True,
+            ),
+        }
+
+    def _get_current_auth_state_key(self) -> AuthenticationState:
+        """
+        Evaluates the credentials source, authentication status, and API availability
+        to determine which authentication state the widget should display.
+
+        Returns:
+            AuthenticationState: The current authentication state enum value
+        """
+        is_refreshing = (
+            self._status.creds_source is None
+            or self._status.auth_status is None
+            or self._status.api_availability is None
+        )
+
+        if is_refreshing:
+            return AuthenticationState.REFRESHING
+        elif (
+            self._status.auth_status == api.AwsAuthenticationStatus.AUTHENTICATED
+            and self._status.api_availability
+        ):
+            return AuthenticationState.AUTHENTICATED_READY
+        elif (
+            self._status.auth_status == api.AwsAuthenticationStatus.AUTHENTICATED
+            and not self._status.api_availability
+        ):
+            return AuthenticationState.AUTHENTICATED_NO_API
+        elif self._status.auth_status == api.AwsAuthenticationStatus.NEEDS_LOGIN:
+            return AuthenticationState.NEEDS_LOGIN
+        elif self._status.auth_status == api.AwsAuthenticationStatus.CONFIGURATION_ERROR:
+            return AuthenticationState.CONFIGURATION_ERROR
         else:
-            color = "green"
-            text = self._status.creds_source.name
-        self.creds_source_group.label.setText(f"<b style='color:{color};'>{text}</b>")
+            return AuthenticationState.UNEXPECTED_ERROR
 
-    def _auth_status_changed(self) -> None:
-        if self._status.auth_status is None:
-            color = "white"
-            text = "&lt;Refreshing&gt;"
-        elif self._status.auth_status == api.AwsAuthenticationStatus.AUTHENTICATED:
-            color = "green"
-            text = self._status.auth_status.name
+    def _show_more_info(self) -> None:
+        """
+        Show a QMessageBox with detailed information about the current authentication issue
+        and hopefully steps the user can take to resolve it.
+        """
+
+        current_state = self._get_current_auth_state_key()
+
+        # Determine the current authentication state and provide appropriate help
+        if current_state == AuthenticationState.AUTHENTICATED_NO_API:
+            # Authenticated but no API availability - permissions issue or possibly configuration issue
+            title = "Unable to Call AWS Deadline Cloud API"
+            message = (
+                f"You are authenticated with the profile '{self._get_profile_name()}', "
+                "but this profile is unable to call AWS Deadline Cloud ListFarms and unable to submit jobs to AWS Deadline Cloud.\n\n"
+                "To resolve this issue:\n\n"
+                "• Check that there aren't any environment variables pointing to the wrong AWS region (e.g., AWS_DEFAULT_REGION)\n"
+                "• If you are not using a Deadline Cloud Monitor profile, check that the profile has permissions for these AWS Deadline Cloud APIs needed for submitting:\n"
+                "  • deadline:AssumeQueueRoleForUser\n"
+                "  • deadline:CreateJob\n"
+                "  • deadline:GetJob\n"
+                "  • deadline:GetQueue\n"
+                "  • deadline:GetQueueEnvironment\n"
+                "  • deadline:GetStorageProfileForQueue\n"
+                "  • deadline:GetStorageProfile\n"
+                "  • deadline:ListFarms\n"
+                "  • deadline:ListQueues\n"
+                "  • deadline:ListQueueEnvironments\n"
+                "  • deadline:ListStorageProfilesForQueue"
+            )
+        elif self._status.auth_status == api.AwsAuthenticationStatus.CONFIGURATION_ERROR:
+            title = "Issue With Profile Configuration"
+            message = (
+                f"There is a configuration issue with the profile '{self._get_profile_name()}'.\n\n"
+                "To resolve this issue:\n"
+                "• Verify your AWS config and credentials files are correct\n"
+                "  • By default these files can be found in ~/.aws on Linux/MacOS or %USERPROFILE%/.aws on Windows\n"
+                "• Verify that the correct AWS region is set\n"
+                "  • Check that no environment variables like AWS_DEFAULT_REGION are set to an incorrect region\n"
+                "• If you are not using a Deadline Cloud Monitor profile:\n"
+                "  • Verify that any credential process being used is able to retrieve the credentials or that they aren't expired\n"
+                "    • You can run the following command to check: aws sts get-caller-identity --profile <PROFILE_NAME>"
+            )
         else:
-            color = "red"
-            text = self._status.auth_status.name
-        self.auth_status_group.label.setText(f"<b style='color:{color};'>{text}</b>")
+            title = "Unknown Issue With Configured Profile"
+            message = (
+                f"There was an unknown issue when trying to authenticate with the profile '{self._get_profile_name()}'.\n\n"
+                "Check any available console logs for errors to try and diagnose the problem.\n"
+                "Logs are commonly found:\n"
+                "  • In the terminal that the dialog or software the submitter is running in was launched from"
+                "  • In the built-in console within the software that the submitter is running in"
+            )
 
-    def _api_availability_changed(self) -> None:
-        if self._status.api_availability is None:
-            color = "white"
-            text = "&lt;Refreshing&gt;"
-        elif self._status.api_availability:
-            color = "green"
-            text = "AUTHORIZED"
+        # Show the message box
+        msg_box = QMessageBox(self)
+        msg_box.setWindowTitle(title)
+        msg_box.setText(message)
+        msg_box.setIcon(QMessageBox.Information)
+        msg_box.setStandardButtons(QMessageBox.Ok)
+        msg_box.exec_()
+
+    def _update_ui(self) -> None:
+        """
+        Update the UI based on the current authentication state.
+
+        This method is called whenever the authentication status changes.
+        It determines the current state and applies the appropriate UI configuration.
+        """
+        state_key = self._get_current_auth_state_key()
+        state_configs = self._get_auth_state_configs()
+        config = state_configs[state_key]
+
+        self._apply_ui_state(config)
+
+    def _apply_ui_state(self, config: AuthenticationStateConfig) -> None:
+        """
+        Apply the UI configuration for a specific authentication state.
+
+        Updates the widget's appearance and behavior based on the provided configuration,
+        including setting the status icon, profile button text, and controlling the
+        visibility of various action buttons and menu items.
+
+        Args:
+            config (AuthenticationStateConfig): The configuration object containing
+                UI settings for the current authentication state.
+        """
+        # Set icon
+        self._status_icon.setPixmap(QApplication.style().standardIcon(config.icon).pixmap(16, 16))
+
+        # Set text
+        text = config.text() if callable(config.text) else config.text
+        self._profile_button.setText(text)
+        self._profile_button.setToolTip(text)
+
+        # Set visibility states
+        # Only one of the switch profile button or menu action are shown at a time
+        self._switch_profile_button.setVisible(
+            config.switch_profile_button_visible and self._show_profile_switch
+        )
+        self._switch_profile_menu_action.setVisible(
+            not config.switch_profile_button_visible and self._show_profile_switch
+        )
+
+        self._login_button.setVisible(config.login_visible)
+        logout_visible = (
+            config.logout_visible() if callable(config.logout_visible) else config.logout_visible
+        )
+        self._logout_menu_action.setVisible(logout_visible)
+        self._more_info_button.setVisible(config.more_info_visible)
+
+        # Hide the dropdown menu if there are no visible actions for the current state
+        if any(action.isVisible() for action in self._auth_menu.actions()):
+            self._profile_button.setMenu(self._auth_menu)
         else:
-            color = "red"
-            text = "UNAVAILABLE"
-        self.deadline_authorized_group.label.setText(f"<b style='color:{color};'>{text}</b>")
-
-
-class AuthenticationStatusGroup(QGroupBox):
-    """
-    UI element to group the status of authentication.
-    """
-
-    def __init__(self, *, title: str, parent: Optional[QWidget] = None):
-        super().__init__(parent=parent, title=title)
-
-        self._build_ui()
-
-    def _build_ui(self):
-        self.layout = QFormLayout(self)
-        self.layout.setContentsMargins(0, 0, 0, 0)
-        self.layout.setFieldGrowthPolicy(QFormLayout.AllNonFixedFieldsGrow)
-        self.label = QLabel("")
-
-        self.label.setAlignment(Qt.AlignCenter)
-        self.layout.addWidget(self.label)
+            self._profile_button.setMenu(None)


### PR DESCRIPTION
Fixes: #727 

### What was the problem/requirement? (What/Why)
We have received feedback multiple times that the authentication status widgets at the bottom of the submitters that use deadline-cloud are unclear and ugly(see #727)

### What was the solution? (How)
Reworked the authentication status widget section to more nicely display the authentication status and provide more helpful hints to users when there are issues with their current profile or configuration.

Additionally fixed a bug where changing profiles in the config menu and then selecting cancel would result in the profile change persisting, but the default farm/queue still being for the previous profile

### What is the impact of this change?
The authentication status is displayed in a nicer manner and there are now help dialogs to point users in the right direction when there are problems with their credentials

#### Screenshots
##### User logged in using a DCM or named profile
<img width="806" height="102" alt="image" src="https://github.com/user-attachments/assets/e3aa71b7-d0b2-46b9-84dc-5ffbdd337776" />

##### User logged out using a DCM profile
<img width="807" height="113" alt="image" src="https://github.com/user-attachments/assets/87ae5d53-3c4b-418e-add5-9a6648738e4f" />

##### User attempting to use a profile without the right permissions
<img width="407" height="58" alt="image" src="https://github.com/user-attachments/assets/ed96a4a5-6cc0-4b93-9977-2b98f7e76107" />

More Info Text
<img width="401" height="340" alt="image" src="https://github.com/user-attachments/assets/fa2d3ecb-6546-4b63-9c6c-a50b12f99362" />

##### User attempting to use a profile with a misconfigured credential process
<img width="453" height="55" alt="image" src="https://github.com/user-attachments/assets/f8c9af58-9044-4040-827e-40f72d76432e" />

More Info Text
<img width="402" height="187" alt="image" src="https://github.com/user-attachments/assets/dbe61b43-e215-4b88-9250-17625a2d84f8" />


##### Refreshing state when switching profiles
<img width="484" height="59" alt="image" src="https://github.com/user-attachments/assets/fb49079d-f683-4587-a8b2-8dd478f484ed" />

##### Dropdown menu to change profiles or log out
* The log out option only shows if using a DCM profile
* The switch profile option is only available if not already in the configuration dialog
<img width="810" height="97" alt="image" src="https://github.com/user-attachments/assets/b7f64cb0-2cd8-44fd-965b-6fd2dcce7f73" />

Example in the configuration menu where switch profile and logout don't show when using a named profile
<img width="487" height="55" alt="image" src="https://github.com/user-attachments/assets/bf07e7be-4116-4aee-9d27-3ec5684bad29" />



### How was this change tested?

* Validated all button functionality and UI state changes as well as did a job submission when using Pyside6 and doing a `deadline bundle gui-submit`
* Validated all button functionality and UI state changes as well as did a job submission when using Pyside2 and doing a `deadline bundle gui-submit`
* Validated that the UI appeared correctly in a few of the DCC submitters on Windows to catch any glaring issues as a smoke test. As this is a breaking change each DCC repo will need to test with these changes as they choose to upgrade.
  * No issues in Nuke 15 on Windows
  * No issues in Maya 2024 on Windows
  * No issues in Houdini 19.5/20.5 on Windows
  * No issues in Blender 3.6 on Windows
* Had a team member run manual tests on Mac OS with Pyside6 and Pyside2 running `deadline bundle gui-submit` and verifying the behaviour and look
* Ran my own tests on RHEL 9 and verified the UI looked and behaved correctly with both Pyside2 and Pyside6

- Have you run the unit tests?
  - Yes(not that they test any UI functionality as far as I know) 
- Have you run the integration tests?
  - No 
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass.
  - N/A

### Was this change documented?

In the commit alone

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [X] This PR does not add any new dependencies.

### Is this a breaking change?

Yes, and the commit has a description with the breaking details.

```
BREAKING_CHANGE: The DeadlineAuthenticationStatusWidget class has been
rewritten and the AuthenticationStatusGroup widget class has been removed.
The login/logout buttons have been removed from the SubmitJobToDeadlineDialog
and the DeadlineConfigDialog.
```

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
