### PR TITLE
chore(experimental): add incremental output download feature to user agent header

### DIFF
--- a/src/deadline/client/api/_list_jobs_by_filter_expression.py
+++ b/src/deadline/client/api/_list_jobs_by_filter_expression.py
@@ -7,7 +7,7 @@ __all__ = ["_list_jobs_by_filter_expression"]
 from typing import Any
 import boto3
 
-from deadline.client.api._session import get_default_client_config
+from deadline.client.api._session import get_session_client
 from botocore.exceptions import ClientError
 from deadline.client.exceptions import DeadlineOperationError
 
@@ -102,7 +102,7 @@ def _list_jobs_by_filter_expression(
     # This holds {job_id: job_from_search_jobs_call, ...}
     result_jobs = {}
 
-    deadline = boto3_session.client("deadline", config=get_default_client_config())
+    deadline = get_session_client(boto3_session, "deadline")
 
     # Sort jobs in ascending order of the timestamp field
     sort_expressions = [{"fieldSort": {"name": "CREATED_AT", "sortOrder": "ASCENDING"}}]

--- a/src/deadline/client/api/_session.py
+++ b/src/deadline/client/api/_session.py
@@ -16,6 +16,7 @@ from typing import Optional, Tuple
 
 import boto3  # type: ignore[import]
 import botocore
+import botocore.config
 from botocore.client import BaseClient  # type: ignore[import]
 from botocore.credentials import CredentialProvider, RefreshableCredentials
 from botocore.exceptions import (  # type: ignore[import]
@@ -43,7 +44,10 @@ class AwsAuthenticationStatus(Enum):
 
 
 # Place for stashing context to be attached to boto clients.
-session_context: dict[str, Optional[str]] = {"submitter-name": None}
+session_context: dict[str, Optional[str]] = {
+    "submitter-name": None,
+    "cli-command-name": None,
+}
 
 
 def get_boto3_session(
@@ -108,14 +112,16 @@ def invalidate_boto3_session_cache() -> None:
 
 def get_default_client_config() -> botocore.config.Config:
     """
-    Gets the default botocore Config object to use with `boto3 sessions`.
+    Gets the default botocore Config object to use with `boto3 clients`.
     This method adds user agent version and submitter context into botocore calls.
     """
     user_agent_extra = f"app/deadline-client#{version}"
     if session_context.get("submitter-name"):
         user_agent_extra += f" submitter/{session_context['submitter-name']}"
-    session_config = botocore.config.Config(user_agent_extra=user_agent_extra)
-    return session_config
+    if session_context.get("cli-command-name"):
+        user_agent_extra += f" cli-command/{session_context['cli-command-name']}"
+    client_config = botocore.config.Config(user_agent_extra=user_agent_extra)
+    return client_config
 
 
 @lru_cache

--- a/src/deadline/client/cli/_groups/queue_group.py
+++ b/src/deadline/client/cli/_groups/queue_group.py
@@ -16,6 +16,7 @@ from botocore.exceptions import ClientError  # type: ignore[import]
 from datetime import datetime, timedelta, timezone
 
 from ... import api
+from ...api._session import get_session_client
 from ...config import config_file
 from ...exceptions import DeadlineOperationError
 from .._common import _apply_cli_options_to_config, _cli_object_repr, _handle_error
@@ -291,6 +292,8 @@ def sync_output(
 
     [NOTE] This command is still WIP and partially implemented right now.
     """
+    api._session.session_context["cli-command-name"] = "deadline.queue.sync-output"
+
     if os.environ.get("ENABLE_INCREMENTAL_OUTPUT_DOWNLOAD") != "1":
         raise DeadlineOperationError(
             "The sync-output command is not fully implemented. You must set the environment variable ENABLE_INCREMENTAL_OUTPUT_DOWNLOAD to 1 to acknowledge this."
@@ -325,8 +328,7 @@ def sync_output(
     farm_id = config_file.get_setting("defaults.farm_id", config=config)
     queue_id = config_file.get_setting("defaults.queue_id", config=config)
     boto3_session: boto3.Session = api.get_boto3_session(config=config)
-
-    deadline = boto3_session.client("deadline")
+    deadline = get_session_client(boto3_session, "deadline")
 
     if ignore_storage_profiles:
         local_storage_profile_id = None

--- a/src/deadline/client/cli/_incremental_download.py
+++ b/src/deadline/client/cli/_incremental_download.py
@@ -19,6 +19,7 @@ import boto3
 from botocore.client import BaseClient  # type: ignore[import]
 from ..exceptions import DeadlineOperationError
 from ..api._list_jobs_by_filter_expression import _list_jobs_by_filter_expression
+from ..api._session import get_session_client
 from ...common.path_utils import summarize_path_list, human_readable_file_size
 from ...job_attachments._incremental_downloads.incremental_download_state import (
     IncrementalDownloadState,
@@ -241,7 +242,7 @@ def _categorize_jobs_in_checkpoint(
             checkpoint.downloads_completed_timestamp when saving the checkpoint.
         print_function_callback: Callback for printing output to the terminal or log.
     """
-    deadline = boto3_session.client("deadline")
+    deadline = get_session_client(boto3_session, "deadline")
     checkpoint_jobs = {job.job_id: job.job for job in checkpoint.jobs}
     checkpoint_job_ids = set(checkpoint_jobs.keys())
 
@@ -600,7 +601,7 @@ def _get_job_sessions(
         if job.session_ended_timestamp is not None
     }
 
-    deadline = boto3_session.client("deadline")
+    deadline = get_session_client(boto3_session, "deadline")
     job_sessions: dict[str, list] = {}
 
     # Retrieve all the sessions with some parallelism
@@ -1027,7 +1028,7 @@ def _incremental_output_download(
         raise DeadlineOperationError("The sync-output command requires Python version 3.9 or later")
 
     durations = IncrementalOutputDownloadLatencies()
-    deadline = boto3_session.client("deadline")
+    deadline = get_session_client(boto3_session, "deadline")
 
     # When this function is done, we will be confident that downloads are complete up to
     # new_completed_timestamp. We subtract a duration from now() that gives a generous amount of


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We want to add identifying information in the User Agent header of our AWS API requests so that we can tell which requests came from a usage of the incremental-output-download CLI

### What was the solution? (How)
Add the `cli-command/incremental-output-download` string to the user agent header to our Deadline Cloud API requests when called from this CLI command.

### What is the impact of this change?
Requests have identifying information in the User Agent header that they came from this CLI

### How was this change tested?

Invoke the CLI in dry-run mode with debug logging on, verified the boto logs indicate that the user agent header was modified correctly. e.g. for a SearchJobs call and verified the new `cli-command/incremental-output-download` is in the user agent:

```
DEBUG:botocore.endpoint:Making request for OperationModel(name=GetQueue) with params: {'url_path': '/2023-10-12/farms/farm-3668bdc1c58345b8b29ce1526eef1588/queues/queue-2d99516455c042f0bf03ace4f9f648f2', 'query_string': {}, 'method': 'GET', 'headers': {'User-Agent': 'Boto3/1.40.16 md/Botocore#1.40.16 ua/2.1 os/linux#5.10.240-218.959.amzn2int.x86_64 md/arch#x86_64 lang/python#3.11.7 md/pyimpl#CPython m/Z,D,b cfg/retry-mode#legacy Botocore/1.40.16 app/deadline-client#0.52.0.post7+gcc721f579 cli-command/deadline.queue.sync-output'}, 'body': b'', 'host_prefix': 'management.', 'url': 'https://management.deadline.us-west-2.amazonaws.com/2023-10-12/farms/farm-3668bdc1c58345b8b29ce1526eef1588/queues/queue-2d99516455c042f0bf03ace4f9f648f2', 'context': {'client_region': 'us-west-2', 'client_config': <botocore.config.Config object at 0x7f2f796f3750>, 'has_streaming_input': False, 'auth_type': None, 'unsigned_payload': None, 'auth_options': ['aws.auth#sigv4']}}
```

...and to make the params a bit easier to read, made it "almost json":

```json
{
    "url_path": "/2023-10-12/farms/farm-3668bdc1c58345b8b29ce1526eef1588/queues/queue-2d99516455c042f0bf03ace4f9f648f2",
    "query_string": {},
    "method": "GET",
    "headers": {
        "User-Agent": "Boto3/1.40.16 md/Botocore#1.40.16 ua/2.1 os/linux#5.10.240-218.959.amzn2int.x86_64 md/arch#x86_64 lang/python#3.11.7 md/pyimpl#CPython m/Z,D,b cfg/retry-mode#legacy Botocore/1.40.16 app/deadline-client#0.52.0.post7+gcc721f579 cli-command/deadline.queue.sync-output"
    },
    "body": b"",
    "host_prefix": "management.",
    "url": "https://management.deadline.us-west-2.amazonaws.com/2023-10-12/farms/farm-3668bdc1c58345b8b29ce1526eef1588/queues/queue-2d99516455c042f0bf03ace4f9f648f2",
    "context": {
        "client_region": "us-west-2",
        "client_config": <botocore.config.Config object at 0x7f2f796f3750>,
        "has_streaming_input": False,
        "auth_type": None,
        "unsigned_payload": None,
        "auth_options": [
            "aws.auth#sigv4"
        ]
    }
}
```

Also verified it is not passed in for other commands by running `deadline farm get` and inspecting the user agent:

```
DEBUG:botocore.endpoint:Making request for OperationModel(name=GetFarm) with params: {'url_path': '/2023-10-12/farms/farm-52989b2a791c45b391a79710729109df', 'query_string': {}, 'method': 'GET', 'headers': {'User-Agent': 'Boto3/1.40.15 md/Botocore#1.40.15 ua/2.1 os/linux#5.10.240-218.959.amzn2int.x86_64 md/arch#x86_64 lang/python#3.11.7 md/pyimpl#CPython m/D,b,Z cfg/retry-mode#legacy Botocore/1.40.15 app/deadline-client#0.52.0.post4+g6fc4c7cf1.d20250822'}, 'body': b'', 'host_prefix': 'management.', 'url': 'https://management.deadline.us-west-2.amazonaws.com/2023-10-12/farms/farm-52989b2a791c45b391a79710729109df', 'context': {'client_region': 'us-west-2', 'client_config': <botocore.config.Config object at 0x7fb44c57c090>, 'has_streaming_input': False, 'auth_type': None, 'unsigned_payload': None, 'auth_options': ['aws.auth#sigv4']}}
```

```json
{
    "url_path": "/2023-10-12/farms/farm-52989b2a791c45b391a79710729109df",
    "query_string": {},
    "method": "GET",
    "headers": {
        "User-Agent": "Boto3/1.40.15 md/Botocore#1.40.15 ua/2.1 os/linux#5.10.240-218.959.amzn2int.x86_64 md/arch#x86_64 lang/python#3.11.7 md/pyimpl#CPython m/D,b,Z cfg/retry-mode#legacy Botocore/1.40.15 app/deadline-client#0.52.0.post4+g6fc4c7cf1.d20250822"
    },
    "body": b"",
    "host_prefix": "management.",
    "url": "https://management.deadline.us-west-2.amazonaws.com/2023-10-12/farms/farm-52989b2a791c45b391a79710729109df",
    "context": {
        "client_region": "us-west-2",
        "client_config": <botocore.config.Config object at 0x7fb44c57c090>,
        "has_streaming_input": False,
        "auth_type": None,
        "unsigned_payload": None,
        "auth_options": [
            "aws.auth#sigv4"
        ]
    }
}
```

- Have you run the unit tests?
    - Yes
- Have you run the integration tests?
    - N/A - no integ tests for this feature yet
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass.
    - N/A

### Was this change documented?

N/A

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?
No

### Does this change impact security?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
