### PR TITLE
chore: Added a script for running profiling tests

### DIFF
--- a/scripted_tests/profiling/README.md
+++ b/scripted_tests/profiling/README.md
@@ -1,0 +1,44 @@
+# Profiling
+
+The application level profiling tests submit job bundles with invocations wrapped by pyinstrument to generate
+profiling data.
+
+## Running
+
+You will need a farm and a queue that you can submit jobs to.
+
+### bash/zsh
+```sh
+# Replace values with your own
+export AWS_DEFAULT_REGION=us-west-2
+export AWS_DEFAULT_PROFILE=myprofile
+export FARM_ID=farm-myfarmid
+export QUEUE_ID=queue-myqueueid
+
+uv venv .venv-profiling
+source .venv-profiling/bin/activate
+uv pip install -e .
+uv pip install -r requirements-testing.txt
+
+python scripted_tests/profiling/profiling.py --output-dir path/where/you/want/output
+````
+
+### fish
+```fish
+# Replace values with your own
+set -x AWS_DEFAULT_REGION us-west-2
+set -x AWS_DEFAULT_PROFILE myprofile
+set -x FARM_ID farm-myfarmid
+set -x QUEUE_ID queue-myqueueid
+
+uv venv .venv-profiling
+source .venv-profiling/bin/activate.fish
+uv pip install -e .
+uv pip install -r requirements-testing.txt
+
+python scripted_tests/profiling/profiling.py --output-dir path/where/you/want/output
+````
+
+After running the script your output will be in the directory you specified. By default, the output will be an
+html file for each test.
+

--- a/scripted_tests/profiling/profiling.py
+++ b/scripted_tests/profiling/profiling.py
@@ -1,0 +1,91 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import subprocess
+
+from enum import Enum, unique
+from pathlib import Path
+from typing import Optional, Union
+
+import click
+
+
+@unique
+class OutputFormat(Enum):
+    HTML = "html"
+    JSON = "json"
+
+
+def profile(
+    name: str,
+    farm_id: str,
+    queue_id: str,
+    job_bundle: Path,
+    output_dir: Path,
+    output_format: OutputFormat,
+    parameters: Optional[dict[str, Union[int, float, str, Path]]] = None,
+) -> None:
+    expanded_params = [
+        ["--parameter", f"{key}={str(value)}"]
+        for key, value in (parameters.values() if parameters is not None else {})
+    ]
+    subprocess.run(
+        [
+            "pyinstrument",
+            "--renderer",
+            str(output_format.value).lower(),
+            "--outfile",
+            str(output_dir / f"{name}.{str(output_format.value).lower()}"),
+            "--from-path",
+            "deadline",
+            "bundle",
+            "submit",
+            str(job_bundle),
+            "--farm-id",
+            farm_id,
+            "--queue-id",
+            queue_id,
+            *expanded_params,
+            "--yes",
+        ],
+        input="y\n",
+        text=True,
+        check=True,
+    )
+
+
+@click.command()
+@click.option("--farm-id", envvar="FARM_ID", type=str, required=True, help="The farm to submit to")
+@click.option(
+    "--queue-id", envvar="QUEUE_ID", type=str, required=True, help="The queue to submit to"
+)
+@click.option("--output-dir", type=Path, required=True, help="The prefix to output the results to")
+@click.option(
+    "--output-format",
+    type=click.Choice(OutputFormat),
+    default=OutputFormat.HTML,
+    help="The format the output should be in",
+)
+def cli(farm_id: str, queue_id: str, output_dir: Path, output_format: OutputFormat) -> None:
+    job_bundle_dir = Path(__file__).parent.parent / "job_bundles"
+    if not output_dir.is_dir():
+        output_dir.mkdir(parents=True)
+    profile(
+        "minimal_job_bundle",
+        farm_id,
+        queue_id,
+        job_bundle_dir / "minimal_job_bundle",
+        output_dir,
+        output_format,
+    )
+    profile(
+        "with_job_attachments",
+        farm_id,
+        queue_id,
+        job_bundle_dir / "with_job_attachments",
+        output_dir,
+        output_format,
+    )
+
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

In order to run profiling of job submission as part of our releases, we need profiling to be scripted.

### What was the solution? (How)

Write a script that runs profiling on submission of a sample of job bundles.

### What is the impact of this change?

We will be able to run profiling via a script.

### How was this change tested?

Ran the script.

<img width="3409" height="705" alt="Screenshot 2025-07-31 140222" src="https://github.com/user-attachments/assets/430dc9b6-de0f-4963-af4f-6e8c3ccf8650" />

### Was this change documented?

Yes

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?

No

### Does this change impact security?

No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
