### PR TITLE
chore: do not force pytest color - codebuild doesn't support the ansi color escape codes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,7 +131,6 @@ known-first-party = ["deadline"]
 xfail_strict = true
 addopts = [
   "--durations=5",
-  "--color=yes",
   "--cov=src/deadline",
   "--cov-report=html:build/coverage",
   "--cov-report=xml:build/coverage/coverage.xml",


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Some environments do not support ansi color escape codes (ie. CodeBuild), so those logs become unreadable

Example
```
        for·[39;49;00m downloaded_file in·[39;49;00m downloaded_files:·[39;49;00m
            filename = downloaded_file.name·[39;49;00m
            if·[39;49;00m filename in·[39;49;00m expected_files:·[39;49;00m
                expected_marker = expected_files[filename]·[39;49;00m
                content = downloaded_file.read_text()·[39;49;00m
                # Verify file contains the original input·[39;49;00m·[39;49;00m
                if·[39;49;00m "·[39;49;00m1. Input to CreateJob from data_dir·[39;49;00m"·[39;49;00m in·[39;49;00m content and·[39;49;00m expected_marker in·[39;49;00m content:·[39;49;00m
                    verified_files.append(filename)·[39;49;00m
                else·[39;49;00m:·[39;49;00m
                    print·[39;49;00m(f·[39;49;00m"·[39;49;00m[dep_data_flow] WARNING: ·[39;49;00m{·[39;49;00mfilename}·[39;49;00m missing expected content·[39;49;00m"·[39;49;00m)·[39;49;00m
    ·[39;49;00m
        # Verify all 8 expected files were created and have correct content·[39;49;00m·[39;49;00m
>       assert·[39;49;00m len·[39;49;00m(verified_files) == 8·[39;49;00m, (·[39;49;00m
            f·[39;49;00m"·[39;49;00mExpected exactly 8 verified output files, found ·[39;49;00m{·[39;49;00mlen·[39;49;00m(verified_files)}·[39;49;00m: ·[39;49;00m{·[39;49;00mverified_files}·[39;49;00m"·[39;49;00m·[39;49;00m
        )·[39;49;00m
```

Since we're forcing it on with the pytest option. specifying `NO_COLOR=1` does not actually turn off the color escape codes

### What was the solution? (How)

Do not force color on by removing the option. Allow the user/env to detect if it's able to or to turn it off via `NO_COLOR`

### What is the impact of this change?

More readable logs in places where those escape codes are not available

### How was this change tested?



```
export NO_COLOR=1
```

<img width="937" height="267" alt="image" src="https://github.com/user-attachments/assets/db6ec677-cc1a-4254-b485-010db52b83b0" />


```
unset NO_COLOR
```

<img width="945" height="272" alt="image" src="https://github.com/user-attachments/assets/719fbcef-2d5e-4b8f-a31c-8d950fe72c2f" />


### Was this change documented?

N/A

### Does this PR introduce new dependencies?

No

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
