### PR TITLE
chore: add python 3 dynamic libaries to validation allow-list

### DIFF
--- a/scripts/pyinstaller/allowlist.py
+++ b/scripts/pyinstaller/allowlist.py
@@ -65,6 +65,8 @@ ALLOWLIST = {
         "_internal/cli/_internal/api-ms-win-*.dll",
         "_internal/cli/_internal/libpython3.*.so.1.0",
         "_internal/libpython3.*.so.1.0",
+        "_internal/libpython3.*.dylib",
+        "_internal/cli/_internal/libpython3.*.dylib",
         "_internal/python3*.dll",
         "_internal/cli/_internal/python3*.dll",
         "_internal/pywin32_system32/pywintypes3*.dll",


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
pyinstaller validation script fails when running on MacOS.

### What was the solution? (How)
Add missing python dynamic libraries, these are licensed under PSF which we already attribute.

### What is the impact of this change?
validation script is compatible with mac

### How was this change tested?

Ran validation script...

before:
```
(.venv-validation) moorec@bcd074a5e7fe deadline-cloud % python scripts/pyinstaller/validate.py
Extracting: /Users/moorec/Workspace/attribution/deadline-cloud/dist/deadline-client-exe.zip
Extracting: /var/folders/db/q6zs6kr125l801158wnx79100000gq/T/tmptirdsdol/deadline
Extracting: /var/folders/db/q6zs6kr125l801158wnx79100000gq/T/tmpayx9ciod/PYZ.pyz
Extracting: /var/folders/db/q6zs6kr125l801158wnx79100000gq/T/tmptirdsdol/_internal/base_library.zip
Extracting: /var/folders/db/q6zs6kr125l801158wnx79100000gq/T/tmptirdsdol/_internal/cli/deadline_cli
Extracting: /var/folders/db/q6zs6kr125l801158wnx79100000gq/T/tmp78sxl036/PYZ.pyz
Extracting: /var/folders/db/q6zs6kr125l801158wnx79100000gq/T/tmptirdsdol/_internal/cli/_internal/base_library.zip
Found file _internal/libpython3.12.dylib which was not included in the allowlist
Found file _internal/cli/_internal/libpython3.12.dylib which was not included in the allowlist
```

after:
```
Extracting: /Users/moorec/Workspace/attribution/deadline-cloud/dist/deadline-client-exe.zip
Extracting: /var/folders/db/q6zs6kr125l801158wnx79100000gq/T/tmph9b0ssxb/deadline
Extracting: /var/folders/db/q6zs6kr125l801158wnx79100000gq/T/tmpo_ynp9vg/PYZ.pyz
Extracting: /var/folders/db/q6zs6kr125l801158wnx79100000gq/T/tmph9b0ssxb/_internal/base_library.zip
Extracting: /var/folders/db/q6zs6kr125l801158wnx79100000gq/T/tmph9b0ssxb/_internal/cli/deadline_cli
Extracting: /var/folders/db/q6zs6kr125l801158wnx79100000gq/T/tmp8elf2g8d/PYZ.pyz
Extracting: /var/folders/db/q6zs6kr125l801158wnx79100000gq/T/tmph9b0ssxb/_internal/cli/_internal/base_library.zip
Validation passed
```

- Have you run the unit tests?
    - n/a
- Have you run the integration tests?
    - n/a

- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass.
    - n/a

### Was this change documented?

- Are relevant docstrings in the code base updated?
- Has the README.md been updated? If you modified CLI arguments, for instance.

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [X] This PR does not add any new dependencies.

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
