### PR TITLE
fix!: update attachment api visibility for future development as per code comment

### DIFF
--- a/src/deadline/client/cli/_groups/attachment_group.py
+++ b/src/deadline/client/cli/_groups/attachment_group.py
@@ -18,7 +18,10 @@ from .._common import _apply_cli_options_to_config, _handle_error
 from ...config import config_file
 
 from deadline.client import api
-from deadline.job_attachments import api as attachment_api
+from deadline.job_attachments.api.attachment import (
+    _attachment_download,
+    _attachment_upload,
+)
 from deadline.job_attachments._aws.deadline import get_queue
 from deadline.job_attachments.exceptions import MissingJobAttachmentSettingsError
 from deadline.job_attachments.models import FileConflictResolution, JobAttachmentS3Settings
@@ -120,7 +123,7 @@ def attachment_download(
     ):
         conflict_resolution = FileConflictResolution[conflict_resolution_setting]
 
-    attachment_api.attachment_download(
+    _attachment_download(
         manifests=manifests,
         s3_root_uri=s3_root_uri,
         boto3_session=boto3_session,
@@ -203,7 +206,7 @@ def attachment_upload(
     if not s3_root_uri:
         raise MissingJobAttachmentSettingsError("No valid s3 root path available")
 
-    attachment_api.attachment_upload(
+    _attachment_upload(
         root_dirs=root_dirs,
         manifests=manifests,
         s3_root_uri=s3_root_uri,

--- a/src/deadline/job_attachments/api/__init__.py
+++ b/src/deadline/job_attachments/api/__init__.py
@@ -1,8 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 __all__ = [
-    "attachment_download",
-    "attachment_upload",
     "summarize_paths_by_nested_directory",
     "summarize_paths_by_sequence",
     "human_readable_file_size",
@@ -10,7 +8,6 @@ __all__ = [
     "PathSummary",
 ]
 
-from .attachment import attachment_download, attachment_upload
 from ...common.path_utils import (
     human_readable_file_size,
     summarize_paths_by_nested_directory,

--- a/src/deadline/job_attachments/api/attachment.py
+++ b/src/deadline/job_attachments/api/attachment.py
@@ -24,7 +24,7 @@ from deadline.client.config import config_file
 from deadline.client.exceptions import NonValidInputError
 
 
-def attachment_download(
+def _attachment_download(
     manifests: List[str],
     s3_root_uri: str,
     boto3_session: boto3.Session,
@@ -124,12 +124,13 @@ def _attachment_download_with_root_manifests(
     logger.json(asdict(download_summary.convert_to_summary_statistics()))
 
 
-def attachment_upload(
+def _attachment_upload(
     manifests: List[str],
     s3_root_uri: str,
     boto3_session: boto3.Session,
     root_dirs: List[str] = [],
     path_mapping_rules: Optional[str] = None,
+    manifest_path_mapping: Optional[Dict[str, str]] = None,
     upload_manifest_path: Optional[str] = None,
     logger: ClickLogger = ClickLogger(False),
 ) -> List[UploadManifestInfo]:

--- a/test/unit/deadline_job_attachments/api/test_attachment.py
+++ b/test/unit/deadline_job_attachments/api/test_attachment.py
@@ -17,7 +17,10 @@ import deadline
 from deadline.client import api
 from deadline.client.config import config_file
 from deadline.client.exceptions import NonValidInputError
-from deadline.job_attachments import api as attachment_api
+from deadline.job_attachments.api.attachment import (
+    _attachment_download,
+    _attachment_upload,
+)
 from deadline.job_attachments.exceptions import MalformedAttachmentSettingError
 from deadline.job_attachments.progress_tracker import DownloadSummaryStatistics
 from deadline.job_attachments.asset_manifests import HashAlgorithm, hash_data
@@ -135,7 +138,7 @@ class TestAttachmentDownload:
             AssertionError,
             match="Path mapping rules have to be a list of dict.",
         ):
-            attachment_api.attachment_download(
+            _attachment_download(
                 manifests=[os.path.join(temp_assets_dir, PATH_MAPPING_HASH)],
                 s3_root_uri="s3://bucket/assetRoot",
                 boto3_session=session_mock,
@@ -166,7 +169,7 @@ class TestAttachmentDownload:
             json.dump([PATH_MAPPING], f)
 
         if conflict_resolution:
-            attachment_api.attachment_download(
+            _attachment_download(
                 manifests=[os.path.join(temp_assets_dir, PATH_MAPPING_HASH)],
                 s3_root_uri="s3://bucket/assetRoot",
                 boto3_session=session_mock,
@@ -174,7 +177,7 @@ class TestAttachmentDownload:
                 conflict_resolution=conflict_resolution,
             )
         else:
-            attachment_api.attachment_download(
+            _attachment_download(
                 manifests=[os.path.join(temp_assets_dir, PATH_MAPPING_HASH)],
                 s3_root_uri="s3://bucket/assetRoot",
                 boto3_session=session_mock,
@@ -206,7 +209,7 @@ class TestAttachmentDownload:
         ) as f:
             json.dump(MOCK_MANIFEST_CASE[manifest_case_key], f)
 
-        attachment_api.attachment_download(
+        _attachment_download(
             manifests=[os.path.join(temp_assets_dir, manifest_case_key)],
             s3_root_uri="s3://bucket/assetRoot",
             boto3_session=session_mock,
@@ -240,7 +243,7 @@ class TestAttachmentDownload:
             ) as f:
                 json.dump(MOCK_MANIFEST_CASE[manifest_case_key], f)
 
-        attachment_api.attachment_download(
+        _attachment_download(
             manifests=[os.path.join(temp_assets_dir, key) for key in MOCK_MANIFEST_CASE.keys()],
             s3_root_uri="s3://bucket/assetRoot",
             boto3_session=session_mock,
@@ -256,7 +259,7 @@ class TestAttachmentDownload:
 
     def test_download_invalid_input_manifests(self, session_mock):
         with pytest.raises(NonValidInputError):
-            attachment_api.attachment_download(
+            _attachment_download(
                 manifests=["file-not-found"],
                 s3_root_uri=TEST_S3_URI,
                 boto3_session=session_mock,
@@ -264,7 +267,7 @@ class TestAttachmentDownload:
 
     def test_download_invalid_input_path_mapping_rules(self, session_mock):
         with pytest.raises(NonValidInputError):
-            attachment_api.attachment_download(
+            _attachment_download(
                 manifests=[],
                 s3_root_uri=TEST_S3_URI,
                 boto3_session=session_mock,
@@ -273,7 +276,7 @@ class TestAttachmentDownload:
 
     def test_download_invalid_input_s3_root_uri(self, session_mock):
         with pytest.raises(MalformedAttachmentSettingError):
-            attachment_api.attachment_download(
+            _attachment_download(
                 manifests=[],
                 s3_root_uri="MalformedPath",
                 boto3_session=session_mock,
@@ -289,7 +292,7 @@ class TestAttachmentUpload:
             yield mock_upload_assets
 
     def test_upload_returns_manifest_info_list(self, temp_assets_dir, session_mock):
-        """Test that attachment_upload returns a list of UploadManifestInfo objects corresponding to the input manifests."""
+        """Test that _attachment_upload returns a list of UploadManifestInfo objects corresponding to the input manifests."""
         # Create a path mapping file with two rules
         path_mapping = [
             {
@@ -319,8 +322,8 @@ class TestAttachmentUpload:
         ) as mock_upload_assets:
             mock_upload_assets.return_value = ("key1", "hash1")
 
-            # Call attachment_upload
-            result = attachment_api.attachment_upload(
+            # Call _attachment_upload
+            result = _attachment_upload(
                 manifests=[os.path.join(temp_assets_dir, file_name)],
                 s3_root_uri=TEST_S3_URI,
                 boto3_session=session_mock,
@@ -339,7 +342,7 @@ class TestAttachmentUpload:
 
     def test_upload_invalid_input_manifests(self, session_mock):
         with pytest.raises(NonValidInputError):
-            attachment_api.attachment_upload(
+            _attachment_upload(
                 manifests=["file-not-found"],
                 s3_root_uri=TEST_S3_URI,
                 boto3_session=session_mock,
@@ -347,7 +350,7 @@ class TestAttachmentUpload:
 
     def test_upload_invalid_input_path_mapping_rules(self, session_mock):
         with pytest.raises(NonValidInputError):
-            attachment_api.attachment_upload(
+            _attachment_upload(
                 manifests=[],
                 s3_root_uri=TEST_S3_URI,
                 boto3_session=session_mock,
@@ -356,7 +359,7 @@ class TestAttachmentUpload:
 
     def test_upload_invalid_input_s3_root_uri(self, temp_assets_dir, session_mock):
         with pytest.raises(MalformedAttachmentSettingError):
-            attachment_api.attachment_upload(
+            _attachment_upload(
                 manifests=[],
                 s3_root_uri="MalformedPath",
                 root_dirs=[temp_assets_dir],
@@ -376,7 +379,7 @@ class TestAttachmentUpload:
         with open(mapping_file_path, "w", encoding="utf8") as f:
             json.dump([PATH_MAPPING], f)
 
-        attachment_api.attachment_upload(
+        _attachment_upload(
             manifests=[os.path.join(temp_assets_dir, file_name)],
             s3_root_uri=TEST_S3_URI,
             boto3_session=session_mock,
@@ -414,7 +417,7 @@ class TestAttachmentUpload:
         ) as f:
             json.dump(MOCK_MANIFEST_CASE[manifest_case_key], f)
 
-        attachment_api.attachment_upload(
+        _attachment_upload(
             manifests=[os.path.join(temp_assets_dir, file_name)],
             s3_root_uri=TEST_S3_URI,
             boto3_session=session_mock,
@@ -446,7 +449,7 @@ class TestAttachmentUpload:
 
         # Test No valid root defined for given manifest
         with pytest.raises(NonValidInputError) as error:
-            attachment_api.attachment_upload(
+            _attachment_upload(
                 manifests=[os.path.join(temp_assets_dir, manifest_case_key)],
                 s3_root_uri="s3://bucket/assetRoot",
                 root_dirs=[temp_assets_dir],
@@ -457,7 +460,7 @@ class TestAttachmentUpload:
 
     def test_upload_no_root_dir_or_mapping(self, temp_assets_dir, session_mock):
         with pytest.raises(NonValidInputError) as error:
-            attachment_api.attachment_upload(
+            _attachment_upload(
                 manifests=[],
                 s3_root_uri="s3://bucketName/rootPrefix",
                 boto3_session=session_mock,
@@ -467,7 +470,7 @@ class TestAttachmentUpload:
 
     def test_upload_both_root_dir_and_mapping(self, temp_assets_dir, session_mock):
         with pytest.raises(NonValidInputError) as error:
-            attachment_api.attachment_upload(
+            _attachment_upload(
                 manifests=[],
                 path_mapping_rules="fakefilepath",
                 root_dirs=[temp_assets_dir],


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The job attachment APIs are currently under active development. While the code comments already indicate these functions are internal, the function names don't follow the underscore prefix convention for internal APIs, creating inconsistency in the codebase.

### What was the solution? (How)
- Marked job attachment APIs as internal by adding underscore prefixes to function names
- Updated all internal references and imports to use the new internal naming convention

### What is the impact of this change?
- Clear API boundaries: Developers can easily identify which APIs are stable vs under development
- Prevents external dependencies on unstable APIs during the worker agent integration development
- Consistent codebase conventions for internal vs public APIs
- Reduces risk of breaking changes affecting external consumers

### How was this change tested?
- [x] Have you run the unit tests?
- [x] Have you run the integration tests?
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended that you ensure that the docker-based unit tests pass.

### Was this change documented?

- Are relevant docstrings in the code base updated?
  - They're already indicating the attachment CLI and API is beta
- Has the README.md been updated? If you modified CLI arguments, for instance.

### Does this PR introduce new dependencies?
*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?
Yes, any external code directly importing these functions will need to update imports.

Instead of importing 
```
from deadline.job_attachments import attachment_upload, attachment_download
```

Caller needs to directly import from

```
from deadline.job_attachments.api.attachment import (
    _attachment_download,
    _attachment_upload,
)
```
### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
