### PR TITLE
feat: Add 'deadline job requeue-tasks' command

### DIFF
--- a/src/deadline/client/api/_session.py
+++ b/src/deadline/client/api/_session.py
@@ -110,17 +110,18 @@ def invalidate_boto3_session_cache() -> None:
     _get_queue_user_boto3_session.cache_clear()
 
 
-def get_default_client_config() -> botocore.config.Config:
+def get_default_client_config(**kwargs) -> botocore.config.Config:
     """
     Gets the default botocore Config object to use with `boto3 clients`.
     This method adds user agent version and submitter context into botocore calls.
+    Additional arguments are forwarded to the Config constructor.
     """
     user_agent_extra = f"app/deadline-client#{version}"
     if session_context.get("submitter-name"):
         user_agent_extra += f" submitter/{session_context['submitter-name']}"
     if session_context.get("cli-command-name"):
         user_agent_extra += f" cli-command/{session_context['cli-command-name']}"
-    client_config = botocore.config.Config(user_agent_extra=user_agent_extra)
+    client_config = botocore.config.Config(user_agent_extra=user_agent_extra, **kwargs)
     return client_config
 
 

--- a/src/deadline/client/cli/_groups/bundle_group.py
+++ b/src/deadline/client/cli/_groups/bundle_group.py
@@ -140,7 +140,7 @@ def _interactive_confirmation_prompt(message: str, default_response: bool) -> bo
 @click.option(
     "--yes",
     is_flag=True,
-    help="Skip any confirmation prompts",
+    help="Automatically accept any confirmation prompts",
 )
 @click.option(
     "--require-paths-exist",

--- a/src/deadline/client/cli/_groups/job_group.py
+++ b/src/deadline/client/cli/_groups/job_group.py
@@ -19,22 +19,22 @@ import textwrap
 import click
 from botocore.exceptions import ClientError
 
-from deadline.client.api._session import _modified_logging_level
-from deadline.job_attachments.download import OutputDownloader
-from deadline.job_attachments.models import (
+from ...api._session import _modified_logging_level
+from ....job_attachments.download import OutputDownloader
+from ....job_attachments.models import (
     FileConflictResolution,
     JobAttachmentS3Settings,
     PathFormat,
 )
-from deadline.job_attachments._utils import (
+from ....job_attachments._utils import (
     WINDOWS_MAX_PATH_LENGTH,
     _is_windows_long_path_registry_enabled,
 )
-from deadline.job_attachments.progress_tracker import (
+from ....job_attachments.progress_tracker import (
     DownloadSummaryStatistics,
     ProgressReportMetadata,
 )
-from deadline.job_attachments._path_summarization import (
+from ....job_attachments._path_summarization import (
     human_readable_file_size,
     summarize_path_list,
 )
@@ -45,6 +45,7 @@ from ...exceptions import DeadlineOperationError, DeadlineOperationTimedOut
 from .._common import _apply_cli_options_to_config, _cli_object_repr, _handle_error
 from .._main import main
 from ._sigint_handler import SigIntHandler
+from ...api._session import get_default_client_config
 
 logger = logging.getLogger("deadline.client.cli")
 
@@ -186,14 +187,14 @@ def job_get(**args):
 @click.option("--job-id", help="The job to cancel.")
 @click.option(
     "--mark-as",
-    type=click.Choice(["CANCELED", "FAILED", "SUCCEEDED"], case_sensitive=False),
+    type=click.Choice(["SUSPENDED", "CANCELED", "FAILED", "SUCCEEDED"], case_sensitive=False),
     default="CANCELED",
     help="The status to apply to all active tasks in the job.",
 )
 @click.option(
     "--yes",
     is_flag=True,
-    help="Skip any confirmation prompts",
+    help="Automatically accept any confirmation prompts",
 )
 @_handle_error
 def job_cancel(mark_as: str, yes: bool, **args):
@@ -259,6 +260,158 @@ def job_cancel(mark_as: str, yes: bool, **args):
     else:
         click.echo(f"Canceling job and marking as {mark_as}...")
     deadline.update_job(farmId=farm_id, queueId=queue_id, jobId=job_id, targetTaskRunStatus=mark_as)
+
+
+@cli_job.command(name="requeue-tasks")
+@click.option("--profile", help="The AWS profile to use.")
+@click.option("--farm-id", help="The farm to use.")
+@click.option("--queue-id", help="The queue to use.")
+@click.option("--job-id", help="The job to requeue tasks for.")
+@click.option(
+    "--run-status",
+    type=click.Choice(
+        ["SUSPENDED", "CANCELED", "FAILED", "SUCCEEDED", "NOT_COMPATIBLE"], case_sensitive=False
+    ),
+    multiple=True,
+    help="Requeue tasks of this status. Repeat the option to provide multiple statuses.",
+)
+@click.option(
+    "--yes",
+    is_flag=True,
+    help="Automatically accept any confirmation prompts",
+)
+@_handle_error
+def job_requeue_tasks(run_status: Optional[list[str]], **args):
+    """
+    Requeue tasks of a job. By default, requeues all FAILED, CANCELED, and SUSPENDED tasks.
+
+    Use the --run-status option to requeue tasks of different status.
+    """
+    # Get a temporary config object with the standard options handled
+    config = _apply_cli_options_to_config(
+        required_options={"farm_id", "queue_id", "job_id"}, **args
+    )
+
+    farm_id = config_file.get_setting("defaults.farm_id", config=config)
+    queue_id = config_file.get_setting("defaults.queue_id", config=config)
+    job_id = config_file.get_setting("defaults.job_id", config=config)
+
+    if not run_status:
+        run_status_set = {"SUSPENDED", "CANCELED", "FAILED"}
+    else:
+        run_status_set = {status.upper() for status in run_status}
+
+    session = api.get_boto3_session(config=config)
+    deadline_client = api.get_boto3_client("deadline", config=config)
+
+    # Create a separate API client for the update_task calls, using the "adaptive" retry strategy.
+    # This strategy is better suited to repeatedly calling the API for a longer duration, because it
+    # retains backoff data across calls instead of starting fresh each time.
+    requeues_client_config = get_default_client_config(
+        retries=dict(mode="adaptive", total_max_attempts=5)
+    )
+    deadline_client_for_requeues = session.client("deadline", config=requeues_client_config)
+
+    # Print a summary of the job's task run statuses
+    job = deadline_client.get_job(farmId=farm_id, queueId=queue_id, jobId=job_id)
+
+    click.echo(f"Job: {job['name']} ({job['jobId']})")
+    # Remove the zero-count status counts for a shorter summary
+    task_run_status_counts = {
+        name.upper(): count for name, count in job["taskRunStatusCounts"].items() if count != 0
+    }
+    click.echo(_cli_object_repr({"taskRunStatusCounts": task_run_status_counts}))
+    click.echo(f"Requeuing all tasks with run status among: {', '.join(sorted(run_status_set))}")
+
+    total_task_count_to_requeue = sum(
+        count for name, count in task_run_status_counts.items() if name in run_status_set
+    )
+    summary_task_count_by_status = ", ".join(
+        f"{count} {name} tasks"
+        for name, count in task_run_status_counts.items()
+        if name in run_status_set and count != 0
+    )
+    summary_tasks_message = f"{total_task_count_to_requeue} total tasks"
+
+    if total_task_count_to_requeue == 0:
+        click.echo("No tasks to requeue.")
+        return
+
+    # Ask for confirmation about requeuing the selected tasks
+    if config_file.str2bool(config_file.get_setting("settings.auto_accept", config=config)):
+        click.echo(
+            f"Estimated {summary_tasks_message} ({summary_task_count_by_status}) to requeue."
+        )
+    else:
+        click.echo(
+            f"This action will requeue an estimated {summary_tasks_message} ({summary_task_count_by_status})"
+        )
+        if not click.confirm(
+            "Are you sure you want to requeue these tasks?",
+            default=None,
+        ):
+            click.echo("No tasks were requeued.")
+            sys.exit(1)
+        click.echo("Requeuing tasks...")
+
+    total_count_requeued = 0
+    # Use a paginator to get all the steps
+    paginator = deadline_client.get_paginator("list_steps")
+    steps = []
+    for page in paginator.paginate(farmId=farm_id, queueId=queue_id, jobId=job_id):
+        steps.extend(page["steps"])
+
+    # For each step, requeue all the tasks matching the run statuses
+    for step in steps:
+        click.echo(f"\nStep: {step['name']} ({step['stepId']})")
+        step_task_count_to_requeue = sum(
+            count for name, count in step["taskRunStatusCounts"].items() if name in run_status_set
+        )
+        summary_task_count_by_status = ", ".join(
+            f"{count} {name} tasks"
+            for name, count in step["taskRunStatusCounts"].items()
+            if name in run_status_set and count != 0
+        )
+        summary_tasks_message = f"{step_task_count_to_requeue} total tasks"
+        if step_task_count_to_requeue == 0:
+            click.echo("  Step has no tasks to requeue.")
+            continue
+        else:
+            click.echo(
+                f"  Requeuing an estimated {summary_tasks_message} ({summary_task_count_by_status})..."
+            )
+
+        paginator = deadline_client.get_paginator("list_tasks")
+        for page in paginator.paginate(
+            farmId=farm_id, queueId=queue_id, jobId=job_id, stepId=step["stepId"]
+        ):
+            for task in page["tasks"]:
+                if task["runStatus"].upper() in run_status_set:
+                    parameters = task.get("parameters", {})
+                    if parameters:
+                        task_summary = (
+                            ",".join(
+                                f"{param}={list(parameters[param].values())[0]}"
+                                for param in parameters
+                            )
+                            + f" ({task['taskId']})"
+                        )
+                    else:
+                        task_summary = task["taskId"]
+                    click.echo(f"    {task['runStatus']} {task_summary}")
+                    # Requeue means to set the target run status to PENDING. If a task has no dependencies,
+                    # it will switch to READY immediately.
+                    deadline_client_for_requeues.update_task(
+                        farmId=farm_id,
+                        queueId=queue_id,
+                        jobId=job_id,
+                        stepId=step["stepId"],
+                        taskId=task["taskId"],
+                        targetRunStatus="PENDING",
+                    )
+                    total_count_requeued += 1
+
+    click.echo(f"\nRequeued a total of {total_count_requeued} tasks.")
 
 
 def _download_job_output(
@@ -715,7 +868,7 @@ def _assert_valid_path(path: str) -> None:
 @click.option(
     "--yes",
     is_flag=True,
-    help="Skip any confirmation prompts",
+    help="Automatically accept any confirmation prompts",
 )
 @click.option(
     "--output",

--- a/test/unit/deadline_client/cli/test_cli_job_requeue_tasks.py
+++ b/test/unit/deadline_client/cli/test_cli_job_requeue_tasks.py
@@ -1,0 +1,356 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Tests for the CLI job commands.
+"""
+
+import pytest
+from unittest.mock import patch, call
+
+import click
+from click.testing import CliRunner
+
+from deadline.client.cli import main
+from ..shared_constants import (
+    MOCK_FARM_ID,
+    MOCK_JOB_ID,
+    MOCK_QUEUE_ID,
+    MOCK_STEP_ID,
+)
+
+
+MOCK_TASK_ID_PREFIX = MOCK_STEP_ID.replace("step-", "task-")
+
+
+def add_mocks_for_job_requeue_tasks(deadline_mock):
+    """
+    Adds mock return values to the deadline_mock for sharing across
+    the different 'deadline job requeue-tasks' tests.
+    """
+    # These mock returns only contain the properties that requeue-tasks needs
+    deadline_mock.GetJob.return_value = {
+        "jobId": MOCK_JOB_ID,
+        "name": "Mock Job",
+        "taskRunStatus": "RUNNING",
+        "taskRunStatusCounts": {
+            "SUCCEEDED": 1,
+            "SUSPENDED": 1,
+            "CANCELED": 1,
+            "FAILED": 1,
+            "NOT_COMPATIBLE": 1,
+            "RUNNING": 1,
+        },
+    }
+    deadline_mock.ListSteps.return_value = {
+        "steps": [
+            {
+                "stepId": MOCK_STEP_ID,
+                "name": "Step Name",
+                "taskRunStatus": "RUNNING",
+                "taskRunStatusCounts": {
+                    "SUCCEEDED": 1,
+                    "SUSPENDED": 1,
+                    "CANCELED": 1,
+                    "FAILED": 1,
+                    "NOT_COMPATIBLE": 1,
+                    "RUNNING": 1,
+                },
+            }
+        ]
+    }
+    deadline_mock.ListTasks.return_value = {
+        "tasks": [
+            {
+                "taskId": f"{MOCK_TASK_ID_PREFIX}-0",
+                "runStatus": "SUCCEEDED",
+                "parameters": {"TestCase": {"string": "SUCCEEDED task"}},
+            },
+            {
+                "taskId": f"{MOCK_TASK_ID_PREFIX}-1",
+                "runStatus": "SUSPENDED",
+                "parameters": {"TestCase": {"string": "SUSPENDED task"}},
+            },
+            {
+                "taskId": f"{MOCK_TASK_ID_PREFIX}-2",
+                "runStatus": "CANCELED",
+                "parameters": {"TestCase": {"string": "CANCELED task"}},
+            },
+            {
+                "taskId": f"{MOCK_TASK_ID_PREFIX}-3",
+                "runStatus": "FAILED",
+                "parameters": {"TestCase": {"string": "FAILED task"}},
+            },
+            {
+                "taskId": f"{MOCK_TASK_ID_PREFIX}-4",
+                "runStatus": "NOT_COMPATIBLE",
+                "parameters": {"TestCase": {"string": "NOT_COMPATIBLE task"}},
+            },
+            {
+                "taskId": f"{MOCK_TASK_ID_PREFIX}-5",
+                "runStatus": "RUNNING",
+                "parameters": {"TestCase": {"string": "RUNNING task"}},
+            },
+        ]
+    }
+    deadline_mock.UpdateTask.return_value = {}
+
+
+def test_cli_job_requeue_tasks(fresh_deadline_config, deadline_mock):
+    """
+    Tests that 'deadline job requeue-tasks' requeues all the tasks of the correct run status.
+    """
+    add_mocks_for_job_requeue_tasks(deadline_mock)
+
+    with patch.object(click, "confirm") as mock_confirm:
+        mock_confirm.return_value = True
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "job",
+                "requeue-tasks",
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--job-id",
+                MOCK_JOB_ID,
+            ],
+        )
+
+    assert (
+        result.output
+        == f"""Job: Mock Job ({MOCK_JOB_ID})
+taskRunStatusCounts:
+  SUCCEEDED: 1
+  SUSPENDED: 1
+  CANCELED: 1
+  FAILED: 1
+  NOT_COMPATIBLE: 1
+  RUNNING: 1
+
+Requeuing all tasks with run status among: CANCELED, FAILED, SUSPENDED
+This action will requeue an estimated 3 total tasks (1 SUSPENDED tasks, 1 CANCELED tasks, 1 FAILED tasks)
+Requeuing tasks...
+
+Step: Step Name ({MOCK_STEP_ID})
+  Requeuing an estimated 3 total tasks (1 SUSPENDED tasks, 1 CANCELED tasks, 1 FAILED tasks)...
+    SUSPENDED TestCase=SUSPENDED task ({MOCK_TASK_ID_PREFIX}-1)
+    CANCELED TestCase=CANCELED task ({MOCK_TASK_ID_PREFIX}-2)
+    FAILED TestCase=FAILED task ({MOCK_TASK_ID_PREFIX}-3)
+
+Requeued a total of 3 tasks.
+"""
+    )
+    mock_confirm.assert_called_once_with(
+        "Are you sure you want to requeue these tasks?", default=None
+    )
+    assert deadline_mock.UpdateTask.call_args_list == [
+        call(
+            farmId=MOCK_FARM_ID,
+            queueId=MOCK_QUEUE_ID,
+            jobId=MOCK_JOB_ID,
+            stepId=MOCK_STEP_ID,
+            taskId=f"{MOCK_TASK_ID_PREFIX}-1",
+            targetRunStatus="PENDING",
+        ),
+        call(
+            farmId=MOCK_FARM_ID,
+            queueId=MOCK_QUEUE_ID,
+            jobId=MOCK_JOB_ID,
+            stepId=MOCK_STEP_ID,
+            taskId=f"{MOCK_TASK_ID_PREFIX}-2",
+            targetRunStatus="PENDING",
+        ),
+        call(
+            farmId=MOCK_FARM_ID,
+            queueId=MOCK_QUEUE_ID,
+            jobId=MOCK_JOB_ID,
+            stepId=MOCK_STEP_ID,
+            taskId=f"{MOCK_TASK_ID_PREFIX}-3",
+            targetRunStatus="PENDING",
+        ),
+    ]
+
+
+def test_cli_job_requeue_tasks_user_says_no(fresh_deadline_config, deadline_mock):
+    """
+    Tests that 'deadline job requeue-tasks' requeues nothing if the user says "no" to the confirmation prompt.
+    """
+    add_mocks_for_job_requeue_tasks(deadline_mock)
+
+    with patch.object(click, "confirm") as mock_confirm:
+        mock_confirm.return_value = False
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "job",
+                "requeue-tasks",
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--job-id",
+                MOCK_JOB_ID,
+            ],
+        )
+
+    assert (
+        result.output
+        == f"""Job: Mock Job ({MOCK_JOB_ID})
+taskRunStatusCounts:
+  SUCCEEDED: 1
+  SUSPENDED: 1
+  CANCELED: 1
+  FAILED: 1
+  NOT_COMPATIBLE: 1
+  RUNNING: 1
+
+Requeuing all tasks with run status among: CANCELED, FAILED, SUSPENDED
+This action will requeue an estimated 3 total tasks (1 SUSPENDED tasks, 1 CANCELED tasks, 1 FAILED tasks)
+No tasks were requeued.
+"""
+    )
+    mock_confirm.assert_called_once_with(
+        "Are you sure you want to requeue these tasks?", default=None
+    )
+    assert deadline_mock.UpdateTask.call_args_list == []
+
+
+@pytest.mark.parametrize(
+    "run_status,task_id",
+    [
+        ("SUCCEEDED", f"{MOCK_TASK_ID_PREFIX}-0"),
+        ("SUSPENDED", f"{MOCK_TASK_ID_PREFIX}-1"),
+        ("CANCELED", f"{MOCK_TASK_ID_PREFIX}-2"),
+        ("FAILED", f"{MOCK_TASK_ID_PREFIX}-3"),
+        ("NOT_COMPATIBLE", f"{MOCK_TASK_ID_PREFIX}-4"),
+    ],
+)
+def test_cli_job_requeue_tasks_of_each_status(
+    run_status, task_id, fresh_deadline_config, deadline_mock
+):
+    """
+    Tests that 'deadline job requeue-tasks' requeues the one task of each selected run status.
+    """
+    add_mocks_for_job_requeue_tasks(deadline_mock)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "job",
+            "requeue-tasks",
+            "--farm-id",
+            MOCK_FARM_ID,
+            "--queue-id",
+            MOCK_QUEUE_ID,
+            "--job-id",
+            MOCK_JOB_ID,
+            "--yes",
+            "--run-status",
+            run_status,
+        ],
+    )
+
+    assert (
+        result.output
+        == f"""Job: Mock Job ({MOCK_JOB_ID})
+taskRunStatusCounts:
+  SUCCEEDED: 1
+  SUSPENDED: 1
+  CANCELED: 1
+  FAILED: 1
+  NOT_COMPATIBLE: 1
+  RUNNING: 1
+
+Requeuing all tasks with run status among: {run_status}
+Estimated 1 total tasks (1 {run_status} tasks) to requeue.
+
+Step: Step Name ({MOCK_STEP_ID})
+  Requeuing an estimated 1 total tasks (1 {run_status} tasks)...
+    {run_status} TestCase={run_status} task ({task_id})
+
+Requeued a total of 1 tasks.
+"""
+    )
+    assert deadline_mock.UpdateTask.call_args_list == [
+        call(
+            farmId=MOCK_FARM_ID,
+            queueId=MOCK_QUEUE_ID,
+            jobId=MOCK_JOB_ID,
+            stepId=MOCK_STEP_ID,
+            taskId=task_id,
+            targetRunStatus="PENDING",
+        ),
+    ]
+
+
+def test_cli_job_requeue_tasks_multiple_statuses(fresh_deadline_config, deadline_mock):
+    """
+    Tests that 'deadline job requeue-tasks' requeues all statuses provided with repeated
+    --run-status options.
+    """
+    add_mocks_for_job_requeue_tasks(deadline_mock)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "job",
+            "requeue-tasks",
+            "--farm-id",
+            MOCK_FARM_ID,
+            "--queue-id",
+            MOCK_QUEUE_ID,
+            "--job-id",
+            MOCK_JOB_ID,
+            "--run-status",
+            "CANCELED",
+            "--yes",
+            "--run-status",
+            "FAILED",
+        ],
+    )
+
+    assert (
+        result.output
+        == f"""Job: Mock Job ({MOCK_JOB_ID})
+taskRunStatusCounts:
+  SUCCEEDED: 1
+  SUSPENDED: 1
+  CANCELED: 1
+  FAILED: 1
+  NOT_COMPATIBLE: 1
+  RUNNING: 1
+
+Requeuing all tasks with run status among: CANCELED, FAILED
+Estimated 2 total tasks (1 CANCELED tasks, 1 FAILED tasks) to requeue.
+
+Step: Step Name ({MOCK_STEP_ID})
+  Requeuing an estimated 2 total tasks (1 CANCELED tasks, 1 FAILED tasks)...
+    CANCELED TestCase=CANCELED task ({MOCK_TASK_ID_PREFIX}-2)
+    FAILED TestCase=FAILED task ({MOCK_TASK_ID_PREFIX}-3)
+
+Requeued a total of 2 tasks.
+"""
+    )
+    assert deadline_mock.UpdateTask.call_args_list == [
+        call(
+            farmId=MOCK_FARM_ID,
+            queueId=MOCK_QUEUE_ID,
+            jobId=MOCK_JOB_ID,
+            stepId=MOCK_STEP_ID,
+            taskId=f"{MOCK_TASK_ID_PREFIX}-2",
+            targetRunStatus="PENDING",
+        ),
+        call(
+            farmId=MOCK_FARM_ID,
+            queueId=MOCK_QUEUE_ID,
+            jobId=MOCK_JOB_ID,
+            stepId=MOCK_STEP_ID,
+            taskId=f"{MOCK_TASK_ID_PREFIX}-3",
+            targetRunStatus="PENDING",
+        ),
+    ]

--- a/test/unit/deadline_client/cli/test_cli_queue_incremental_download.py
+++ b/test/unit/deadline_client/cli/test_cli_queue_incremental_download.py
@@ -7,15 +7,12 @@ Tests for the CLI queue incremental output download command.
 import os
 import sys
 import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 from datetime import datetime, timedelta
 
-import botocore
-from moto import mock_aws
 from freezegun import freeze_time
 from click.testing import CliRunner
 from deadline.client.cli import main
-import deadline.client
 import psutil
 
 from ..shared_constants import (
@@ -35,6 +32,7 @@ from deadline.job_attachments._incremental_downloads.incremental_download_state 
     EVENTUAL_CONSISTENCY_MAX_SECONDS,
 )
 from deadline.job_attachments.models import StorageProfileOperatingSystemFamily
+import deadline.client.api
 
 ISO_FREEZE_TIME_MINUS_5MIN = "2025-05-26 11:55:00+00:00"
 ISO_FREEZE_TIME_MINUS_1MIN = "2025-05-26 11:59:00+00:00"
@@ -63,54 +61,6 @@ def checkpoint_dir(tmp_path_factory):
 def deadline_telemetry_client_mock():
     with patch.object(deadline.client.api, "get_deadline_cloud_library_telemetry_client") as m:
         yield m
-
-
-@pytest.fixture
-def deadline_mock(deadline_telemetry_client_mock):
-    """Create a mock boto3 session for all tests to use."""
-    os.environ["AWS_ACCESS_KEY_ID"] = "ACCESSKEY"
-    os.environ["AWS_SECRET_ACCESS_KEY"] = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
-    os.environ["AWS_SECURITY_TOKEN"] = "testing"
-    os.environ["AWS_SESSION_TOKEN"] = "testing"
-    os.environ["AWS_DEFAULT_REGION"] = "us-west-2"
-
-    with mock_aws():
-        deadline_magicmock = MagicMock()
-
-        # See https://docs.getmoto.org/en/latest/docs/services/patching_other_services.html
-        original_make_api_call = botocore.client.BaseClient._make_api_call
-
-        def mock_make_api_call(self, operation_name, kwarg):
-            service_name = self._service_model.service_name
-
-            if service_name == "deadline":
-                # Send the "GetQueue" operation, i.e. the get_queue call, to deadline_magicmock.GetQueue()
-                return getattr(deadline_magicmock, operation_name)(**kwarg)
-
-            # If we don't want to patch the API call
-            return original_make_api_call(self, operation_name, kwarg)
-
-        deadline_magicmock.GetQueue.return_value = {
-            "queueId": MOCK_QUEUE_ID,
-            "displayName": "Mock Queue",
-            "jobAttachmentSettings": {
-                "rootPrefix": "MockRootPrefix",
-                "s3BucketName": "mock-s3-bucket",
-            },
-        }
-        deadline_magicmock.ListSessions.return_value = {"sessions": []}
-        deadline_magicmock.ListSessionActions.return_value = {"sessionActions": []}
-        deadline_magicmock.AssumeQueueRoleForUser.return_value = {
-            "credentials": {
-                "accessKeyId": "ACCESSKEY",
-                "secretAccessKey": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-                "sessionToken": "testing",
-                "expiration": datetime.fromisoformat("2025-08-07T01:01:44+00:00"),
-            }
-        }
-
-        with patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call):
-            yield deadline_magicmock
 
 
 @pytest.mark.skipif(

--- a/test/unit/deadline_client/conftest.py
+++ b/test/unit/deadline_client/conftest.py
@@ -4,12 +4,18 @@
 Common fixtures for Deadline Client Library tests.
 """
 
+import botocore
+from moto import mock_aws
+import deadline.client.api
 from deadline.client.api._telemetry import TelemetryClient
 import tempfile
 import os
+from datetime import datetime
 
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 import pytest
+
+from .shared_constants import MOCK_QUEUE_ID
 
 
 @pytest.fixture(scope="function")
@@ -57,3 +63,59 @@ def mock_telemetry():
 
     with patch.object(TelemetryClient, "record_event") as mock_telemetry:
         yield mock_telemetry
+
+
+@pytest.fixture
+def deadline_mock():
+    """
+    Uses the moto library to create a mock boto3 session for all tests to use.
+    Mocks Deadline Cloud via the approach moto recommends for services that it
+    lacks an implementation for.
+
+    Returns a MagicMock that handles all the deadline client operations.
+    """
+    os.environ["AWS_ACCESS_KEY_ID"] = "ACCESSKEY"
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+    os.environ["AWS_SECURITY_TOKEN"] = "testing"
+    os.environ["AWS_SESSION_TOKEN"] = "testing"
+    os.environ["AWS_DEFAULT_REGION"] = "us-west-2"
+
+    with mock_aws():
+        deadline_magicmock = MagicMock()
+
+        # See https://docs.getmoto.org/en/latest/docs/services/patching_other_services.html
+        original_make_api_call = botocore.client.BaseClient._make_api_call
+
+        def mock_make_api_call(self, operation_name, kwarg):
+            service_name = self._service_model.service_name
+
+            if service_name == "deadline":
+                # Send the "GetQueue" operation, i.e. the get_queue call, to deadline_magicmock.GetQueue()
+                return getattr(deadline_magicmock, operation_name)(**kwarg)
+
+            # If we don't want to patch the API call
+            return original_make_api_call(self, operation_name, kwarg)
+
+        deadline_magicmock.GetQueue.return_value = {
+            "queueId": MOCK_QUEUE_ID,
+            "displayName": "Mock Queue",
+            "jobAttachmentSettings": {
+                "rootPrefix": "MockRootPrefix",
+                "s3BucketName": "mock-s3-bucket",
+            },
+        }
+        deadline_magicmock.ListSessions.return_value = {"sessions": []}
+        deadline_magicmock.ListSessionActions.return_value = {"sessionActions": []}
+        deadline_magicmock.AssumeQueueRoleForUser.return_value = {
+            "credentials": {
+                "accessKeyId": "ACCESSKEY",
+                "secretAccessKey": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                "sessionToken": "testing",
+                "expiration": datetime.fromisoformat("2025-08-07T01:01:44+00:00"),
+            }
+        }
+
+        with patch(
+            "botocore.client.BaseClient._make_api_call", new=mock_make_api_call
+        ), patch.object(deadline.client.api, "get_deadline_cloud_library_telemetry_client"):
+            yield deadline_magicmock


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The Deadline CLI doesn't provide a command to requeue tasks, equivalent to functionality in Deadline Cloud monitor.
In particular, requeuing based on a set of statuses would be useful, e.g. requeuing all SUSPENDED or CANCELED tasks.

### What was the solution? (How)

* This command lets you requeue tasks in a job that match a set of task run statuses.
* Promoted the deadline_mock fixture to the client unit test conftest.py to use the moto/deadline mocking for tests of the new command.
* Added unit tests of the new CLI command.
* Change the wording on the '--yes' option from "Skip" to "Automatically accept" so it matches the config dialog.

### What is the impact of this change?

The Deadline CLI provides more needed functionality for managing a farm.

### How was this change tested?

Wrote unit tests, and tested manually on a few jobs.

### Was this change documented?

It's in the help output of the CLI.

### Does this PR introduce new dependencies?

No

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
