### PR TITLE
chore: add cli-command to User Agent header in AWS API calls

### DIFF
--- a/src/deadline/client/cli/__init__.py
+++ b/src/deadline/client/cli/__init__.py
@@ -3,4 +3,5 @@
 __all__ = ["deadline_dev_gui_main", "main"]
 
 from . import deadline_dev_gui_main
+
 from ._deadline_cli import main

--- a/src/deadline/client/cli/_deadline_cli.py
+++ b/src/deadline/client/cli/_deadline_cli.py
@@ -1,102 +1,22 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 """
-The AWS Deadline Cloud CLI interface.
+This module exists to work around circular imports between the main CLI and each CLI group
 """
 
-import logging
-from logging import getLogger
-import sys
+from ._main import main  # noqa: F401
 
-import click
-
-from .. import version
-from ..config import get_setting, get_setting_default
-from ._common import _PROMPT_WHEN_COMPLETE
-from ._groups.bundle_group import cli_bundle
-from ._groups.config_group import cli_config
-from ._groups.auth_group import cli_auth
-from ._groups.farm_group import cli_farm
-from ._groups.fleet_group import cli_fleet
-from ._groups.handle_web_url_command import cli_handle_web_url
-from ._groups.job_group import cli_job
-from ._groups.queue_group import cli_queue
-from ._groups.worker_group import cli_worker
-from ._groups.attachment_group import cli_attachment
-from ._groups.manifest_group import cli_manifest
-
-logger = getLogger(__name__)
-
-CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
-_DEADLINE_LOG_LEVELS = [
-    "ERROR",
-    "WARNING",
-    "INFO",
-    "DEBUG",
-]  # Log Levels AWS Deadline Cloud Allows
-
-# Set the default log level based on the setting, must do here so we can pass into the click option
-_SETTING_LOG_LEVEL = get_setting("settings.log_level").upper()
-_DEFAULT_LOG_LEVEL = get_setting_default("settings.log_level")
-_CLI_DEFAULT_LOG_LEVEL = _DEFAULT_LOG_LEVEL
-if _SETTING_LOG_LEVEL not in _DEADLINE_LOG_LEVELS:
-    logger.warning(
-        f"Log Level '{_SETTING_LOG_LEVEL}' not in {_DEADLINE_LOG_LEVELS}. Defaulting to {_DEFAULT_LOG_LEVEL}"
-    )
-else:
-    _CLI_DEFAULT_LOG_LEVEL = _SETTING_LOG_LEVEL
-
-
-@click.group(context_settings=CONTEXT_SETTINGS)
-@click.version_option(version=version, prog_name="deadline")
-@click.option(
-    "--log-level",
-    type=click.Choice(_DEADLINE_LOG_LEVELS, case_sensitive=False),
-    default=_CLI_DEFAULT_LOG_LEVEL,
-    help="Set the logging level.",
+# New groups must be imported here to get added to the main CLI as subcommands
+from ._groups import (  # noqa: F401
+    bundle_group,
+    config_group,
+    auth_group,
+    farm_group,
+    fleet_group,
+    handle_web_url_command,
+    job_group,
+    queue_group,
+    worker_group,
+    attachment_group,
+    manifest_group,
 )
-@click.option(
-    "--redirect-output",
-    help="Redirects stdout and stderr messages to append to the specified file. "
-    "Useful for the 'deadlinew' command which does not produce terminal output by default on Windows.",
-)
-@click.option(
-    "--redirect-mode",
-    type=click.Choice(["append", "replace"], case_sensitive=False),
-    default="append",
-    help="When using the --redirect-output option, controls whether to append to or replace the output file.",
-)
-@click.pass_context
-def main(ctx: click.Context, log_level: str, redirect_output: str, redirect_mode: str):
-    """
-    The AWS Deadline Cloud CLI provides functionality to interact with the AWS Deadline Cloud
-    service.
-    """
-    if redirect_output:
-        # Set both stdout and stderr to write to the specified file, writing in line buffering mode
-        if redirect_mode == "append":
-            open_mode = "a"
-        else:
-            open_mode = "w"
-        sys.stdout = sys.stderr = open(redirect_output, open_mode, encoding="utf-8", buffering=1)
-    logging.basicConfig(level=log_level)
-    if log_level == "DEBUG":
-        logger.debug("Debug logging is on")
-
-    ctx.ensure_object(dict)
-    # By default don't prompt when the operation is complete
-    ctx.obj[_PROMPT_WHEN_COMPLETE] = False
-
-
-main.add_command(cli_bundle)
-main.add_command(cli_config)
-main.add_command(cli_auth)
-main.add_command(cli_farm)
-main.add_command(cli_fleet)
-main.add_command(cli_handle_web_url)
-main.add_command(cli_job)
-main.add_command(cli_queue)
-main.add_command(cli_worker)
-
-main.add_command(cli_attachment)
-main.add_command(cli_manifest)

--- a/src/deadline/client/cli/_groups/attachment_group.py
+++ b/src/deadline/client/cli/_groups/attachment_group.py
@@ -16,6 +16,7 @@ from typing import Optional
 from .click_logger import ClickLogger
 from .._common import _apply_cli_options_to_config, _handle_error
 from ...config import config_file
+from .._main import main
 
 from deadline.client import api
 from deadline.job_attachments.api.attachment import (
@@ -27,7 +28,7 @@ from deadline.job_attachments.exceptions import MissingJobAttachmentSettingsErro
 from deadline.job_attachments.models import FileConflictResolution, JobAttachmentS3Settings
 
 
-@click.group(name="attachment")
+@main.group(name="attachment")
 @_handle_error
 def cli_attachment():
     """

--- a/src/deadline/client/cli/_groups/auth_group.py
+++ b/src/deadline/client/cli/_groups/auth_group.py
@@ -12,6 +12,7 @@ import json
 import logging
 
 from ... import api
+from .._main import main
 from ...api._session import _modified_logging_level, AwsCredentialsSource
 from ...config import config_file, get_setting
 from .._common import _apply_cli_options_to_config, _handle_error
@@ -31,7 +32,7 @@ def _cli_on_pending_authorization(**kwargs):
         click.echo("Opening Deadline Cloud monitor. Please log in and then return here.")
 
 
-@click.group(name="auth")
+@main.group(name="auth")
 @_handle_error
 def cli_auth():
     """

--- a/src/deadline/client/cli/_groups/bundle_group.py
+++ b/src/deadline/client/cli/_groups/bundle_group.py
@@ -30,6 +30,7 @@ from .._common import (
     _handle_error,
     _ProgressBarCallbackManager,
 )
+from .._main import main
 from ._sigint_handler import SigIntHandler
 
 logger = logging.getLogger(__name__)
@@ -38,7 +39,7 @@ logger = logging.getLogger(__name__)
 sigint_handler = SigIntHandler()
 
 
-@click.group(name="bundle")
+@main.group(name="bundle")
 @_handle_error
 def cli_bundle():
     """

--- a/src/deadline/client/cli/_groups/config_group.py
+++ b/src/deadline/client/cli/_groups/config_group.py
@@ -10,9 +10,10 @@ import textwrap
 
 from ...config import config_file
 from .._common import _handle_error
+from .._main import main
 
 
-@click.group(name="config")
+@main.group(name="config")
 @_handle_error
 def cli_config():
     """

--- a/src/deadline/client/cli/_groups/farm_group.py
+++ b/src/deadline/client/cli/_groups/farm_group.py
@@ -11,9 +11,10 @@ from ... import api
 from ...config import config_file
 from ...exceptions import DeadlineOperationError
 from .._common import _apply_cli_options_to_config, _cli_object_repr, _handle_error
+from .._main import main
 
 
-@click.group(name="farm")
+@main.group(name="farm")
 @_handle_error
 def cli_farm():
     """

--- a/src/deadline/client/cli/_groups/fleet_group.py
+++ b/src/deadline/client/cli/_groups/fleet_group.py
@@ -11,9 +11,10 @@ from ... import api
 from ...config import config_file
 from ...exceptions import DeadlineOperationError
 from .._common import _apply_cli_options_to_config, _cli_object_repr, _handle_error
+from .._main import main
 
 
-@click.group(name="fleet")
+@main.group(name="fleet")
 @_handle_error
 def cli_fleet():
     """

--- a/src/deadline/client/cli/_groups/handle_web_url_command.py
+++ b/src/deadline/client/cli/_groups/handle_web_url_command.py
@@ -23,10 +23,11 @@ from .._deadline_web_url import (
     uninstall_deadline_web_url_handler,
     validate_resource_ids,
 )
+from .._main import main
 from .job_group import _download_job_output
 
 
-@click.command(name="handle-web-url")
+@main.command(name="handle-web-url")
 @click.argument("url", required=False)
 @click.option(
     "--prompt-when-complete",

--- a/src/deadline/client/cli/_groups/job_group.py
+++ b/src/deadline/client/cli/_groups/job_group.py
@@ -43,6 +43,7 @@ from ... import api
 from ...config import config_file
 from ...exceptions import DeadlineOperationError, DeadlineOperationTimedOut
 from .._common import _apply_cli_options_to_config, _cli_object_repr, _handle_error
+from .._main import main
 from ._sigint_handler import SigIntHandler
 
 logger = logging.getLogger("deadline.client.cli")
@@ -86,7 +87,7 @@ def _format_timestamp(timestamp: datetime.datetime, use_local_time: bool = False
 sigint_handler = SigIntHandler()
 
 
-@click.group(name="job")
+@main.group(name="job")
 @_handle_error
 def cli_job():
     """

--- a/src/deadline/client/cli/_groups/manifest_group.py
+++ b/src/deadline/client/cli/_groups/manifest_group.py
@@ -41,10 +41,11 @@ from deadline.job_attachments.models import (
 
 from ...exceptions import NonValidInputError
 from .._common import _apply_cli_options_to_config, _handle_error
+from .._main import main
 from .click_logger import ClickLogger
 
 
-@click.group(name="manifest")
+@main.group(name="manifest")
 @_handle_error
 def cli_manifest():
     """

--- a/src/deadline/client/cli/_groups/queue_group.py
+++ b/src/deadline/client/cli/_groups/queue_group.py
@@ -24,6 +24,7 @@ from ....job_attachments.models import (
     FileConflictResolution,
 )
 from .click_logger import ClickLogger
+from .._main import main
 from .._incremental_download import _incremental_output_download
 from .._pid_file_lock import PidFileLock
 from ....job_attachments._incremental_downloads.incremental_download_state import (
@@ -33,7 +34,7 @@ from ....job_attachments._incremental_downloads.incremental_download_state impor
 DOWNLOAD_CHECKPOINT_FILE_NAME = "download_checkpoint.json"
 
 
-@click.group(name="queue")
+@main.group(name="queue")
 @_handle_error
 def cli_queue():
     """

--- a/src/deadline/client/cli/_groups/worker_group.py
+++ b/src/deadline/client/cli/_groups/worker_group.py
@@ -11,9 +11,10 @@ from ... import api
 from ...config import config_file
 from ...exceptions import DeadlineOperationError
 from .._common import _apply_cli_options_to_config, _cli_object_repr, _handle_error
+from .._main import main
 
 
-@click.group(name="worker")
+@main.group(name="worker")
 @_handle_error
 def cli_worker():
     """

--- a/src/deadline/client/cli/_main.py
+++ b/src/deadline/client/cli/_main.py
@@ -1,0 +1,113 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+The AWS Deadline Cloud CLI interface.
+"""
+
+import logging
+import sys
+from logging import getLogger
+from typing import Optional
+
+import click
+
+from .. import version
+from ..api._session import session_context
+from ..config import get_setting, get_setting_default
+from ._common import _PROMPT_WHEN_COMPLETE
+
+logger = getLogger(__name__)
+
+CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
+_DEADLINE_LOG_LEVELS = [
+    "ERROR",
+    "WARNING",
+    "INFO",
+    "DEBUG",
+]  # Log Levels AWS Deadline Cloud Allows
+
+
+def _get_default_log_level() -> str:
+    """
+    Get the default log level from the config file.
+    """
+    # Set the default log level based on the setting, must do here so we can pass into the click option
+    _SETTING_LOG_LEVEL = get_setting("settings.log_level").upper()
+    _DEFAULT_LOG_LEVEL = get_setting_default("settings.log_level")
+    _CLI_DEFAULT_LOG_LEVEL = _DEFAULT_LOG_LEVEL
+    if _SETTING_LOG_LEVEL not in _DEADLINE_LOG_LEVELS:
+        logger.warning(
+            f"Log Level '{_SETTING_LOG_LEVEL}' not in {_DEADLINE_LOG_LEVELS}. Defaulting to {_DEFAULT_LOG_LEVEL}"
+        )
+    else:
+        _CLI_DEFAULT_LOG_LEVEL = _SETTING_LOG_LEVEL
+    return _CLI_DEFAULT_LOG_LEVEL
+
+
+class ContextTrackingCommand(click.Command):
+    """
+    Adds the current CLI command name to User Agent headers in boto requests
+    """
+
+    def invoke(self, ctx: click.Context):
+        # This is a global variable used to modify User Agent header in the default boto config
+        session_context["cli-command-name"] = ctx.command_path.replace(" ", ".")
+        return super().invoke(ctx)
+
+
+class ContextTrackingGroup(click.Group):
+    """
+    Adds the current CLI command name to User Agent headers in boto requests
+    """
+
+    # Special value documented in Click to make this group class the default
+    # See https://click.palletsprojects.com/en/stable/api/#click.Group.group_class
+    group_class = type
+
+    # Special value documented in Click to make this command class the default
+    # See https://click.palletsprojects.com/en/stable/api/#click.Group.command_class
+    command_class = ContextTrackingCommand
+
+
+@click.group(cls=ContextTrackingGroup, context_settings=CONTEXT_SETTINGS)
+@click.version_option(version=version, prog_name="deadline")
+@click.option(
+    "--log-level",
+    type=click.Choice(_DEADLINE_LOG_LEVELS, case_sensitive=False),
+    default=None,
+    help="Set the logging level.",
+)
+@click.option(
+    "--redirect-output",
+    help="Redirects stdout and stderr messages to append to the specified file. "
+    "Useful for the 'deadlinew' command which does not produce terminal output by default on Windows.",
+)
+@click.option(
+    "--redirect-mode",
+    type=click.Choice(["append", "replace"], case_sensitive=False),
+    default="append",
+    help="When using the --redirect-output option, controls whether to append to or replace the output file.",
+)
+@click.pass_context
+def main(ctx: click.Context, log_level: Optional[str], redirect_output: str, redirect_mode: str):
+    """
+    The AWS Deadline Cloud CLI provides functionality to interact with the AWS Deadline Cloud
+    service.
+    """
+    if redirect_output:
+        # Set both stdout and stderr to write to the specified file, writing in line buffering mode
+        if redirect_mode == "append":
+            open_mode = "a"
+        else:
+            open_mode = "w"
+        sys.stdout = sys.stderr = open(redirect_output, open_mode, encoding="utf-8", buffering=1)
+    if log_level is None:
+        log_level = _get_default_log_level()
+
+    logging.basicConfig(level=log_level)
+    if log_level == "DEBUG":
+        logger.debug("Debug logging is on")
+
+    ctx.ensure_object(dict)
+    # By default don't prompt when the operation is complete
+    ctx.obj[_PROMPT_WHEN_COMPLETE] = False

--- a/test/unit/deadline_client/cli/test_cli.py
+++ b/test/unit/deadline_client/cli/test_cli.py
@@ -7,13 +7,17 @@ Tests for the CLI generally.
 import subprocess
 import sys
 from unittest.mock import patch
+from typing import List
 
+import click
 import pytest
 from click.testing import CliRunner
 
 from deadline.client import api
 from deadline.client.cli import main
 from deadline.client.cli._common import _cli_object_repr
+from deadline.client.cli._main import ContextTrackingCommand, ContextTrackingGroup
+from deadline.client.api._session import get_default_client_config
 
 
 def test_cli_debug_logging_on(fresh_deadline_config):
@@ -162,3 +166,48 @@ def test_cli_object_repr(obj, expected):
     Test that the CLI object represntation is expected.
     """
     assert _cli_object_repr(obj) == expected
+
+
+def test_all_cli_commands_use_context_tracking_command():
+    """
+    Retrieves all click commands and verifies they all use the ContextTrackingCommand subclass
+    """
+
+    def _get_all_click_commands(
+        cmd: click.Command,
+        found_cmds: List[click.Command],
+    ) -> List[click.Command]:
+        """Gets all leaf commands under a given command"""
+        if isinstance(cmd, click.Group):
+            for subcmd in cmd.commands.values():
+                _get_all_click_commands(subcmd, found_cmds)
+        else:
+            found_cmds.append(cmd)
+        return found_cmds
+
+    all_commands = _get_all_click_commands(cmd=main, found_cmds=[])
+    assert all([isinstance(cmd, ContextTrackingCommand) for cmd in all_commands])
+
+
+def test_context_tracking_command_sets_boto_user_agent_extra():
+    """
+    Verifies that the ContextTrackingCommand sets the user_agent_extra in boto clients
+    """
+
+    @click.group(cls=ContextTrackingGroup, name="main")
+    def test_main():
+        pass
+
+    @test_main.group(name="subcommand")
+    def test_subcmd():
+        pass
+
+    @test_subcmd.command(name="command")
+    def test_command():
+        pass
+
+    CliRunner().invoke(test_main, args=["subcommand", "command"])
+
+    config = get_default_client_config()
+
+    assert "cli-command/main.subcommand.command" in config.user_agent_extra

--- a/test/unit/deadline_client/cli/test_cli_config.py
+++ b/test/unit/deadline_client/cli/test_cli_config.py
@@ -4,15 +4,14 @@
 Tests for the CLI config command.
 """
 
-import importlib
 import json
 import logging
-from unittest.mock import patch
 
 import pytest
 from click.testing import CliRunner
+from unittest.mock import patch
 
-import deadline
+import deadline.client.cli._main
 from deadline.client import config
 from deadline.client.cli import main
 from deadline.client.config import config_file
@@ -63,15 +62,12 @@ def test_log_level_updated(fresh_deadline_config, caplog, log_level):
     """Tests that the logging level is set to debug"""
     # GIVEN
     config.set_setting("settings.log_level", log_level)
-    # because the log level gets passed into a click decorator we need to reload the module to get
-    # the updated setting. This is fine for CLI usage because the module is reloaded each invocation
-    importlib.reload(deadline.client.cli._deadline_cli)
-    # WHEN
+
     with caplog.at_level(logging.DEBUG), patch.object(
-        deadline.client.cli._deadline_cli.logging, "basicConfig"
+        deadline.client.cli._main.logging, "basicConfig"
     ) as mock_basic_config:
-        # THEN
-        CliRunner().invoke(deadline.client.cli._deadline_cli.main, ["config", "show"])
+        # WHEN
+        CliRunner().invoke(deadline.client.cli._main.main, ["config", "show"])
 
     # THEN
     assert (
@@ -80,7 +76,7 @@ def test_log_level_updated(fresh_deadline_config, caplog, log_level):
     ) == (log_level == "NOT_A_LOG_LEVEL")
     # This only ever gets logged if the log_level passed into click is DEBUG
     assert ("Debug logging is on" in caplog.text) == (log_level == "DEBUG")
-    mock_basic_config.assert_called_with(
+    mock_basic_config.assert_called_once_with(
         level=log_level if log_level != "NOT_A_LOG_LEVEL" else "WARNING"
     )
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
In https://github.com/aws-deadline/deadline-cloud/pull/796, we modified the user agent header for requests coming from the new `deadline queue sync-output` command. This can actually be done for all CLI commands in a generic way with `click` so that all AWS API requests would have the same user agent header applied if coming from this CLI.

### What was the solution? (How)
Add a special `click.Group` and `click.Command` that will add `cli-command/<name>` user agent extra to all boto clients created with the default configuration. This should apply in most places, but not all currently (see https://github.com/aws-deadline/deadline-cloud/issues/814).

### What is the impact of this change?
User agent header for API calls made using boto clients includes `cli-command/<name>` information in them

### How was this change tested?

Manual testing with debug logging and invoking various commands from different groups

`deadline handle-web-url`

```
DEBUG:botocore.endpoint:Making request for OperationModel(name=GetStep) with params: {'url_path': '/2023-10-12/farms/farm-52989b2a791c45b391a79710729109df/queues/queue-a0c1468a7b7e49f98507ece8136b3ef2/jobs/job-c1b9069004af44fc9260cbc3e0375c64/steps/step-46c40f47188c452a9a98d2c09361af09', 'query_string': {}, 'method': 'GET', 'headers': {'User-Agent': 'Boto3/1.40.19 md/Botocore#1.40.19 ua/2.1 os/linux#5.10.240-218.959.amzn2int.x86_64 md/arch#x86_64 lang/python#3.11.7 md/pyimpl#CPython m/Z,b,D cfg/retry-mode#legacy Botocore/1.40.19 app/deadline-client#0.52.0 cli-command/deadline.handle-web-url'}, 'body': b'', 'host_prefix': 'management.', 'url': 'https://management.deadline.us-west-2.amazonaws.com/2023-10-12/farms/farm-52989b2a791c45b391a79710729109df/queues/queue-a0c1468a7b7e49f98507ece8136b3ef2/jobs/job-c1b9069004af44fc9260cbc3e0375c64/steps/step-46c40f47188c452a9a98d2c09361af09', 'context': {'client_region': 'us-west-2', 'client_config': <botocore.config.Config object at 0x7f5a68dac850>, 'has_streaming_input': False, 'auth_type': None, 'unsigned_payload': None, 'auth_options': ['aws.auth#sigv4']}}
```

`deadline farm get`

```
DEBUG:botocore.endpoint:Making request for OperationModel(name=GetFarm) with params: {'url_path': '/2023-10-12/farms/farm-3668bdc1c58345b8b29ce1526eef1588', 'query_string': {}, 'method': 'GET', 'headers': {'User-Agent': 'Boto3/1.40.18 md/Botocore#1.40.18 ua/2.1 os/linux#5.10.240-218.959.amzn2int.x86_64 md/arch#x86_64 lang/python#3.11.7 md/pyimpl#CPython m/Z,D,b cfg/retry-mode#legacy Botocore/1.40.18 app/deadline-client#0.52.1.post5+g8fc11d80d cli-command/deadline.farm.get'}, 'body': b'', 'host_prefix': 'management.', 'url': 'https://management.deadline.us-west-2.amazonaws.com/2023-10-12/farms/farm-3668bdc1c58345b8b29ce1526eef1588', 'context': {'client_region': 'us-west-2', 'client_config': <botocore.config.Config object at 0x7f5ff8bfc9d0>, 'has_streaming_input': False, 'auth_type': None, 'unsigned_payload': None, 'auth_options': ['aws.auth#sigv4']}}
```

`deadline queue list`

```
DEBUG:botocore.endpoint:Making request for OperationModel(name=ListQueues) with params: {'url_path': '/2023-10-12/farms/farm-3668bdc1c58345b8b29ce1526eef1588/queues', 'query_string': {}, 'method': 'GET', 'headers': {'User-Agent': 'Boto3/1.40.19 md/Botocore#1.40.19 ua/2.1 os/linux#5.10.240-218.959.amzn2int.x86_64 md/arch#x86_64 lang/python#3.11.7 md/pyimpl#CPython m/b,Z,D cfg/retry-mode#legacy Botocore/1.40.19 app/deadline-client#0.52.0 cli-command/deadline.queue.list'}, 'body': b'', 'host_prefix': 'management.', 'url': 'https://management.deadline.us-west-2.amazonaws.com/2023-10-12/farms/farm-3668bdc1c58345b8b29ce1526eef1588/queues', 'context': {'client_region': 'us-west-2', 'client_config': <botocore.config.Config object at 0x7fc1baa7c510>, 'has_streaming_input': False, 'auth_type': None, 'unsigned_payload': None, 'auth_options': ['aws.auth#sigv4']}}
```

- Have you run the unit tests?
    - Yes
- Have you run the integration tests?
    - Yes. All passed with a fleet size of 10.
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass.
    - No


Integ test results:

```
============================= slowest 5 durations ==============================
594.43s call     test/integ/cli/test_cli_incremental_download.py::test_incremental_download_dependency_chain
241.75s call     test/integ/cli/test_cli_incremental_download.py::test_conflict_resolution_with_requeue[step]
240.37s call     test/integ/cli/test_cli_incremental_download.py::test_conflict_resolution_with_requeue[task]
205.49s call     test/integ/cli/test_cli_incremental_download.py::test_incremental_download_many_small_files
189.99s call     test/integ/cli/test_cli_incremental_download.py::test_conflict_resolution_with_requeue[job]
============ 56 passed, 4 skipped, 1 xpassed in 1691.24s (0:28:11) =============
```

### Was this change documented?

N/A

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?
No

### Does this change impact security?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
