### PR TITLE
fix: Improve config read robustness

### DIFF
--- a/src/deadline/client/config/config_file.py
+++ b/src/deadline/client/config/config_file.py
@@ -189,7 +189,14 @@ def read_config() -> ConfigParser:
         # Read the config file with a fresh config parser, and update the last-modified time stamp
         __config = ConfigParser()
         __config_file_path = config_file_path
-        __config.read(config_file_path)
+        try:
+            with open(config_file_path, mode="r", encoding="utf-8") as fh:
+                config_contents = fh.read()
+            __config.read_string(config_contents, str(config_file_path))
+        except FileNotFoundError:
+            # If the config file doesn't exist, leave an empty ConfigParser() object, in all
+            # other cases let the error pass through.
+            pass
         if config_file_path.is_file():
             __config_mtime = config_file_path.stat().st_mtime
         else:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

In some cases, for example if an antivirus scanner locks the config file at the same time it is being read, a sharing violation will be raised. The previous code treated that the same as a missing file, returning an empty config object.

### What was the solution? (How)

The new code lets all OSErrors except for FileNotFoundError fail the function instead.

As a future enhancement, we could add a retry loop for reading the file, but raising an error will prevent cases of incorrect configs being returned very occasionally.

### What is the impact of this change?

More robust reading of ~/.deadline/config. In the test scenario where it previously returned an empty config, here is an example of the exception it gets:

```
Exception in thread Thread-711 (submit_test_job):
Traceback (most recent call last):
  File "C:\Programs\Python\Lib\threading.py", line 1041, in _bootstrap_inner
    self.run()
    ~~~~~~~~^^
  File "C:\Programs\Python\Lib\threading.py", line 992, in run
    self._target(*self._args, **self._kwargs)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Dev\test-case-repo\submit_test_jobs.py", line 38, in submit_test_job
    create_job_from_job_bundle(
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "C:\Dev\deadline-cloud\src\deadline\client\api\_telemetry.py", line 439, in wrapper
    ret_val = function(*args, **kwargs)
  File "C:\Dev\deadline-cloud\src\deadline\client\api\_submit_job_bundle.py", line 360, in create_job_from_job_bundle
    job_attachments_file_system = get_setting(
        "defaults.job_attachments_file_system", config=config
    )
  File "C:\Dev\deadline-cloud\src\deadline\client\config\config_file.py", line 364, in get_setting
    config = read_config()
  File "C:\Dev\deadline-cloud\src\deadline\client\config\config_file.py", line 193, in read_config
    with open(config_file_path, mode="r", encoding="utf-8") as fh:
         ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
PermissionError: [Errno 13] Permission denied: 'C:\\Users\\username\\.deadline\\config'
```

### How was this change tested?

I have a long-running test case that encountered this problem after long enough. I ran the test case in the background long enough to see the new error (shown above).

### Was this change documented?

No

### Does this PR introduce new dependencies?

No

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
