### PR TITLE
fix!: Remove create_job_response parameter from ui.dialogs.SubmitJobToDeadlineDialog

### DIFF
--- a/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
@@ -125,9 +125,6 @@ class SubmitJobToDeadlineDialog(QDialog):
         self.submitter_name = submitter_name or self.job_settings_type().submitter_name
         self.on_create_job_bundle_callback = on_create_job_bundle_callback
         self.job_id = None
-        self.create_job_response = (
-            None  # This parameter is deprecated and will be removed in 0.52.0
-        )
         self.job_history_bundle_dir: Optional[str] = None
         self.deadline_authentication_status = DeadlineAuthenticationStatus.getInstance()
         self.show_host_requirements_tab = show_host_requirements_tab


### PR DESCRIPTION
…logs.SubmitJobToDeadlineDialog

### What was the problem/requirement? (What/Why)

`SubmitJobToDeadlineDialog.create_job_response` was broken in 0.51.0. The parameter existed still but it wouldn't ever be updated to the create job response.

### What was the solution? (How)

Since `create_job_response` is no longer being set we should remove it. It is being replaced with `SubmitJobToDeadlineDialog.job_id` which is updated with the value from the create job response.

### What is the impact of this change?

Customers referencing `SubmitJobToDeadlineDialog.create_job_response`  will need to update their code to use `SubmitJobToDeadlineDialog.job_id` which is set to the job_id of the submitted job.

### Was this change documented?

- Through the changelog, yes.

### Does this PR introduce new dependencies?

No

### Is this a breaking change?

Yes

Customers referencing `SubmitJobToDeadlineDialog.create_job_response`  will need to update their code to use `SubmitJobToDeadlineDialog.job_id` which is set to the job_id of the submitted job.

### Does this change impact security?

No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
