### PR TITLE
feat(job download): Add fileCount to JSON summary for programmatic access

### DIFF
--- a/src/deadline/client/cli/_groups/job_group.py
+++ b/src/deadline/client/cli/_groups/job_group.py
@@ -609,6 +609,7 @@ def _get_download_summary_message(
         return _get_json_line(
             JSON_MSG_TYPE_SUMMARY,
             f"Downloaded {download_summary.processed_files} files",
+            extra_properties={"fileCount": download_summary.processed_files},
         )
     else:
         paths_joined = "\n        ".join(
@@ -649,8 +650,15 @@ def _get_conflicting_filenames(filenames_by_root: dict[str, list[str]]) -> list[
     return conflicting_filenames
 
 
-def _get_json_line(messageType: str, value: Union[str, list[str], dict[str, Any]]) -> str:
-    return json.dumps({"messageType": messageType, "value": value}, ensure_ascii=True)
+def _get_json_line(
+    messageType: str,
+    value: Union[str, list[str], dict[str, Any]],
+    extra_properties: Optional[dict[str, Any]] = None,
+) -> str:
+    json_obj = {"messageType": messageType, "value": value}
+    if extra_properties:
+        json_obj.update(extra_properties)
+    return json.dumps(json_obj, ensure_ascii=True)
 
 
 def _get_value_from_json_line(

--- a/test/unit/deadline_client/cli/test_cli_job.py
+++ b/test/unit/deadline_client/cli/test_cli_job.py
@@ -21,7 +21,11 @@ from dateutil.tz import tzutc  # type: ignore[import]
 from deadline.client import api, config
 from deadline.client.cli import main
 from deadline.client.cli._groups import job_group
-from deadline.client.cli._groups.job_group import _get_summary_of_files_to_download_message
+from deadline.client.cli._groups.job_group import (
+    _get_summary_of_files_to_download_message,
+    _get_json_line,
+    _get_download_summary_message,
+)
 from deadline.client.exceptions import DeadlineOperationError, DeadlineOperationTimedOut
 from deadline.job_attachments.models import (
     FileConflictResolution,
@@ -1543,3 +1547,97 @@ You are about to download files which may come from multiple root directories. H
         assert "Download Summary:" in result.output
         assert result.exit_code == 0
         mock_expanduser.assert_any_call("~")
+
+
+class TestJsonLineHelpers:
+    """Tests for JSON line helper functions."""
+
+    def test_get_json_line_basic(self):
+        """Test _get_json_line with basic parameters."""
+        result = _get_json_line("test", "value")
+        parsed = json.loads(result)
+
+        assert parsed["messageType"] == "test"
+        assert parsed["value"] == "value"
+        assert len(parsed) == 2  # Only messageType and value
+
+    def test_get_json_line_with_none_extra_properties(self):
+        """Test _get_json_line with explicit None extra_properties."""
+        result = _get_json_line("test", "value", extra_properties=None)
+        parsed = json.loads(result)
+
+        assert parsed["messageType"] == "test"
+        assert parsed["value"] == "value"
+        assert len(parsed) == 2  # Only messageType and value
+
+    def test_get_json_line_with_kwargs(self):
+        """Test _get_json_line with additional properties."""
+        result = _get_json_line(
+            "summary", "Downloaded 5 files", extra_properties={"fileCount": 5, "status": "complete"}
+        )
+        parsed = json.loads(result)
+
+        assert parsed["messageType"] == "summary"
+        assert parsed["value"] == "Downloaded 5 files"
+        assert parsed["fileCount"] == 5
+        assert parsed["status"] == "complete"
+
+    def test_get_json_line_with_list_value(self):
+        """Test _get_json_line with list value and extra properties."""
+        result = _get_json_line("path", ["/path1", "/path2"], extra_properties={"count": 2})
+        parsed = json.loads(result)
+
+        assert parsed["messageType"] == "path"
+        assert parsed["value"] == ["/path1", "/path2"]
+        assert parsed["count"] == 2
+
+    def test_get_download_summary_message_json_with_file_count(self):
+        """Test _get_download_summary_message includes fileCount in JSON format."""
+        from deadline.job_attachments.progress_tracker import DownloadSummaryStatistics
+
+        # Create mock download summary
+        summary = DownloadSummaryStatistics()
+        summary.processed_files = 3
+        summary.processed_bytes = 1024
+        summary.total_time = 2.5
+        summary.transfer_rate = 409.6
+        summary.file_counts_by_root_directory = {"/downloads": 3}
+
+        result = _get_download_summary_message(summary, is_json_format=True)
+        parsed = json.loads(result)
+
+        assert parsed["messageType"] == "summary"
+        assert parsed["value"] == "Downloaded 3 files"
+        assert parsed["fileCount"] == 3
+
+    def test_get_download_summary_message_json_zero_files(self):
+        """Test _get_download_summary_message with zero files."""
+        from deadline.job_attachments.progress_tracker import DownloadSummaryStatistics
+
+        summary = DownloadSummaryStatistics()
+        summary.processed_files = 0
+
+        result = _get_download_summary_message(summary, is_json_format=True)
+        parsed = json.loads(result)
+
+        assert parsed["messageType"] == "summary"
+        assert parsed["value"] == "Downloaded 0 files"
+        assert parsed["fileCount"] == 0
+
+    def test_get_download_summary_message_non_json_unchanged(self):
+        """Test _get_download_summary_message non-JSON format is unchanged."""
+        from deadline.job_attachments.progress_tracker import DownloadSummaryStatistics
+
+        summary = DownloadSummaryStatistics()
+        summary.processed_files = 2
+        summary.processed_bytes = 512
+        summary.total_time = 1.0
+        summary.transfer_rate = 512.0
+        summary.file_counts_by_root_directory = {"/downloads": 2}
+
+        result = _get_download_summary_message(summary, is_json_format=False)
+
+        # Should be human-readable format, not JSON
+        assert "Download Summary:" in result
+        assert "Downloaded 2 files totaling" in result
+        assert not result.startswith('{"messageType":')


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Downstream tools (like Deadline Cloud Monitor) need to programmatically determine how many files were downloaded from the CLI's 
JSON output. Currently, they must parse the human-readable message string "Downloaded 5 files" to extract the file count.

Why this is problematic:
• String parsing is fragile and could break with message changes
• Future internationalization (i18n) would break existing parsing logic
• Not following established patterns for structured JSON API outputs
• Creates maintenance burden for downstream consumers

Requirement:
Provide a structured, backwards-compatible way for programmatic tools to access the file count without relying on string parsing.
### What was the solution? (How)

Enhanced the JSON summary output to include a dedicated fileCount field alongside the existing human-readable message.

Implementation:
1. Enhanced _get_json_line() function:
• Added extra_properties parameter to accept additional JSON fields
• Made it extensible for future metadata additions

2. Updated JSON summary output:
• Added fileCount field to summary messages in JSON format
• Preserved existing human-readable value field for backwards compatibility

Before:
```json
{"messageType": "summary", "value": "Downloaded 5 files"}
```


After:
```json
{"messageType": "summary", "fileCount": 5, "value": "Downloaded 5 files"}
```
### What is the impact of this change?

For Downstream Tools:
• Reliable programmatic access to file count via structured data
• No dependency on string parsing or message format
• Future-proof against i18n and message changes
• Consistent with other structured JSON outputs in the CLI

For Maintainability:
• Follows established JSON API patterns for backwards compatibility
• Reduces fragility in downstream integrations
• Enables confident CLI message updates without breaking consumers

Risk Mitigation:
• **Zero breaking changes:** Existing tools continue to work unchanged
• **Backwards compatible:** Original value field preserved
• **Extensible pattern:** Framework for adding future structured fields

Scope:
This change only affects the JSON output format (--output json flag). Human-readable output remains unchanged. The enhancement 
supports existing and future programmatic consumers while maintaining full backwards compatibility.
### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests?
- Yes
- Have you run the integration tests?
- No
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
- Yes
  that you ensure that the docker-based unit tests pass.

### Was this change documented?

N/A

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?
No
A breaking change is one that modifies a public contract in a way that is not backwards compatible. See the 
[Public Contracts](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#public-contracts) section
of the DEVELOPMENT.md for more information on the public contracts.

If so, then please describe the changes that users of this package must make to update their scripts, or Python applications.

### Does this change impact security?
No
- Does the change need to be threat modeled? For example, does it create or modify files/directories that must only be readable by the process owner?
    - If so, then please label this pull request with the "security" label. We'll work with you to analyze the threats.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
