### PR TITLE
feat: Adding target_task_run_status optional to create_job_from_job_b…

### DIFF
--- a/src/deadline/client/api/_submit_job_bundle.py
+++ b/src/deadline/client/api/_submit_job_bundle.py
@@ -246,6 +246,7 @@ def create_job_from_job_bundle(
     max_failed_tasks_count: Optional[int] = None,
     max_retries_per_task: Optional[int] = None,
     max_worker_count: Optional[int] = None,
+    target_task_run_status: Optional[str] = None,
     require_paths_exist: bool = False,
     submitter_name: Optional[str] = None,
     known_asset_paths: Collection[str] = [],
@@ -311,6 +312,8 @@ def create_job_from_job_bundle(
         max_failed_tasks_count (int, optional): explicit value for the maximum allowed failed tasks.
         max_retries_per_task (int, optional): explicit value for the maximum retries per task.
         max_worker_count (int, optional): explicit value for the max worker count of the job.
+        target_task_run_status (str, optional): explicit value for the target task run status of the job.
+                Valid values are "READY" or "SUSPENDED".
         require_paths_exist (bool, optional): Whether to require that all input paths exist.
         submitter_name (str, optional): Name of the application submitting the bundle.
         known_asset_paths (list[str], optional): A list of paths that should not generate
@@ -616,6 +619,8 @@ def create_job_from_job_bundle(
         create_job_args["maxFailedTasksCount"] = max_failed_tasks_count
     if max_retries_per_task is not None:
         create_job_args["maxRetriesPerTask"] = max_retries_per_task
+    if target_task_run_status is not None:
+        create_job_args["targetTaskRunStatus"] = target_task_run_status
 
     if logging.DEBUG >= logger.getEffectiveLevel():
         logger.debug(json.dumps(create_job_args, indent=1))

--- a/src/deadline/client/cli/_groups/bundle_group.py
+++ b/src/deadline/client/cli/_groups/bundle_group.py
@@ -123,6 +123,12 @@ def _interactive_confirmation_prompt(message: str, default_response: bool) -> bo
     help="The max worker count of the job.",
 )
 @click.option(
+    "--target-task-run-status",
+    type=click.Choice(["READY", "SUSPENDED"], case_sensitive=False),
+    help="The target task run status for the job. READY means tasks will start immediately, "
+    "SUSPENDED means tasks will be created but not start until manually resumed.",
+)
+@click.option(
     "--job-attachments-file-system",
     help="The method workers use to access job attachments. "
     "COPIED means to copy files to the worker and VIRTUAL means to load "
@@ -163,6 +169,7 @@ def bundle_submit(
     max_failed_tasks_count,
     max_retries_per_task,
     max_worker_count,
+    target_task_run_status,
     require_paths_exist,
     submitter_name,
     **args,
@@ -190,6 +197,7 @@ def bundle_submit(
             max_failed_tasks_count=max_failed_tasks_count,
             max_retries_per_task=max_retries_per_task,
             max_worker_count=max_worker_count,
+            target_task_run_status=target_task_run_status,
             hashing_progress_callback=hash_callback_manager.callback,
             upload_progress_callback=upload_callback_manager.callback,
             create_job_result_callback=_check_create_job_wait_canceled,

--- a/test/unit/deadline_client/api/test_job_bundle_submission.py
+++ b/test/unit/deadline_client/api/test_job_bundle_submission.py
@@ -912,6 +912,59 @@ def test_create_job_from_job_bundle_with_single_asset_file(
         ]
 
 
+def test_create_job_from_job_bundle_with_target_task_run_status(
+    fresh_deadline_config,
+    temp_job_bundle_dir,
+):
+    """
+    Test that create_job_from_job_bundle passes the target_task_run_status parameter to create_job.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+
+    # Create a minimal template file like other tests do
+    with open(os.path.join(temp_job_bundle_dir, "template.json"), "w", encoding="utf8") as f:
+        f.write('{"specificationVersion": "jobtemplate-2023-09", "name": "TestJob", "steps": []}')
+
+    with patch_calls_for_create_job_from_job_bundle() as mock:
+        api.create_job_from_job_bundle(
+            temp_job_bundle_dir,
+            target_task_run_status="SUSPENDED",
+            queue_parameter_definitions=[],
+        )
+
+        # Verify that targetTaskRunStatus was passed to create_job
+        create_job_call = mock.get_boto3_client().create_job.call_args
+        assert create_job_call is not None
+        assert create_job_call.kwargs["targetTaskRunStatus"] == "SUSPENDED"
+
+
+def test_create_job_from_job_bundle_without_target_task_run_status(
+    fresh_deadline_config,
+    temp_job_bundle_dir,
+):
+    """
+    Test that create_job_from_job_bundle does not pass targetTaskRunStatus when not specified.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+
+    # Create a minimal template file like other tests do
+    with open(os.path.join(temp_job_bundle_dir, "template.json"), "w", encoding="utf8") as f:
+        f.write('{"specificationVersion": "jobtemplate-2023-09", "name": "TestJob", "steps": []}')
+
+    with patch_calls_for_create_job_from_job_bundle() as mock:
+        api.create_job_from_job_bundle(
+            temp_job_bundle_dir,
+            queue_parameter_definitions=[],
+        )
+
+        # Verify that targetTaskRunStatus was not passed to create_job
+        create_job_call = mock.get_boto3_client().create_job.call_args
+        assert create_job_call is not None
+        assert "targetTaskRunStatus" not in create_job_call.kwargs
+
+
 get_job_responses = [
     pytest.param(
         [

--- a/test/unit/deadline_client/cli/test_cli_bundle.py
+++ b/test/unit/deadline_client/cli/test_cli_bundle.py
@@ -668,3 +668,61 @@ def test_gui_submit_submitter_name(_mock_context):
     )
     _args, kwargs = mock_job_bundle_submitter.show_job_bundle_submitter.call_args
     assert kwargs["submitter_name"] == "MyDCC"
+
+
+def test_bundle_submit_with_target_task_run_status(fresh_deadline_config, temp_job_bundle_dir):
+    """
+    Test that the --target-task-run-status CLI option is passed through correctly.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+
+    # Write a JSON template
+    with open(os.path.join(temp_job_bundle_dir, "template.json"), "w", encoding="utf8") as f:
+        f.write(MOCK_JOB_TEMPLATE_CASES["MINIMAL_JSON"][1])
+
+    with patch_calls_for_create_job_from_job_bundle() as mock:
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "bundle",
+                "submit",
+                "--target-task-run-status",
+                "SUSPENDED",
+                temp_job_bundle_dir,
+            ],
+        )
+
+        assert result.exit_code == 0
+        mock.create_job_from_job_bundle.assert_called_once()
+        _, kwargs = mock.create_job_from_job_bundle.call_args
+        assert kwargs["target_task_run_status"] == "SUSPENDED"
+
+
+def test_bundle_submit_without_target_task_run_status(fresh_deadline_config, temp_job_bundle_dir):
+    """
+    Test that when --target-task-run-status is not specified, None is passed.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+
+    # Write a JSON template
+    with open(os.path.join(temp_job_bundle_dir, "template.json"), "w", encoding="utf8") as f:
+        f.write(MOCK_JOB_TEMPLATE_CASES["MINIMAL_JSON"][1])
+
+    with patch_calls_for_create_job_from_job_bundle() as mock:
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "bundle",
+                "submit",
+                temp_job_bundle_dir,
+            ],
+        )
+
+        assert result.exit_code == 0
+        mock.create_job_from_job_bundle.assert_called_once()
+        _, kwargs = mock.create_job_from_job_bundle.call_args
+        assert kwargs["target_task_run_status"] is None


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
target_task_run_status wasn't exposed in create_job_from_job_bundle or deadline bundle submit

### What was the solution? (How)
Expose it as an optional parameter

### What is the impact of this change?
Customers can more easily submit jobs in SUSPENDED status

### How was this change tested?
new tests added, pass
unit tests pass
integ tests pass
ran a manual test with and without the option, both work as expected

### Was this change documented?
Y

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [X ] This PR does not add any new dependencies.

### Is this a breaking change?
No

### Does this change impact security?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
