### PR TITLE
chore: allow code ql to run on patch branches

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -2,7 +2,7 @@ name: Code Quality
 
 on:
   pull_request:
-    branches: [ mainline, release, feature_assets_cli ]
+    branches: [ mainline, release, feature_assets_cli, 'patch_*' ]
   workflow_call:
     inputs:
       branch:


### PR DESCRIPTION
Fixes: *<insert link to GitHub issue here>*

### What was the problem/requirement? (What/Why)

Code QL are not running on patch branches

### What was the solution? (How)

Fix the config so that it runs on patch branches

### What is the impact of this change?

Code QL will run on patch branches

### How was this change tested?

O.O

### Was this change documented?

No

-----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
