### PR TITLE
fix: CHECK_BOX parameter isn't enabled on load when value is ON, YES, or 1

### DIFF
--- a/src/deadline/client/ui/widgets/openjd_parameters_widget.py
+++ b/src/deadline/client/ui/widgets/openjd_parameters_widget.py
@@ -779,7 +779,7 @@ class _JobTemplateCheckBoxWidget(_JobTemplateWidget):
             return self.false_value
 
     def set_value(self, value: str) -> None:
-        if value.lower() == "true":
+        if value == self.true_value:
             self.edit_control.setChecked(True)
         else:
             self.edit_control.setChecked(False)


### PR DESCRIPTION
Fixes: #797 

### What was the problem/requirement? (What/Why)

Job Bundles that had CHECK_BOX parameters with allowed values of "on", "yes", or "1" would not load with it enabled. This is because we were explicitly checking for a variation of "true" which does not match the [spec](https://github.com/OpenJobDescription/openjd-specifications/wiki/2023-09-Template-Schemas#21-jobstringparameterdefinition)

### What was the solution? (How)

We're already loading all the different allowed values for the parameter, so we just use that.

### What is the impact of this change?

Correct behaviour around loading bundles with check boxes!

### How was this change tested?

Used this bundle locally to ensure that it shows up as checked:

Template.yaml
```yaml
specificationVersion: 'jobtemplate-2023-09'
name: Checkbox Test Job
description: Simple job bundle to test checkbox parameter handling

parameterDefinitions:
- name: EnableFeature
  type: STRING
  default: "ON"
  allowedValues: ["ON", "OFF"]
  userInterface:
    control: CHECK_BOX
    label: Enable Feature
  description: Test checkbox with ON/OFF values

steps:
- name: TestStep
  script:
    actions:
      onRun:
        command: echo
        args: 
        - "Feature is {{Param.EnableFeature}}"
```

parameter_values:
```yaml
parameterValues:
- name: EnableFeature
  value: "ON"
```

as well with `["1", "0"]` and `["Yes", "No"]`

### Was this change documented?

N/A

### Does this PR introduce new dependencies?

N/A

### Is this a breaking change?

Fixing!

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
