### PR TITLE
feat(experimental): Add storage profile support for incremental download

### DIFF
--- a/src/deadline/client/cli/_groups/attachment_group.py
+++ b/src/deadline/client/cli/_groups/attachment_group.py
@@ -85,7 +85,7 @@ def attachment_download(
     config = _apply_cli_options_to_config(**args)
 
     # Assuming when passing with config, session constructs from the profile id for S3 calls
-    # TODO - add type for profile, if queue type, get queue sesson directly
+    # TODO - add type for profile, if queue type, get queue session directly
     boto3_session: boto3.session = api.get_boto3_session(config=config)
 
     # If profile is not provided via args, default to use local config file
@@ -179,7 +179,7 @@ def attachment_upload(
     config = _apply_cli_options_to_config(**args)
 
     # Assuming when passing with config, session constructs from the profile id for S3 calls
-    # TODO - add type for profile, if queue type, get queue sesson directly
+    # TODO - add type for profile, if queue type, get queue session directly
     boto3_session: boto3.session = api.get_boto3_session(config=config)
 
     # If profile is not provided via args, default to use local config file

--- a/src/deadline/client/cli/_groups/queue_group.py
+++ b/src/deadline/client/cli/_groups/queue_group.py
@@ -29,7 +29,6 @@ from ....job_attachments._incremental_downloads.incremental_download_state impor
     IncrementalDownloadState,
 )
 
-PID_FILE_NAME = "incremental_output_download.pid"
 DOWNLOAD_CHECKPOINT_FILE_NAME = "download_checkpoint.json"
 
 
@@ -213,6 +212,10 @@ def queue_get(**args):
 @cli_queue.command(name="incremental-output-download")
 @click.option("--farm-id", help="The AWS Deadline Cloud Farm to use.")
 @click.option("--queue-id", help="The AWS Deadline Cloud Queue to use.")
+@click.option(
+    "--storage-profile-id",
+    help="The storage profile to use for mapping paths to local. Cannot be used together with --ignore-storage-profiles",
+)
 @click.option("--json", default=None, is_flag=True, help="Output is printed as JSON for scripting.")
 @click.option(
     "--bootstrap-lookback-minutes",
@@ -231,6 +234,13 @@ def queue_get(**args):
     "--force-bootstrap",
     is_flag=True,
     help="Forces command to start from the bootstrap lookback period and overwrite any previous checkpoint.\n"
+    "Default value is False.",
+    default=False,
+)
+@click.option(
+    "--ignore-storage-profiles",
+    is_flag=True,
+    help="Ignores the storage profile configuration. Only use if all jobs in the queue are submitted and downloaded from the same machine. Downloads all jobs to unmapped paths regardless of operating system.\n"
     "Default value is False.",
     default=False,
 )
@@ -263,6 +273,7 @@ def incremental_output_download(
     bootstrap_lookback_minutes: float,
     checkpoint_dir: str,
     force_bootstrap: bool,
+    ignore_storage_profiles: bool,
     dry_run: bool,
     **args,
 ):
@@ -287,6 +298,11 @@ def incremental_output_download(
             "The incremental-output-download command requires Python version 3.9 or later"
         )
 
+    if ignore_storage_profiles and args.get("storage_profile_id") is not None:
+        raise click.UsageError(
+            "Options '--storage-profile-id' and '--ignore-storage-profiles' cannot be provided together"
+        )
+
     logger: ClickLogger = ClickLogger(is_json=json)
 
     # Expand '~' to home directory and create the checkpoint directory if necessary
@@ -309,13 +325,49 @@ def incremental_output_download(
     queue_id = config_file.get_setting("defaults.queue_id", config=config)
     boto3_session: boto3.Session = api.get_boto3_session(config=config)
 
-    # Get download progress file name appended by the queue id - a unique progress file exists per queue
-    download_checkpoint_file_name: str = f"{queue_id}_{DOWNLOAD_CHECKPOINT_FILE_NAME}"
+    deadline = boto3_session.client("deadline")
+
+    if ignore_storage_profiles:
+        local_storage_profile_id = None
+        logger.echo("Ignoring all storage profiles.")
+    else:
+        local_storage_profile_id = config_file.get_setting(
+            "settings.storage_profile_id", config=config
+        )
+        if not local_storage_profile_id:
+            raise DeadlineOperationError(
+                "The incremental-output-download operation requires a storage profile configured locally\n"
+                "or provided with the --storage-profile-id option in order to determine file system paths\n"
+                "for download. Storage profiles are used to generate path mappings when a job was submitted\n"
+                "from a machine with a different operating system or file system mount locations than the download machine. \n\n"
+                "See https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/modeling-your-shared-filesystem-locations-with-storage-profiles.html\n\n"
+                "If you only submit and download jobs from one machine, you can use the --ignore-storage-profiles option\n"
+                "to ignore the storage profiles, and download all job outputs to whereever the paths are configured.\n"
+                "This is not recommended if more than one machine will submit or download jobs."
+            )
+
+        try:
+            local_storage_profile = deadline.get_storage_profile_for_queue(
+                farmId=farm_id,
+                queueId=queue_id,
+                storageProfileId=local_storage_profile_id,
+            )
+        except ClientError as e:
+            id_source = (
+                "configured locally"
+                if args.get("storage_profile_id") is None
+                else "provided with --storage-profile-id"
+            )
+            raise DeadlineOperationError(
+                f"Could not retrieve the storage profile {local_storage_profile_id!r}, {id_source}, from Deadline Cloud:\n{e}"
+            )
+
+    # Get download progress file name appended by the queue id and storage profile id - a unique progress file exists per queue/storage profile
+    download_checkpoint_file_name: str = f"{queue_id}_{local_storage_profile_id or 'ignore-storage-profiles'}_{DOWNLOAD_CHECKPOINT_FILE_NAME}"
 
     # Get saved progress file full path now that we've validated all file inputs are valid
     checkpoint_file_path: str = os.path.join(checkpoint_dir, download_checkpoint_file_name)
 
-    deadline = boto3_session.client("deadline")
     queue = deadline.get_queue(farmId=farm_id, queueId=queue_id)
     if "jobAttachmentSettings" not in queue:
         raise DeadlineOperationError(
@@ -326,23 +378,33 @@ def incremental_output_download(
     logger.echo(f"Checkpoint: {checkpoint_file_path}")
     logger.echo()
 
+    if local_storage_profile_id:
+        logger.echo(
+            f"Mapping job output paths to the local storage profile {local_storage_profile['displayName']} ({local_storage_profile_id})"
+        )
+        logger.echo("  File system locations for the storage profile are:")
+        for location in local_storage_profile["fileSystemLocations"]:
+            logger.echo(f"    {location['name']}: {location['path']}")
+        logger.echo()
+
     # Perform incremental download while holding a process id lock
 
-    pid_lock_file_path: str = os.path.join(checkpoint_dir, f"{queue_id}_{PID_FILE_NAME}")
+    pid_lock_file_path: str = os.path.join(checkpoint_dir, f"{download_checkpoint_file_name}.pid")
 
     with PidFileLock(
         pid_lock_file_path,
         operation_name="incremental output download",
     ):
-        current_download_state: IncrementalDownloadState
+        checkpoint: IncrementalDownloadState
 
         if force_bootstrap or not os.path.exists(checkpoint_file_path):
             bootstrap_timestamp = datetime.now(timezone.utc) - timedelta(
                 minutes=bootstrap_lookback_minutes
             )
             # Bootstrap with the specified lookback duration
-            current_download_state = IncrementalDownloadState(
-                downloads_started_timestamp=bootstrap_timestamp
+            checkpoint = IncrementalDownloadState(
+                local_storage_profile_id=local_storage_profile_id,
+                downloads_started_timestamp=bootstrap_timestamp,
             )
 
             # Print the bootstrap time in local time
@@ -355,12 +417,27 @@ def incremental_output_download(
             logger.echo(f"Initializing from: {bootstrap_timestamp.astimezone().isoformat()}")
         else:
             # Load the incremental download checkpoint file
-            current_download_state = IncrementalDownloadState.from_file(checkpoint_file_path)
+            checkpoint = IncrementalDownloadState.from_file(checkpoint_file_path)
 
             # Print the previous download completed time in local time
             logger.echo("Checkpoint found")
+
+            # The checkpoint's local storage profile id must match the CLI option
+            if local_storage_profile_id != checkpoint.local_storage_profile_id:
+                if checkpoint.local_storage_profile_id is None:
+                    raise DeadlineOperationError(
+                        "The checkpoint was created with the --ignore-storage-profiles, you must use the same option to continue from it."
+                    )
+                if local_storage_profile_id is None:
+                    raise DeadlineOperationError(
+                        "The checkpoint was created without the --ignore-storage-profiles, you must leave out the option to continue from it."
+                    )
+                raise DeadlineOperationError(
+                    f"The checkpoint was created with local storage profile {checkpoint.local_storage_profile_id}, but the configured storage profile is {local_storage_profile_id}"
+                )
+
             logger.echo(
-                f"Continuing from: {current_download_state.downloads_completed_timestamp.astimezone().isoformat()}"
+                f"Continuing from: {checkpoint.downloads_completed_timestamp.astimezone().isoformat()}"
             )
 
         logger.echo()
@@ -369,7 +446,8 @@ def incremental_output_download(
             boto3_session=boto3_session,
             farm_id=farm_id,
             queue=queue,
-            checkpoint=current_download_state,
+            checkpoint=checkpoint,
+            config=config,
             print_function_callback=logger.echo,
             dry_run=dry_run,
         )

--- a/src/deadline/client/cli/_incremental_download.py
+++ b/src/deadline/client/cli/_incremental_download.py
@@ -11,6 +11,7 @@ from typing import Any, Callable
 import sys
 import time
 import concurrent.futures
+import textwrap
 
 from .. import api
 import boto3
@@ -29,6 +30,7 @@ from ...job_attachments._incremental_downloads._manifest_s3_downloads import (
     _merge_absolute_path_manifest_list,
     _download_manifest_paths,
 )
+from ...job_attachments._path_mapping import _generate_path_mapping_rules, _PathMappingRuleApplier
 from ...job_attachments.asset_manifests import (
     BaseAssetManifest,
     BaseManifestPath,
@@ -38,6 +40,8 @@ from ...job_attachments.asset_manifests import (
 )
 from ...job_attachments.models import (
     FileConflictResolution,
+    PathFormat,
+    StorageProfileOperatingSystemFamily,
 )
 from ...job_attachments.progress_tracker import (
     ProgressReportMetadata,
@@ -181,6 +185,9 @@ class CategorizedJobIds:
         completed: The job finished running so all output is available for download.
         inactive: The job can no longer have any new downloads unless it is requeued. Minimal
             metadata is tracked to detect if it is requeued.
+        missing_storage_profile: The job has no storage profile, but the operation requires one.
+            If incremental download was called with local_storage_profile_id=None, this set
+            will always be empty.
         attachments_free: The job has no job attachments associated that can produce
             outputs for download.
     """
@@ -190,6 +197,7 @@ class CategorizedJobIds:
     unchanged: set[str] = set()
     completed: set[str] = set()
     inactive: set[str] = set()
+    missing_storage_profile: set[str] = set()
     attachments_free: set[str] = set()
 
 
@@ -206,7 +214,7 @@ def _categorize_jobs_in_checkpoint(
     Categorizes the provided download candidate jobs by id into a CategorizedJobIds object,
     updating the jobs within download_candidate_jobs where necessary.
 
-    * Calls boto3 deadline.get_job() to get job attachments manifest information if it is not stored yet.
+    * Calls boto3 deadline.get_job() to get job attachments manifest information and storage profile id if it is not stored yet.
 
     Args:
         boto3_session: The boto3.Session for accessing AWS.
@@ -236,11 +244,12 @@ def _categorize_jobs_in_checkpoint(
     # The following sets get populated while analyzing the jobs
     unchanged_job_ids = set()
     attachments_free_job_ids = set()
+    missing_storage_profile = set()
     completed_job_ids = set()
 
-    # Copy the job attachments manifest data from the checkpoint to the new job objects. This data is not returned
-    # by deadline:SearchJobs, so we need to call deadline:GetJob on every job to retrieve it. The manifests on a job
-    # don't change, so after the call to deadline:GetJob we can cache it indefinitely.
+    # Copy the job attachments manifest data and storage profile id from the checkpoint to the new job objects. This data
+    # is not returned by deadline:SearchJobs, so we need to call deadline:GetJob on every job to retrieve it. This data
+    # on a job don't change, so after the call to deadline:GetJob we can cache it indefinitely.
     for job_id in updated_job_ids:
         ip_job = checkpoint_jobs[job_id]
         dc_job = download_candidate_jobs[job_id]
@@ -252,11 +261,18 @@ def _categorize_jobs_in_checkpoint(
             # Carry over the minimal placeholder identifying the job as not using job attachments
             download_candidate_jobs[job_id] = ip_job
             attachments_free_job_ids.add(job_id)
+        elif ip_job["storageProfileId"] is None and checkpoint.local_storage_profile_id is not None:
+            # Carry over the minimal placeholder identifying the job as missing a storage profile
+            download_candidate_jobs[job_id] = ip_job
+            missing_storage_profile.add(job_id)
         else:
             # Copy the attachments manifest metadata as it is not returned by deadline:SearchJobs
             dc_job["attachments"] = ip_job["attachments"]
+            dc_job["storageProfileId"] = ip_job["storageProfileId"]
+
     updated_job_ids.difference_update(attachments_free_job_ids)
     updated_job_ids.difference_update(new_job_ids)
+    updated_job_ids.difference_update(missing_storage_profile)
 
     # Prune jobs that we are (almost) certain have no changes by looking at its task status counts. We treat a job as unchanged if its
     # value job["taskRunStatusCounts"]["SUCCEEDED"] stayed the same and its timestamp job["endedAt"] stayed the same.
@@ -346,6 +362,7 @@ def _categorize_jobs_in_checkpoint(
         # Call deadline:GetJob to retrieve attachments manifest information
         job = deadline.get_job(jobId=job_id, queueId=queue_id, farmId=farm_id)
         dc_job["attachments"] = job.get("attachments")
+        dc_job["storageProfileId"] = job.get("storageProfileId")
         dc_succeeded_task_count = dc_job["taskRunStatusCounts"]["SUCCEEDED"]
         dc_total_task_count = sum(value for _, value in dc_job["taskRunStatusCounts"].items())
 
@@ -642,6 +659,120 @@ def _get_job_sessions(
     return job_sessions
 
 
+def _get_storage_profiles(
+    deadline: BaseClient,
+    farm_id: str,
+    queue: dict[str, Any],
+    job_sessions: dict[str, list],
+    checkpoint: IncrementalDownloadState,
+    download_candidate_jobs: dict[str, dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    """
+    Retrieves all the needed storage profiles. To call this function,
+    checkpoint.local_storage_profile_id must be set.
+
+    Args:
+        deadline: An AWS client for calling deadline APIs.
+        farm_id: The farm id for the operation.
+        queue: The queue as returned by boto3 deadline.get_queue().
+        checkpoint: The checkpoint for the incremental download.
+        job_sessions: Contains each job's sessions and session actions, structured as job_sessions[job_id][session_index]["sessionActions"][session_action_index].
+                      See the function _get_job_sessions for more details.
+        download_candidate_jobs: The result of a _get_download_candidate_jobs call, {job_id: job} where
+            job is a result from a deadline.search_jobs() or deadline.get_job() call.
+    """
+    if checkpoint.local_storage_profile_id is None:
+        raise ValueError("The checkpoint local storage profile id must be set.")
+
+    # Collect all the storage profile ids
+    storage_profile_ids: set[str] = {checkpoint.local_storage_profile_id}
+    for job_id in job_sessions.keys():
+        storage_profile_ids.add(download_candidate_jobs[job_id]["storageProfileId"])
+
+    # Load all the storage profiles from Deadline Cloud
+    storage_profiles = {
+        storage_profile_id: deadline.get_storage_profile_for_queue(
+            farmId=farm_id,
+            queueId=queue["queueId"],
+            storageProfileId=storage_profile_id,
+        )
+        for storage_profile_id in storage_profile_ids
+    }
+
+    return storage_profiles
+
+
+def _create_path_mapping_rule_appliers(
+    storage_profiles: dict[str, dict[str, Any]],
+    checkpoint: IncrementalDownloadState,
+    download_candidate_jobs: dict[str, dict[str, Any]],
+    print_function_callback: Callable[[str], None] = lambda msg: None,
+) -> dict[str, Optional[_PathMappingRuleApplier]]:
+    """
+    Retrieves all the needed storage profiles and constructs path mapping rule applies for them.
+    To call this function, checkpoint.local_storage_profile_id must be set.
+
+    Args:
+        storage_profiles: A mapping from storage profile id to the storage profile as returned by boto3 deadline.get_storage_profile_for_queue.
+        checkpoint: The checkpoint for the incremental download.
+        job_sessions: Contains each job's sessions and session actions, structured as job_sessions[job_id][session_index]["sessionActions"][session_action_index].
+                      See the function _get_job_sessions for more details.
+        download_candidate_jobs: The result of a _get_download_candidate_jobs call, {job_id: job} where
+            job is a result from a deadline.search_jobs() or deadline.get_job() call.
+        print_function_callback: Callback for printing output to the terminal or log.
+    """
+    if checkpoint.local_storage_profile_id is None:
+        raise ValueError("The checkpoint local storage profile id must be set.")
+
+    path_mapping_rule_appliers: dict[str, Optional[_PathMappingRuleApplier]] = {}
+
+    # Create a path mapping rule applier for each storage profile
+    local_storage_profile = storage_profiles[checkpoint.local_storage_profile_id]
+    local_storage_profile_name = local_storage_profile["displayName"]
+    print_function_callback("")
+    print_function_callback(
+        f"Local storage profile is {local_storage_profile_name} ({checkpoint.local_storage_profile_id})"
+    )
+    print_function_callback(
+        f"  {len([job for job in download_candidate_jobs.values() if job.get('storageProfileId') == checkpoint.local_storage_profile_id])} download candidate jobs will have no path mapping because they use this storage profile"
+    )
+    for storage_profile_id, storage_profile in storage_profiles.items():
+        storage_profile_name = storage_profile["displayName"]
+        if storage_profile_id == checkpoint.local_storage_profile_id:
+            path_mapping_rule_appliers[storage_profile_id] = None
+        else:
+            rules = _generate_path_mapping_rules(storage_profile, local_storage_profile)
+            path_mapping_rule_appliers[storage_profile_id] = _PathMappingRuleApplier(rules)
+
+            # Print the path mapping rules for each source storage profile
+            print_function_callback("")
+            job_count = len(
+                [
+                    job
+                    for job in download_candidate_jobs.values()
+                    if job.get("storageProfileId") == storage_profile_id
+                ]
+            )
+            print_function_callback(
+                f"Path mapping rules for {job_count} download candidate jobs with storage profile {storage_profile_name} ({storage_profile_id})"
+            )
+            print_function_callback(
+                f"  job storage profile: {storage_profile_name} ({storage_profile['osFamily']})"
+            )
+            print_function_callback(
+                f"  local storage profile: {local_storage_profile_name} ({local_storage_profile['osFamily']})"
+            )
+            if rules:
+                for rule in rules:
+                    print_function_callback(f"  - from: {rule.source_path}")
+                    print_function_callback(f"    to:   {rule.destination_path}")
+            else:
+                print_function_callback(
+                    f"   No rules generated. Storage profiles {local_storage_profile_name} and {storage_profile_name} share no file system location names."
+                )
+    return path_mapping_rule_appliers
+
+
 def _add_missing_output_manifests_to_job_sessions(
     boto3_session_for_s3: boto3.Session,
     farm_id: str,
@@ -789,6 +920,23 @@ def _update_checkpoint_jobs_list(
                 {},
             )
         )
+    # This category keeps a signal that it is missing a storage profile by populating the attachments but
+    # having a storageProfileId field with None in it. By keeping the attachments in the checkpoint, someone
+    # inspecting the checkpoint to understand what's happening can get an idea about the paths for the job
+    # and diagnose problems quicker.
+    for job_id in categorized_job_ids.missing_storage_profile:
+        updated_jobs.append(
+            IncrementalDownloadJob(
+                {
+                    "jobId": job_id,
+                    "name": download_candidate_jobs[job_id]["name"],
+                    "attachments": download_candidate_jobs[job_id]["attachments"],
+                    "storageProfileId": None,
+                },
+                None,
+                {},
+            )
+        )
     # Keep completed jobs around until they become inactive
     for job_id in categorized_job_ids.completed:
         updated_jobs.append(
@@ -930,20 +1078,58 @@ def _incremental_output_download(
         print_function_callback,
     )
 
+    # If storage profiles are being used, get them and construct all the path mapping rules
+    path_mapping_rule_appliers: dict[str, Optional[_PathMappingRuleApplier]] = {}
+    if checkpoint.local_storage_profile_id:
+        storage_profiles = _get_storage_profiles(
+            deadline, farm_id, queue, job_sessions, checkpoint, download_candidate_jobs
+        )
+        path_mapping_rule_appliers = _create_path_mapping_rule_appliers(
+            storage_profiles,
+            checkpoint,
+            download_candidate_jobs,
+            print_function_callback,
+        )
+
     # Use the information collected so far to update the jobs list in checkpoint
     _update_checkpoint_jobs_list(
         checkpoint, download_candidate_jobs, categorized_job_ids, job_sessions
     )
 
+    unmapped_paths: dict[str, list[str]] = {}
     downloaded_manifests: list[tuple[datetime, BaseAssetManifest]] = (
         _download_all_manifests_with_absolute_paths(
             queue,
             download_candidate_jobs,
             job_sessions,
+            path_mapping_rule_appliers,
+            unmapped_paths,
             boto3_session_for_s3,
             print_function_callback,
         )
     )
+
+    # Print warning messages about all the output paths that will not be downloaded due to lack of path mapping.
+    if unmapped_paths:
+        print_function_callback("")
+        for job_id, unmapped_path_list in unmapped_paths.items():
+            print_function_callback(
+                f"WARNING: Job {download_candidate_jobs[job_id]['name']} ({job_id}) has outputs with unmapped paths"
+            )
+            storage_profile = storage_profiles[download_candidate_jobs[job_id]["storageProfileId"]]
+            print_function_callback(
+                f"         Job storage profile is {storage_profile['displayName']} ({storage_profile['storageProfileId']})"
+            )
+            print_function_callback("         Summary of unmapped paths:")
+            path_format = (
+                PathFormat.WINDOWS
+                if storage_profile["osFamily"] == StorageProfileOperatingSystemFamily.WINDOWS.value
+                else PathFormat.POSIX
+            )
+            paths_summary = summarize_path_list(
+                unmapped_path_list, max_entries=30, path_format=path_format
+            )
+            print_function_callback(textwrap.indent(paths_summary, "         "))
 
     # Merge the manifests ordered by the last modified timestamp
     manifest_paths_to_download: list[BaseManifestPath] = _merge_absolute_path_manifest_list(
@@ -1028,6 +1214,9 @@ def _incremental_output_download(
     print_function_callback("  Jobs without downloads:")
     print_function_callback(
         f"    not using job attachments: {len(categorized_job_ids.attachments_free)}"
+    )
+    print_function_callback(
+        f"    missing storage profile: {len(categorized_job_ids.missing_storage_profile)}"
     )
     print_function_callback(f"    unchanged: {len(categorized_job_ids.unchanged)}")
     print_function_callback(f"    inactive: {len(categorized_job_ids.inactive)}")

--- a/src/deadline/common/path_utils.py
+++ b/src/deadline/common/path_utils.py
@@ -2,9 +2,13 @@
 from __future__ import annotations
 import os
 import re
-from typing import Optional, Iterable, Union
+from typing import Any, Optional, Iterable, Union
 from collections.abc import Collection
-from pathlib import Path
+from pathlib import PurePath, PurePosixPath, PureWindowsPath
+import ntpath
+import posixpath
+
+from ..job_attachments.models import PathFormat
 
 
 def human_readable_file_size(size_in_bytes: int) -> str:
@@ -58,9 +62,7 @@ class _NumberedPath:
     number: Optional[int] = None
     """The number in the path, or None if the path is not numbered"""
 
-    def __init__(self, path: Union[Path, str]):
-        if isinstance(path, Path):
-            path = str(path)
+    def __init__(self, path: str):
         m = _NUMBERED_PATH_REGEX.match(path)
         if m:
             self.path = path
@@ -76,6 +78,9 @@ class _NumberedPath:
         else:
             self.path = self.grouping = path
             self.padding_min = self.padding_max = -1
+
+    def __repr__(self):
+        return f"_NumberedPath({self.path!r})"
 
 
 def _divide_numbered_path_group(group: list[_NumberedPath]) -> dict[str, set[int]]:
@@ -131,15 +136,26 @@ class PathSummary:
     children: Optional[dict[str, "PathSummary"]]
     """The children of this path, if the summary is nested"""
 
+    _os_path: Any
+    """Either ntpath or posixpath depending on the path_format from construction."""
+
     def __init__(
         self,
         path: str,
         *,
+        path_format: Optional[PathFormat] = None,
         index_set: Optional[set[int]] = None,
         file_count: Optional[int] = None,
         total_size: Optional[int] = None,
         children: Optional[dict[str, "PathSummary"]] = None,
     ):
+        if path_format is None:
+            self._os_path = os.path
+        elif path_format == PathFormat.WINDOWS:
+            self._os_path = ntpath
+        else:
+            self._os_path = posixpath
+
         self.path = path
         self.index_set = index_set or set()
         if index_set:
@@ -154,18 +170,18 @@ class PathSummary:
     def is_dir(self) -> bool:
         """Returns True if the path is a directory (indicated by a trailing '/')"""
         # On Windows, both '/' and '\\' are directory separators, so check both sep and altsep
-        return self.path.endswith(os.path.sep) or (
-            os.path.altsep and self.path.endswith(os.path.altsep)
+        return self.path.endswith(self._os_path.sep) or (
+            self._os_path.altsep and self.path.endswith(self._os_path.altsep)
         )  # type: ignore
 
-    def summary(self, *, include_totals=True, relative_to: Optional[Union[Path, str]] = None):
+    def summary(self, *, include_totals=True, relative_to: Optional[Union[PurePath, str]] = None):
         """Returns the path summary, including file count and size totals by default."""
         relpath = self.path
         if relative_to is not None:
-            relpath = os.path.relpath(self.path, relative_to)
+            relpath = self._os_path.relpath(self.path, relative_to)
             # Ensure a trailing separator for directories
             if self.is_dir():
-                relpath = os.path.join(relpath, "")
+                relpath = self._os_path.join(relpath, "")
 
         if include_totals:
             return f"{relpath} ({self.summary_totals()})"
@@ -246,7 +262,10 @@ def _int_set_to_range_expr(int_set: set[int]) -> str:
 
 
 def summarize_paths_by_sequence(
-    path_list: Collection[Union[Path, str]], *, total_size_by_path: Optional[dict[str, int]] = None
+    path_list: Collection[Union[PurePath, str]],
+    *,
+    path_format: Optional[PathFormat] = None,
+    total_size_by_path: Optional[dict[str, int]] = None,
 ) -> list[PathSummary]:
     """
     Identifies numbered sequences of files/directories within a list of paths.
@@ -262,9 +281,24 @@ def summarize_paths_by_sequence(
     if len(path_list) == 0:
         return []
 
+    if path_format is None:
+        path_format = PathFormat.get_host_path_format()
+
+    # Convert all the paths into strings, and deduplicate by converting into a set
+    path_list_as_str: set[str] = {
+        str(path) if isinstance(path, PurePath) else path for path in path_list
+    }
+    # On Windows, convert all "/" separators to "\\"
+    if path_format == PathFormat.WINDOWS:
+        path_list_as_str = {path.replace("/", "\\") for path in path_list_as_str}
+        if total_size_by_path:
+            total_size_by_path = {
+                path.replace("/", "\\"): size for path, size in total_size_by_path.items()
+            }
+
     # Group according to the _NumberedPath.grouping property
     raw_grouped_paths: dict[str, list[_NumberedPath]] = {}
-    for path in path_list:
+    for path in path_list_as_str:
         numbered_path = _NumberedPath(path)
         raw_grouped_paths.setdefault(numbered_path.grouping, []).append(numbered_path)
 
@@ -276,7 +310,7 @@ def summarize_paths_by_sequence(
 
     # Sort the result by the printf pattern and convert to PathSummary objects
     result = [
-        PathSummary(path, index_set=index_set)
+        PathSummary(path, path_format=path_format, index_set=index_set)
         for path, index_set in sorted(grouped_paths.items(), key=lambda x: x[0])
     ]
 
@@ -307,23 +341,43 @@ def _collapse_each_path_summary(path_summary_list: Iterable[PathSummary]) -> lis
 
 
 def summarize_paths_by_nested_directory(
-    path_list: Collection[Union[Path, str]], *, total_size_by_path: Optional[dict[str, int]] = None
+    path_list: Collection[Union[PurePath, str]],
+    *,
+    path_format: Optional[PathFormat] = None,
+    total_size_by_path: Optional[dict[str, int]] = None,
 ) -> list[PathSummary]:
-    """Summarizes the provided paths by sequence, and then nests them into
+    """
+    Summarizes the provided paths by sequence, and then nests them into
     common parent paths. The returned summaries do not contain a common parent,
     for example if they are different relative paths, or absolute paths for
-    different drives on Windows"""
+    different drives on Windows
+
+    By default, paths are for the current operating system. If path_format is provided, you can
+    override that to PathFormat.WINDOWS or PathFormat.POSIX as necessary.
+    """
     if len(path_list) == 0:
         return []
 
+    if path_format is None:
+        path_format = PathFormat.get_host_path_format()
+
+    if path_format == PathFormat.WINDOWS:
+        path_type: Any = PureWindowsPath
+        os_path: Any = ntpath
+    else:
+        path_type = PurePosixPath
+        os_path = posixpath
+
     # First summarize the paths by sequence
-    summary_list = summarize_paths_by_sequence(path_list, total_size_by_path=total_size_by_path)
+    summary_list = summarize_paths_by_sequence(
+        path_list, total_size_by_path=total_size_by_path, path_format=path_format
+    )
 
     # Put all the summaries into a temporary common root.
-    nested_summary = PathSummary("ROOT/")
+    nested_summary = PathSummary("ROOT/", path_format=path_format)
     for path_summary in summary_list:
         # Split the path into its components
-        path_components = Path(path_summary.path).parts
+        path_components = path_type(path_summary.path).parts
         # Start with the root component, and build up the nested structure
         current_level: PathSummary = nested_summary
         for i in range(len(path_components) - 1):
@@ -333,7 +387,8 @@ def summarize_paths_by_nested_directory(
                 current_level.children = {}
             if component not in current_level.children:
                 current_level.children[component] = PathSummary(
-                    os.path.join(*path_components[: i + 1], ""),
+                    os_path.join(*path_components[: i + 1], ""),
+                    path_format=path_format,
                     total_size=0 if total_size_by_path else None,
                 )
             # Descend into the new level
@@ -352,8 +407,9 @@ def summarize_paths_by_nested_directory(
 
 
 def summarize_path_list(
-    path_list: Collection[Union[Path, str]],
+    path_list: Collection[Union[PurePath, str]],
     *,
+    path_format: Optional[PathFormat] = None,
     total_size_by_path: Optional[dict[str, int]] = None,
     max_entries=10,
     include_totals=True,
@@ -362,6 +418,9 @@ def summarize_path_list(
     Creates a string summary of the files in the list provided,
     grouping numbered filenames by their sequence pattern, and nesting
     summaries of the directory into the specified maximum number of entries.
+
+    By default, paths are for the current operating system. If path_format is provided, you can
+    override that to PathFormat.WINDOWS or PathFormat.POSIX as necessary.
 
     If total_size_by_path is provided, it must provide a total size for every path in path_list.
 
@@ -372,9 +431,12 @@ def summarize_path_list(
     if len(path_list) == 0:
         return ""
 
+    if path_format is None:
+        path_format = PathFormat.get_host_path_format()
+
     lines = []
     summary_list = summarize_paths_by_nested_directory(
-        path_list, total_size_by_path=total_size_by_path
+        path_list, total_size_by_path=total_size_by_path, path_format=path_format
     )
 
     # If the summary list has one entry, and its path is a very shallow root like '/' or 'C:/',

--- a/src/deadline/job_attachments/_incremental_downloads/_manifest_s3_downloads.py
+++ b/src/deadline/job_attachments/_incremental_downloads/_manifest_s3_downloads.py
@@ -15,6 +15,8 @@ import os
 import concurrent.futures
 from threading import Lock
 from pathlib import Path
+import posixpath
+import ntpath
 
 import boto3
 from boto3.s3.transfer import ProgressCallbackInvoker
@@ -40,6 +42,7 @@ from ..models import (
     FileConflictResolution,
     JobAttachmentS3Settings,
     S3_MANIFEST_FOLDER_NAME,
+    PathFormat,
 )
 from ..exceptions import (
     COMMON_ERROR_GUIDANCE_FOR_S3,
@@ -60,6 +63,7 @@ from ..progress_tracker import (
     ProgressReportMetadata,
 )
 from .._utils import _get_long_path_compatible_path
+from ...job_attachments._path_mapping import _PathMappingRuleApplier
 
 
 """
@@ -198,10 +202,13 @@ def _add_output_manifests_from_s3(
 def _download_manifest_and_make_paths_absolute(
     index: int,
     queue: dict[str, Any],
+    job_id: str,
     root_path: str,
     manifest_s3_key: str,
+    path_mapping_rule_applier: Optional[_PathMappingRuleApplier],
     boto3_session_for_s3: boto3.Session,
     output_manifests: list,
+    output_unmapped_paths: list[tuple[str, str]],
 ):
     """
     Downloads the specified manifest, makes all its paths absolute using root_path,
@@ -211,10 +218,33 @@ def _download_manifest_and_make_paths_absolute(
     _, last_modified, manifest = _get_asset_root_and_manifest_from_s3_with_last_modified(
         manifest_s3_key, queue["jobAttachmentSettings"]["s3BucketName"], boto3_session_for_s3
     )
+    if path_mapping_rule_applier:
+        new_manifest_paths = []
+        if path_mapping_rule_applier.source_path_format == PathFormat.WINDOWS.value:
+            source_os_path: Any = ntpath
+        else:
+            source_os_path = posixpath
+    else:
+        source_os_path = os.path
+
     # Convert all the manifest paths to have absolute normalized local paths
     for manifest_path in manifest.paths:
-        manifest_path.path = os.path.normpath(os.path.join(root_path, manifest_path.path))
-        # TODO: Apply path mapping rules to manifest_path.path right here
+        manifest_path.path = source_os_path.normpath(
+            source_os_path.join(root_path, manifest_path.path)
+        )
+        if path_mapping_rule_applier:
+            try:
+                manifest_path.path = str(
+                    path_mapping_rule_applier.strict_transform(manifest_path.path)
+                )
+                new_manifest_paths.append(manifest_path)
+            except ValueError:
+                output_unmapped_paths.append((job_id, manifest_path.path))
+
+    if path_mapping_rule_applier:
+        # Update the manifest to only include the mapped paths
+        manifest.paths = new_manifest_paths
+
     output_manifests[index] = (last_modified, manifest)
 
 
@@ -222,9 +252,10 @@ def _get_manifests_to_download(
     job_attachments_root_prefix: str,
     download_candidate_jobs: dict[str, dict[str, Any]],
     job_sessions: dict[str, list],
-) -> list[tuple[str, str]]:
+    path_mapping_rule_appliers: dict[str, Optional[_PathMappingRuleApplier]],
+) -> list[tuple[Optional[_PathMappingRuleApplier], str, str, str]]:
     """
-    Collect a list of (rootPath, manifest_s3_key) tuples for all the job attachments that need to be downloaded.
+    Collect a list of (pathMappingRuleApplier, jobId, rootPath, manifest_s3_key) tuples for all the job attachments that need to be downloaded.
 
     Args:
         job_attachments_root_prefix: The queue.jobAttachmentSettings.rootPrefix field from the Deadline
@@ -232,11 +263,13 @@ def _get_manifests_to_download(
         download_candidate_jobs: A mapping from job id to jobs as returned by deadline.search_jobs.
         job_sessions: Contains each job's sessions and session actions, structured as job_sessions[job_id][session_index]["sessionActions"][session_action_index].
                       See the function _get_job_sessions for more details.
+        path_mapping_rule_appliers: A mapping from storage profile ID to the path mapping rule applier to use for it.
+            If no path mapping should be used, is the empty {}.
 
     Returns:
-        A list of (rootPath, manifest_s3_key) tuples for the manifest objects that need to be downloaded.
+        A list of (pathMappingRuleApplier, jobId, rootPath, manifest_s3_key) tuples for the manifest objects that need to be downloaded.
     """
-    manifests_to_download: list[tuple[str, str]] = []
+    manifests_to_download: list[tuple[Optional[_PathMappingRuleApplier], str, str, str]] = []
     for job_id, session_list in job_sessions.items():
         job = download_candidate_jobs[job_id]
         for session in session_list:
@@ -249,6 +282,10 @@ def _get_manifests_to_download(
                     if "outputManifestPath" in session_action_manifest:
                         manifests_to_download.append(
                             (
+                                path_mapping_rule_appliers[job["storageProfileId"]]
+                                if path_mapping_rule_appliers
+                                else None,
+                                job_id,
                                 job_manifest["rootPath"],
                                 "/".join(
                                     [
@@ -266,6 +303,8 @@ def _download_all_manifests_with_absolute_paths(
     queue: dict[str, Any],
     download_candidate_jobs: dict[str, dict[str, Any]],
     job_sessions: dict[str, list],
+    path_mapping_rule_appliers: dict[str, Optional[_PathMappingRuleApplier]],
+    output_unmapped_paths: dict[str, list[str]],
     boto3_session_for_s3: boto3.Session,
     print_function_callback: Callable[[str], None] = lambda msg: None,
 ) -> list[tuple[datetime, BaseAssetManifest]]:
@@ -278,43 +317,64 @@ def _download_all_manifests_with_absolute_paths(
         download_candidate_jobs: A mapping from job id to jobs as returned by deadline.search_jobs.
         job_sessions: Contains each job's sessions and session actions, structured as job_sessions[job_id][session_index]["sessionActions"][session_action_index].
                       See the function _get_job_sessions for more details.
+        path_mapping_rule_appliers: A mapping from storage profile ID to the path mapping rule applier to use for it.
+            If no path mapping should be used, is the empty {}.
         boto3_session_for_s3: The boto3.Session to use for accessing S3.
+        output_unmapped_paths: A mapping from the job id to a list of all the paths that were not mapped
+            and therefore will not be downloaded.
         print_function_callback: Callback for printing output to the terminal or log.
 
     Returns:
         A list of BaseAssetManifest objects containing local absolute file paths sorted by the last_modified timestamp.
     """
     # Get the list of (rootPath, manifest_s3_key) tuples to download from S3.
-    manifests_to_download: list[tuple[str, str]] = _get_manifests_to_download(
-        queue["jobAttachmentSettings"]["rootPrefix"], download_candidate_jobs, job_sessions
+    manifests_to_download: list[tuple[Optional[_PathMappingRuleApplier], str, str, str]] = (
+        _get_manifests_to_download(
+            queue["jobAttachmentSettings"]["rootPrefix"],
+            download_candidate_jobs,
+            job_sessions,
+            path_mapping_rule_appliers,
+        )
     )
 
+    print_function_callback("")
     print_function_callback(f"Downloading {len(manifests_to_download)} asset manifests from S3...")
     start_time = datetime.now(tz=timezone.utc)
 
     # Download all the manifest files from S3, and make the paths in the manifests absolute local paths
     # by joining with the root path and normalizing
     downloaded_manifests: list = [None] * len(manifests_to_download)
+    # All the unmapped paths get recorded here as (jobId, unmappedPath)
+    unmapped_paths: list[tuple[str, str]] = []
 
     max_workers = S3_DOWNLOAD_MAX_CONCURRENCY
     print_function_callback(f"Using {max_workers} threads")
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
         futures = []
-        for index, (root_path, manifest_s3_key) in enumerate(manifests_to_download):
+        for index, (path_mapping_rule_applier, job_id, root_path, manifest_s3_key) in enumerate(
+            manifests_to_download
+        ):
             futures.append(
                 executor.submit(
                     _download_manifest_and_make_paths_absolute,
                     index,
                     queue,
+                    job_id,
                     root_path,
                     manifest_s3_key,
+                    path_mapping_rule_applier,
                     boto3_session_for_s3,
                     downloaded_manifests,
+                    unmapped_paths,
                 )
             )
         # surfaces any exceptions in the thread
         for future in concurrent.futures.as_completed(futures):
             future.result()
+
+    # Transform the unmapped paths into the output, grouping by job id
+    for job_id, unmapped_path in unmapped_paths:
+        output_unmapped_paths.setdefault(job_id, []).append(unmapped_path)
 
     duration = datetime.now(tz=timezone.utc) - start_time
     print_function_callback(f"...downloaded manifests in {duration}")

--- a/src/deadline/job_attachments/_incremental_downloads/incremental_download_state.py
+++ b/src/deadline/job_attachments/_incremental_downloads/incremental_download_state.py
@@ -134,8 +134,12 @@ class IncrementalDownloadState:
         "downloadsStartedTimestamp",
         "downloadsCompletedTimestamp",
         "eventualConsistencyMaxSeconds",
+        "localStorageProfileId",
         "jobs",
     ]
+
+    local_storage_profile_id: Optional[str]
+    """The storage profile of the host running the incremental download operation, or None if --ignore-storage-profiles is used."""
 
     downloads_started_timestamp: datetime
     """The timestamp of when the download state was bootstrapped."""
@@ -149,6 +153,7 @@ class IncrementalDownloadState:
 
     def __init__(
         self,
+        local_storage_profile_id: Optional[str],
         downloads_started_timestamp: datetime,
         downloads_completed_timestamp: Optional[datetime] = None,
         jobs: Optional[list] = None,
@@ -158,12 +163,17 @@ class IncrementalDownloadState:
         Initialize a IncrementalDownloadState instance. To bootstrap the state, construct with only the downloads_started_timestamp.
 
         Args:
+            local_storage_profile_id: The storage profile id for the host running the download command.
+                If set to None, all jobs will be downloaded to the paths specified in the job, even if the machine
+                that submitted the job has a different configuration.
             downloads_started_timestamp (datetime): The timestamp of when the download state was bootstrapped.
             downloads_completed_timestamp (datetime): The timestamp up to which we are confident downloads are complete.
             jobs (list[IncrementalDownloadJob]): The list of jobs that entered 'active' status between downloads_started_timestamp
-                    and downloads_completed_timestamp, and are not completed.
-            eventual_consistency_max_seconds (Optional[int]): The duration, in seconds, for deadline:SearchJobs query overlap, to account for eventual consistency.
+                and downloads_completed_timestamp, and are not completed.
+            eventual_consistency_max_seconds (Optional[int]): The duration, in seconds, for deadline:SearchJobs query overlap,
+                to account for eventual consistency.
         """
+        self.local_storage_profile_id = local_storage_profile_id
         self.downloads_started_timestamp = downloads_started_timestamp
         if downloads_completed_timestamp is not None:
             self.downloads_completed_timestamp = downloads_completed_timestamp
@@ -189,6 +199,7 @@ class IncrementalDownloadState:
             raise ValueError(f"Input is missing required fields: {missing_fields}")
 
         return cls(
+            local_storage_profile_id=data["localStorageProfileId"],
             downloads_started_timestamp=datetime.fromisoformat(data["downloadsStartedTimestamp"]),
             downloads_completed_timestamp=datetime.fromisoformat(
                 data["downloadsCompletedTimestamp"]
@@ -204,6 +215,7 @@ class IncrementalDownloadState:
             dict: Dictionary representation of the state file model
         """
         result = {
+            "localStorageProfileId": self.local_storage_profile_id,
             "downloadsStartedTimestamp": self.downloads_started_timestamp.isoformat(),
             "eventualConsistencyMaxSeconds": self.eventual_consistency_max_seconds,
             "jobs": [job.to_dict() for job in self.jobs],

--- a/src/deadline/job_attachments/_path_mapping.py
+++ b/src/deadline/job_attachments/_path_mapping.py
@@ -51,7 +51,10 @@ def _generate_path_mapping_rules(
         for location in destination_storage_profile["fileSystemLocations"]
     }
 
-    if source_storage_profile["osFamily"] == StorageProfileOperatingSystemFamily.WINDOWS.value:
+    if (
+        source_storage_profile["osFamily"].lower()
+        == StorageProfileOperatingSystemFamily.WINDOWS.value
+    ):
         source_path_format = PathFormat.WINDOWS.value
     else:
         source_path_format = PathFormat.POSIX.value

--- a/src/deadline/job_attachments/models.py
+++ b/src/deadline/job_attachments/models.py
@@ -136,6 +136,18 @@ class StorageProfileOperatingSystemFamily(str, Enum):
                 return member
         return None
 
+    @classmethod
+    def get_host_os_family(cls) -> StorageProfileOperatingSystemFamily:
+        """Get the current path format."""
+        if sys.platform.startswith("win"):
+            return cls.WINDOWS
+        if sys.platform.startswith("darwin"):
+            return cls.MACOS
+        if sys.platform.startswith("linux"):
+            return cls.LINUX
+        else:
+            raise NotImplementedError(f"Operating system {sys.platform} is not supported.")
+
 
 class AssetType(str, Enum):
     INPUT = "input"

--- a/test/unit/deadline_client/cli/test_cli_queue_incremental_download.py
+++ b/test/unit/deadline_client/cli/test_cli_queue_incremental_download.py
@@ -10,14 +10,22 @@ import pytest
 from unittest.mock import patch, MagicMock
 from datetime import datetime, timedelta
 
-import boto3
+import botocore
+from moto import mock_aws
 from freezegun import freeze_time
 from click.testing import CliRunner
 from deadline.client.cli import main
 import deadline.client
 import psutil
 
-from ..shared_constants import MOCK_FARM_ID, MOCK_QUEUE_ID, MOCK_JOB_ID
+from ..shared_constants import (
+    MOCK_FARM_ID,
+    MOCK_QUEUE_ID,
+    MOCK_JOB_ID,
+    MOCK_STORAGE_PROFILE_ID,
+    MOCK_FLEET_ID,
+    MOCK_WORKER_ID,
+)
 from ..mock_deadline_job_apis import (
     mock_search_jobs_for_set,
     create_fake_job_list,
@@ -26,6 +34,7 @@ from ..mock_deadline_job_apis import (
 from deadline.job_attachments._incremental_downloads.incremental_download_state import (
     EVENTUAL_CONSISTENCY_MAX_SECONDS,
 )
+from deadline.job_attachments.models import StorageProfileOperatingSystemFamily
 
 ISO_FREEZE_TIME_MINUS_5MIN = "2025-05-26 11:55:00+00:00"
 ISO_FREEZE_TIME_MINUS_1MIN = "2025-05-26 11:59:00+00:00"
@@ -34,6 +43,11 @@ ISO_FREEZE_TIME_PLUS_1MIN = "2025-05-26 12:01:00+00:00"
 ISO_FREEZE_TIME_PLUS_3MIN = "2025-05-26 12:03:00+00:00"
 ISO_FREEZE_TIME_PLUS_5MIN = "2025-05-26 12:05:00+00:00"
 ISO_FREEZE_TIME_PLUS_7MIN = "2025-05-26 12:07:00+00:00"
+
+MOCK_STORAGE_PROFILE_ID_LOCAL = "sp-a123456789abcdefabcdefabcdefabcf"
+MOCK_SESSION_ID = "session-0123456789abcdefabcdefabcdefabcd"
+MOCK_SESSION_ACTION_ID_1 = "sessionaction-0123456789abcdefabcdefabcdefabcd-0"
+MOCK_SESSION_ACTION_ID_2 = "sessionaction-0123456789abcdefabcdefabcdefabcd-1"
 
 
 # Fixtures for shared resources
@@ -46,31 +60,53 @@ def checkpoint_dir(tmp_path_factory):
 
 
 @pytest.fixture
-def boto3_session():
+def deadline_mock():
     """Create a mock boto3 session for all tests to use."""
-    mock_session = MagicMock(spec=boto3.Session)
-    mock_session.client().get_queue.return_value = {
-        "queueId": MOCK_QUEUE_ID,
-        "displayName": "Mock Queue",
-        "jobAttachmentSettings": {
-            "rootPrefix": "MockRootPrefix",
-            "s3BucketName": "mock-s3-bucket",
-        },
-    }
-    with patch.object(boto3, "Session", return_value=mock_session), patch.object(
-        deadline.client.api, "get_deadline_cloud_library_telemetry_client"
-    ):
-        yield mock_session
+    os.environ["AWS_ACCESS_KEY_ID"] = "ACCESSKEY"
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+    os.environ["AWS_SECURITY_TOKEN"] = "testing"
+    os.environ["AWS_SESSION_TOKEN"] = "testing"
+    os.environ["AWS_DEFAULT_REGION"] = "us-west-2"
 
+    with mock_aws():
+        deadline_magicmock = MagicMock()
 
-@pytest.fixture
-def pid_lock_file(checkpoint_dir):
-    """Create a PID lock file path for tests that need it."""
-    pid_file_path = os.path.join(checkpoint_dir, f"{MOCK_QUEUE_ID}_incremental_output_download.pid")
-    yield pid_file_path
-    # Clean up
-    if os.path.exists(pid_file_path):
-        os.remove(pid_file_path)
+        # See https://docs.getmoto.org/en/latest/docs/services/patching_other_services.html
+        original_make_api_call = botocore.client.BaseClient._make_api_call
+
+        def mock_make_api_call(self, operation_name, kwarg):
+            service_name = self._service_model.service_name
+
+            if service_name == "deadline":
+                # Send the "GetQueue" operation, i.e. the get_queue call, to deadline_magicmock.GetQueue()
+                return getattr(deadline_magicmock, operation_name)(**kwarg)
+
+            # If we don't want to patch the API call
+            return original_make_api_call(self, operation_name, kwarg)
+
+        deadline_magicmock.GetQueue.return_value = {
+            "queueId": MOCK_QUEUE_ID,
+            "displayName": "Mock Queue",
+            "jobAttachmentSettings": {
+                "rootPrefix": "MockRootPrefix",
+                "s3BucketName": "mock-s3-bucket",
+            },
+        }
+        deadline_magicmock.ListSessions.return_value = {"sessions": []}
+        deadline_magicmock.ListSessionActions.return_value = {"sessionActions": []}
+        deadline_magicmock.AssumeQueueRoleForUser.return_value = {
+            "credentials": {
+                "accessKeyId": "ACCESSKEY",
+                "secretAccessKey": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                "sessionToken": "testing",
+                "expiration": datetime.fromisoformat("2025-08-07T01:01:44+00:00"),
+            }
+        }
+
+        with patch(
+            "botocore.client.BaseClient._make_api_call", new=mock_make_api_call
+        ), patch.object(deadline.client.api, "get_deadline_cloud_library_telemetry_client"):
+            yield deadline_magicmock
 
 
 @pytest.fixture
@@ -82,7 +118,7 @@ def with_incremental_download_enabled():
 
 
 def test_incremental_output_download_requires_beta_acknowledgement(
-    fresh_deadline_config, boto3_session, checkpoint_dir
+    fresh_deadline_config, deadline_mock, checkpoint_dir
 ):
     # Make sure the acknowledgement env var is not defined
     if "ENABLE_INCREMENTAL_OUTPUT_DOWNLOAD" in os.environ:
@@ -96,6 +132,7 @@ def test_incremental_output_download_requires_beta_acknowledgement(
             [
                 "queue",
                 "incremental-output-download",
+                "--ignore-storage-profiles",
                 "--farm-id",
                 MOCK_FARM_ID,
                 "--queue-id",
@@ -118,10 +155,10 @@ def test_incremental_output_download_requires_beta_acknowledgement(
     sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
 )
 def test_incremental_output_download_requires_queue_with_job_attachments(
-    fresh_deadline_config, boto3_session, with_incremental_download_enabled, checkpoint_dir
+    fresh_deadline_config, deadline_mock, with_incremental_download_enabled, checkpoint_dir
 ):
     # The response does not include the "jobAttachmentSettings" field
-    boto3_session.client().get_queue.return_value = {
+    deadline_mock.GetQueue.return_value = {
         "queueId": MOCK_QUEUE_ID,
         "displayName": "Mock Queue",
     }
@@ -134,6 +171,7 @@ def test_incremental_output_download_requires_queue_with_job_attachments(
             [
                 "queue",
                 "incremental-output-download",
+                "--ignore-storage-profiles",
                 "--farm-id",
                 MOCK_FARM_ID,
                 "--queue-id",
@@ -157,12 +195,14 @@ def test_incremental_output_download_requires_queue_with_job_attachments(
 def test_incremental_output_download_pid_lock_already_held_error(
     fresh_deadline_config,
     with_incremental_download_enabled,
-    boto3_session,
+    deadline_mock,
     checkpoint_dir,
-    pid_lock_file,
 ):
     """Test incremental_output_download when PidLockAlreadyHeld is raised"""
     # Write a fake PID to the file
+    pid_lock_file = os.path.join(
+        checkpoint_dir, f"{MOCK_QUEUE_ID}_ignore-storage-profiles_download_checkpoint.json.pid"
+    )
     with open(pid_lock_file, "w") as f:
         f.write("12345678")  # Use a fake PID
 
@@ -176,6 +216,7 @@ def test_incremental_output_download_pid_lock_already_held_error(
             [
                 "queue",
                 "incremental-output-download",
+                "--ignore-storage-profiles",
                 "--farm-id",
                 MOCK_FARM_ID,
                 "--queue-id",
@@ -188,7 +229,7 @@ def test_incremental_output_download_pid_lock_already_held_error(
     # Assert the command did not execute successfully and wrote a message about another download in progress
     assert result.exit_code == 1, result.output
     assert (
-        f"Unable to perform incremental output download as process with pid 12345678 already holds the lock {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_incremental_output_download.pid')}"
+        f"Unable to perform incremental output download as process with pid 12345678 already holds the lock {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_ignore-storage-profiles_download_checkpoint.json.pid')}"
         in result.output
     ), result.output
 
@@ -199,10 +240,56 @@ def test_incremental_output_download_pid_lock_already_held_error(
 @pytest.mark.skipif(
     sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
 )
-def test_incremental_output_download_bootstrap_and_completion(
-    fresh_deadline_config, with_incremental_download_enabled, boto3_session, checkpoint_dir
+def test_incremental_output_download_storage_profile_options_mutually_exclusive(
+    fresh_deadline_config,
+    with_incremental_download_enabled,
+    deadline_mock,
+    checkpoint_dir,
 ):
-    """Test a new job through bootstrap, completion, and retirement."""
+    """Test that --storage-profile-id and --ignore-storage-profiles can't be provided together"""
+
+    # Run the CLI command
+    runner = CliRunner()
+    with patch.object(psutil, "pid_exists") as mock_pid_exists:
+        # Make psutil.pid_exists return True to simulate the process is running
+        mock_pid_exists.return_value = True
+        result = runner.invoke(
+            main,
+            [
+                "queue",
+                "incremental-output-download",
+                "--ignore-storage-profiles",
+                "--storage-profile-id",
+                MOCK_STORAGE_PROFILE_ID,
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--checkpoint-dir",
+                checkpoint_dir,
+            ],
+        )
+
+    assert result.exit_code != 0, result.output
+    assert (
+        "Options '--storage-profile-id' and '--ignore-storage-profiles' cannot be provided together"
+        in result.output
+    ), result.output
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
+)
+@pytest.mark.parametrize("storage_profile_id", [None, MOCK_STORAGE_PROFILE_ID])
+def test_incremental_output_download_bootstrap_and_completion(
+    fresh_deadline_config,
+    with_incremental_download_enabled,
+    deadline_mock,
+    checkpoint_dir,
+    storage_profile_id,
+):
+    """Test a new job through bootstrap, completion, and retirement. Both without storage profiles,
+    and with the job storage profile matching the local one."""
     mock_jobs = create_fake_job_list(1)
     mock_jobs[0]["name"] = "Mock Job"
     mock_jobs[0]["jobId"] = MOCK_JOB_ID
@@ -218,12 +305,15 @@ def test_incremental_output_download_bootstrap_and_completion(
         "fileSystem": "VIRTUAL",
     }
     del mock_jobs[0]["endedAt"]
-    boto3_session.client().search_jobs = mock_search_jobs_for_set(
-        MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs
-    )
-    boto3_session.client().get_job = mock_get_job_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+    deadline_mock.SearchJobs = mock_search_jobs_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+    deadline_mock.GetJob = mock_get_job_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
 
     # RUN 1: Run the CLI command once to bootstrap the operation
+    if storage_profile_id is None:
+        storage_profile_options = ["--ignore-storage-profiles"]
+    else:
+        storage_profile_options = ["--storage-profile-id", storage_profile_id]
+        mock_jobs[0]["storageProfileId"] = storage_profile_id
     runner = CliRunner()
     with freeze_time(ISO_FREEZE_TIME):
         result = runner.invoke(
@@ -231,6 +321,9 @@ def test_incremental_output_download_bootstrap_and_completion(
             [
                 "queue",
                 "incremental-output-download",
+            ]
+            + storage_profile_options
+            + [
                 "--farm-id",
                 MOCK_FARM_ID,
                 "--queue-id",
@@ -243,10 +336,29 @@ def test_incremental_output_download_bootstrap_and_completion(
     # Assert the command executed successfully
     assert result.exit_code == 0, result.output
 
+    if storage_profile_id is None:
+        storage_profile_in_message = "ignore-storage-profiles"
+    else:
+        storage_profile_in_message = storage_profile_id
+
+    # Assert that information is or isn't printed about the storage profile.
+    if storage_profile_id is None:
+        assert "Local storage profile is" not in result.output, result.output
+        assert (
+            "download candidate jobs will have no path mapping because they use this storage profile"
+            not in result.output
+        ), result.output
+    else:
+        assert "Local storage profile is" in result.output, result.output
+        assert f"({storage_profile_id})" in result.output, result.output
+        assert (
+            "1 download candidate jobs will have no path mapping because they use this storage profile"
+            in result.output
+        ), result.output
     # Assert that the output contained information about the bootstrapping and the mocked resources
     assert "Started incremental download for queue: Mock Queue" in result.output, result.output
     assert (
-        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_download_checkpoint.json')}"
+        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_' + storage_profile_in_message + '_download_checkpoint.json')}"
         in result.output
     ), result.output
     assert "Checkpoint not found, lookback is 0.0 minutes" in result.output, result.output
@@ -276,6 +388,9 @@ def test_incremental_output_download_bootstrap_and_completion(
             [
                 "queue",
                 "incremental-output-download",
+            ]
+            + storage_profile_options
+            + [
                 "--farm-id",
                 MOCK_FARM_ID,
                 "--queue-id",
@@ -291,7 +406,7 @@ def test_incremental_output_download_bootstrap_and_completion(
     # Assert that the output contained information about loading the checkpoint and the mocked resources
     assert "Started incremental download for queue: Mock Queue" in result.output, result.output
     assert (
-        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_download_checkpoint.json')}"
+        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_' + storage_profile_in_message + '_download_checkpoint.json')}"
         in result.output
     ), result.output
     assert "Checkpoint found" in result.output, result.output
@@ -313,6 +428,9 @@ def test_incremental_output_download_bootstrap_and_completion(
             [
                 "queue",
                 "incremental-output-download",
+            ]
+            + storage_profile_options
+            + [
                 "--farm-id",
                 MOCK_FARM_ID,
                 "--queue-id",
@@ -328,7 +446,7 @@ def test_incremental_output_download_bootstrap_and_completion(
     # Assert that the output contained information about loading the checkpoint and the mocked resources
     assert "Started incremental download for queue: Mock Queue" in result.output, result.output
     assert (
-        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_download_checkpoint.json')}"
+        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_' + storage_profile_in_message + '_download_checkpoint.json')}"
         in result.output
     ), result.output
     assert "Checkpoint found" in result.output, result.output
@@ -348,6 +466,9 @@ def test_incremental_output_download_bootstrap_and_completion(
             [
                 "queue",
                 "incremental-output-download",
+            ]
+            + storage_profile_options
+            + [
                 "--farm-id",
                 MOCK_FARM_ID,
                 "--queue-id",
@@ -363,7 +484,7 @@ def test_incremental_output_download_bootstrap_and_completion(
     # Assert that the output contained information about loading the checkpoint and the mocked resources
     assert "Started incremental download for queue: Mock Queue" in result.output, result.output
     assert (
-        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_download_checkpoint.json')}"
+        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_' + storage_profile_in_message + '_download_checkpoint.json')}"
         in result.output
     ), result.output
     assert "Checkpoint found" in result.output, result.output
@@ -380,8 +501,168 @@ def test_incremental_output_download_bootstrap_and_completion(
 @pytest.mark.skipif(
     sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
 )
+def test_incremental_output_download_storage_profile_path_mapping(
+    fresh_deadline_config,
+    with_incremental_download_enabled,
+    tmp_path,
+    deadline_mock,
+    checkpoint_dir,
+):
+    """Test a new job with a different storage profile on the job than
+    configured locally so as to get some path mapping rules."""
+    mock_jobs = create_fake_job_list(1)
+    mock_jobs[0]["name"] = "Mock Job"
+    mock_jobs[0]["jobId"] = MOCK_JOB_ID
+    mock_jobs[0]["taskRunStatus"] = "READY"
+    mock_jobs[0]["taskRunStatusCounts"] = {
+        "SUCCEEDED": 1,
+        "READY": 1,
+    }
+    mock_jobs[0]["attachments"] = {
+        "manifests": [
+            {"rootPath": "/", "rootPathFormat": "posix", "outputRelativeDirectories": ["."]}
+        ],
+        "fileSystem": "VIRTUAL",
+    }
+    mock_jobs[0]["storageProfileId"] = MOCK_STORAGE_PROFILE_ID
+    del mock_jobs[0]["endedAt"]
+    deadline_mock.SearchJobs = mock_search_jobs_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+    deadline_mock.GetJob = mock_get_job_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+
+    # Mock enough of get_storage_profile_for_queue two return two for mapping between them
+    def mock_get_storage_profile_for_queue(farmId: str, queueId: str, storageProfileId: str):
+        assert farmId == MOCK_FARM_ID
+        assert queueId == MOCK_QUEUE_ID
+        if storageProfileId == MOCK_STORAGE_PROFILE_ID:
+            return {
+                "storageProfileId": MOCK_STORAGE_PROFILE_ID,
+                "displayName": "Mock-Storage-Profile-For-Job",
+                "osFamily": "MACOS",
+                "fileSystemLocations": [
+                    {"name": "Location1", "path": "/Volumes/loc1", "type": "LOCAL"},
+                    {"name": "Location2", "path": "/Home/user", "type": "LOCAL"},
+                ],
+            }
+        else:
+            return {
+                "storageProfileId": MOCK_STORAGE_PROFILE_ID_LOCAL,
+                "displayName": "Mock-Storage-Profile-For-Local",
+                "osFamily": StorageProfileOperatingSystemFamily.get_host_os_family().value.upper(),
+                "fileSystemLocations": [
+                    {"name": "Location1", "path": str(tmp_path / "Location1"), "type": "LOCAL"},
+                    {"name": "Location2", "path": str(tmp_path / "Location2"), "type": "LOCAL"},
+                ],
+            }
+
+    deadline_mock.GetStorageProfileForQueue = mock_get_storage_profile_for_queue
+    # Mock list_sessions to return one session
+    deadline_mock.ListSessions.return_value = {
+        "sessions": [
+            {
+                "sessionId": MOCK_SESSION_ID,
+                "fleetId": MOCK_FLEET_ID,
+                "workerId": MOCK_WORKER_ID,
+                "startedAt": "2025-08-06T00:15:45.712000+00:00",
+                "lifecycleStatus": "STARTED",
+            }
+        ]
+    }
+    # Mock list_session_actions to return one task run session action
+    deadline_mock.ListSessionActions.return_value = {
+        "sessionActions": [
+            {
+                "sessionActionId": MOCK_SESSION_ACTION_ID_1,
+                "status": "SUCCEEDED",
+                "startedAt": "2025-08-06T00:20:58.454000+00:00",
+                "endedAt": "2025-08-06T00:20:59.992000+00:00",
+                "progressPercent": 100.0,
+                "definition": {
+                    "taskRun": {
+                        "taskId": "task-b1764261dff54214aace3932bde8ae7e-0",
+                        "stepId": "step-b1764261dff54214aace3932bde8ae7e",
+                    }
+                },
+                # This test doesn't go into the S3 object layer, so the manifests list is empty.
+                "manifests": [],
+            },
+            {
+                "sessionActionId": MOCK_SESSION_ACTION_ID_2,
+                "status": "RUNNING",
+                "startedAt": "2025-08-06T00:20:59.997000+00:00",
+                "progressPercent": 20.0,
+                "definition": {
+                    "taskRun": {
+                        "taskId": "task-b1764261dff54214aace3932bde8ae7e-1",
+                        "stepId": "step-b1764261dff54214aace3932bde8ae7e",
+                    }
+                },
+            },
+        ]
+    }
+
+    # RUN 1: Run the CLI command once to bootstrap the operation
+    runner = CliRunner()
+    with freeze_time(ISO_FREEZE_TIME):
+        result = runner.invoke(
+            main,
+            [
+                "queue",
+                "incremental-output-download",
+                "--storage-profile-id",
+                MOCK_STORAGE_PROFILE_ID_LOCAL,
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--checkpoint-dir",
+                checkpoint_dir,
+            ],
+        )
+
+    # Assert the command executed successfully
+    assert result.exit_code == 0, result.output
+
+    # Assert that both storage profiles were retrieved for local and the job
+    assert (
+        f"Local storage profile is Mock-Storage-Profile-For-Local ({MOCK_STORAGE_PROFILE_ID_LOCAL})"
+        in result.output
+    ), result.output
+    assert (
+        "0 download candidate jobs will have no path mapping because they use this storage profile"
+        in result.output
+    ), result.output
+    assert (
+        f"Path mapping rules for 1 download candidate jobs with storage profile Mock-Storage-Profile-For-Job ({MOCK_STORAGE_PROFILE_ID})"
+        in result.output
+    ), result.output
+    assert "job storage profile: Mock-Storage-Profile-For-Job (MACOS)" in result.output, (
+        result.output
+    )
+    assert (
+        f"local storage profile: Mock-Storage-Profile-For-Local ({StorageProfileOperatingSystemFamily.get_host_os_family().value.upper()})"
+        in result.output
+    ), result.output
+    assert "- from: /Volumes/loc1" in result.output, result.output
+    assert f" to:   {tmp_path / 'Location1'}" in result.output, result.output
+    assert "- from: /Home/user" in result.output, result.output
+    assert f"to:   {tmp_path / 'Location2'}" in result.output, result.output
+
+    # Assert that it warned about the lack of outputs
+    assert (
+        f"WARNING: Job Mock Job ({MOCK_JOB_ID}) ran 1 / 1 session actions with no output."
+        in result.output
+    ), result.output
+    assert (
+        "This may indicate steps in the job that strictly perform validation or save results elsewhere like a shared file system or S3."
+        in result.output
+    ), result.output
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
+)
 def test_incremental_output_download_bootstrap_retire_job_without_attachments(
-    fresh_deadline_config, with_incremental_download_enabled, boto3_session, checkpoint_dir
+    fresh_deadline_config, with_incremental_download_enabled, deadline_mock, checkpoint_dir
 ):
     """Test a new job through bootstrap and completion over two incremental download commands."""
     mock_jobs = create_fake_job_list(1)
@@ -393,10 +674,8 @@ def test_incremental_output_download_bootstrap_retire_job_without_attachments(
         "READY": 1,
     }
     del mock_jobs[0]["endedAt"]
-    boto3_session.client().search_jobs = mock_search_jobs_for_set(
-        MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs
-    )
-    boto3_session.client().get_job = mock_get_job_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+    deadline_mock.SearchJobs = mock_search_jobs_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+    deadline_mock.GetJob = mock_get_job_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
 
     # RUN 1: Run the CLI command once to bootstrap the operation
     runner = CliRunner()
@@ -406,6 +685,7 @@ def test_incremental_output_download_bootstrap_retire_job_without_attachments(
             [
                 "queue",
                 "incremental-output-download",
+                "--ignore-storage-profiles",
                 "--farm-id",
                 MOCK_FARM_ID,
                 "--queue-id",
@@ -421,7 +701,7 @@ def test_incremental_output_download_bootstrap_retire_job_without_attachments(
     # Assert that the output contained information about the bootstrapping and the mocked resources
     assert "Started incremental download for queue: Mock Queue" in result.output, result.output
     assert (
-        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_download_checkpoint.json')}"
+        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_ignore-storage-profiles_download_checkpoint.json')}"
         in result.output
     ), result.output
     assert "Checkpoint not found, lookback is 0.0 minutes" in result.output, result.output
@@ -451,6 +731,7 @@ def test_incremental_output_download_bootstrap_retire_job_without_attachments(
             [
                 "queue",
                 "incremental-output-download",
+                "--ignore-storage-profiles",
                 "--farm-id",
                 MOCK_FARM_ID,
                 "--queue-id",
@@ -466,7 +747,7 @@ def test_incremental_output_download_bootstrap_retire_job_without_attachments(
     # Assert that the output contained information about loading the checkpoint and the mocked resources
     assert "Started incremental download for queue: Mock Queue" in result.output, result.output
     assert (
-        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_download_checkpoint.json')}"
+        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_ignore-storage-profiles_download_checkpoint.json')}"
         in result.output
     ), result.output
     assert "Checkpoint found" in result.output, result.output
@@ -485,6 +766,7 @@ def test_incremental_output_download_bootstrap_retire_job_without_attachments(
             [
                 "queue",
                 "incremental-output-download",
+                "--ignore-storage-profiles",
                 "--farm-id",
                 MOCK_FARM_ID,
                 "--queue-id",
@@ -500,7 +782,7 @@ def test_incremental_output_download_bootstrap_retire_job_without_attachments(
     # Assert that the output contained information about loading the checkpoint and the mocked resources
     assert "Started incremental download for queue: Mock Queue" in result.output, result.output
     assert (
-        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_download_checkpoint.json')}"
+        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_ignore-storage-profiles_download_checkpoint.json')}"
         in result.output
     ), result.output
     assert "Checkpoint found" in result.output, result.output
@@ -516,7 +798,7 @@ def test_incremental_output_download_bootstrap_retire_job_without_attachments(
     sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
 )
 def test_incremental_output_download_job_unchanged(
-    fresh_deadline_config, with_incremental_download_enabled, boto3_session, checkpoint_dir
+    fresh_deadline_config, with_incremental_download_enabled, deadline_mock, checkpoint_dir
 ):
     """Test a new job through bootstrap and an 'UNCHANGED' message."""
     mock_jobs = create_fake_job_list(1)
@@ -534,10 +816,8 @@ def test_incremental_output_download_job_unchanged(
         "fileSystem": "VIRTUAL",
     }
     del mock_jobs[0]["endedAt"]
-    boto3_session.client().search_jobs = mock_search_jobs_for_set(
-        MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs
-    )
-    boto3_session.client().get_job = mock_get_job_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+    deadline_mock.SearchJobs = mock_search_jobs_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+    deadline_mock.GetJob = mock_get_job_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
 
     # RUN 1: Run the CLI command once to bootstrap the operation
     runner = CliRunner()
@@ -547,6 +827,7 @@ def test_incremental_output_download_job_unchanged(
             [
                 "queue",
                 "incremental-output-download",
+                "--ignore-storage-profiles",
                 "--farm-id",
                 MOCK_FARM_ID,
                 "--queue-id",
@@ -562,7 +843,7 @@ def test_incremental_output_download_job_unchanged(
     # Assert that the output contained information about the bootstrapping and the mocked resources
     assert "Started incremental download for queue: Mock Queue" in result.output, result.output
     assert (
-        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_download_checkpoint.json')}"
+        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_ignore-storage-profiles_download_checkpoint.json')}"
         in result.output
     ), result.output
     assert "Checkpoint not found, lookback is 0.0 minutes" in result.output, result.output
@@ -582,6 +863,7 @@ def test_incremental_output_download_job_unchanged(
             [
                 "queue",
                 "incremental-output-download",
+                "--ignore-storage-profiles",
                 "--farm-id",
                 MOCK_FARM_ID,
                 "--queue-id",
@@ -597,7 +879,7 @@ def test_incremental_output_download_job_unchanged(
     # Assert that the output contained information about loading the checkpoint and the mocked resources
     assert "Started incremental download for queue: Mock Queue" in result.output, result.output
     assert (
-        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_download_checkpoint.json')}"
+        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_ignore-storage-profiles_download_checkpoint.json')}"
         in result.output
     ), result.output
     assert "Checkpoint found" in result.output, result.output
@@ -614,7 +896,7 @@ def test_incremental_output_download_job_unchanged(
     sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
 )
 def test_incremental_output_download_job_canceled(
-    fresh_deadline_config, with_incremental_download_enabled, boto3_session, checkpoint_dir
+    fresh_deadline_config, with_incremental_download_enabled, deadline_mock, checkpoint_dir
 ):
     """Test a new job through bootstrap and cancelation before it's complete"""
     mock_jobs = create_fake_job_list(1)
@@ -632,10 +914,8 @@ def test_incremental_output_download_job_canceled(
         "fileSystem": "VIRTUAL",
     }
     del mock_jobs[0]["endedAt"]
-    boto3_session.client().search_jobs = mock_search_jobs_for_set(
-        MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs
-    )
-    boto3_session.client().get_job = mock_get_job_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+    deadline_mock.SearchJobs = mock_search_jobs_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+    deadline_mock.GetJob = mock_get_job_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
 
     # RUN 1: Run the CLI command once to bootstrap the operation
     runner = CliRunner()
@@ -645,6 +925,7 @@ def test_incremental_output_download_job_canceled(
             [
                 "queue",
                 "incremental-output-download",
+                "--ignore-storage-profiles",
                 "--farm-id",
                 MOCK_FARM_ID,
                 "--queue-id",
@@ -660,7 +941,7 @@ def test_incremental_output_download_job_canceled(
     # Assert that the output contained information about the bootstrapping and the mocked resources
     assert "Started incremental download for queue: Mock Queue" in result.output, result.output
     assert (
-        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_download_checkpoint.json')}"
+        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_ignore-storage-profiles_download_checkpoint.json')}"
         in result.output
     ), result.output
     assert "Checkpoint not found, lookback is 0.0 minutes" in result.output, result.output
@@ -685,6 +966,7 @@ def test_incremental_output_download_job_canceled(
             [
                 "queue",
                 "incremental-output-download",
+                "--ignore-storage-profiles",
                 "--farm-id",
                 MOCK_FARM_ID,
                 "--queue-id",
@@ -700,7 +982,7 @@ def test_incremental_output_download_job_canceled(
     # Assert that the output contained information about loading the checkpoint and the mocked resources
     assert "Started incremental download for queue: Mock Queue" in result.output, result.output
     assert (
-        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_download_checkpoint.json')}"
+        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_ignore-storage-profiles_download_checkpoint.json')}"
         in result.output
     ), result.output
     assert "Checkpoint found" in result.output, result.output
@@ -721,7 +1003,7 @@ def test_incremental_output_download_job_canceled(
     sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
 )
 def test_incremental_output_download_job_completed_then_requeued(
-    fresh_deadline_config, with_incremental_download_enabled, boto3_session, checkpoint_dir
+    fresh_deadline_config, with_incremental_download_enabled, deadline_mock, checkpoint_dir
 ):
     """Test a new job through bootstrap, retirement, then requeue."""
     iso_freeze_time = datetime.fromisoformat(ISO_FREEZE_TIME)
@@ -740,10 +1022,8 @@ def test_incremental_output_download_job_completed_then_requeued(
         "fileSystem": "VIRTUAL",
     }
     mock_jobs[0]["endedAt"] = iso_freeze_time - timedelta(minutes=3)
-    boto3_session.client().search_jobs = mock_search_jobs_for_set(
-        MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs
-    )
-    boto3_session.client().get_job = mock_get_job_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+    deadline_mock.SearchJobs = mock_search_jobs_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+    deadline_mock.GetJob = mock_get_job_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
 
     # RUN 1: Run the CLI command once to bootstrap the operation
     # We've set up the job and timestamps so it bootstraps as completed
@@ -754,6 +1034,7 @@ def test_incremental_output_download_job_completed_then_requeued(
             [
                 "queue",
                 "incremental-output-download",
+                "--ignore-storage-profiles",
                 "--farm-id",
                 MOCK_FARM_ID,
                 "--queue-id",
@@ -771,7 +1052,7 @@ def test_incremental_output_download_job_completed_then_requeued(
     # Assert that the output contained information about the bootstrapping and the mocked resources
     assert "Started incremental download for queue: Mock Queue" in result.output, result.output
     assert (
-        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_download_checkpoint.json')}"
+        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_ignore-storage-profiles_download_checkpoint.json')}"
         in result.output
     ), result.output
     assert "Checkpoint not found, lookback is 4.5 minutes" in result.output, result.output
@@ -791,6 +1072,7 @@ def test_incremental_output_download_job_completed_then_requeued(
             [
                 "queue",
                 "incremental-output-download",
+                "--ignore-storage-profiles",
                 "--farm-id",
                 MOCK_FARM_ID,
                 "--queue-id",
@@ -806,7 +1088,7 @@ def test_incremental_output_download_job_completed_then_requeued(
     # Assert that the output contained information about loading the checkpoint and the mocked resources
     assert "Started incremental download for queue: Mock Queue" in result.output, result.output
     assert (
-        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_download_checkpoint.json')}"
+        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_ignore-storage-profiles_download_checkpoint.json')}"
         in result.output
     ), result.output
     assert "Checkpoint found" in result.output, result.output
@@ -830,6 +1112,7 @@ def test_incremental_output_download_job_completed_then_requeued(
             [
                 "queue",
                 "incremental-output-download",
+                "--ignore-storage-profiles",
                 "--farm-id",
                 MOCK_FARM_ID,
                 "--queue-id",
@@ -845,7 +1128,7 @@ def test_incremental_output_download_job_completed_then_requeued(
     # Assert that the output contained information about loading the checkpoint and the mocked resources
     assert "Started incremental download for queue: Mock Queue" in result.output, result.output
     assert (
-        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_download_checkpoint.json')}"
+        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_ignore-storage-profiles_download_checkpoint.json')}"
         in result.output
     ), result.output
     assert "Checkpoint found" in result.output, result.output
@@ -863,7 +1146,7 @@ def test_incremental_output_download_job_completed_then_requeued(
     sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
 )
 def test_incremental_output_download_dry_run(
-    fresh_deadline_config, with_incremental_download_enabled, boto3_session, checkpoint_dir
+    fresh_deadline_config, with_incremental_download_enabled, deadline_mock, checkpoint_dir
 ):
     """Test a new job through bootstrap, completion, and retirement."""
     mock_jobs = create_fake_job_list(1)
@@ -881,10 +1164,8 @@ def test_incremental_output_download_dry_run(
         "fileSystem": "VIRTUAL",
     }
     del mock_jobs[0]["endedAt"]
-    boto3_session.client().search_jobs = mock_search_jobs_for_set(
-        MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs
-    )
-    boto3_session.client().get_job = mock_get_job_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+    deadline_mock.SearchJobs = mock_search_jobs_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+    deadline_mock.GetJob = mock_get_job_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
 
     # RUN 1: Run the CLI command once to bootstrap the operation
     runner = CliRunner()
@@ -894,6 +1175,7 @@ def test_incremental_output_download_dry_run(
             [
                 "queue",
                 "incremental-output-download",
+                "--ignore-storage-profiles",
                 "--farm-id",
                 MOCK_FARM_ID,
                 "--queue-id",
@@ -910,7 +1192,7 @@ def test_incremental_output_download_dry_run(
     # Assert that the output contained information about the bootstrapping and the mocked resources
     assert "Started incremental download for queue: Mock Queue" in result.output, result.output
     assert (
-        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_download_checkpoint.json')}"
+        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_ignore-storage-profiles_download_checkpoint.json')}"
         in result.output
     ), result.output
     assert "Checkpoint not found, lookback is 0.0 minutes" in result.output, result.output

--- a/test/unit/deadline_job_attachments/api/test_path_summarization.py
+++ b/test/unit/deadline_job_attachments/api/test_path_summarization.py
@@ -10,6 +10,7 @@ from deadline.job_attachments.api import (
     summarize_paths_by_nested_directory,
     summarize_path_list,
 )
+from deadline.job_attachments.models import PathFormat
 
 
 PARAMETRIZE_CASES: tuple = (
@@ -192,8 +193,8 @@ PARAMETRIZE_CASES = (
     (
         ["a/b/c/frame_1.png", "a/b/c/frame_3.png", "a/b/c/frame_20.png", "a/b/d/readme.txt"],
         [
-            PathSummary("a/b/c/frame_%d.png", index_set={1, 3, 20}),
-            PathSummary("a/b/d/readme.txt"),
+            PathSummary("a/b/c/frame_%d.png".replace("/", os.path.sep), index_set={1, 3, 20}),
+            PathSummary("a/b/d/readme.txt".replace("/", os.path.sep)),
         ],
         [
             PathSummary(
@@ -205,7 +206,7 @@ PARAMETRIZE_CASES = (
                         file_count=3,
                         children={
                             "frame_%d.png": PathSummary(
-                                "a/b/c/frame_%d.png",
+                                "a/b/c/frame_%d.png".replace("/", os.path.sep),
                                 index_set={1, 3, 20},
                             )
                         },
@@ -213,7 +214,9 @@ PARAMETRIZE_CASES = (
                     "d": PathSummary(
                         "a/b/d/".replace("/", os.path.sep),
                         file_count=1,
-                        children={"readme.txt": PathSummary("a/b/d/readme.txt")},
+                        children={
+                            "readme.txt": PathSummary("a/b/d/readme.txt".replace("/", os.path.sep))
+                        },
                     ),
                 },
             )
@@ -223,21 +226,21 @@ PARAMETRIZE_CASES = (
         ["seq/frame_01.png", "frame_1.png", "seq/frame_30.png", "seq/frame_09.png"],
         [
             PathSummary("frame_1.png"),
-            PathSummary("seq/frame_%02d.png", index_set={1, 9, 30}),
+            PathSummary("seq/frame_%02d.png".replace("/", os.path.sep), index_set={1, 9, 30}),
         ],
         [
             PathSummary("frame_1.png"),
-            PathSummary("seq/frame_%02d.png", index_set={1, 9, 30}),
+            PathSummary("seq/frame_%02d.png".replace("/", os.path.sep), index_set={1, 9, 30}),
         ],
     ),
     (
         ["/abc/def/ghi/00", "/abc/xyz/02", "/abc/def/jkl/mno/03", "/www/07", "/abc/def/10"],
         [
-            PathSummary("/abc/def/10"),
-            PathSummary("/abc/def/ghi/00"),
-            PathSummary("/abc/def/jkl/mno/03"),
-            PathSummary("/abc/xyz/02"),
-            PathSummary("/www/07"),
+            PathSummary("/abc/def/10".replace("/", os.path.sep)),
+            PathSummary("/abc/def/ghi/00".replace("/", os.path.sep)),
+            PathSummary("/abc/def/jkl/mno/03".replace("/", os.path.sep)),
+            PathSummary("/abc/xyz/02".replace("/", os.path.sep)),
+            PathSummary("/www/07".replace("/", os.path.sep)),
         ],
         [
             PathSummary(
@@ -255,7 +258,11 @@ PARAMETRIZE_CASES = (
                                     "ghi": PathSummary(
                                         "/abc/def/ghi/".replace("/", os.path.sep),
                                         file_count=1,
-                                        children={"00": PathSummary("/abc/def/ghi/00")},
+                                        children={
+                                            "00": PathSummary(
+                                                "/abc/def/ghi/00".replace("/", os.path.sep)
+                                            )
+                                        },
                                     ),
                                     "jkl": PathSummary(
                                         "/abc/def/jkl/".replace("/", os.path.sep),
@@ -264,24 +271,32 @@ PARAMETRIZE_CASES = (
                                             "mno": PathSummary(
                                                 "/abc/def/jkl/mno/".replace("/", os.path.sep),
                                                 file_count=1,
-                                                children={"03": PathSummary("/abc/def/jkl/mno/03")},
+                                                children={
+                                                    "03": PathSummary(
+                                                        "/abc/def/jkl/mno/03".replace(
+                                                            "/", os.path.sep
+                                                        )
+                                                    )
+                                                },
                                             )
                                         },
                                     ),
-                                    "10": PathSummary("/abc/def/10"),
+                                    "10": PathSummary("/abc/def/10".replace("/", os.path.sep)),
                                 },
                             ),
                             "xyz": PathSummary(
                                 "/abc/xyz/".replace("/", os.path.sep),
                                 file_count=1,
-                                children={"02": PathSummary("/abc/xyz/02")},
+                                children={
+                                    "02": PathSummary("/abc/xyz/02".replace("/", os.path.sep))
+                                },
                             ),
                         },
                     ),
                     "www": PathSummary(
                         "/www/".replace("/", os.path.sep),
                         file_count=1,
-                        children={"07": PathSummary("/www/07")},
+                        children={"07": PathSummary("/www/07".replace("/", os.path.sep))},
                     ),
                 },
             )
@@ -305,6 +320,13 @@ def test_summarize_paths_with_nesting_without_sizes(
 PARAMETRIZE_CASES = (
     ([], {}, [], []),
     (
+        # Repeated paths will be deduplicated
+        ["a/b/c", "a/b/c", "a/b/c", "a/b/c"],
+        {"a/b/c": 1},
+        [PathSummary("a/b/c".replace("/", os.path.sep), total_size=1)],
+        [PathSummary("a/b/c".replace("/", os.path.sep), total_size=1)],
+    ),
+    (
         ["a/b/c/frame_1.png", "a/b/c/frame_3.png", "a/b/c/frame_20.png", "a/b/d/readme.txt"],
         {
             "a/b/c/frame_1.png": 1,
@@ -313,8 +335,10 @@ PARAMETRIZE_CASES = (
             "a/b/d/readme.txt": 8,
         },
         [
-            PathSummary("a/b/c/frame_%d.png", index_set={1, 3, 20}, total_size=7),
-            PathSummary("a/b/d/readme.txt", total_size=8),
+            PathSummary(
+                "a/b/c/frame_%d.png".replace("/", os.path.sep), index_set={1, 3, 20}, total_size=7
+            ),
+            PathSummary("a/b/d/readme.txt".replace("/", os.path.sep), total_size=8),
         ],
         [
             PathSummary(
@@ -328,7 +352,7 @@ PARAMETRIZE_CASES = (
                         total_size=7,
                         children={
                             "frame_%d.png": PathSummary(
-                                "a/b/c/frame_%d.png",
+                                "a/b/c/frame_%d.png".replace("/", os.path.sep),
                                 index_set={1, 3, 20},
                                 total_size=7,
                             )
@@ -338,7 +362,11 @@ PARAMETRIZE_CASES = (
                         "a/b/d/".replace("/", os.path.sep),
                         file_count=1,
                         total_size=8,
-                        children={"readme.txt": PathSummary("a/b/d/readme.txt", total_size=8)},
+                        children={
+                            "readme.txt": PathSummary(
+                                "a/b/d/readme.txt".replace("/", os.path.sep), total_size=8
+                            )
+                        },
                     ),
                 },
             )
@@ -349,11 +377,15 @@ PARAMETRIZE_CASES = (
         {"seq/frame_01.png": 1, "frame_1.png": 2, "seq/frame_30.png": 4, "seq/frame_09.png": 8},
         [
             PathSummary("frame_1.png", total_size=2),
-            PathSummary("seq/frame_%02d.png", index_set={1, 9, 30}, total_size=13),
+            PathSummary(
+                "seq/frame_%02d.png".replace("/", os.path.sep), index_set={1, 9, 30}, total_size=13
+            ),
         ],
         [
             PathSummary("frame_1.png", total_size=2),
-            PathSummary("seq/frame_%02d.png", index_set={1, 9, 30}, total_size=13),
+            PathSummary(
+                "seq/frame_%02d.png".replace("/", os.path.sep), index_set={1, 9, 30}, total_size=13
+            ),
         ],
     ),
     (
@@ -366,11 +398,11 @@ PARAMETRIZE_CASES = (
             "/abc/def/10": 16,
         },
         [
-            PathSummary("/abc/def/10", total_size=16),
-            PathSummary("/abc/def/ghi/00", total_size=1),
-            PathSummary("/abc/def/jkl/mno/03", total_size=4),
-            PathSummary("/abc/xyz/02", total_size=2),
-            PathSummary("/www/07", total_size=8),
+            PathSummary("/abc/def/10".replace("/", os.path.sep), total_size=16),
+            PathSummary("/abc/def/ghi/00".replace("/", os.path.sep), total_size=1),
+            PathSummary("/abc/def/jkl/mno/03".replace("/", os.path.sep), total_size=4),
+            PathSummary("/abc/xyz/02".replace("/", os.path.sep), total_size=2),
+            PathSummary("/www/07".replace("/", os.path.sep), total_size=8),
         ],
         [
             PathSummary(
@@ -393,7 +425,10 @@ PARAMETRIZE_CASES = (
                                         file_count=1,
                                         total_size=1,
                                         children={
-                                            "00": PathSummary("/abc/def/ghi/00", total_size=1)
+                                            "00": PathSummary(
+                                                "/abc/def/ghi/00".replace("/", os.path.sep),
+                                                total_size=1,
+                                            )
                                         },
                                     ),
                                     "jkl": PathSummary(
@@ -407,20 +442,29 @@ PARAMETRIZE_CASES = (
                                                 total_size=4,
                                                 children={
                                                     "03": PathSummary(
-                                                        "/abc/def/jkl/mno/03", total_size=4
+                                                        "/abc/def/jkl/mno/03".replace(
+                                                            "/", os.path.sep
+                                                        ),
+                                                        total_size=4,
                                                     )
                                                 },
                                             )
                                         },
                                     ),
-                                    "10": PathSummary("/abc/def/10", total_size=16),
+                                    "10": PathSummary(
+                                        "/abc/def/10".replace("/", os.path.sep), total_size=16
+                                    ),
                                 },
                             ),
                             "xyz": PathSummary(
                                 "/abc/xyz/".replace("/", os.path.sep),
                                 file_count=1,
                                 total_size=2,
-                                children={"02": PathSummary("/abc/xyz/02", total_size=2)},
+                                children={
+                                    "02": PathSummary(
+                                        "/abc/xyz/02".replace("/", os.path.sep), total_size=2
+                                    )
+                                },
                             ),
                         },
                     ),
@@ -428,7 +472,9 @@ PARAMETRIZE_CASES = (
                         "/www/".replace("/", os.path.sep),
                         file_count=1,
                         total_size=8,
-                        children={"07": PathSummary("/www/07", total_size=8)},
+                        children={
+                            "07": PathSummary("/www/07".replace("/", os.path.sep), total_size=8)
+                        },
                     ),
                 },
             )
@@ -628,3 +674,27 @@ def test_summarize_path_list(path_list, kwargs, expected_output):
     assert summarize_path_list(
         [path.replace("/", os.path.sep) for path in path_list], **kwargs
     ) == expected_output.replace("/", os.path.sep)
+
+
+PARAMETRIZE_CASES = (
+    (
+        PATH_LIST_NESTED_FILES,
+        dict(path_format=PathFormat.POSIX),
+        "doc/ (3 files):\n  images/ (1 file)\n  imagination.md (1 file)\n  sword.txt (1 file)\nseq/file%d.tar.gz (3 files, sequence 1-3)\nREADME.md (1 file)\n",
+    ),
+    (
+        PATH_LIST_NESTED_FILES,
+        dict(path_format=PathFormat.WINDOWS),
+        "doc\\ (3 files):\n  images\\ (1 file)\n  imagination.md (1 file)\n  sword.txt (1 file)\nseq\\file%d.tar.gz (3 files, sequence 1-3)\nREADME.md (1 file)\n",
+    ),
+    (
+        [path.replace("/", "\\") for path in PATH_LIST_NESTED_FILES],
+        dict(path_format=PathFormat.WINDOWS),
+        "doc\\ (3 files):\n  images\\ (1 file)\n  imagination.md (1 file)\n  sword.txt (1 file)\nseq\\file%d.tar.gz (3 files, sequence 1-3)\nREADME.md (1 file)\n",
+    ),
+)
+
+
+@pytest.mark.parametrize(("path_list", "kwargs", "expected_output"), PARAMETRIZE_CASES)
+def test_summarize_path_list_with_path_format(path_list, kwargs, expected_output):
+    assert summarize_path_list(path_list, **kwargs) == expected_output

--- a/test/unit/deadline_job_attachments/incremental_downloads/test_incremental_download_state.py
+++ b/test/unit/deadline_job_attachments/incremental_downloads/test_incremental_download_state.py
@@ -70,6 +70,7 @@ class TestIncrementalDownloadState:
         Fixture to create a sample IncrementalDownloadState. This state matches the sample_state_data fixture.
         """
         return IncrementalDownloadState(
+            "sp-123",
             downloads_started_timestamp=datetime.fromisoformat("2023-01-01T00:00:00+00:00"),
             downloads_completed_timestamp=datetime.fromisoformat("2023-01-02T00:00:00+00:00"),
             jobs=[
@@ -90,7 +91,7 @@ class TestIncrementalDownloadState:
         completed_time = datetime.fromisoformat("2023-01-02T00:00:00")
 
         # Test with minimal bootstrapped construction
-        state = IncrementalDownloadState(bootstrap_time)
+        state = IncrementalDownloadState("sp-123", bootstrap_time)
         assert state.downloads_started_timestamp == bootstrap_time
         assert state.downloads_completed_timestamp == bootstrap_time
         assert state.eventual_consistency_max_seconds == 120
@@ -99,6 +100,7 @@ class TestIncrementalDownloadState:
         # Test with provided values
         jobs = [IncrementalDownloadJob({"jobId": "job-123"}, None, {})]
         state = IncrementalDownloadState(
+            "sp-123",
             downloads_started_timestamp=bootstrap_time,
             downloads_completed_timestamp=completed_time,
             jobs=jobs,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Ben, working on https://github.com/aws-deadline/deadline-cloud/pull/743, moved to other priorities before being able to address code review comments on that PR. We need to support storage profile and source the file system locations from the submitting workstation and the downloading workstation to map output files as specified by the manifests.

We considered two CLI interface options, whether to try to do the best thing possible, or to require storage profiles by default with an explicit override. We chose the latter so that when someone starts using the command but haven't set up storage profiles, they learn this immediately and what benefit storage profiles can give them, but then have an immediate way to ignore them if they see it doesn't apply.

### What was the solution? (How)

Take elements from the previous PR, along with consideration of the comments there, into this new PR.

* Change the default behavior of 'deadline queue
  incremental-output-download' to require storage profiles.
   * Add an option --ignore-storage-profiles that lets you override this behavior
     and ignore them. This option should only be used if all jobs in the
     queue are submitted and downloaded from the same machine.
   * Add an option --storage-profile-id that lets you set the storage
     profile to download for independently of the configuration file.
* Add the localStorageProfileId to IncrementalDownloadState so that subsequent runs can validate that the value remains identical across runs.
* Generalize the path summarization code to accept a PathFormat (WINDOWS or POSIX) so that the incremental download can summarize paths that had no path mapping rule appropriately for the source operating system.
* Modify the path summarization code to de-duplicate repeated paths within the input.
  * Add a test case for this.
* Modify the path summarization code to normalize all Windows paths with "\\" separators instead of "/". Update the tests to reflect this.
* Change the unit tests in test_cli_queue_incremental_download.py to be based on moto instead of mocking boto3.Session. Used the documented https://docs.getmoto.org/en/latest/docs/services/patching_other_services.html for mocking deadline service calls. This allows features like paginators to work in the tests, that were not working with the boto3.Session mock approach.

### What is the impact of this change?

The incremental download command will download job outputs to the correct locations when they were run on different operating systems. It uses storage profile configurations that customers can use to input corresponding paths, e.g. projects are on '/Volumes/Projects' on Mac but 'X:\Projects' on Windows.

### How was this change tested?

Added unit tests for the new functionality. Created a farm configuration with various storage profiles on Linux and Windows, and manually confirmed expected behavior in a variety of cases.

### Was this change documented?

New options are in the CLI help output.

### Does this PR introduce new dependencies?

No

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
