### PR TITLE
chore: add patch branches to semantic release config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -215,4 +215,4 @@ trim_blocks = true
 lstrip_blocks = true
 
 [tool.semantic_release.branches.release]
-match = "(mainline|release)"
+match = "(mainline|release|patch_.*)"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We are adding the ability to do patch releases, using branches with cherry picked commits.

### What was the solution? (How)
Add `patch_.*` to semantic config to allow branches with the `patch_` prefix to be considered part of semantic release group.

### What is the impact of this change?
python semantic release can be triggered from branches with the `patch_` prefixed. These are protected branches that require 2PR.

### How was this change tested?

n/a

### Was this change documented?

No

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [X] This PR does not add any new dependencies.

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
