### PR TITLE
chore: add unmapped paths to queue sync-output telemetry

### DIFF
--- a/src/deadline/client/cli/_incremental_download.py
+++ b/src/deadline/client/cli/_incremental_download.py
@@ -1255,6 +1255,7 @@ def _incremental_output_download(
             "unchanged": len(categorized_job_ids.unchanged),
             "inactive": len(categorized_job_ids.inactive),
         },
+        "unmapped_paths": len(unmapped_paths),
     }
     api.get_deadline_cloud_library_telemetry_client().record_event(
         event_type="com.amazon.rum.deadline.queue_sync_output_stats",

--- a/test/unit/deadline_client/cli/test_cli_queue_incremental_download.py
+++ b/test/unit/deadline_client/cli/test_cli_queue_incremental_download.py
@@ -60,7 +60,13 @@ def checkpoint_dir(tmp_path_factory):
 
 
 @pytest.fixture
-def deadline_mock():
+def deadline_telemetry_client_mock():
+    with patch.object(deadline.client.api, "get_deadline_cloud_library_telemetry_client") as m:
+        yield m
+
+
+@pytest.fixture
+def deadline_mock(deadline_telemetry_client_mock):
     """Create a mock boto3 session for all tests to use."""
     os.environ["AWS_ACCESS_KEY_ID"] = "ACCESSKEY"
     os.environ["AWS_SECRET_ACCESS_KEY"] = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
@@ -103,9 +109,7 @@ def deadline_mock():
             }
         }
 
-        with patch(
-            "botocore.client.BaseClient._make_api_call", new=mock_make_api_call
-        ), patch.object(deadline.client.api, "get_deadline_cloud_library_telemetry_client"):
+        with patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call):
             yield deadline_magicmock
 
 
@@ -1160,3 +1164,78 @@ def test_incremental_output_download_dry_run(fresh_deadline_config, deadline_moc
         in result.output
     ), result.output
     assert "This is a DRY RUN so the checkpoint was not saved" in result.output, result.output
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
+)
+def test_incremental_output_download_stats_telemetry(
+    fresh_deadline_config,
+    deadline_mock,
+    checkpoint_dir,
+    deadline_telemetry_client_mock,
+):
+    """Verifies the telemetry event for statistics matches the expected format"""
+    mock_job = create_fake_job_list(1)[0]
+    mock_job.update(
+        {
+            "name": "Mock Job",
+            "jobId": MOCK_JOB_ID,
+            "taskRunStatus": "READY",
+            "taskRunStatusCounts": {"SUCCEEDED": 1},
+            "storageProfileId": MOCK_STORAGE_PROFILE_ID,
+            "attachments": {
+                "manifests": [{"rootPath": "/", "rootPathFormat": "posix"}],
+                "fileSystem": "VIRTUAL",
+            },
+        }
+    )
+    del mock_job["endedAt"]
+    deadline_mock.SearchJobs = mock_search_jobs_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, [mock_job])
+    deadline_mock.GetJob = mock_get_job_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, [mock_job])
+
+    runner = CliRunner()
+    with freeze_time(ISO_FREEZE_TIME):
+        runner.invoke(
+            main,
+            [
+                "queue",
+                "sync-output",
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--storage-profile-id",
+                MOCK_STORAGE_PROFILE_ID,
+                "--checkpoint-dir",
+                checkpoint_dir,
+            ],
+        )
+
+    deadline_telemetry_client_mock().record_event.assert_called_once_with(
+        event_type="com.amazon.rum.deadline.queue_sync_output_stats",
+        event_details={
+            # All latencies will be zero due to freeze_time()
+            "latencies": {
+                "_get_download_candidate_jobs": 0,
+                "_categorize_jobs_in_checkpoint": 0,
+                "_get_job_sessions": 0,
+                "_update_checkpoint_jobs_list": 0,
+                "_download_all_manifests_with_absolute_paths": 0,
+                "download": 0,
+                "path_mapping": 0,
+            },
+            "dry_run": False,
+            "downloaded_session_actions": 0,
+            "downloaded_files": 0,
+            "downloaded_bytes": 0,
+            "jobs_with_downloads": {"completed": 0, "added": 1, "updated": 0},
+            "jobs_without_downloads": {
+                "not_using_job_attachments": 0,
+                "missing_storage_profile": 0,
+                "unchanged": 0,
+                "inactive": 0,
+            },
+            "unmapped_paths": 0,
+        },
+    )


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Follow up to telemetry PR for `deadline queue sync-output` https://github.com/aws-deadline/deadline-cloud/pull/793

We want to include the number of unmapped paths in the telemetry event as well

### What was the solution? (How)
Add `unmapped_paths` to the telemetry as well.

### What is the impact of this change?
`unmapped_paths` is included in telemetry events

### How was this change tested?

Ran the command with debug logging and verified telemetry event had new `unmapped_paths` field in it:

```json
{
    "latencies": {
        "_get_download_candidate_jobs": 1002399412,
        "_categorize_jobs_in_checkpoint": 7636531859,
        "_get_job_sessions": 29443605479,
        "_update_checkpoint_jobs_list": 1448302,
        "_download_all_manifests_with_absolute_paths": 11110526007,
        "download": null,
        "path_mapping": null
    },
    "dry_run": true,
    "downloaded_session_actions": 1060,
    "downloaded_files": 50363,
    "downloaded_bytes": 76044395,
    "jobs_with_downloads": {
        "completed": 45,
        "added": 1,
        "updated": 0
    },
    "jobs_without_downloads": {
        "not_using_job_attachments": 0,
        "missing_storage_profile": 0,
        "unchanged": 0,
        "inactive": 0
    },
    "unmapped_paths": 0,
    "accountId": "162923712518",
    "usage_mode": "CLI"
}
```

- Have you run the unit tests?
    - Yes
- Have you run the integration tests?
    - Yes
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass.
    - N/A

```
============================= slowest 5 durations ==============================
576.10s call     test/integ/cli/test_cli_incremental_download.py::test_incremental_download_dependency_chain
247.45s call     test/integ/cli/test_cli_incremental_download.py::test_conflict_resolution_with_requeue[step]
225.47s call     test/integ/cli/test_cli_incremental_download.py::test_conflict_resolution_with_requeue[task]
219.66s call     test/integ/cli/test_cli_incremental_download.py::test_conflict_resolution_with_requeue[job]
112.16s call     test/integ/cli/test_cli_incremental_download.py::test_incremental_download_dep_data_flow
============ 56 passed, 4 skipped, 1 xpassed in 1579.17s (0:26:19) =============
```

### Was this change documented?
No

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?
No

### Does this change impact security?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
