### PR TITLE
feat: Add deadlinew command and --redirect-output option

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,18 @@ api.list_farms()
 # {'farms': [{'farmId': 'farm-1234567890abcdefg', 'displayName': 'my-first-farm', ...},]}
 ```
 
+The `deadlinew` command can be used from GUIs to avoid displaying a terminal window in the background when on Windows.
+You can use the `--redirect-output` option to write the terminal output to a file.
+```sh
+$ deadlinew --redirect-output out.txt farm list
+$ cat out.txt
+- farmId: farm-1234567890abcdefg
+  displayName: my-first-farm
+```
+
+An example usage is to create a shortcut called "Deadline Settings" on your desktop that runs `C:\path\to\deadlinew.exe config gui`.
+Opening the shortcut will show the Deadline Settings dialog without a terminal window behind it.
+
 ## Job-related Files
 For job-related files and data, AWS Deadline Cloud supports either transferring files to AWS using job attachments or reading files from network storage that is shared between both your local workstation and your farm.
 
@@ -215,7 +227,7 @@ The command blocks until the job reaches a terminal state (SUCCEEDED, FAILED, CA
 - `2` - Job failed or has failed tasks
 - `3` - Job was canceled
 - `4` - Job was archived
-- `5` - Job is not compatible 
+- `5` - Job is not compatible
 
 ### Retrieving Job Logs
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,8 +58,11 @@ gui = [
 ]
 
 [project.scripts]
-deadline-dev-gui = "deadline.client.cli.deadline_dev_gui_main:main"
 deadline = "deadline.client.cli:main"
+
+[project.gui-scripts]
+deadline-dev-gui = "deadline.client.cli.deadline_dev_gui_main:main"
+deadlinew = "deadline.client.cli:main"
 
 [tool.hatch.build]
 artifacts = ["*_version.py"]

--- a/src/deadline/client/cli/_deadline_cli.py
+++ b/src/deadline/client/cli/_deadline_cli.py
@@ -6,6 +6,7 @@ The AWS Deadline Cloud CLI interface.
 
 import logging
 from logging import getLogger
+import sys
 
 import click
 
@@ -54,12 +55,30 @@ else:
     default=_CLI_DEFAULT_LOG_LEVEL,
     help="Set the logging level.",
 )
+@click.option(
+    "--redirect-output",
+    help="Redirects stdout and stderr messages to append to the specified file. "
+    "Useful for the 'deadlinew' command which does not produce terminal output by default on Windows.",
+)
+@click.option(
+    "--redirect-mode",
+    type=click.Choice(["append", "replace"], case_sensitive=False),
+    default="append",
+    help="When using the --redirect-output option, controls whether to append to or replace the output file.",
+)
 @click.pass_context
-def main(ctx: click.Context, log_level: str):
+def main(ctx: click.Context, log_level: str, redirect_output: str, redirect_mode: str):
     """
     The AWS Deadline Cloud CLI provides functionality to interact with the AWS Deadline Cloud
     service.
     """
+    if redirect_output:
+        # Set both stdout and stderr to write to the specified file, writing in line buffering mode
+        if redirect_mode == "append":
+            open_mode = "a"
+        else:
+            open_mode = "w"
+        sys.stdout = sys.stderr = open(redirect_output, open_mode, encoding="utf-8", buffering=1)
     logging.basicConfig(level=log_level)
     if log_level == "DEBUG":
         logger.debug("Debug logging is on")

--- a/test/unit/deadline_client/cli/test_cli.py
+++ b/test/unit/deadline_client/cli/test_cli.py
@@ -32,6 +32,83 @@ def test_cli_debug_logging_on(fresh_deadline_config):
     assert "Debug logging is on" in output
 
 
+def test_cli_redirect_output(fresh_deadline_config, tmp_path):
+    """
+    Confirm that --redirect-output FILENAME sends stdout/stderr to a file.
+    """
+    # The CliRunner environment already has the logger configured,
+    # so we instead run it as a subprocess to match the actual
+    # environment.
+    out_file = tmp_path / "out.txt"
+    output = subprocess.check_output(
+        args=[
+            sys.executable,
+            "-m",
+            "deadline",
+            "--redirect-output",
+            str(out_file),
+            "config",
+            "--help",
+        ],
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+
+    # No output should be printed to stdout or stderr.
+    assert output == ""
+
+    # The help information should be in the provided output file.
+    with open(out_file, encoding="utf-8") as fh:
+        file_output = fh.read()
+    assert file_output.startswith("Usage: ")
+    assert "Manage Deadline's workstation configuration." in file_output
+
+
+@pytest.mark.parametrize("redirect_mode", ("append", "replace"))
+def test_cli_redirect_output_with_mode(fresh_deadline_config, tmp_path, redirect_mode):
+    """
+    Confirm that --redirect-output FILENAME sends stdout/stderr to a file,
+    and --redirect-mode controls appending vs replacing.
+    """
+
+    out_file = tmp_path / "out.txt"
+    with open(out_file, "w", encoding="utf-8") as fh:
+        fh.write("Initial contents\n")
+
+    # The CliRunner environment already has the logger configured,
+    # so we instead run it as a subprocess to match the actual
+    # environment.
+    output = subprocess.check_output(
+        args=[
+            sys.executable,
+            "-m",
+            "deadline",
+            "--redirect-output",
+            str(out_file),
+            "--redirect-mode",
+            redirect_mode,
+            "config",
+            "--help",
+        ],
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+
+    # No output should be printed to stdout or stderr.
+    assert output == ""
+
+    # The help information should be in the provided output file.
+    with open(out_file, encoding="utf-8") as fh:
+        file_output = fh.read()
+    if redirect_mode == "append":
+        # Should be appended to the starting file contents.
+        assert file_output.startswith("Initial contents\nUsage: "), file_output
+    else:
+        # The starting file contents should be replaced
+        assert file_output.startswith("Usage: "), file_output
+    assert "Manage Deadline's workstation configuration." in file_output, file_output
+
+
 def test_cli_unfamiliar_exception(fresh_deadline_config):
     """
     Test that unfamiliar exceptions get the extra context


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Calling `deadline` CLI commands on Windows from shortcuts, GUI applications, or scheduled tasks, it opens
a terminal window in the background because deadline.exe is for the console subsystem. Python provides
`python.exe` for the console subsystem and `pythonw.exe` for the GUI subsystem. Deadline 10 provides the [deadlinecommandbg](https://docs.thinkboxsoftware.com/products/deadline/latest/1_User%20Manual/manual/command.html#running-background-commands) command.

### What was the solution? (How)

* The deadlinew command is like pythonw. It is a GUI entry point that on Windows, does not use the console subsystem. Running the command from a shortcut or as a subprocess from a GUI will not open a terminal window in the background while it runs.
* The `--redirect-output` option accepts a filename where to send all stdout and stderr from the command. This option is useful together with deadlinew to redirect the output of a command to a file.
* The `--redirect-mode` option controls whether `--redirect-output` should append to the output file, or replace it starting from the beginning.

### What is the impact of this change?

Use cases to call the Deadline CLI in Windows GUI contexts can now call `deadlinew` to avoid the terminal window
in the background, and can use the `--redirect-output` to save the printed output to a file.

### How was this change tested?

Added unit tests. Used deadlinew.exe in a Windows scheduled task, following https://docs.aws.amazon.com/deadline-cloud/latest/userguide/auto-downloads.html but without a .bat file in between and confirmed the expected behavior.

Here's the command I used to create the scheduled task. I used the farm and queue ids from the configuration, so they are not part of the command.
```
schtasks /create /tn "DeadlineOutputSync" /tr "C:\Programs\Python\Scripts\deadlinew.exe --redirect-output C:\auto-download\deadline_sync.log --redirect-mode append queue sync-output --profile mw-farm --checkpoint-dir C:\auto-download --storage-profile-id STORAGE_PROFILE_ID" /sc minute /mo 1
```

### Was this change documented?

Options are in the help output. Added a mention of `deadlinew` in the README.md.

### Does this PR introduce new dependencies?

No

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
