### PR TITLE
fix: Switching job causes submission error in GUI submitter

### DIFF
--- a/src/deadline/client/ui/widgets/job_bundle_settings_tab.py
+++ b/src/deadline/client/ui/widgets/job_bundle_settings_tab.py
@@ -98,6 +98,9 @@ class JobBundleSettingsWidget(QWidget):
         if not input_job_bundle_dir:
             return
 
+        # Update job bundle directory path
+        self.input_job_bundle_dir = input_job_bundle_dir
+
         # Warn the user if the Job Bundle could not be loaded
         try:
             validate_directory_symlink_containment(input_job_bundle_dir)


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud/issues/699

### What was the problem/requirement? (What/Why)
Switching job bundles in the GUI submitter caused submission errors, preventing users from successfully submitting jobs after changing to a different bundle.

### What was the solution? (How)
Updated the job bundle directory path to match the new job's location after a job bundle switch.

### What is the impact of this change?
Users will be able to submit the new job after a job bundle switch.

### How was this change tested?
Tried submit a job then switch to another job bundle, successful no error.

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests?
  - Yes
  - ```====================================================================================================================== 1704 passed, 62 skipped, 1 xfailed, 14 warnings in 98.43s (0:01:38) =======================================================================================================================```
- Have you run the integration tests?
  - No
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass.
  - No

### Was this change documented?
No
- Are relevant docstrings in the code base updated?
- Has the README.md been updated? If you modified CLI arguments, for instance.

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?
No
A breaking change is one that modifies a public contract in a way that is not backwards compatible. See the 
[Public Contracts](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#public-contracts) section
of the DEVELOPMENT.md for more information on the public contracts.

If so, then please describe the changes that users of this package must make to update their scripts, or Python applications.

### Does this change impact security?
No
- Does the change need to be threat modeled? For example, does it create or modify files/directories that must only be readable by the process owner?
    - If so, then please label this pull request with the "security" label. We'll work with you to analyze the threats.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
