### PR TITLE
test: Remove xfail from sync-output test as bug with conflict resolution is fixed

### DIFF
--- a/test/integ/cli/test_cli_incremental_download.py
+++ b/test/integ/cli/test_cli_incremental_download.py
@@ -387,7 +387,6 @@ def test_incremental_download_dependency_chain(incremental_download_test, tmp_pa
 
 @pytest.mark.integ
 @pytest.mark.timeout(900)  # 15 minutes timeout
-@pytest.mark.xfail(reason="Known bug with create_copy conflict resolution causes this to fail")
 @pytest.mark.parametrize("requeue_level", ["job", "step", "task"])
 def test_conflict_resolution_with_requeue(incremental_download_test, requeue_level, tmp_path):
     """Test incremental download with re-queuing at different levels and conflict resolution."""


### PR DESCRIPTION
Fixes: N/A

### What was the problem/requirement? (What/Why)
Tests using conflict resolution with re-queue were marked xfail due to known bug. Bug was fixed in https://github.com/aws-deadline/deadline-cloud/pull/794/files

### What was the solution? (How)
Remove xfail from the tests as they should pass now

### What is the impact of this change?
More test coverage

### How was this change tested?
Ran them on my dev:
```
================================================================================ test session starts ================================================================================
platform darwin -- Python 3.10.13, pytest-8.4.1, pluggy-1.6.0 -- /Users/sakshie/Library/Application Support/hatch/env/virtual/deadline/dNymoyhZ/integ/bin/python
cachedir: .pytest_cache
rootdir: /Volumes/workplace/deadline-cloud
configfile: pyproject.toml
plugins: xdist-3.8.0, timeout-2.4.0, cov-6.2.1, deadline-cloud-test-fixtures-0.18.4
1 worker [3 items]     
scheduling tests via LoadScheduling

test/integ/cli/test_cli_incremental_download.py::test_conflict_resolution_with_requeue[job] 
[gw0] [ 33%] PASSED test/integ/cli/test_cli_incremental_download.py::test_conflict_resolution_with_requeue[job] 
test/integ/cli/test_cli_incremental_download.py::test_conflict_resolution_with_requeue[step] 
[gw0] [ 66%] PASSED test/integ/cli/test_cli_incremental_download.py::test_conflict_resolution_with_requeue[step] 
test/integ/cli/test_cli_incremental_download.py::test_conflict_resolution_with_requeue[task] 
[gw0] [100%] PASSED test/integ/cli/test_cli_incremental_download.py::test_conflict_resolution_with_requeue[task] 

================================================================================ slowest 5 durations ================================================================================
178.75s call     test/integ/cli/test_cli_incremental_download.py::test_conflict_resolution_with_requeue[job]
81.71s call     test/integ/cli/test_cli_incremental_download.py::test_conflict_resolution_with_requeue[step]
54.28s call     test/integ/cli/test_cli_incremental_download.py::test_conflict_resolution_with_requeue[task]
0.13s setup    test/integ/cli/test_cli_incremental_download.py::test_conflict_resolution_with_requeue[job]
0.00s setup    test/integ/cli/test_cli_incremental_download.py::test_conflict_resolution_with_requeue[task]
=========================================================================== 3 passed in 315.81s (0:05:15) ===========================================================================
(
```
- Have you run the unit tests? N/A
- Have you run the integration tests? Yes
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass. No

### Was this change documented?

- Are relevant docstrings in the code base updated? N/A
- Has the README.md been updated? If you modified CLI arguments, for instance. N/A

### Does this PR introduce new dependencies?

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?
No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
