### PR TITLE
feat: Support automatic download of job attachments output

### DIFF
--- a/src/deadline/client/cli/_groups/queue_group.py
+++ b/src/deadline/client/cli/_groups/queue_group.py
@@ -281,23 +281,19 @@ def sync_output(
     **args,
 ):
     """
-    BETA - Downloads any new job attachments output for all jobs in a queue since the last run of the same command.
+    Downloads any new job attachments output for all jobs in a queue since the last run of the same command.
 
     When run for the first time or with the --force-bootstrap option, it starts downloading from --bootstrap-lookback-minutes
     in the past. When run each subsequent time, it loads  the previous checkpoint and continues
     where it left off.
 
-    To try this command, set the ENABLE_INCREMENTAL_OUTPUT_DOWNLOAD environment variable to 1 to acknowledge its
-    incomplete beta status.
+    With default options, the sync-output operation requires a storage profile defined in the deadline client configuration
+    or provided with the --storage-profile-id option. Storage profiles are used to generate path mappings when a job was
+    submitted from a machine with a different operating system or file system mount locations than the machine downloading outputs.
 
-    [NOTE] This command is still WIP and partially implemented right now.
+    If you only submit and download jobs from the same operating system and mount locations, you can use the --ignore-storage-profiles option.
     """
     api._session.session_context["cli-command-name"] = "deadline.queue.sync-output"
-
-    if os.environ.get("ENABLE_INCREMENTAL_OUTPUT_DOWNLOAD") != "1":
-        raise DeadlineOperationError(
-            "The sync-output command is not fully implemented. You must set the environment variable ENABLE_INCREMENTAL_OUTPUT_DOWNLOAD to 1 to acknowledge this."
-        )
 
     if sys.version_info < (3, 9):
         raise DeadlineOperationError("The sync-output command requires Python version 3.9 or later")

--- a/test/integ/cli/test_cli_incremental_download.py
+++ b/test/integ/cli/test_cli_incremental_download.py
@@ -83,14 +83,9 @@ class IncrementalDownloadTest:
         if lookback_window is not None:
             cmd.extend(["--bootstrap-lookback-minutes", str(lookback_window)])
 
-        env = os.environ.copy()
-        env["ENABLE_INCREMENTAL_OUTPUT_DOWNLOAD"] = "1"
-
         # Run from the specified output directory so files are downloaded to their manifest paths
         # The CLI will create the necessary directory structure based on job manifests
-        return subprocess.run(
-            cmd, capture_output=True, text=True, check=False, env=env, cwd=output_dir
-        )
+        return subprocess.run(cmd, capture_output=True, text=True, check=False, cwd=output_dir)
 
 
 @pytest.fixture(scope="session")

--- a/test/unit/deadline_client/cli/test_cli_queue_incremental_download.py
+++ b/test/unit/deadline_client/cli/test_cli_queue_incremental_download.py
@@ -109,53 +109,11 @@ def deadline_mock():
             yield deadline_magicmock
 
 
