### PR TITLE
feat: Add functions to support path mapping

### DIFF
--- a/src/deadline/job_attachments/_path_mapping.py
+++ b/src/deadline/job_attachments/_path_mapping.py
@@ -1,0 +1,186 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from __future__ import annotations
+
+from pathlib import Path, PurePosixPath, PureWindowsPath
+from typing import Any, Callable, Optional, Union
+
+from .models import PathFormat, PathMappingRule, StorageProfileOperatingSystemFamily
+
+__all__ = ["_generate_path_mapping_rules", "_PathMappingRuleApplier"]
+
+"""
+This file contains functionality related to path mapping rules. This functionality is internal-only for now,
+to be marked as public after developing some experience with it.
+"""
+
+
+def _generate_path_mapping_rules(
+    source_storage_profile: dict[str, Any],
+    destination_storage_profile: dict[str, Any],
+) -> list[PathMappingRule]:
+    """
+    Given a pair of storage profiles, generate all the path mapping rules to transform paths
+    from the source to the destination.
+
+    A mapping rule is generated for every file system location name that's shared between
+    the storage profile regardless of the type (SHARED vs LOCAL), to account for the broadest
+    possible storage profile configurations.
+
+    Args:
+        source_storage_profile: A storage profile as returned by boto3 deadline.get_storage_profile or
+            deadline.get_storage_profile_for_queue.
+        destination_storage_profile: A storage profile as returned by boto3 deadline.get_storage_profile or
+            deadline.get_storage_profile_for_queue.
+    Returns:
+        A list of path mapping rules to transform paths.
+    """
+    # If the source and destination are identical, no transformation is needed
+    if (
+        source_storage_profile["storageProfileId"]
+        == destination_storage_profile["storageProfileId"]
+    ):
+        return []
+
+    # Put the locations into dictionaries to match up the names
+    source_locations = {
+        location["name"]: location for location in source_storage_profile["fileSystemLocations"]
+    }
+    destination_locations = {
+        location["name"]: location
+        for location in destination_storage_profile["fileSystemLocations"]
+    }
+
+    if source_storage_profile["osFamily"] == StorageProfileOperatingSystemFamily.WINDOWS.value:
+        source_path_format = PathFormat.WINDOWS.value
+    else:
+        source_path_format = PathFormat.POSIX.value
+
+    path_mapping_rules: list[PathMappingRule] = []
+    for source_name, source_location in source_locations.items():
+        if source_name in destination_locations:
+            path_mapping_rules.append(
+                PathMappingRule(
+                    source_path_format,
+                    source_location["path"],
+                    destination_locations[source_name]["path"],
+                )
+            )
+
+    return path_mapping_rules
+
+
+class _PathMappingRuleApplier:
+    """
+    This class provides an accelerated implementation for transforming paths according to a list of
+    path mapping rules. For details about how rules are applied, see the documentation
+    https://github.com/OpenJobDescription/openjd-specifications/wiki/How-Jobs-Are-Run#applying-path-mapping-rules-within-a-job-template
+
+    When mapping a path, the most specific rule is the one that applies. For example, if there are two rules
+        * '/mnt/Projects -> X:\\Projects'
+        * '/mnt/Projects/Special -> Y:\\'
+    then '/mnt/Projects/Special/data.txt' maps to 'Y:\\data.txt', not to 'X:\\Projects\\Special\\data.txt'.
+
+    The implementation uses a trie data structure for acceleration, as follows:
+
+    1. The trie is a dictionary, where every key is a string and every value is another trie.
+       The one exception is the key ".", which holds the destination path of a rule instead.
+    2. Each source path is divided into parts by the PurePosixPath or PureWindowsPath class.
+    3. Each subsequent level of the trie corresponds to the matching subsequent part of a path.
+    4. A rule with parts (part1, part2, ..., partN) -> destination_path is represented in the trie
+       by the equation trie[part1][part2]...[partN]["."] == destination_path.
+
+    For Windows source paths, the parts are transformed to lower case within the trie to make the transformation
+    case insensitive while still case preserving.
+    """
+
+    source_path_format: Optional[str] = None
+    path_mapping_rules: list[PathMappingRule]
+
+    _path_mapping_trie: dict[str, Any]
+
+    # These two members implement the windows- or posix-specific parts of the trie.
+    # _split_source_path is used to divide a source path into parts, and _part_normalization is used
+    # to normalize a part for trie insertion or lookup.
+    _split_source_path: Callable[[str], tuple[str, ...]]
+    _normalize_part: Callable[[str], str]
+
+    def __init__(self, path_mapping_rules: list[PathMappingRule]):
+        self.path_mapping_rules = path_mapping_rules
+        self._path_mapping_trie = {}
+
+        trie_entry: dict
+
+        if path_mapping_rules:
+            self.source_path_format = path_mapping_rules[0].source_path_format
+            if not all(
+                rule.source_path_format == self.source_path_format for rule in path_mapping_rules
+            ):
+                formats = list({rule.source_path_format for rule in path_mapping_rules})
+                raise ValueError(
+                    f"The path mapping rules included multiple source path formats {', '.join(formats)}, only one is permitted."
+                )
+
+            if self.source_path_format == PathFormat.POSIX.value:
+                self._split_source_path = lambda v: PurePosixPath(v).parts
+                self._normalize_part = lambda v: v
+            elif self.source_path_format == PathFormat.WINDOWS.value:
+                self._split_source_path = lambda v: PureWindowsPath(v).parts
+                self._normalize_part = lambda v: v.lower()
+            else:
+                raise ValueError(f"Unexpected source path format {self.source_path_format}")
+
+            for rule in path_mapping_rules:
+                trie_entry = self._path_mapping_trie
+                parts = self._split_source_path(rule.source_path)
+                # Traverse all the parts using trie_entry
+                for part in parts:
+                    trie_entry = trie_entry.setdefault(self._normalize_part(part), {})
+                # Set the destination path of the trie entry
+                trie_entry["."] = Path(rule.destination_path)
+        else:
+            self.source_path_format = None
+
+    def _transform(self, path: str) -> Union[None, Path]:
+        parts = self._split_source_path(path)
+
+        matched_destination_path = None
+        matched_remaining_parts = None
+
+        # Traverse the trie using trie_entry
+        trie_entry: dict = self._path_mapping_trie
+        for i, part in enumerate(parts):
+            next_trie_entry = trie_entry.get(self._normalize_part(part))
+            # Stop if there are no rules with this path prefix
+            if next_trie_entry is None:
+                break
+            # Record the match if there is one at this path prefix,
+            # overwriting any previous match to apply the longest rule.
+            destination_path = next_trie_entry.get(".")
+            if destination_path:
+                matched_destination_path = destination_path
+                matched_remaining_parts = parts[i + 1 :]
+            trie_entry = next_trie_entry
+
+        if matched_destination_path is None:
+            return None
+        else:
+            return matched_destination_path.joinpath(*matched_remaining_parts)
+
+    def strict_transform(self, source_path: str) -> Path:
+        """Transform the provided path according to the path mapping rules. Raise ValueError if no rule applied."""
+        if self.source_path_format is not None:
+            result = self._transform(source_path)
+            if result:
+                return result
+
+        raise ValueError("No path mapping rule could be applied")
+
+    def transform(self, source_path: str) -> Union[str, Path]:
+        """Transform the provided path according to the path mapping rules. Return an untransformed path if no rule applied."""
+        if self.source_path_format is not None:
+            result = self._transform(source_path)
+            if result:
+                return result
+
+        return source_path

