### PR TITLE
test(experimental): Modified the incremental output download CLI name to sync-output in tests

### DIFF
--- a/test/integ/cli/test_cli_incremental_download.py
+++ b/test/integ/cli/test_cli_incremental_download.py
@@ -64,7 +64,7 @@ class IncrementalDownloadTest:
         cmd = [
             "deadline",
             "queue",
-            "incremental-output-download",
+            "sync-output",
             "--farm-id",
             self.farm_id,
             "--queue-id",


### PR DESCRIPTION
Fixes: N/A

### What was the problem/requirement? (What/Why)
We updated the CLI name from ``incremental-output-download`` to ``sync-output`` with https://github.com/aws-deadline/deadline-cloud/pull/794. We need to update the test to include the same

### What was the solution? (How)
Changed the CLI name to ``sync-output``

### What is the impact of this change?
Integ tests running!

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests? No
- Have you run the integration tests? Yes
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass. No

### Was this change documented?

- Are relevant docstrings in the code base updated?N/A
- Has the README.md been updated? If you modified CLI arguments, for instance. N/A

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?
No

### Does this change impact security?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
