### PR TITLE
fix: uncaught telemetry exception when collecting account ID

### DIFF
--- a/src/deadline/client/api/_telemetry.py
+++ b/src/deadline/client/api/_telemetry.py
@@ -10,7 +10,7 @@ import uuid
 import random
 import time
 
-from botocore.exceptions import ClientError, ProfileNotFound, NoCredentialsError
+from botocore.exceptions import ClientError, NoCredentialsError
 from configparser import ConfigParser
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
@@ -318,9 +318,9 @@ class TelemetryClient:
     ):
         try:
             self.update_common_details({"accountId": self.get_account_id(get_boto3_session())})
-        except ProfileNotFound as pnf:
+        except Exception as e:
             # Print any errors when getting the boto3 session, then proceed
-            logger.debug(f"Could not add account ID to telemetry: {str(pnf)}")
+            logger.debug(f"Could not add account ID to telemetry: {str(e)}")
 
         event_details.update(self._common_details)
         event_details["usage_mode"] = "GUI" if from_gui else "CLI"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
When using a DCM profile that is not currently logged in, trying to access the Account ID results in an unhandled exception in the telemetry code

### What was the solution? (How)
Catch every Exception when trying to grab the account ID. We never want telemetry errors to fail any user workflows

### What is the impact of this change?
No uncaught telemetry exceptions

### How was this change tested?

- Ran unit tests
- Did a smoke test submission and no errors. This was presenting itself during a future change I'm working on and confirmed that this fix prevents the uncaught exception from being raised.

### Was this change documented?

No

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [X] This PR does not add any new dependencies.

### Is this a breaking change?
No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
