### PR TITLE
refactor(experimental): Refinements in incremental download

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -18,9 +18,23 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     uses: aws-deadline/.github/.github/workflows/reusable_python_build.yml@mainline
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
       ref: ${{inputs.tag}}
+
+  TestPy38:
+    name: Python
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ['3.8']
+    uses: ./.github/workflows/reusable_python_build_coverage_override.yml
+    with:
+      os: ${{ matrix.os }}
+      python-version: ${{ matrix.python-version }}
+      ref: ${{inputs.tag}}
+      # The incremental output download feature doesn't run on Python 3.8, so test coverage is lower
+      cov-fail-under: "75"

--- a/.github/workflows/reusable_python_build_coverage_override.yml
+++ b/.github/workflows/reusable_python_build_coverage_override.yml
@@ -1,0 +1,82 @@
+# TODO: Move the ability to override the coverage fail-under back to the aws-deadline/.github repo,
+#       by making the cov-fail-under parameter optional and using conditionals in the Run Tests step.
+name: Python Build
+
+on:
+  workflow_call:
+    inputs:
+      branch:
+        required: false
+        type: string
+      commit:
+        required: false
+        type: string
+      ref:
+        required: false
+        type: string
+      python-version:
+        required: true
+        type: string
+      os:
+        required: true
+        type: string
+      cov-fail-under:
+        required: true
+        type: string
+
+
+jobs:
+  Python:
+    name: ${{ inputs.os }}, python ${{ inputs.python-version }}
+    runs-on: ${{ inputs.os }}
+    permissions:
+      contents: read
+    env:
+      PYTHON: ${{ inputs.python-version }}
+    steps:
+    - uses: actions/checkout@v4
+      if: ${{ !inputs.branch && !inputs.commit && !inputs.ref }}
+
+    - uses: actions/checkout@v4
+      if: ${{ inputs.branch }}
+      with:
+        ref: ${{ inputs.branch }}
+        fetch-depth: 0
+
+    - uses: actions/checkout@v4
+      if: ${{ inputs.commit }}
+      with:
+        ref: ${{ inputs.commit }}
+
+    - uses: actions/checkout@v4
+      if: ${{ inputs.ref }}
+      with:
+        ref: ${{ inputs.ref }}
+
+    - name: setup ${{ inputs.os }}
+      if: inputs.os == 'ubuntu-latest'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libegl1 libdbus-1-3 libxkbcommon-x11-0 \
+          libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 \
+          libxcb-render-util0 libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0 \
+          x11-utils libxcb-cursor0 libopengl0
+
+
+    - name: Set up Python ${{ inputs.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Install Hatch
+      run: |
+        pip install --upgrade hatch
+
+    - name: Run Linting
+      run: hatch -v run lint
+
+    - name: Run Build
+      run: hatch -v build
+
+    - name: Run Tests
+      run: hatch run test --cov-fail-under=${{ inputs.cov-fail-under }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,8 @@ classifiers = [
 # Applications that consume this library should be the ones that are more strictly
 # limiting dependencies if they want/need to.
 dependencies = [
-  "boto3 >= 1.36.8",
+  "boto3 >= 1.39.10; python_version >= '3.9'",
+  "boto3 >= 1.36.8; python_version < '3.9'",
   # Click 8.2 dropped python 3.8/3.9 support
   "click >= 8.1.7",
   "pyyaml >= 6.0",

--- a/src/deadline/client/cli/_groups/queue_group.py
+++ b/src/deadline/client/cli/_groups/queue_group.py
@@ -8,6 +8,7 @@ import click
 import json
 import time
 import os
+import sys
 from configparser import ConfigParser
 from typing import Optional
 import boto3
@@ -279,6 +280,11 @@ def incremental_output_download(
     if os.environ.get("ENABLE_INCREMENTAL_OUTPUT_DOWNLOAD") != "1":
         raise DeadlineOperationError(
             "The incremental-output-download command is not fully implemented. You must set the environment variable ENABLE_INCREMENTAL_OUTPUT_DOWNLOAD to 1 to acknowledge this."
+        )
+
+    if sys.version_info < (3, 9):
+        raise DeadlineOperationError(
+            "The incremental-output-download command requires Python version 3.9 or later"
         )
 
     logger: ClickLogger = ClickLogger(is_json=json)

--- a/src/deadline/client/cli/_incremental_download.py
+++ b/src/deadline/client/cli/_incremental_download.py
@@ -8,12 +8,14 @@ import difflib
 from typing import Optional
 from configparser import ConfigParser
 from typing import Any, Callable
+import sys
 import time
 import concurrent.futures
 
 from .. import api
 import boto3
 from botocore.client import BaseClient  # type: ignore[import]
+from ..exceptions import DeadlineOperationError
 from ..api._list_jobs_by_filter_expression import _list_jobs_by_filter_expression
 from ...common.path_utils import summarize_path_list, human_readable_file_size
 from ...job_attachments._incremental_downloads.incremental_download_state import (
@@ -132,32 +134,6 @@ def _get_download_candidate_jobs(
     # - Any recently ended job (job went from active to terminal with a taskRunStatus
     #   in SUSPENDED, CANCELED, FAILED, SUCCEEDED, NOT_COMPATIBLE), that has at least
     #   one SUCCEEDED task. The endedAt timestamp field gets updated when that occurs.
-    # TODO: Enable this when filtering by ENDED_AT works.
-    # download_candidate_jobs.update(
-    #     {
-    #         job["jobId"]: job
-    #         for job in _list_jobs_by_filter_expression(
-    #             boto3_session,
-    #             farm_id,
-    #             queue_id,
-    #             filter_expression={
-    #                 "filters": [
-    #                     {
-    #                         "dateTimeFilter": {
-    #                             "name": "ENDED_AT",
-    #                             "dateTime": starting_timestamp,
-    #                             "operator": "GREATER_THAN_EQUAL_TO",
-    #                         }
-    #                     }
-    #                 ],
-    #                 "operator": "AND",
-    #             },
-    #         )
-    #     }
-    # )
-    # WORKAROUND: Get all jobs with a SUCCEEDED, SUSPENDED, or FAILED task run status, and filter by endedAt client-side.
-    #             We want to download all parts of these jobs that succeeded, even when the whole did not.
-    #             We do not download anything more for a job that was CANCELED or is NOT_COMPATIBLE.
     recently_ended_jobs = _list_jobs_by_filter_expression(
         boto3_session,
         farm_id,
@@ -165,34 +141,24 @@ def _get_download_candidate_jobs(
         filter_expression={
             "filters": [
                 {
-                    "stringFilter": {
-                        "name": "TASK_RUN_STATUS",
-                        "operator": "EQUAL",
-                        "value": status_value,
-                    },
+                    "dateTimeFilter": {
+                        "name": "ENDED_AT",
+                        "dateTime": starting_timestamp,
+                        "operator": "GREATER_THAN_EQUAL_TO",
+                    }
                 }
-                for status_value in ["SUCCEEDED", "SUSPENDED", "FAILED"]
             ],
-            "operator": "OR",
+            "operator": "AND",
         },
     )
-    print(f"DEBUG: Got {len(recently_ended_jobs)} succeeded/suspended jobs")
-    print(f"DEBUG: Filtering to job[endedAt] >= {starting_timestamp.astimezone().isoformat()}")
-    # Jobs that are submitted with a SUSPENDED status will have no "endedAt" field
-    # Filter to jobs that:
-    # 1. Have an endedAt field. (jobs submitted as SUSPENDED will not have one)
-    # 2. Timestamp endedAt is after the timestamp threshold.
-    # 3. The count of SUCCEEDED tasks is positive.
-    recently_ended_jobs = [
-        job
-        for job in recently_ended_jobs
-        if "endedAt" in job
-        and job["endedAt"] >= starting_timestamp
-        and job["taskRunStatusCounts"]["SUCCEEDED"] > 0
-    ]
     print(
-        f"DEBUG: Filtered down to {len(recently_ended_jobs)} succeeded/suspended jobs based on endedAt timestamp threshold and SUCCEEDED task filter"
+        f"DEBUG: Got {len(recently_ended_jobs)} jobs with job[endedAt] >= {starting_timestamp.astimezone().isoformat()}"
     )
+    # Filter to jobs where the count of SUCCEEDED tasks is positive.
+    recently_ended_jobs = [
+        job for job in recently_ended_jobs if job["taskRunStatusCounts"]["SUCCEEDED"] > 0
+    ]
+    print(f"DEBUG: Filtered down to {len(recently_ended_jobs)} jobs based on SUCCEEDED task filter")
     download_candidate_jobs.update(
         {job["jobId"]: _datetimes_to_str(job) for job in recently_ended_jobs}
     )
@@ -264,7 +230,7 @@ def _categorize_jobs_in_checkpoint(
     )
     start_time = datetime.now(tz=timezone.utc)
 
-    became_inactive_job_ids = checkpoint_job_ids.difference(download_candidate_job_ids)
+    finished_tracking_job_ids = checkpoint_job_ids.difference(download_candidate_job_ids)
     updated_job_ids = checkpoint_job_ids.intersection(download_candidate_job_ids)
     new_job_ids = download_candidate_job_ids.difference(checkpoint_job_ids)
     # The following sets get populated while analyzing the jobs
@@ -313,8 +279,8 @@ def _categorize_jobs_in_checkpoint(
             unchanged_job_ids.add(job_id)
     updated_job_ids.difference_update(unchanged_job_ids)
 
-    # First make note of any jobs that were dropped, for example if they were canceled or they failed
-    for job_id in became_inactive_job_ids:
+    # First make note of any jobs that were dropped from tracking, for example if they were canceled or they failed
+    for job_id in finished_tracking_job_ids:
         ip_job = checkpoint_jobs[job_id]
         if "taskRunStatusCounts" in ip_job:
             ip_succeeded_task_count = ip_job["taskRunStatusCounts"]["SUCCEEDED"]
@@ -325,7 +291,7 @@ def _categorize_jobs_in_checkpoint(
 
         # Print something only if the job is more than a minimal "jobId" tracker
         if set(ip_job.keys()) != {"jobId"}:
-            print_function_callback(f"DROPPED Job: {ip_job['name']} ({job_id})")
+            print_function_callback(f"FINISHED TRACKING Job: {ip_job['name']} ({job_id})")
             if ip_job["attachments"] is None:
                 print_function_callback("  Job without job attachments is no longer active")
             elif ip_succeeded_task_count == ip_total_task_count:
@@ -417,7 +383,7 @@ def _categorize_jobs_in_checkpoint(
     result = CategorizedJobIds()
     result.attachments_free = attachments_free_job_ids
     result.completed = completed_job_ids
-    result.inactive = became_inactive_job_ids
+    result.inactive = finished_tracking_job_ids
     result.added = new_job_ids
     result.unchanged = unchanged_job_ids
     result.updated = updated_job_ids
@@ -881,6 +847,11 @@ def _incremental_output_download(
     Returns:
         An updated checkpoint object.
     """
+    if sys.version_info < (3, 9):
+        raise DeadlineOperationError(
+            "The incremental-output-download command requires Python version 3.9 or later"
+        )
+
     deadline = boto3_session.client("deadline")
 
     # When this function is done, we will be confident that downloads are complete up to

--- a/test/unit/deadline_client/cli/test_cli_queue_incremental_download.py
+++ b/test/unit/deadline_client/cli/test_cli_queue_incremental_download.py
@@ -5,6 +5,7 @@ Tests for the CLI queue incremental output download command.
 """
 
 import os
+import sys
 import pytest
 from unittest.mock import patch, MagicMock
 from datetime import datetime, timedelta
@@ -113,6 +114,9 @@ def test_incremental_output_download_requires_beta_acknowledgement(
     ), result.output
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
+)
 def test_incremental_output_download_requires_queue_with_job_attachments(
     fresh_deadline_config, boto3_session, with_incremental_download_enabled, checkpoint_dir
 ):
@@ -147,6 +151,9 @@ def test_incremental_output_download_requires_queue_with_job_attachments(
     )
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
+)
 def test_incremental_output_download_pid_lock_already_held_error(
     fresh_deadline_config,
     with_incremental_download_enabled,
@@ -189,6 +196,9 @@ def test_incremental_output_download_pid_lock_already_held_error(
     assert os.path.exists(pid_lock_file)
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
+)
 def test_incremental_output_download_bootstrap_and_completion(
     fresh_deadline_config, with_incremental_download_enabled, boto3_session, checkpoint_dir
 ):
@@ -327,7 +337,7 @@ def test_incremental_output_download_bootstrap_and_completion(
         f"Continuing from: {(datetime.fromisoformat(ISO_FREEZE_TIME_PLUS_3MIN) - timedelta(seconds=EVENTUAL_CONSISTENCY_MAX_SECONDS)).astimezone().isoformat()}"
         in result.output
     ), result.output
-    assert f"DROPPED Job: Mock Job ({MOCK_JOB_ID})" in result.output, result.output
+    assert f"FINISHED TRACKING Job: Mock Job ({MOCK_JOB_ID})" in result.output, result.output
     assert "Job succeeded" in result.output, result.output
     assert "inactive: 1" in result.output, result.output
 
@@ -367,6 +377,9 @@ def test_incremental_output_download_bootstrap_and_completion(
     assert "inactive: 0" in result.output, result.output
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
+)
 def test_incremental_output_download_bootstrap_retire_job_without_attachments(
     fresh_deadline_config, with_incremental_download_enabled, boto3_session, checkpoint_dir
 ):
@@ -499,6 +512,9 @@ def test_incremental_output_download_bootstrap_retire_job_without_attachments(
     assert "inactive: 1" in result.output, result.output
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
+)
 def test_incremental_output_download_job_unchanged(
     fresh_deadline_config, with_incremental_download_enabled, boto3_session, checkpoint_dir
 ):
@@ -594,6 +610,9 @@ def test_incremental_output_download_job_unchanged(
     assert "unchanged: 1" in result.output, result.output
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
+)
 def test_incremental_output_download_job_canceled(
     fresh_deadline_config, with_incremental_download_enabled, boto3_session, checkpoint_dir
 ):
@@ -690,7 +709,7 @@ def test_incremental_output_download_job_canceled(
         f"Continuing from: {datetime.fromisoformat(ISO_FREEZE_TIME).astimezone().isoformat()}"
         in result.output
     ), result.output
-    assert f"DROPPED Job: Mock Job ({MOCK_JOB_ID})" in result.output, result.output
+    assert f"FINISHED TRACKING Job: Mock Job ({MOCK_JOB_ID})" in result.output, result.output
     assert (
         "Job is not a download candidate anymore (likely suspended, canceled or failed)"
         in result.output
@@ -698,6 +717,9 @@ def test_incremental_output_download_job_canceled(
     assert "inactive: 1" in result.output, result.output
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
+)
 def test_incremental_output_download_job_completed_then_requeued(
     fresh_deadline_config, with_incremental_download_enabled, boto3_session, checkpoint_dir
 ):
@@ -837,6 +859,9 @@ def test_incremental_output_download_job_completed_then_requeued(
     assert "added: 1" in result.output, result.output
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
+)
 def test_incremental_output_download_dry_run(
     fresh_deadline_config, with_incremental_download_enabled, boto3_session, checkpoint_dir
 ):


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

We updated the deadline:SearchJobs API to enable filtering by ENDED_AT. This can reduce the number of candidate jobs to filter client-side. The log output "DROPPED Job" is unclear that it's dropped from tracking, not from downloading, should change that wording for clarity.

### What was the solution? (How)

* Add service-side filtering of jobs by ENDED_AT. Update boto3 dependency range that supports the parameter.
* Rename "DROPPED Job:" to "FINISHED TRACKING Job:" to make the log output of the incremental download more straightforward to understand.
* Require Python >= 3.9 for the incremental download command. It relies
on filtering by endedAt in the deadline:SearchJobs call available with
boto3 1.39.10 and later, released after the Python 3.8 April 2025 date
documented for boto3 in
https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/

### What is the impact of this change?

Slightly improved performance, and better logging.

### How was this change tested?

Ran unit tests, tested the operation on a queue with randomly submitted jobs.

### Was this change documented?

No

### Does this PR introduce new dependencies?

No

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