-@pytest.fixture
-def with_incremental_download_enabled():
-    """Set the ENABLE_INCREMENTAL_OUTPUT_DOWNLOAD environment variable to 1 for testing the incremental download command."""
-    os.environ["ENABLE_INCREMENTAL_OUTPUT_DOWNLOAD"] = "1"
-    yield None
-    del os.environ["ENABLE_INCREMENTAL_OUTPUT_DOWNLOAD"]
-
-
-def test_incremental_output_download_requires_beta_acknowledgement(
-    fresh_deadline_config, deadline_mock, checkpoint_dir
-):
-    # Make sure the acknowledgement env var is not defined
-    if "ENABLE_INCREMENTAL_OUTPUT_DOWNLOAD" in os.environ:
-        del os.environ["ENABLE_INCREMENTAL_OUTPUT_DOWNLOAD"]
-
-    # Run the CLI command once to bootstrap the operation
-    runner = CliRunner()
-    with freeze_time(ISO_FREEZE_TIME):
-        result = runner.invoke(
-            main,
-            [
-                "queue",
-                "sync-output",
-                "--ignore-storage-profiles",
-                "--farm-id",
-                MOCK_FARM_ID,
-                "--queue-id",
-                MOCK_QUEUE_ID,
-                "--checkpoint-dir",
-                checkpoint_dir,
-            ],
-        )
-
-    # Assert the command executed successfully
-    assert result.exit_code == 1, result.output
-
-    assert (
-        "The sync-output command is not fully implemented. You must set the environment variable ENABLE_INCREMENTAL_OUTPUT_DOWNLOAD to 1 to acknowledge this."
-        in result.output
-    ), result.output
-
-
 @pytest.mark.skipif(
     sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
 )
 def test_incremental_output_download_requires_queue_with_job_attachments(
-    fresh_deadline_config, deadline_mock, with_incremental_download_enabled, checkpoint_dir
+    fresh_deadline_config, deadline_mock, checkpoint_dir
 ):
     # The response does not include the "jobAttachmentSettings" field
     deadline_mock.GetQueue.return_value = {
@@ -194,7 +152,6 @@ def test_incremental_output_download_requires_queue_with_job_attachments(
 )
 def test_incremental_output_download_pid_lock_already_held_error(
     fresh_deadline_config,
-    with_incremental_download_enabled,
     deadline_mock,
     checkpoint_dir,
 ):
@@ -242,7 +199,6 @@ def test_incremental_output_download_pid_lock_already_held_error(
 )
 def test_incremental_output_download_storage_profile_options_mutually_exclusive(
     fresh_deadline_config,
-    with_incremental_download_enabled,
     deadline_mock,
     checkpoint_dir,
 ):
@@ -283,7 +239,6 @@ def test_incremental_output_download_storage_profile_options_mutually_exclusive(
 @pytest.mark.parametrize("storage_profile_id", [None, MOCK_STORAGE_PROFILE_ID])
 def test_incremental_output_download_bootstrap_and_completion(
     fresh_deadline_config,
-    with_incremental_download_enabled,
     deadline_mock,
     checkpoint_dir,
     storage_profile_id,
@@ -503,7 +458,6 @@ def test_incremental_output_download_bootstrap_and_completion(
 )
 def test_incremental_output_download_storage_profile_path_mapping(
     fresh_deadline_config,
-    with_incremental_download_enabled,
     tmp_path,
     deadline_mock,
     checkpoint_dir,
@@ -662,7 +616,7 @@ def test_incremental_output_download_storage_profile_path_mapping(
     sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
 )
 def test_incremental_output_download_bootstrap_retire_job_without_attachments(
-    fresh_deadline_config, with_incremental_download_enabled, deadline_mock, checkpoint_dir
+    fresh_deadline_config, deadline_mock, checkpoint_dir
 ):
     """Test a new job through bootstrap and completion over two incremental download commands."""
     mock_jobs = create_fake_job_list(1)
@@ -798,7 +752,7 @@ def test_incremental_output_download_bootstrap_retire_job_without_attachments(
     sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
 )
 def test_incremental_output_download_job_unchanged(
-    fresh_deadline_config, with_incremental_download_enabled, deadline_mock, checkpoint_dir
+    fresh_deadline_config, deadline_mock, checkpoint_dir
 ):
     """Test a new job through bootstrap and an 'UNCHANGED' message."""
     mock_jobs = create_fake_job_list(1)
@@ -896,7 +850,7 @@ def test_incremental_output_download_job_unchanged(
     sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
 )
 def test_incremental_output_download_job_canceled(
-    fresh_deadline_config, with_incremental_download_enabled, deadline_mock, checkpoint_dir
+    fresh_deadline_config, deadline_mock, checkpoint_dir
 ):
     """Test a new job through bootstrap and cancelation before it's complete"""
     mock_jobs = create_fake_job_list(1)
@@ -1003,7 +957,7 @@ def test_incremental_output_download_job_canceled(
     sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
 )
 def test_incremental_output_download_job_completed_then_requeued(
-    fresh_deadline_config, with_incremental_download_enabled, deadline_mock, checkpoint_dir
+    fresh_deadline_config, deadline_mock, checkpoint_dir
 ):
     """Test a new job through bootstrap, retirement, then requeue."""
     iso_freeze_time = datetime.fromisoformat(ISO_FREEZE_TIME)
@@ -1145,9 +1099,7 @@ def test_incremental_output_download_job_completed_then_requeued(
 @pytest.mark.skipif(
     sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
 )
-def test_incremental_output_download_dry_run(
-    fresh_deadline_config, with_incremental_download_enabled, deadline_mock, checkpoint_dir
-):
+def test_incremental_output_download_dry_run(fresh_deadline_config, deadline_mock, checkpoint_dir):
     """Test a new job through bootstrap, completion, and retirement."""
     mock_jobs = create_fake_job_list(1)
     mock_jobs[0]["name"] = "Mock Job"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Testing of the command for automatic job attachments output download is complete. This feature adds a new command `deadline queue sync-output` that downloads any new output from tasks completed in a queue since the last checkpoint from when it was run, or from a bootstrap lookback time.

### What was the solution? (How)

* Remove the beta status of the command.

### What is the impact of this change?

Can run `deadline queue sync-output` without setting the environment variable feature flag.

### How was this change tested?

Tested running the command without the environment variable set. Updated unit tests to no longer set the variable in a fixture.

### Was this change documented?

Updated the docstring to show this:

```
$ deadline queue sync-output -h
Usage: deadline queue sync-output [OPTIONS]

  Downloads any new job attachments output for all jobs in a queue since the
  last run of the same command.

  When run for the first time or with the --force-bootstrap option, it starts
  downloading from --bootstrap-lookback-minutes in the past. When run each
  subsequent time, it loads  the previous checkpoint and continues where it
  left off.

  With default options, the sync-output operation requires a storage profile
  defined in the deadline client configuration or provided with the --storage-
  profile-id option. Storage profiles are used to generate path mappings when
  a job was submitted from a machine with a different operating system or file
  system mount locations than the machine downloading outputs.

  If you only submit and download jobs from the same operating system and
  mount locations, you can use the --ignore-storage-profiles option.

Options:
  --farm-id TEXT                  The AWS Deadline Cloud Farm to use.
  --queue-id TEXT                 The AWS Deadline Cloud Queue to use.
  --storage-profile-id TEXT       The storage profile to use for mapping paths
                                  to local. Cannot be used together with
                                  --ignore-storage-profiles
  --json                          Output is printed as JSON for scripting.
  --bootstrap-lookback-minutes FLOAT
                                  Downloads outputs for job-session-actions
                                  that have been completed since these many
                                  minutes at bootstrap. Default value is 0
                                  minutes.
  --checkpoint-dir TEXT           Proceed downloading from the previous
                                  progress file stored in this directory, if
                                  it exists. If the file does not exist, the
                                  download will initialize using the bootstrap
                                  lookback in minutes.
  --force-bootstrap               Forces command to start from the bootstrap
                                  lookback period and overwrite any previous
                                  checkpoint. Default value is False.
  --ignore-storage-profiles       Ignores the storage profile configuration.
                                  Only use if all jobs in the queue are
                                  submitted and downloaded from the same
                                  machine. Downloads all jobs to unmapped
                                  paths regardless of operating system.
                                  Default value is False.
  --conflict-resolution [skip|overwrite|create_copy]
                                  How to handle downloads if an output file
                                  already exists: CREATE_COPY: Download the
                                  file with a new name, appending '(1)' to the
                                  end SKIP: Do not download the file OVERWRITE
                                  (default): Download and replace the existing
                                  file. Default behaviour is to OVERWRITE.
  --dry-run                       Perform a dry run of the operation, don't
                                  actually download the output files.
  -h, --help                      Show this message and exit.
```

### Does this PR introduce new dependencies?

No

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
