### PR TITLE
chore(experimental): rename telemetry event to reflect sync-output command name

### DIFF
--- a/src/deadline/client/cli/_incremental_download.py
+++ b/src/deadline/client/cli/_incremental_download.py
@@ -1256,7 +1256,7 @@ def _incremental_output_download(
         },
     }
     api.get_deadline_cloud_library_telemetry_client().record_event(
-        event_type="com.amazon.rum.deadline.incremental_output_download_stats",
+        event_type="com.amazon.rum.deadline.queue_sync_output_stats",
         event_details={
             "latencies": asdict(durations),
             "dry_run": dry_run,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We recently renamed the `incremental-output-download` command to `sync-output`. The telemetry event name should be updated to reflect that.

### What was the solution? (How)
Update the telemetry event name to reflect new command name

### What is the impact of this change?
Telemetry event name matches command name

### How was this change tested?
Manually ran command with debug logging and verified telemetry event logs looked correct:

```
DEBUG:deadline.client.api._telemetry:Sending telemetry data: {'BatchId': '1e4adbb8-16da-4d17-8f84-a1e136df5758', 'RumEvents': [{'details': '{"latencies": {"_get_download_candidate_jobs": 973743549, "_categorize_jobs_in_checkpoint": 867381480, "_get_job_sessions": 7680357464, "_update_checkpoint_jobs_list": 138144, "_download_all_manifests_with_absolute_paths": 1108166308, "download": null, "path_mapping": null}, "dry_run": true, "downloaded_session_actions": 120, "downloaded_files": 10020, "downloaded_bytes": 320343, "jobs_with_downloads": {"completed": 4, "added": 0, "updated": 0}, "jobs_without_downloads": {"not_using_job_attachments": 0, "missing_storage_profile": 0, "unchanged": 0, "inactive": 0}, "accountId": "162923712518", "usage_mode": "CLI"}', 'id': 'a30e1d40-58ed-4346-ad37-2f59e6603323', 'metadata': '{"service": "deadline-cloud-library", "version": "0.52.0", "python_version": "3.11.7", "osName": "Linux", "osVersion": "5.10.240-218.959.amzn2int.x86_64"}', 'timestamp': 1756147708, 'type': 'com.amazon.rum.deadline.queue_sync_output_stats'}], 'UserDetails': {'sessionId': '760151e1-8695-4021-b1df-73fea258935e', 'userId': '1fd4f0c8-c8df-4914-9162-d2daa4a2488f'}}
```

```
{
    "BatchId": "1e4adbb8-16da-4d17-8f84-a1e136df5758",
    "RumEvents": [
        {
            "details": "{\"latencies\": {\"_get_download_candidate_jobs\": 973743549, \"_categorize_jobs_in_checkpoint\": 867381480, \"_get_job_sessions\": 7680357464, \"_update_checkpoint_jobs_list\": 138144, \"_download_all_manifests_with_absolute_paths\": 1108166308, \"download\": null, \"path_mapping\": null}, \"dry_run\": true, \"downloaded_session_actions\": 120, \"downloaded_files\": 10020, \"downloaded_bytes\": 320343, \"jobs_with_downloads\": {\"completed\": 4, \"added\": 0, \"updated\": 0}, \"jobs_without_downloads\": {\"not_using_job_attachments\": 0, \"missing_storage_profile\": 0, \"unchanged\": 0, \"inactive\": 0}, \"accountId\": \"162923712518\", \"usage_mode\": \"CLI\"}",
            "id": "a30e1d40-58ed-4346-ad37-2f59e6603323",
            "metadata": "{\"service\": \"deadline-cloud-library\", \"version\": \"0.52.0\", \"python_version\": \"3.11.7\", \"osName\": \"Linux\", \"osVersion\": \"5.10.240-218.959.amzn2int.x86_64\"}",
            "timestamp": 1756147708,
            "type": "com.amazon.rum.deadline.queue_sync_output_stats"
        }
    ],
    "UserDetails": {
        "sessionId": "760151e1-8695-4021-b1df-73fea258935e",
        "userId": "1fd4f0c8-c8df-4914-9162-d2daa4a2488f"
    }
}
```


### Was this change documented?
N/A

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?
No

### Does this change impact security?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
