### PR TITLE
chore: Improve incremental download message clarity

### DIFF
--- a/src/deadline/client/cli/_groups/queue_group.py
+++ b/src/deadline/client/cli/_groups/queue_group.py
@@ -337,14 +337,13 @@ def sync_output(
         )
         if not local_storage_profile_id:
             raise DeadlineOperationError(
-                "The sync-output operation requires a storage profile configured locally\n"
-                "or provided with the --storage-profile-id option in order to determine file system paths\n"
-                "for download. Storage profiles are used to generate path mappings when a job was submitted\n"
-                "from a machine with a different operating system or file system mount locations than the download machine. \n\n"
-                "See https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/modeling-your-shared-filesystem-locations-with-storage-profiles.html\n\n"
-                "If you only submit and download jobs from one machine, you can use the --ignore-storage-profiles option\n"
-                "to ignore the storage profiles, and download all job outputs to whereever the paths are configured.\n"
-                "This is not recommended if more than one machine will submit or download jobs."
+                "The sync-output operation requires a storage profile defined in the deadline client configuration or "
+                "provided with the --storage-profile-id option.\n\n"
+                "Storage profiles are used to generate path mappings when a job was submitted from a machine with a different "
+                "operating system or file system mount locations than the machine downloading outputs. See "
+                "https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/modeling-your-shared-filesystem-locations-with-storage-profiles.html "
+                "for more information.\n\n"
+                "If you only submit and download jobs from the same operating system and mount locations, you can use the --ignore-storage-profiles option."
             )
 
         try:

--- a/src/deadline/client/cli/_incremental_download.py
+++ b/src/deadline/client/cli/_incremental_download.py
@@ -382,9 +382,13 @@ def _categorize_jobs_in_checkpoint(
 
         print_function_callback(f"NEW Job: {dc_job['name']} ({job_id})")
 
-        if dc_job["storageProfileId"] is None and checkpoint.local_storage_profile_id is not None:
+        if (
+            dc_job["attachments"] is not None
+            and dc_job["storageProfileId"] is None
+            and checkpoint.local_storage_profile_id is not None
+        ):
             print_function_callback(
-                "  Job does not have a storage profile, will not download its output."
+                "  WARNING: THE JOB OUTPUT WILL NOT BE DOWNLOADED, IT HAS NO STORAGE PROFILE."
             )
             missing_storage_profile.add(job_id)
             continue
@@ -757,7 +761,7 @@ def _create_path_mapping_rule_appliers(
         f"Local storage profile is {local_storage_profile_name} ({checkpoint.local_storage_profile_id})"
     )
     print_function_callback(
-        f"  {len([job for job in download_candidate_jobs.values() if job.get('storageProfileId') == checkpoint.local_storage_profile_id])} download candidate jobs will have no path mapping because they use this storage profile"
+        f"  {len([job for job in download_candidate_jobs.values() if job.get('storageProfileId') == checkpoint.local_storage_profile_id])} download candidate jobs have the same storage profile and will be downloaded to their original specified paths"
     )
     for storage_profile_id, storage_profile in storage_profiles.items():
         storage_profile_name = storage_profile["displayName"]
@@ -1147,15 +1151,16 @@ def _incremental_output_download(
     # Print warning messages about all the output paths that will not be downloaded due to lack of path mapping.
     if unmapped_paths:
         print_function_callback("")
+        print_function_callback("WARNING: THE FOLLOWING FILES WILL NOT BE DOWNLOADED")
         for job_id, unmapped_path_list in unmapped_paths.items():
             print_function_callback(
-                f"WARNING: Job {download_candidate_jobs[job_id]['name']} ({job_id}) has outputs with unmapped paths"
+                f"    Job {download_candidate_jobs[job_id]['name']} ({job_id}) has outputs with unmapped paths that will not be downloaded"
             )
             storage_profile = storage_profiles[download_candidate_jobs[job_id]["storageProfileId"]]
             print_function_callback(
-                f"         Job storage profile is {storage_profile['displayName']} ({storage_profile['storageProfileId']})"
+                f"      Job storage profile is {storage_profile['displayName']} ({storage_profile['storageProfileId']})"
             )
-            print_function_callback("         Summary of unmapped paths:")
+            print_function_callback("      Summary of unmapped paths:")
             path_format = (
                 PathFormat.WINDOWS
                 if storage_profile["osFamily"] == StorageProfileOperatingSystemFamily.WINDOWS.value
@@ -1164,7 +1169,7 @@ def _incremental_output_download(
             paths_summary = summarize_path_list(
                 unmapped_path_list, max_entries=30, path_format=path_format
             )
-            print_function_callback(textwrap.indent(paths_summary, "         "))
+            print_function_callback(textwrap.indent(paths_summary, "      "))
 
     # Merge the manifests ordered by the last modified timestamp
     manifest_paths_to_download: list[BaseManifestPath] = _merge_absolute_path_manifest_list(

--- a/test/unit/deadline_client/cli/test_cli_queue_incremental_download.py
+++ b/test/unit/deadline_client/cli/test_cli_queue_incremental_download.py
@@ -345,14 +345,14 @@ def test_incremental_output_download_bootstrap_and_completion(
     if storage_profile_id is None:
         assert "Local storage profile is" not in result.output, result.output
         assert (
-            "download candidate jobs will have no path mapping because they use this storage profile"
+            "download candidate jobs have the same storage profile and will be downloaded to their original specified paths"
             not in result.output
         ), result.output
     else:
         assert "Local storage profile is" in result.output, result.output
         assert f"({storage_profile_id})" in result.output, result.output
         assert (
-            "1 download candidate jobs will have no path mapping because they use this storage profile"
+            "1 download candidate jobs have the same storage profile and will be downloaded to their original specified paths"
             in result.output
         ), result.output
     # Assert that the output contained information about the bootstrapping and the mocked resources
@@ -628,7 +628,7 @@ def test_incremental_output_download_storage_profile_path_mapping(
         in result.output
     ), result.output
     assert (
-        "0 download candidate jobs will have no path mapping because they use this storage profile"
+        "0 download candidate jobs have the same storage profile and will be downloaded to their original specified paths"
         in result.output
     ), result.output
     assert (


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Testing identified a number of output messages with unclear meaning.

### What was the solution? (How)

This change applies the improved wording.

It also adds a check to distinguish between jobs lacking a storage profile and jobs that do not use job attachments.

### What is the impact of this change?

It becomes easier to interpret messages from the `deadline queue sync-output` command.

### How was this change tested?

Ran unit tests, generated scenarios in a Deadline Cloud farm that produced all of the various updated messages.

### Was this change documented?

N/A

### Does this PR introduce new dependencies?

No

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
