### PR TITLE
chore: fix incremental-output-download CLI help text

### DIFF
--- a/src/deadline/client/api/_telemetry.py
+++ b/src/deadline/client/api/_telemetry.py
@@ -416,6 +416,7 @@ def record_success_fail_telemetry_event(**decorator_kwargs: Any) -> Callable[[F]
                     event_details=event_details,
                 )
 
+        wrapper.__doc__ = function.__doc__
         return cast(F, wrapper)
 
     return inner
@@ -448,6 +449,7 @@ def record_function_latency_telemetry_event(**decorator_kwargs: Any) -> Callable
 
             return ret_val
 
+        wrapper.__doc__ = function.__doc__
         return cast(F, wrapper)
 
     return inner


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The `incremental-output-download` command's CLI help text was overriden with the telemetry decorator wrapper function's docstring:

```
deadline queue incremental-output-download --help                                     
Usage: deadline queue incremental-output-download [OPTIONS]

  Wrapper to try-catch a function for telemetry :param * Python variable
  argument. See https://docs.python.org/3/glossary.html#term-parameter :param
  ** Python variable argument. See
  https://docs.python.org/3/glossary.html#term-parameter

Options:
...<all the options>....
```

### What was the solution? (How)
Retain the original function docstring in the wrapper function for our telemetry decorators.

### What is the impact of this change?
Fixed CLI help text:

```
$ hatch run deadline queue incremental-output-download -h
Usage: deadline queue incremental-output-download [OPTIONS]

  BETA - Downloads job attachments output incrementally for all jobs in a
  queue. When run for the first time or with the --force-bootstrap option, it
  starts downloading from --bootstrap-lookback-minutes in the past. When run
  each subsequent time, it loads  the previous checkpoint and continues where
  it left off.

  To try this command, set the ENABLE_INCREMENTAL_OUTPUT_DOWNLOAD environment
  variable to 1 to acknowledge its incomplete beta status.

  [NOTE] This command is still WIP and partially implemented right now.

Options:
  --farm-id TEXT                  The AWS Deadline Cloud Farm to use.
  --queue-id TEXT                 The AWS Deadline Cloud Queue to use.
  --storage-profile-id TEXT       The storage profile to use for mapping paths
                                  to local. Cannot be used together with
                                  --ignore-storage-profiles
  --json                          Output is printed as JSON for scripting.
  --bootstrap-lookback-minutes FLOAT
                                  Downloads outputs for job-session-actions
                                  that have been completed since these many
                                  minutes at bootstrap. Default value is 0
                                  minutes.
  --checkpoint-dir TEXT           Proceed downloading from the previous
                                  progress file stored in this directory, if
                                  it exists. If the file does not exist, the
                                  download will initialize using the bootstrap
                                  lookback in minutes.
  --force-bootstrap               Forces command to start from the bootstrap
                                  lookback period and overwrite any previous
                                  checkpoint. Default value is False.
  --ignore-storage-profiles       Ignores the storage profile configuration.
                                  Only use if all jobs in the queue are
                                  submitted and downloaded from the same
                                  machine. Downloads all jobs to unmapped
                                  paths regardless of operating system.
                                  Default value is False.
  --conflict-resolution [skip|overwrite|create_copy]
                                  How to handle downloads if an output file
                                  already exists: CREATE_COPY: Download the
                                  file with a new name, appending '(1)' to the
                                  end SKIP: Do not download the file OVERWRITE
                                  (default): Download and replace the existing
                                  file. Default behaviour is to OVERWRITE.
  --dry-run                       Perform a dry run of the operation, don't
                                  actually download the output files.
  -h, --help                      Show this message and exit.
```

### How was this change tested?

- Manually via command line invocation

### Was this change documented?

N/A

### Does this PR introduce new dependencies?
No

### Is this a breaking change?
No

### Does this change impact security?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
