### PR TITLE
chore: add statistics telemetry for incremental-output-download command

### DIFF
--- a/src/deadline/client/cli/_incremental_download.py
+++ b/src/deadline/client/cli/_incremental_download.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 __all__ = ["_incremental_output_download"]
 
+from dataclasses import dataclass, asdict
 from datetime import datetime, timedelta, timezone
 import difflib
 from typing import Optional
@@ -50,6 +51,19 @@ from ._common import _cli_object_repr, sigint_handler
 
 
 SESSIONS_API_MAX_CONCURRENCY = 3
+
+
+@dataclass
+class IncrementalOutputDownloadLatencies:
+    """Dataclass for tracking latencies of operations in this command"""
+
+    _get_download_candidate_jobs: int = 0
+    _categorize_jobs_in_checkpoint: int = 0
+    _get_job_sessions: int = 0
+    _update_checkpoint_jobs_list: int = 0
+    _download_all_manifests_with_absolute_paths: int = 0
+    download: Optional[int] = None
+    path_mapping: Optional[int] = None
 
 
 def _get_download_candidate_jobs(
@@ -1008,6 +1022,7 @@ def _incremental_output_download(
     if sys.version_info < (3, 9):
         raise DeadlineOperationError("The sync-output command requires Python version 3.9 or later")
 
+    durations = IncrementalOutputDownloadLatencies()
     deadline = boto3_session.client("deadline")
 
     # When this function is done, we will be confident that downloads are complete up to
@@ -1050,6 +1065,7 @@ def _incremental_output_download(
     }
 
     # Call deadline:SearchJobs to get a set of jobs that includes every job with downloads available.
+    start_t = time.perf_counter_ns()
     download_candidate_jobs: dict[str, dict[str, Any]] = _get_download_candidate_jobs(
         boto3_session,
         farm_id,
@@ -1057,10 +1073,12 @@ def _incremental_output_download(
         checkpoint.downloads_completed_timestamp,
         print_function_callback,
     )
+    durations._get_download_candidate_jobs = time.perf_counter_ns() - start_t
 
     print_function_callback("")
 
     # Compare the download candidates with the previously saved checkpoint state to categorize the jobs
+    start_t = time.perf_counter_ns()
     categorized_job_ids: CategorizedJobIds = _categorize_jobs_in_checkpoint(
         boto3_session,
         farm_id,
@@ -1070,10 +1088,12 @@ def _incremental_output_download(
         new_completed_timestamp,
         print_function_callback,
     )
+    durations._categorize_jobs_in_checkpoint = time.perf_counter_ns() - start_t
 
     print_function_callback("")
 
     # All the completed, added, and updated jobs might have downloads available. Retrieve the sessions for these jobs.
+    start_t = time.perf_counter_ns()
     job_sessions: dict[str, list] = _get_job_sessions(
         boto3_session,
         boto3_session_for_s3,
@@ -1085,10 +1105,12 @@ def _incremental_output_download(
         download_candidate_jobs,
         print_function_callback,
     )
+    durations._get_job_sessions = time.perf_counter_ns() - start_t
 
     # If storage profiles are being used, get them and construct all the path mapping rules
     path_mapping_rule_appliers: dict[str, Optional[_PathMappingRuleApplier]] = {}
     if checkpoint.local_storage_profile_id:
+        start_t = time.perf_counter_ns()
         storage_profiles = _get_storage_profiles(
             deadline, farm_id, queue, job_sessions, checkpoint, download_candidate_jobs
         )
@@ -1098,12 +1120,16 @@ def _incremental_output_download(
             download_candidate_jobs,
             print_function_callback,
         )
+        durations.path_mapping = time.perf_counter_ns() - start_t
 
     # Use the information collected so far to update the jobs list in checkpoint
+    start_t = time.perf_counter_ns()
     _update_checkpoint_jobs_list(
         checkpoint, download_candidate_jobs, categorized_job_ids, job_sessions
     )
+    durations._update_checkpoint_jobs_list = time.perf_counter_ns() - start_t
 
+    start_t = time.perf_counter_ns()
     unmapped_paths: dict[str, list[str]] = {}
     downloaded_manifests: list[tuple[datetime, BaseAssetManifest]] = (
         _download_all_manifests_with_absolute_paths(
@@ -1116,6 +1142,7 @@ def _incremental_output_download(
             print_function_callback,
         )
     )
+    durations._download_all_manifests_with_absolute_paths = time.perf_counter_ns() - start_t
 
     # Print warning messages about all the output paths that will not be downloaded due to lack of path mapping.
     if unmapped_paths:
@@ -1158,6 +1185,7 @@ def _incremental_output_download(
 
     if not dry_run:
         print_function_callback(f"Downloading {len(manifest_paths_to_download)} files from S3...")
+        start_t = time.perf_counter_ns()
         start_time = datetime.now(tz=timezone.utc)
 
         # Incremental download is mostly a background thing, so don't print status too often while downloading
@@ -1193,6 +1221,7 @@ def _incremental_output_download(
             print_function_callback=print_function_callback,
         )
 
+        durations.download = time.perf_counter_ns() - start_t
         duration = datetime.now(tz=timezone.utc) - start_time
         print_function_callback(f"...downloaded in {duration}")
     else:
@@ -1201,6 +1230,35 @@ def _incremental_output_download(
     # Update the timestamp in the state object to reflect the downloads that were completed
     checkpoint.downloads_completed_timestamp = new_completed_timestamp
 
+    stats: dict[str, Any] = {
+        "downloaded_session_actions": sum(
+            len(session.get("sessionActions", []))
+            for session_list in job_sessions.values()
+            for session in session_list
+        ),
+        "downloaded_files": len(manifest_paths_to_download),
+        "downloaded_bytes": sum(path.size for path in manifest_paths_to_download),
+        "jobs_with_downloads": {
+            "completed": len(categorized_job_ids.completed),
+            "added": len(categorized_job_ids.added),
+            "updated": len(categorized_job_ids.updated),
+        },
+        "jobs_without_downloads": {
+            "not_using_job_attachments": len(categorized_job_ids.attachments_free),
+            "missing_storage_profile": len(categorized_job_ids.missing_storage_profile),
+            "unchanged": len(categorized_job_ids.unchanged),
+            "inactive": len(categorized_job_ids.inactive),
+        },
+    }
+    api.get_deadline_cloud_library_telemetry_client().record_event(
+        event_type="com.amazon.rum.deadline.incremental_output_download_stats",
+        event_details={
+            "latencies": asdict(durations),
+            "dry_run": dry_run,
+            **stats,
+        },
+    )
+
     print_function_callback("")
     if dry_run:
         print_function_callback(
@@ -1208,25 +1266,23 @@ def _incremental_output_download(
         )
     else:
         print_function_callback("Summary of incremental output download:")
+    print_function_callback(f"  Downloaded session actions: {stats['downloaded_session_actions']}")
+    print_function_callback(f"  Downloaded files: {stats['downloaded_files']}")
     print_function_callback(
-        f"  Downloaded session actions: {sum(len(session.get('sessionActions', [])) for session_list in job_sessions.values() for session in session_list)}"
-    )
-    print_function_callback(f"  Downloaded files: {len(manifest_paths_to_download)}")
-    print_function_callback(
-        f"  Downloaded bytes: {human_readable_file_size(sum(path.size for path in manifest_paths_to_download))}"
+        f"  Downloaded bytes: {human_readable_file_size(stats['downloaded_bytes'])}"
     )
     print_function_callback("  Jobs with downloads:")
-    print_function_callback(f"    completed: {len(categorized_job_ids.completed)}")
-    print_function_callback(f"    added: {len(categorized_job_ids.added)}")
-    print_function_callback(f"    updated: {len(categorized_job_ids.updated)}")
+    print_function_callback(f"    completed: {stats['jobs_with_downloads']['completed']}")
+    print_function_callback(f"    added: {stats['jobs_with_downloads']['added']}")
+    print_function_callback(f"    updated: {stats['jobs_with_downloads']['updated']}")
     print_function_callback("  Jobs without downloads:")
     print_function_callback(
-        f"    not using job attachments: {len(categorized_job_ids.attachments_free)}"
+        f"    not using job attachments: {stats['jobs_without_downloads']['not_using_job_attachments']}"
     )
     print_function_callback(
-        f"    missing storage profile: {len(categorized_job_ids.missing_storage_profile)}"
+        f"    missing storage profile: {stats['jobs_without_downloads']['missing_storage_profile']}"
     )
-    print_function_callback(f"    unchanged: {len(categorized_job_ids.unchanged)}")
-    print_function_callback(f"    inactive: {len(categorized_job_ids.inactive)}")
+    print_function_callback(f"    unchanged: {stats['jobs_without_downloads']['unchanged']}")
+    print_function_callback(f"    inactive: {stats['jobs_without_downloads']['inactive']}")
 
     return checkpoint


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We want to track statistics telemetry for the `incremental-output-download` command

### What was the solution? (How)
Add a new `incremental_output_download_stats` telemetry event that records the following stats:
- Latencies of various functions I deemed may be of interest. Feel free to request more or some to be removed.
- Summary of the command such as downloaded jobs/files, etc. Matches the summary the CLI prints out.
- Whether it was a dry run or not. Currently it pushes telemetry even for dry runs. That can be changed upon request.

### What is the impact of this change?
We have telemetry with statistics on the `incremental-output-download` command

### How was this change tested?

Manually ran the command with debug logging:

```
hatch run deadline --log-level debug queue incremental-output-download --farm-id $FARM_ID --queue-id $QUEUE_ID --ignore-storage-profiles --force-bootstrap --bootstrap-lookback-minutes 9999999 --dry-run
```

```py
{'BatchId': '16284f7d-32ae-48ea-97b9-aaa496b612e5', 'RumEvents': [{'details': '', 'timestamp': 1755881643, 'type': 'com.amazon.rum.deadline.incremental_output_download_stats'}], 'UserDetails': {'sessionId': 'dce2f307-4908-4991-be68-744fee726f2c', 'userId': '1fd4f0c8-c8df-4914-9162-d2daa4a2488f'}}
```

`details` of above:

```json
{
    "latencies": {
        "_get_download_candidate_jobs": 1032200181,
        "_categorize_jobs_in_checkpoint": 4032436554,
        "_get_job_sessions": 17572088176,
        "_update_checkpoint_jobs_list": 773193,
        "_download_all_manifests_with_absolute_paths": 1826138687,
        "download": null,
        "path_mapping": null
    },
    "dry_run": true,
    "downloaded_session_actions": 176,
    "downloaded_files": 8,
    "downloaded_bytes": 1948,
    "jobs_with_downloads": {
        "completed": 22,
        "added": 0,
        "updated": 0
    },
    "jobs_without_downloads": {
        "not_using_job_attachments": 0,
        "missing_storage_profile": 0,
        "unchanged": 0,
        "inactive": 0
    },
    "accountId": "162923712518",
    "usage_mode": "CLI"
}
```

example `details` with actual files downloaded:

```json
{
    "latencies": {
        "_get_download_candidate_jobs": 1080901423,
        "_categorize_jobs_in_checkpoint": 4149782474,
        "_get_job_sessions": 18267831439,
        "_update_checkpoint_jobs_list": 714611,
        "_download_all_manifests_with_absolute_paths": 1854522013,
        "download": 84942835,
        "path_mapping": null
    },
    "dry_run": false,
    "downloaded_session_actions": 176,
    "downloaded_files": 8,
    "downloaded_bytes": 1948,
    "jobs_with_downloads": {
        "completed": 22,
        "added": 0,
        "updated": 0
    },
    "jobs_without_downloads": {
        "not_using_job_attachments": 0,
        "missing_storage_profile": 0,
        "unchanged": 0,
        "inactive": 0
    },
    "accountId": "162923712518",
    "usage_mode": "CLI"
}
```

- Have you run the unit tests?
    - Yes
- Have you run the integration tests?
    - No, we don't have integration tests for this feature yet.
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass.
    - N/A

### Was this change documented?

- Are relevant docstrings in the code base updated?
     - N/A
- Has the README.md been updated? If you modified CLI arguments, for instance.
     - N/A

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
