### PR TITLE
fix: Submission window doesn't close after a successful submission

### DIFF
--- a/src/deadline/client/cli/_groups/bundle_group.py
+++ b/src/deadline/client/cli/_groups/bundle_group.py
@@ -318,28 +318,22 @@ def bundle_gui_submit(
 
         app.exec()
 
-        response = None
-        if submitter:
-            response = submitter.create_job_response
-
         _print_response(
             output=output,
-            submitted=True if response else False,
             job_bundle_dir=job_bundle_dir,
             job_history_bundle_dir=submitter.job_history_bundle_dir,
-            job_id=response["jobId"] if response else None,
+            job_id=submitter.job_id,
         )
 
 
 def _print_response(
     output: str,
-    submitted: bool,
     job_bundle_dir: str,
     job_history_bundle_dir: Optional[str],
     job_id: Optional[str],
 ):
     if output == "json":
-        if submitted:
+        if job_id:
             response: dict[str, Any] = {
                 "status": "SUBMITTED",
                 "jobId": job_id,
@@ -349,7 +343,7 @@ def _print_response(
         else:
             click.echo(json.dumps({"status": "CANCELED"}))
     else:
-        if submitted:
+        if job_id:
             click.echo("Submitted job bundle:")
             click.echo(f"   {job_bundle_dir}")
             click.echo(f"Job ID: {job_id}")

--- a/src/deadline/client/ui/dialogs/submit_job_progress_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_progress_dialog.py
@@ -112,7 +112,6 @@ class SubmitJobProgressDialog(QDialog):
     to AWS Deadline Cloud.
     """
 
-    job_id: Optional[str] = None
     cancelation_flag: CancelationFlag
 
     # This signal is sent when the background thread raises an exception.
@@ -126,12 +125,14 @@ class SubmitJobProgressDialog(QDialog):
 
     # This signal is sent when the background thread succeeds.
     submission_thread_succeeded = Signal(str)
+    succeeded = threading.Event()  # Event set after dialog is closed when job submission succeeds
 
     def __init__(self, parent: QWidget) -> None:
         super().__init__(parent=parent)
 
         # Use the CancelationFlag object to decouple the cancelation value
         # from the window lifetime.
+
         self.cancelation_flag = CancelationFlag()
         self.destroyed.connect(self.cancelation_flag.set_canceled)
         self._warning_dialog_canceled = False
@@ -144,6 +145,7 @@ class SubmitJobProgressDialog(QDialog):
         self.submission_thread_succeeded.connect(self.handle_create_job_thread_succeeded)
         self.submission_thread_request_warning_dialog.connect(self.handle_request_warning_dialog)
         self.submission_thread_exception.connect(self.handle_thread_exception)
+        self.__job_id = None
 
         self._build_ui()
 
@@ -152,7 +154,7 @@ class SubmitJobProgressDialog(QDialog):
         job_bundle_dir: str,
         job_parameters: list[dict[str, Any]] = [],
         **kwargs,
-    ):
+    ) -> None:
         """
         Starts a job submission background thread and returns immediately. It wires up
         appropriate callbacks and then forwards all arguments.
@@ -291,6 +293,7 @@ class SubmitJobProgressDialog(QDialog):
             self.status_label.setText("Submission complete")
             self.button_box.setStandardButtons(QDialogButtonBox.Ok)
             self.button_box.button(QDialogButtonBox.Ok).setDefault(True)
+            self.button_box.button(QDialogButtonBox.Ok).clicked.connect(self.succeeded.set)
         else:
             if self.cancelation_flag or self._warning_dialog_canceled:
                 self.status_label.setText("Submission canceled")
@@ -333,6 +336,23 @@ class SubmitJobProgressDialog(QDialog):
         if super().exec_() == QDialog.Accepted:
             return self.job_id
         return None
+
+    @property
+    def job_id(self) -> Optional[str]:
+        """
+        Returns the job ID if the submission was successful, otherwise None.
+        """
+        return self.__job_id
+
+    @job_id.setter
+    def job_id(self, value: str) -> None:
+        """
+        Sets the job ID if the submission was successful.
+        """
+        self.__job_id = value
+
+        # The submit job to deadline dialogn depends on having this value set.
+        self.parentWidget().job_id = value
 
 
 class JobAttachmentsProgressWidget(QGroupBox):

--- a/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
@@ -11,7 +11,7 @@ import json
 from typing import Any, Dict, Optional, Protocol
 import yaml
 
-from qtpy.QtCore import QSize, Qt  # pylint: disable=import-error
+from qtpy.QtCore import QSize, Qt, QTimer  # pylint: disable=import-error
 from qtpy.QtGui import QKeyEvent  # pylint: disable=import-error
 from qtpy.QtWidgets import (  # pylint: disable=import-error; type: ignore
     QApplication,
@@ -124,11 +124,21 @@ class SubmitJobToDeadlineDialog(QDialog):
         self.job_settings_type = type(initial_job_settings)
         self.submitter_name = submitter_name or self.job_settings_type().submitter_name
         self.on_create_job_bundle_callback = on_create_job_bundle_callback
-        self.create_job_response: Optional[Dict[str, Any]] = None
+        self.__job_id = None
         self.job_history_bundle_dir: Optional[str] = None
         self.deadline_authentication_status = DeadlineAuthenticationStatus.getInstance()
         self.show_host_requirements_tab = show_host_requirements_tab
         self.known_asset_paths = known_asset_paths or []
+        self.job_progress_dialog = None
+        self.should_close = False
+
+        if self.submitter_name != "JobBundle":
+            # We want to close the submitter on success, but this must be done from the main thread.
+            # Since job submission is done in a separate thread we start a timer which checks every
+            # 100ms if the submission has completed, and closes the submitter if it has.
+            self.close_check_timer = QTimer(self)
+            self.close_check_timer.timeout.connect(self._check_should_close)
+            self.close_check_timer.start(100)  # Check every 100ms
 
         self._build_ui(
             job_setup_widget_type,
@@ -141,6 +151,16 @@ class SubmitJobToDeadlineDialog(QDialog):
 
         self.gui_update_counter: Any = None
         self.refresh_deadline_settings()
+
+    def _check_should_close(self):
+        """Check if we should close the dialog"""
+        if (
+            self.submitter_name != "JobBundle"
+            and self.job_progress_dialog
+            and self.job_progress_dialog.succeeded.is_set()
+        ):
+            self.close()
+            self.close_check_timer.stop()
 
     def sizeHint(self):
         return QSize(540, 700)
@@ -455,9 +475,6 @@ class SubmitJobToDeadlineDialog(QDialog):
         """
         Perform a submission when the submit button is pressed
         """
-        # Unset any cached response
-        self.create_job_response = None
-
         # Retrieve all the settings into the dataclass
         settings = self.job_settings_type()
         self.shared_job_settings.update_settings(settings)
@@ -467,8 +484,8 @@ class SubmitJobToDeadlineDialog(QDialog):
 
         asset_references = self.job_attachments.get_asset_references()
 
-        job_progress_dialog = SubmitJobProgressDialog(parent=self)
-        job_progress_dialog.show()
+        self.job_progress_dialog = SubmitJobProgressDialog(parent=self)
+        self.job_progress_dialog.show()
         QApplication.instance().processEvents()  # type: ignore[union-attr]
 
         # Submit the job
@@ -507,7 +524,7 @@ class SubmitJobToDeadlineDialog(QDialog):
             if job_parameters:
                 self.save_job_parameters_to_job_bundle(self.job_history_bundle_dir, job_parameters)
 
-            job_id = job_progress_dialog.start_job_submission(
+            self.job_progress_dialog.start_job_submission(
                 job_bundle_dir=self.job_history_bundle_dir,
                 submitter_name=self.submitter_name,
                 config=config_file.read_config(),
@@ -516,16 +533,14 @@ class SubmitJobToDeadlineDialog(QDialog):
                 known_asset_paths=self.known_asset_paths
                 + parameters_from_callback.get("known_asset_paths", []),
             )
-            if job_id:
-                set_setting("defaults.job_id", job_id)
 
         except UserInitiatedCancel as uic:
             logger.info("Canceling submission.")
             QMessageBox.information(self, f"{self.submitter_name} job submission", str(uic))
-            job_progress_dialog.close()
+            self.job_progress_dialog.close()
         except NonValidInputError as nvie:
             QMessageBox.critical(self, "Non valid inputs detected", str(nvie))
-            job_progress_dialog.close()
+            self.job_progress_dialog.close()
         except Exception as exc:
             logger.exception("error submitting job")
             api.get_deadline_cloud_library_telemetry_client().record_error(
@@ -534,10 +549,19 @@ class SubmitJobToDeadlineDialog(QDialog):
                 from_gui=True,
             )
             QMessageBox.critical(self, f"{self.submitter_name} job submission", str(exc))  # type: ignore[call-arg]
-            job_progress_dialog.close()
+            self.job_progress_dialog.close()
 
-        if self.create_job_response:
-            # Close the submitter window to signal the submission is done but
-            # keep the standalone gui submitter open
-            if self.submitter_name != "JobBundle":
-                self.close()
+    @property
+    def job_id(self) -> Optional[str]:
+        """
+        Returns the job ID if the submission was successful, otherwise None.
+        """
+        return self.__job_id
+
+    @job_id.setter
+    def job_id(self, value: str) -> None:
+        """
+        Sets the job ID locally and as a setting if the submission was successful.
+        """
+        self.__job_id = value
+        set_setting("defaults.job_id", value)


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud/issues/768

### What was the problem/requirement? (What/Why)

The Submission window doesn't close after a successful submission.

The root cause is that a function had its return value changed from the create job response, to `None`. 


### What was the solution? (How)

The solution is to hook up passing the jobId back into the submission window, as well as adding logic to close the window if the job submission is successful. This is a bit more ugly that I'd like it to be as a result of needing to close the dialog from the main thread.

### What is the impact of this change?

The job submission window closes after a successful submit if running inside an integrated submitter. 


### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests?
yes

- Have you run the integration tests?
yes

- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass.
No

### Was this change documented?

No, and it is not required


### Does this PR introduce new dependencies?


*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?

No

### Does this change impact security?

No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
