### PR TITLE
fix: Submission window doesn't close after a successful submission

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,4 +214,4 @@ trim_blocks = true
 lstrip_blocks = true
 
 [tool.semantic_release.branches.release]
-match = "(mainline|release)"
+match = "(mainline|release|patch_.*)"

--- a/src/deadline/client/cli/_groups/bundle_group.py
+++ b/src/deadline/client/cli/_groups/bundle_group.py
@@ -310,28 +310,22 @@ def bundle_gui_submit(
 
         app.exec()
 
-        response = None
-        if submitter:
-            response = submitter.create_job_response
-
         _print_response(
             output=output,
-            submitted=True if response else False,
             job_bundle_dir=job_bundle_dir,
             job_history_bundle_dir=submitter.job_history_bundle_dir,
-            job_id=response["jobId"] if response else None,
+            job_id=submitter.job_id,
         )
 
 
 def _print_response(
     output: str,
-    submitted: bool,
     job_bundle_dir: str,
     job_history_bundle_dir: Optional[str],
     job_id: Optional[str],
 ):
     if output == "json":
-        if submitted:
+        if job_id:
             response: dict[str, Any] = {
                 "status": "SUBMITTED",
                 "jobId": job_id,
@@ -341,7 +335,7 @@ def _print_response(
         else:
             click.echo(json.dumps({"status": "CANCELED"}))
     else:
-        if submitted:
+        if job_id:
             click.echo("Submitted job bundle:")
             click.echo(f"   {job_bundle_dir}")
             click.echo(f"Job ID: {job_id}")

--- a/src/deadline/client/ui/dialogs/submit_job_progress_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_progress_dialog.py
@@ -112,7 +112,6 @@ class SubmitJobProgressDialog(QDialog):
     to AWS Deadline Cloud.
     """
 
-    job_id: Optional[str] = None
     cancelation_flag: CancelationFlag
 
     # This signal is sent when the background thread raises an exception.
@@ -126,6 +125,9 @@ class SubmitJobProgressDialog(QDialog):
 
     # This signal is sent when the background thread succeeds.
     submission_thread_succeeded = Signal(str)
+    progress_window_closed = Signal(None)
+
+    job_id: Optional[str] = None
 
     def __init__(self, parent: QWidget) -> None:
         super().__init__(parent=parent)
@@ -152,7 +154,7 @@ class SubmitJobProgressDialog(QDialog):
         job_bundle_dir: str,
         job_parameters: list[dict[str, Any]] = [],
         **kwargs,
-    ):
+    ) -> None:
         """
         Starts a job submission background thread and returns immediately. It wires up
         appropriate callbacks and then forwards all arguments.
@@ -291,6 +293,9 @@ class SubmitJobProgressDialog(QDialog):
             self.status_label.setText("Submission complete")
             self.button_box.setStandardButtons(QDialogButtonBox.Ok)
             self.button_box.button(QDialogButtonBox.Ok).setDefault(True)
+            self.button_box.button(QDialogButtonBox.Ok).clicked.connect(
+                self.progress_window_closed.emit
+            )
         else:
             if self.cancelation_flag or self._warning_dialog_canceled:
                 self.status_label.setText("Submission canceled")
@@ -314,6 +319,7 @@ class SubmitJobProgressDialog(QDialog):
         closing the dialog. If the submission is complete then any button, even
         'X', should result in the dialog being accepted.
         """
+        self.progress_window_closed.emit()
         if self._submission_complete:
             self.accept()
         else:

--- a/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
@@ -124,11 +124,12 @@ class SubmitJobToDeadlineDialog(QDialog):
         self.job_settings_type = type(initial_job_settings)
         self.submitter_name = submitter_name or self.job_settings_type().submitter_name
         self.on_create_job_bundle_callback = on_create_job_bundle_callback
-        self.create_job_response: Optional[Dict[str, Any]] = None
+        self.job_id = None
         self.job_history_bundle_dir: Optional[str] = None
         self.deadline_authentication_status = DeadlineAuthenticationStatus.getInstance()
         self.show_host_requirements_tab = show_host_requirements_tab
         self.known_asset_paths = known_asset_paths or []
+        self.should_close = False
 
         self._build_ui(
             job_setup_widget_type,
@@ -141,6 +142,15 @@ class SubmitJobToDeadlineDialog(QDialog):
 
         self.gui_update_counter: Any = None
         self.refresh_deadline_settings()
+
+    def _submission_succeeded_signal_receiver(self, job_id: str):
+        self.job_id = job_id
+
+        set_setting("defaults.job_id", job_id)
+
+    def _close_event_receiver(self):
+        if self.submitter_name != "JobBundle" and self.job_id:
+            self.close()
 
     def sizeHint(self):
         return QSize(540, 700)
@@ -465,9 +475,6 @@ class SubmitJobToDeadlineDialog(QDialog):
         """
         Perform a submission when the submit button is pressed
         """
-        # Unset any cached response
-        self.create_job_response = None
-
         # Retrieve all the settings into the dataclass
         settings = self.job_settings_type()
         self.shared_job_settings.update_settings(settings)
@@ -478,6 +485,10 @@ class SubmitJobToDeadlineDialog(QDialog):
         asset_references = self.job_attachments.get_asset_references()
 
         job_progress_dialog = SubmitJobProgressDialog(parent=self)
+        job_progress_dialog.submission_thread_succeeded.connect(
+            self._submission_succeeded_signal_receiver
+        )
+        job_progress_dialog.progress_window_closed.connect(self._close_event_receiver)
         job_progress_dialog.show()
         QApplication.instance().processEvents()  # type: ignore[union-attr]
 
@@ -517,7 +528,7 @@ class SubmitJobToDeadlineDialog(QDialog):
             if job_parameters:
                 self.save_job_parameters_to_job_bundle(self.job_history_bundle_dir, job_parameters)
 
-            job_id = job_progress_dialog.start_job_submission(
+            job_progress_dialog.start_job_submission(
                 job_bundle_dir=self.job_history_bundle_dir,
                 submitter_name=self.submitter_name,
                 config=config_file.read_config(),
@@ -526,8 +537,6 @@ class SubmitJobToDeadlineDialog(QDialog):
                 known_asset_paths=self.known_asset_paths
                 + parameters_from_callback.get("known_asset_paths", []),
             )
-            if job_id:
-                set_setting("defaults.job_id", job_id)
 
         except UserInitiatedCancel as uic:
             logger.info("Canceling submission.")
@@ -545,9 +554,3 @@ class SubmitJobToDeadlineDialog(QDialog):
             )
             QMessageBox.critical(self, f"{self.submitter_name} job submission", str(exc))  # type: ignore[call-arg]
             job_progress_dialog.close()
-
-        if self.create_job_response:
-            # Close the submitter window to signal the submission is done but
-            # keep the standalone gui submitter open
-            if self.submitter_name != "JobBundle":
-                self.close()


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud/issues/768

### What was the problem/requirement? (What/Why)

The Submission window doesn't close after a successful submission.

The root cause is that a function had its return value changed from the create job response, to `None`. 


### What was the solution? (How)

The solution is to hook up passing the jobId back into the submission window, as well as adding logic to close the window if the job submission is successful. This is a bit more ugly that I'd like it to be as a result of needing to close the dialog from the main thread.

### What is the impact of this change?

The job submission window closes after a successful submit if running inside an integrated submitter. 


### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

I ran 

```
deadline bundle gui-submit --output json --submitter-name Testing <path to job bundle>
```

And confirmed that

1. The job window closed after success and I clicked either `ok` or closed the submission progress window
2. The output in the terminal was `{"status": "SUBMITTED", "jobId": "job-0f452c2c73b942f5b05e2937c15ebedc", "jobHistoryBundleDirectory": "<job history bundle>"}`

Also ran 

```
deadline bundle gui-submit --output json <path to job bundle>
```

And confirmed that

1. The job window stayed open after success and I clicked either `ok` or closed the submission progress window
2. The output in the terminal was `{"status": "SUBMITTED", "jobId": "job-0f452c2c73b942f5b05e2937c15ebedc", "jobHistoryBundleDirectory": "<job history bundle>"}`


- Have you run the unit tests?
yes

- Have you run the integration tests?
yes

- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass.
No

### Was this change documented?

No, and it is not required


### Does this PR introduce new dependencies?


*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?

No

### Does this change impact security?

No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
