### PR TITLE
fix: Reverted number of workers running integ test to 1 as it throttles deadline APIs

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -31,7 +31,7 @@ pre-install-commands = [
 ]
 
 [envs.integ.scripts]
-test = "pytest --no-cov {args:test/integ} -vvv --numprocesses=10"
+test = "pytest --no-cov {args:test/integ} -vvv --numprocesses=1"
 
 [envs.installer.env-vars]
 SKIP_BOOTSTRAP_TEST_RESOURCES = "True"


### PR DESCRIPTION
Fixes: N/A

### What was the problem/requirement? (What/Why)
Mainline integ tests are failing because we increased xdist workers to 10 to make the integ tests faster: https://github.com/aws-deadline/deadline-cloud/actions/runs/17167411251/job/48710692985

### What was the solution? (How)
Reverted the num processes back to 1. The deadline APIs are getting throttled

### What is the impact of this change?
Fix the tests

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests?N/A
- Have you run the integration tests?N/A
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass. N/A

### Was this change documented?

- Are relevant docstrings in the code base updated?N/A
- Has the README.md been updated? If you modified CLI arguments, for instance. N/A

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?
No

### Does this change impact security?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
