### PR TITLE
chore: fix typing in telemetry decorators

### DIFF
--- a/src/deadline/client/api/_submit_job_bundle.py
+++ b/src/deadline/client/api/_submit_job_bundle.py
@@ -149,7 +149,7 @@ def _generate_message_for_asset_paths(
     return "".join(warning_messages), default_prompt_response
 
 
-@api.record_success_fail_telemetry_event(metric_name="asset_upload")  # type: ignore
+@api.record_success_fail_telemetry_event(metric_name="asset_upload")
 def _upload_attachments(
     asset_manager: S3AssetManager,
     manifests: List[AssetRootManifest],

--- a/src/deadline/client/api/_telemetry.py
+++ b/src/deadline/client/api/_telemetry.py
@@ -16,7 +16,7 @@ from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from queue import Queue, Full
 from threading import Thread
-from typing import Any, Callable, Dict, List, Optional, TypeVar, cast
+from typing import Any, Callable, Dict, Optional, TypeVar, cast
 from urllib import request, error
 
 from ...job_attachments.progress_tracker import SummaryStatistics
@@ -383,14 +383,14 @@ def get_deadline_cloud_library_telemetry_client(
     return get_telemetry_client("deadline-cloud-library", version, config=config)
 
 
-def record_success_fail_telemetry_event(**decorator_kwargs: Dict[str, Any]) -> Callable[..., F]:
+def record_success_fail_telemetry_event(**decorator_kwargs: Any) -> Callable[[F], F]:
     """
     Decorator to try catch a function. Sends a success / fail telemetry event.
     :param ** Python variable arguments. See https://docs.python.org/3/glossary.html#term-parameter.
     """
 
     def inner(function: F) -> F:
-        def wrapper(*args: List[Any], **kwargs: Dict[str, Any]) -> Any:
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
             """
             Wrapper to try-catch a function for telemetry
             :param * Python variable argument. See https://docs.python.org/3/glossary.html#term-parameter
@@ -413,14 +413,14 @@ def record_success_fail_telemetry_event(**decorator_kwargs: Dict[str, Any]) -> C
     return inner
 
 
-def record_function_latency_telemetry_event(**decorator_kwargs: Dict[str, Any]) -> Callable[[F], F]:
+def record_function_latency_telemetry_event(**decorator_kwargs: Any) -> Callable[[F], F]:
     """
     Decorator to time a function. Sends a latency telemetry event.
     :param ** Python variable arguments. See https://docs.python.org/3/glossary.html#term-parameter.
     """
 
     def inner(function: F) -> F:
-        def wrapper(*args: List[Any], **kwargs: Dict[str, Any]) -> Any:
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
             """
             Wrapper to time a function for latency telemetry
             :param * Python variable argument. See https://docs.python.org/3/glossary.html#term-parameter

--- a/src/deadline/client/cli/_groups/job_group.py
+++ b/src/deadline/client/cli/_groups/job_group.py
@@ -468,7 +468,7 @@ def _download_job_output(
     # makes it keep logging urllib3 warning messages when downloading large files)
     with _modified_logging_level(logging.getLogger("urllib3"), logging.ERROR):
 
-        @api.record_success_fail_telemetry_event(metric_name="download_job_output")  # type: ignore
+        @api.record_success_fail_telemetry_event(metric_name="download_job_output")
         def _download_job_output(
             file_conflict_resolution: Optional[
                 FileConflictResolution


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Some of the typing in the telemetry decorator functions was incorrect, and the decorator to record success/fail metrics had an incorrect return value typing so usages of it required a `# type: ignore`.

The positional (`*args`) and keyword arguments (`**kwargs`) in the functions were typed incorrectly. They should be typed with the expected type of one value in the collection. See https://peps.python.org/pep-0484/#arbitrary-argument-lists-and-default-argument-values

### What was the solution? (How)
- Fix the typing of the success/fail metric decorator and removed the `# type: ignore` in uses of it
- Fix the typing of positional `*args` and keyword arguments `**kwargs`

### What is the impact of this change?
Correct typing, no functional impact.

### How was this change tested?

`hatch run fmt && hatch run lint && hatch run test`

### Was this change documented?
No

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?
No

### Does this change impact security?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
