### PR TITLE
feat: Add --profile option to deadline queue sync-output

### DIFF
--- a/src/deadline/client/cli/_groups/queue_group.py
+++ b/src/deadline/client/cli/_groups/queue_group.py
@@ -211,6 +211,7 @@ def queue_get(**args):
 
 
 @cli_queue.command(name="sync-output")
+@click.option("--profile", help="The AWS profile to use.")
 @click.option("--farm-id", help="The AWS Deadline Cloud Farm to use.")
 @click.option("--queue-id", help="The AWS Deadline Cloud Queue to use.")
 @click.option(


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

All the other `deadline queue *` options accept it.

### What was the solution? (How)

Add the option. The change makes sync-output consistent with them.

### What is the impact of this change?

CLI command consistency.

### How was this change tested?

Ran the command with `--profile` before/after the change, confirmed it uses it correctly after.

### Was this change documented?

It's in the output of `deadline queue sync-output -h`.

### Does this PR introduce new dependencies?

No

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