--- a/test/unit/deadline_job_attachments/test_path_mapping.py
+++ b/test/unit/deadline_job_attachments/test_path_mapping.py
@@ -1,0 +1,331 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from pathlib import Path
+import dataclasses
+
+import pytest
+
+from deadline.job_attachments._path_mapping import (
+    _generate_path_mapping_rules,
+    _PathMappingRuleApplier,
+)
+from deadline.job_attachments.models import (
+    PathFormat,
+    PathMappingRule,
+    StorageProfileOperatingSystemFamily,
+)
+
+
+@dataclasses.dataclass
+class DestPaths:
+    path1: Path
+    path2: Path
+    path3: Path
+
+
+# Fixtures for shared resources
+@pytest.fixture
+def dest_paths(tmp_path_factory: pytest.TempPathFactory):
+    """Create a set of local directory paths to use."""
+    base_dir = tmp_path_factory.mktemp("checkpoint")
+    dest_path1 = base_dir / "path1"
+    dest_path2 = base_dir / "path2" / "with" / "some" / "nesting"
+    dest_path3 = base_dir / ("a" * 1000)
+    yield DestPaths(dest_path1, dest_path2, dest_path3)
+
+
+# Sample storage profiles for testing
+SAMPLE_WINDOWS_STORAGE_PROFILE = {
+    "storageProfileId": "sp-windows-123",
+    "osFamily": StorageProfileOperatingSystemFamily.WINDOWS.value,
+    "fileSystemLocations": [
+        {"name": "shared", "path": "C:\\shared"},
+        {"name": "temp", "path": "C:\\temp"},
+    ],
+}
+
+SAMPLE_LINUX_STORAGE_PROFILE = {
+    "storageProfileId": "sp-linux-456",
+    "osFamily": StorageProfileOperatingSystemFamily.LINUX.value,
+    "fileSystemLocations": [
+        {"name": "shared", "path": "/mnt/shared"},
+        {"name": "temp", "path": "/tmp"},
+    ],
+}
+
+SAMPLE_MACOS_STORAGE_PROFILE = {
+    "storageProfileId": "sp-macos-789",
+    "osFamily": StorageProfileOperatingSystemFamily.MACOS.value,
+    "fileSystemLocations": [
+        {"name": "shared", "path": "/Volumes/shared"},
+        {"name": "temp", "path": "/tmp"},
+    ],
+}
+
+# Storage profiles for edge cases
+EMPTY_LOCATIONS_PROFILE = {
+    "storageProfileId": "sp-empty-001",
+    "osFamily": StorageProfileOperatingSystemFamily.LINUX.value,
+    "fileSystemLocations": [],
+}
+
+NO_MATCHING_LOCATIONS_PROFILE = {
+    "storageProfileId": "sp-nomatch-002",
+    "osFamily": StorageProfileOperatingSystemFamily.LINUX.value,
+    "fileSystemLocations": [
+        {"name": "different", "path": "/mnt/different"},
+        {"name": "other", "path": "/mnt/other"},
+    ],
+}
+
+WINDOWS_DESTINATION_PROFILE = {
+    "storageProfileId": "sp-windows-dest-456",
+    "osFamily": StorageProfileOperatingSystemFamily.WINDOWS.value,
+    "fileSystemLocations": [
+        {"name": "shared", "path": "D:\\shared"},
+        {"name": "temp", "path": "D:\\temp"},
+    ],
+}
+
+LINUX_DESTINATION_PROFILE = {
+    "storageProfileId": "sp-linux-dest-789",
+    "osFamily": StorageProfileOperatingSystemFamily.LINUX.value,
+    "fileSystemLocations": [
+        {"name": "shared", "path": "/opt/shared"},
+        {"name": "temp", "path": "/var/tmp"},
+    ],
+}
+
+# Test cases for _generate_path_mapping_rules function
+GENERATE_PATH_MAPPING_RULES_CASES: tuple = (
+    # (source_profile, destination_profile, expected_rules)
+    pytest.param(
+        SAMPLE_WINDOWS_STORAGE_PROFILE,
+        SAMPLE_WINDOWS_STORAGE_PROFILE,
+        [],
+        id="identical profiles return empty list",
+    ),
+    pytest.param(
+        SAMPLE_LINUX_STORAGE_PROFILE,
+        NO_MATCHING_LOCATIONS_PROFILE,
+        [],
+        id="no matching locations return empty list",
+    ),
+    pytest.param(
+        EMPTY_LOCATIONS_PROFILE,
+        SAMPLE_LINUX_STORAGE_PROFILE,
+        [],
+        id="empty source locations return empty list",
+    ),
+    pytest.param(
+        SAMPLE_WINDOWS_STORAGE_PROFILE,
+        WINDOWS_DESTINATION_PROFILE,
+        [
+            PathMappingRule(PathFormat.WINDOWS.value, "C:\\shared", "D:\\shared"),
+            PathMappingRule(PathFormat.WINDOWS.value, "C:\\temp", "D:\\temp"),
+        ],
+        id="Windows profiles generate Windows format rules",
+    ),
+    pytest.param(
+        SAMPLE_LINUX_STORAGE_PROFILE,
+        LINUX_DESTINATION_PROFILE,
+        [
+            PathMappingRule(PathFormat.POSIX.value, "/mnt/shared", "/opt/shared"),
+            PathMappingRule(PathFormat.POSIX.value, "/tmp", "/var/tmp"),
+        ],
+        id="Linux profiles generate POSIX format rules",
+    ),
+    pytest.param(
+        SAMPLE_MACOS_STORAGE_PROFILE,
+        LINUX_DESTINATION_PROFILE,
+        [
+            PathMappingRule(PathFormat.POSIX.value, "/Volumes/shared", "/opt/shared"),
+            PathMappingRule(PathFormat.POSIX.value, "/tmp", "/var/tmp"),
+        ],
+        id="macOS profiles generate POSIX format rules",
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    (
+        "source_profile",
+        "destination_profile",
+        "expected_rules",
+    ),
+    GENERATE_PATH_MAPPING_RULES_CASES,
+)
+def test_generate_path_mapping_rules(
+    source_profile,
+    destination_profile,
+    expected_rules,
+):
+    """Test that _generate_path_mapping_rules generates correct path mapping rules."""
+    rules = _generate_path_mapping_rules(source_profile, destination_profile)
+
+    assert rules == expected_rules
+
+
+def test_path_mapping_rule_applier_create_empty():
+    applier = _PathMappingRuleApplier([])
+    assert applier.path_mapping_rules == []
+    assert applier._path_mapping_trie == {}
+
+    assert applier.transform("/some/path") == "/some/path"
+    with pytest.raises(ValueError):
+        applier.strict_transform("/some/path")
+
+
+def test_path_mapping_rule_applier_create_bad_source_path(dest_paths: DestPaths):
+    with pytest.raises(ValueError):
+        _PathMappingRuleApplier([PathMappingRule("xisop", "/mnt/shared", str(dest_paths.path1))])
+
+
+def test_path_mapping_rule_applier_create_posix(dest_paths: DestPaths):
+    rules = [
+        PathMappingRule(PathFormat.POSIX.value, "/mnt/shared", str(dest_paths.path1)),
+        PathMappingRule(PathFormat.POSIX.value, "/mnt/projects", str(dest_paths.path2)),
+        PathMappingRule(PathFormat.POSIX.value, "/tmp", str(dest_paths.path3)),
+    ]
+    applier = _PathMappingRuleApplier(rules)
+    assert applier.path_mapping_rules == rules
+    assert applier.source_path_format == PathFormat.POSIX.value
+    assert set(applier._path_mapping_trie.keys()) == {"/"}
+    assert set(applier._path_mapping_trie["/"].keys()) == {"mnt", "tmp"}
+    assert set(applier._path_mapping_trie["/"]["mnt"].keys()) == {"shared", "projects"}
+
+
+def test_path_mapping_rule_applier_create_windows(dest_paths: DestPaths):
+    rules = [
+        PathMappingRule(PathFormat.WINDOWS.value, "C:\\Mnt\\Shared", str(dest_paths.path1)),
+        PathMappingRule(PathFormat.WINDOWS.value, "C:\\Mnt\\proJects", str(dest_paths.path2)),
+        PathMappingRule(PathFormat.WINDOWS.value, "D:\\tmp", str(dest_paths.path3)),
+    ]
+    applier = _PathMappingRuleApplier(rules)
+    assert applier.path_mapping_rules == rules
+    assert applier.source_path_format == PathFormat.WINDOWS.value
+    assert set(applier._path_mapping_trie.keys()) == {"c:\\", "d:\\"}
+    assert set(applier._path_mapping_trie["c:\\"].keys()) == {"mnt"}
+    assert set(applier._path_mapping_trie["d:\\"].keys()) == {"tmp"}
+    assert set(applier._path_mapping_trie["c:\\"]["mnt"].keys()) == {"shared", "projects"}
+
+
+def test_path_mapping_rule_applier_create_mixed(dest_paths: DestPaths):
+    with pytest.raises(ValueError):
+        rules = [
+            PathMappingRule(PathFormat.POSIX.value, "/mnt/shared", str(dest_paths.path1)),
+            PathMappingRule(PathFormat.WINDOWS.value, "D:\\tmp", str(dest_paths.path3)),
+        ]
+        _PathMappingRuleApplier(rules)
+
+
+def test_source_posix_rule(dest_paths: DestPaths):
+    applier = _PathMappingRuleApplier(
+        [
+            PathMappingRule(PathFormat.POSIX.value, "/mnt/shared", str(dest_paths.path1)),
+            PathMappingRule(PathFormat.POSIX.value, "/mnt/projects", str(dest_paths.path2)),
+            PathMappingRule(PathFormat.POSIX.value, "/tmp", str(dest_paths.path3)),
+        ]
+    )
+
+    # All three rules can be used with both regular and strict transform
+    assert applier.transform("/mnt/shared") == dest_paths.path1
+    assert applier.transform("/mnt/projects") == dest_paths.path2
+    assert applier.transform("/tmp") == dest_paths.path3
+    assert applier.strict_transform("/mnt/shared") == dest_paths.path1
+    assert applier.strict_transform("/mnt/projects") == dest_paths.path2
+    assert applier.strict_transform("/tmp") == dest_paths.path3
+
+    # transform passes through other paths
+    assert applier.transform("/other/path") == "/other/path"
+
+    # strict_transform raises for other paths
+    with pytest.raises(ValueError):
+        applier.strict_transform("/other/path")
+
+
+def test_source_windows_rule(dest_paths: DestPaths):
+    applier = _PathMappingRuleApplier(
+        [
+            PathMappingRule(PathFormat.WINDOWS.value, "C:\\Shared", str(dest_paths.path1)),
+            PathMappingRule(PathFormat.WINDOWS.value, "C:\\proJects", str(dest_paths.path2)),
+            PathMappingRule(PathFormat.WINDOWS.value, "D:\\tmp", str(dest_paths.path3)),
+        ]
+    )
+
+    # All three rules can be used with both regular and strict transform
+    assert applier.transform("C:\\Shared") == dest_paths.path1
+    assert applier.transform("C:\\proJects") == dest_paths.path2
+    assert applier.transform("D:\\tmp") == dest_paths.path3
+    assert applier.strict_transform("C:\\Shared") == dest_paths.path1
+    assert applier.strict_transform("C:\\proJects") == dest_paths.path2
+    assert applier.strict_transform("D:\\tmp") == dest_paths.path3
+
+    # Windows is case insensitive but case preserving
+    assert applier.transform("C:\\ShArEd") == dest_paths.path1
+    assert (
+        applier.transform("C:\\PROJECTS\\Case\\Of\\tail\\PreServed")
+        == dest_paths.path2 / "Case" / "Of" / "tail" / "PreServed"
+    )
+
+    # transform passes through other paths
+    assert applier.transform("C:\\other\\path") == "C:\\other\\path"
+
+    # strict_transform raises for other paths
+    with pytest.raises(ValueError):
+        applier.strict_transform("C:\\other\\path")
+
+
+def test_source_posix_rule_edge_cases(dest_paths: DestPaths):
+    applier = _PathMappingRuleApplier(
+        [
+            PathMappingRule(PathFormat.POSIX.value, "/mnt/shared", str(dest_paths.path1)),
+            PathMappingRule(PathFormat.POSIX.value, "/mnt/shared/projects", str(dest_paths.path2)),
+            PathMappingRule(PathFormat.POSIX.value, "/tmp", str(dest_paths.path3)),
+        ]
+    )
+
+    # Paths that are not transformed
+    assert applier.transform("") == ""
+    assert applier.transform("/") == "/"
+    assert applier.transform("/other/path") == "/other/path"
+    assert applier.transform("/mnt/other/path") == "/mnt/other/path"
+    assert applier.transform("/Mnt/shared") == "/Mnt/shared"
+
+    # Edge cases with unicode and spaces
+    assert applier.transform("/mnt/shared/файл.txt") == dest_paths.path1 / "файл.txt"
+    assert (
+        applier.transform("/mnt/shared/file with spaces.txt")
+        == dest_paths.path1 / "file with spaces.txt"
+    )
+
+    # The second rule applies because it is longer and more specific than the first rule
+    assert applier.transform("/mnt/shared/projects") == dest_paths.path2
+    assert applier.transform("/mnt/shared/projects/file.txt") == dest_paths.path2 / "file.txt"
+
+
+def test_source_windows_rule_edge_cases(dest_paths: DestPaths):
+    applier = _PathMappingRuleApplier(
+        [
+            PathMappingRule(PathFormat.WINDOWS.value, "C:\\shared", str(dest_paths.path1)),
+            PathMappingRule(
+                PathFormat.WINDOWS.value, "C:\\shared\\projects", str(dest_paths.path2)
+            ),
+            PathMappingRule(PathFormat.WINDOWS.value, "D:\\temp", str(dest_paths.path3)),
+        ]
+    )
+
+    # Paths that are not transformed
+    assert applier.transform("") == ""
+    assert applier.transform("C:\\other\\path") == "C:\\other\\path"
+
+    # Edge cases with unicode and spaces
+    assert applier.transform("C:\\shared\\файл.txt") == dest_paths.path1 / "файл.txt"
+    assert (
+        applier.transform("C:\\shared\\file with spaces.txt")
+        == dest_paths.path1 / "file with spaces.txt"
+    )
+
+    # The second rule applies because it is longer and more specific than the first rule
+    assert applier.transform("C:\\shared\\projects") == dest_paths.path2
+    assert applier.transform("C:\\shared\\projects\\file.txt") == dest_paths.path2 / "file.txt"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

For the incremental download work, we need functionality to generate path mapping rules from a pair of storage profiles and then to apply those rules to a large number of paths.

### What was the solution? (How)

Write functions to support path mapping between two storage profiles, with a structure for applying them to many paths.

* Functions are marked internal-only for now.
* _generate_path_mapping_rules takes two storage profiles and generates a list of path mapping rules.
* _PathMappingRuleApplier builds an acceleration structure from a list of path mapping rules for mapping a large number of paths.
* Unit tests for new funcitonality.
### What is the impact of this change?

### How was this change tested?

Wrote unit tests.

### Was this change documented?

No

### Does this PR introduce new dependencies?

No

### Is this a breaking change?

No 

### Does this change impact security?

No 

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
