### PR TITLE
test: Add tests for the 'deadline job cancel' command

### DIFF
--- a/test/unit/deadline_client/cli/test_cli_job_cancel.py
+++ b/test/unit/deadline_client/cli/test_cli_job_cancel.py
@@ -1,0 +1,277 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Tests for the CLI job cancel command.
+"""
+
+import pytest
+from unittest.mock import patch
+
+import click
+from click.testing import CliRunner
+
+from deadline.client.cli import main
+from ..shared_constants import (
+    MOCK_FARM_ID,
+    MOCK_JOB_ID,
+    MOCK_QUEUE_ID,
+)
+
+
+def add_mocks_for_job_cancel(deadline_mock):
+    """
+    Adds mock return values to the deadline_mock for sharing across
+    the different 'deadline job cancel' tests.
+    """
+    # These mock returns only contain the properties that job cancel needs
+    deadline_mock.get_job.return_value = {
+        "jobId": MOCK_JOB_ID,
+        "name": "Test Job Name",
+        "taskRunStatus": "RUNNING",
+        "taskRunStatusCounts": {
+            "SUCCEEDED": 2,
+            "RUNNING": 3,
+            "FAILED": 1,
+            "SUSPENDED": 0,  # Will be filtered out in display
+            "CANCELED": 0,  # Will be filtered out in display
+        },
+        "startedAt": "2024-01-01T10:00:00Z",
+        "endedAt": "",
+        "createdBy": "test-user",
+        "createdAt": "2024-01-01T09:00:00Z",
+    }
+    deadline_mock.update_job.return_value = {}
+
+
+def test_cli_job_cancel_default(fresh_deadline_config, deadline_mock):
+    """
+    Tests that 'deadline job cancel' cancels a job with default CANCELED mark-as status.
+    """
+    add_mocks_for_job_cancel(deadline_mock)
+
+    with patch.object(click, "confirm") as mock_confirm:
+        mock_confirm.return_value = True
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "job",
+                "cancel",
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--job-id",
+                MOCK_JOB_ID,
+            ],
+        )
+
+    # Verify the job summary output (filtered taskRunStatusCounts with no zero values)
+    expected_output = f"""name: Test Job Name
+jobId: {MOCK_JOB_ID}
+taskRunStatus: RUNNING
+taskRunStatusCounts:
+  SUCCEEDED: 2
+  RUNNING: 3
+  FAILED: 1
+startedAt: '2024-01-01T10:00:00Z'
+endedAt: ''
+createdBy: test-user
+createdAt: '2024-01-01T09:00:00Z'
+
+Canceling job...
+"""
+
+    assert result.output == expected_output
+    assert result.exit_code == 0
+
+    # Verify confirmation prompt appears with correct message for CANCELED status
+    mock_confirm.assert_called_once_with("Are you sure you want to cancel this job?", default=None)
+
+    # Verify deadline.get_job() and deadline.update_job() are called with correct parameters
+    deadline_mock.get_job.assert_called_once_with(
+        farmId=MOCK_FARM_ID, queueId=MOCK_QUEUE_ID, jobId=MOCK_JOB_ID
+    )
+    deadline_mock.update_job.assert_called_once_with(
+        farmId=MOCK_FARM_ID,
+        queueId=MOCK_QUEUE_ID,
+        jobId=MOCK_JOB_ID,
+        targetTaskRunStatus="CANCELED",
+    )
+
+
+def test_cli_job_cancel_user_declines(fresh_deadline_config, deadline_mock):
+    """
+    Tests that 'deadline job cancel' exits with code 1 and displays appropriate message when user declines.
+    """
+    add_mocks_for_job_cancel(deadline_mock)
+
+    with patch.object(click, "confirm") as mock_confirm:
+        mock_confirm.return_value = False
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "job",
+                "cancel",
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--job-id",
+                MOCK_JOB_ID,
+            ],
+        )
+
+    # Verify the job summary output followed by "Job not canceled." message
+    expected_output = f"""name: Test Job Name
+jobId: {MOCK_JOB_ID}
+taskRunStatus: RUNNING
+taskRunStatusCounts:
+  SUCCEEDED: 2
+  RUNNING: 3
+  FAILED: 1
+startedAt: '2024-01-01T10:00:00Z'
+endedAt: ''
+createdBy: test-user
+createdAt: '2024-01-01T09:00:00Z'
+
+Job not canceled.
+"""
+
+    assert result.output == expected_output
+    assert result.exit_code == 1
+
+    # Verify confirmation prompt appears
+    mock_confirm.assert_called_once_with("Are you sure you want to cancel this job?", default=None)
+
+    # Verify deadline.get_job() is called but deadline.update_job() is NOT called
+    deadline_mock.get_job.assert_called_once_with(
+        farmId=MOCK_FARM_ID, queueId=MOCK_QUEUE_ID, jobId=MOCK_JOB_ID
+    )
+    deadline_mock.update_job.assert_not_called()
+
+
+def test_cli_job_cancel_with_yes_flag(fresh_deadline_config, deadline_mock):
+    """
+    Tests that 'deadline job cancel' with --yes flag skips confirmation prompt and cancels successfully.
+    """
+    add_mocks_for_job_cancel(deadline_mock)
+
+    with patch.object(click, "confirm") as mock_confirm:
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "job",
+                "cancel",
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--job-id",
+                MOCK_JOB_ID,
+                "--yes",
+            ],
+        )
+
+    # Verify the job summary output and cancellation message
+    expected_output = f"""name: Test Job Name
+jobId: {MOCK_JOB_ID}
+taskRunStatus: RUNNING
+taskRunStatusCounts:
+  SUCCEEDED: 2
+  RUNNING: 3
+  FAILED: 1
+startedAt: '2024-01-01T10:00:00Z'
+endedAt: ''
+createdBy: test-user
+createdAt: '2024-01-01T09:00:00Z'
+
+Canceling job...
+"""
+
+    assert result.output == expected_output
+    assert result.exit_code == 0
+
+    # Verify confirmation prompt is skipped when --yes flag is used
+    mock_confirm.assert_not_called()
+
+    # Verify deadline.get_job() and deadline.update_job() are called with correct parameters
+    deadline_mock.get_job.assert_called_once_with(
+        farmId=MOCK_FARM_ID, queueId=MOCK_QUEUE_ID, jobId=MOCK_JOB_ID
+    )
+    deadline_mock.update_job.assert_called_once_with(
+        farmId=MOCK_FARM_ID,
+        queueId=MOCK_QUEUE_ID,
+        jobId=MOCK_JOB_ID,
+        targetTaskRunStatus="CANCELED",
+    )
+
+
+@pytest.mark.parametrize("mark_as", ["CANCELED", "SUSPENDED", "FAILED", "SUCCEEDED"])
+def test_cli_job_cancel_mark_as_status(mark_as, fresh_deadline_config, deadline_mock):
+    """
+    Tests that 'deadline job cancel' with different --mark-as status options works correctly.
+    """
+    add_mocks_for_job_cancel(deadline_mock)
+
+    with patch.object(click, "confirm") as mock_confirm:
+        mock_confirm.return_value = True
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "job",
+                "cancel",
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--job-id",
+                MOCK_JOB_ID,
+                "--mark-as",
+                mark_as,
+            ],
+        )
+
+    # Verify the job summary output (filtered taskRunStatusCounts with no zero values)
+    job_summary = f"""name: Test Job Name
+jobId: {MOCK_JOB_ID}
+taskRunStatus: RUNNING
+taskRunStatusCounts:
+  SUCCEEDED: 2
+  RUNNING: 3
+  FAILED: 1
+startedAt: '2024-01-01T10:00:00Z'
+endedAt: ''
+createdBy: test-user
+createdAt: '2024-01-01T09:00:00Z'
+
+"""
+
+    # Verify correct status message is displayed during cancellation
+    if mark_as == "CANCELED":
+        status_message = "Canceling job..."
+        confirmation_message = "Are you sure you want to cancel this job?"
+    else:
+        status_message = f"Canceling job and marking as {mark_as}..."
+        confirmation_message = (
+            f"Are you sure you want to cancel this job and mark its taskRunStatus as {mark_as}?"
+        )
+
+    expected_output = job_summary + status_message + "\n"
+
+    assert result.output == expected_output
+    assert result.exit_code == 0
+
+    # Verify appropriate confirmation message for each status type
+    mock_confirm.assert_called_once_with(confirmation_message, default=None)
+
+    # Verify correct targetTaskRunStatus parameter is passed to deadline.update_job()
+    deadline_mock.get_job.assert_called_once_with(
+        farmId=MOCK_FARM_ID, queueId=MOCK_QUEUE_ID, jobId=MOCK_JOB_ID
+    )
+    deadline_mock.update_job.assert_called_once_with(
+        farmId=MOCK_FARM_ID, queueId=MOCK_QUEUE_ID, jobId=MOCK_JOB_ID, targetTaskRunStatus=mark_as
+    )

--- a/test/unit/deadline_client/cli/test_cli_job_requeue_tasks.py
+++ b/test/unit/deadline_client/cli/test_cli_job_requeue_tasks.py
@@ -28,7 +28,7 @@ def add_mocks_for_job_requeue_tasks(deadline_mock):
     the different 'deadline job requeue-tasks' tests.
     """
     # These mock returns only contain the properties that requeue-tasks needs
-    deadline_mock.GetJob.return_value = {
+    deadline_mock.get_job.return_value = {
         "jobId": MOCK_JOB_ID,
         "name": "Mock Job",
         "taskRunStatus": "RUNNING",
@@ -41,7 +41,7 @@ def add_mocks_for_job_requeue_tasks(deadline_mock):
             "RUNNING": 1,
         },
     }
-    deadline_mock.ListSteps.return_value = {
+    deadline_mock.list_steps.return_value = {
         "steps": [
             {
                 "stepId": MOCK_STEP_ID,
@@ -58,7 +58,7 @@ def add_mocks_for_job_requeue_tasks(deadline_mock):
             }
         ]
     }
-    deadline_mock.ListTasks.return_value = {
+    deadline_mock.list_tasks.return_value = {
         "tasks": [
             {
                 "taskId": f"{MOCK_TASK_ID_PREFIX}-0",
@@ -92,7 +92,7 @@ def add_mocks_for_job_requeue_tasks(deadline_mock):
             },
         ]
     }
-    deadline_mock.UpdateTask.return_value = {}
+    deadline_mock.update_task.return_value = {}
 
 
 def test_cli_job_requeue_tasks(fresh_deadline_config, deadline_mock):
@@ -145,7 +145,7 @@ Requeued a total of 3 tasks.
     mock_confirm.assert_called_once_with(
         "Are you sure you want to requeue these tasks?", default=None
     )
-    assert deadline_mock.UpdateTask.call_args_list == [
+    assert deadline_mock.update_task.call_args_list == [
         call(
             farmId=MOCK_FARM_ID,
             queueId=MOCK_QUEUE_ID,
@@ -215,7 +215,7 @@ No tasks were requeued.
     mock_confirm.assert_called_once_with(
         "Are you sure you want to requeue these tasks?", default=None
     )
-    assert deadline_mock.UpdateTask.call_args_list == []
+    assert deadline_mock.update_task.call_args_list == []
 
 
 @pytest.mark.parametrize(
@@ -275,7 +275,7 @@ Step: Step Name ({MOCK_STEP_ID})
 Requeued a total of 1 tasks.
 """
     )
-    assert deadline_mock.UpdateTask.call_args_list == [
+    assert deadline_mock.update_task.call_args_list == [
         call(
             farmId=MOCK_FARM_ID,
             queueId=MOCK_QUEUE_ID,
@@ -336,7 +336,7 @@ Step: Step Name ({MOCK_STEP_ID})
 Requeued a total of 2 tasks.
 """
     )
-    assert deadline_mock.UpdateTask.call_args_list == [
+    assert deadline_mock.update_task.call_args_list == [
         call(
             farmId=MOCK_FARM_ID,
             queueId=MOCK_QUEUE_ID,

--- a/test/unit/deadline_client/cli/test_cli_queue_incremental_download.py
+++ b/test/unit/deadline_client/cli/test_cli_queue_incremental_download.py
@@ -70,7 +70,7 @@ def test_incremental_output_download_requires_queue_with_job_attachments(
     fresh_deadline_config, deadline_mock, checkpoint_dir
 ):
     # The response does not include the "jobAttachmentSettings" field
-    deadline_mock.GetQueue.return_value = {
+    deadline_mock.get_queue.return_value = {
         "queueId": MOCK_QUEUE_ID,
         "displayName": "Mock Queue",
     }
@@ -214,8 +214,8 @@ def test_incremental_output_download_bootstrap_and_completion(
         "fileSystem": "VIRTUAL",
     }
     del mock_jobs[0]["endedAt"]
-    deadline_mock.SearchJobs = mock_search_jobs_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
-    deadline_mock.GetJob = mock_get_job_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+    deadline_mock.search_jobs = mock_search_jobs_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+    deadline_mock.get_job = mock_get_job_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
 
     # RUN 1: Run the CLI command once to bootstrap the operation
     if storage_profile_id is None:
@@ -434,8 +434,8 @@ def test_incremental_output_download_storage_profile_path_mapping(
     }
     mock_jobs[0]["storageProfileId"] = MOCK_STORAGE_PROFILE_ID
     del mock_jobs[0]["endedAt"]
-    deadline_mock.SearchJobs = mock_search_jobs_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
-    deadline_mock.GetJob = mock_get_job_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+    deadline_mock.search_jobs = mock_search_jobs_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+    deadline_mock.get_job = mock_get_job_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
 
     # Mock enough of get_storage_profile_for_queue two return two for mapping between them
     def mock_get_storage_profile_for_queue(farmId: str, queueId: str, storageProfileId: str):
@@ -462,9 +462,9 @@ def test_incremental_output_download_storage_profile_path_mapping(
                 ],
             }
 
-    deadline_mock.GetStorageProfileForQueue = mock_get_storage_profile_for_queue
+    deadline_mock.get_storage_profile_for_queue = mock_get_storage_profile_for_queue
     # Mock list_sessions to return one session
-    deadline_mock.ListSessions.return_value = {
+    deadline_mock.list_sessions.return_value = {
         "sessions": [
             {
                 "sessionId": MOCK_SESSION_ID,
@@ -476,7 +476,7 @@ def test_incremental_output_download_storage_profile_path_mapping(
         ]
     }
     # Mock list_session_actions to return one task run session action
-    deadline_mock.ListSessionActions.return_value = {
+    deadline_mock.list_session_actions.return_value = {
         "sessionActions": [
             {
                 "sessionActionId": MOCK_SESSION_ACTION_ID_1,
@@ -582,8 +582,8 @@ def test_incremental_output_download_bootstrap_retire_job_without_attachments(
         "READY": 1,
     }
     del mock_jobs[0]["endedAt"]
-    deadline_mock.SearchJobs = mock_search_jobs_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
-    deadline_mock.GetJob = mock_get_job_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+    deadline_mock.search_jobs = mock_search_jobs_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+    deadline_mock.get_job = mock_get_job_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
 
     # RUN 1: Run the CLI command once to bootstrap the operation
     runner = CliRunner()
@@ -724,8 +724,8 @@ def test_incremental_output_download_job_unchanged(
         "fileSystem": "VIRTUAL",
     }
     del mock_jobs[0]["endedAt"]
-    deadline_mock.SearchJobs = mock_search_jobs_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
-    deadline_mock.GetJob = mock_get_job_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+    deadline_mock.search_jobs = mock_search_jobs_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+    deadline_mock.get_job = mock_get_job_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
 
     # RUN 1: Run the CLI command once to bootstrap the operation
     runner = CliRunner()
@@ -822,8 +822,8 @@ def test_incremental_output_download_job_canceled(
         "fileSystem": "VIRTUAL",
     }
     del mock_jobs[0]["endedAt"]
-    deadline_mock.SearchJobs = mock_search_jobs_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
-    deadline_mock.GetJob = mock_get_job_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+    deadline_mock.search_jobs = mock_search_jobs_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+    deadline_mock.get_job = mock_get_job_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
 
     # RUN 1: Run the CLI command once to bootstrap the operation
     runner = CliRunner()
@@ -930,8 +930,8 @@ def test_incremental_output_download_job_completed_then_requeued(
         "fileSystem": "VIRTUAL",
     }
     mock_jobs[0]["endedAt"] = iso_freeze_time - timedelta(minutes=3)
-    deadline_mock.SearchJobs = mock_search_jobs_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
-    deadline_mock.GetJob = mock_get_job_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+    deadline_mock.search_jobs = mock_search_jobs_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+    deadline_mock.get_job = mock_get_job_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
 
     # RUN 1: Run the CLI command once to bootstrap the operation
     # We've set up the job and timestamps so it bootstraps as completed
@@ -1070,8 +1070,8 @@ def test_incremental_output_download_dry_run(fresh_deadline_config, deadline_moc
         "fileSystem": "VIRTUAL",
     }
     del mock_jobs[0]["endedAt"]
-    deadline_mock.SearchJobs = mock_search_jobs_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
-    deadline_mock.GetJob = mock_get_job_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+    deadline_mock.search_jobs = mock_search_jobs_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+    deadline_mock.get_job = mock_get_job_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
 
     # RUN 1: Run the CLI command once to bootstrap the operation
     runner = CliRunner()
@@ -1141,8 +1141,8 @@ def test_incremental_output_download_stats_telemetry(
         }
     )
     del mock_job["endedAt"]
-    deadline_mock.SearchJobs = mock_search_jobs_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, [mock_job])
-    deadline_mock.GetJob = mock_get_job_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, [mock_job])
+    deadline_mock.search_jobs = mock_search_jobs_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, [mock_job])
+    deadline_mock.get_job = mock_get_job_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, [mock_job])
 
     runner = CliRunner()
     with freeze_time(ISO_FREEZE_TIME):

--- a/test/unit/deadline_client/conftest.py
+++ b/test/unit/deadline_client/conftest.py
@@ -10,6 +10,7 @@ import deadline.client.api
 from deadline.client.api._telemetry import TelemetryClient
 import tempfile
 import os
+import re
 from datetime import datetime
 
 from unittest.mock import patch, MagicMock
@@ -90,13 +91,16 @@ def deadline_mock():
             service_name = self._service_model.service_name
 
             if service_name == "deadline":
-                # Send the "GetQueue" operation, i.e. the get_queue call, to deadline_magicmock.GetQueue()
-                return getattr(deadline_magicmock, operation_name)(**kwarg)
+                # Send the "GetQueue" operation, i.e. the get_queue call, to
+                # deadline_magicmock.get_queue()
+                operation_words = re.findall("[A-Z][a-z]+", operation_name)
+                snake_operation = "_".join(word.lower() for word in operation_words)
+                return getattr(deadline_magicmock, snake_operation)(**kwarg)
 
             # If we don't want to patch the API call
             return original_make_api_call(self, operation_name, kwarg)
 
-        deadline_magicmock.GetQueue.return_value = {
+        deadline_magicmock.get_queue.return_value = {
             "queueId": MOCK_QUEUE_ID,
             "displayName": "Mock Queue",
             "jobAttachmentSettings": {
@@ -104,9 +108,9 @@ def deadline_mock():
                 "s3BucketName": "mock-s3-bucket",
             },
         }
-        deadline_magicmock.ListSessions.return_value = {"sessions": []}
-        deadline_magicmock.ListSessionActions.return_value = {"sessionActions": []}
-        deadline_magicmock.AssumeQueueRoleForUser.return_value = {
+        deadline_magicmock.list_sessions.return_value = {"sessions": []}
+        deadline_magicmock.list_session_actions.return_value = {"sessionActions": []}
+        deadline_magicmock.assume_queue_role_for_user.return_value = {
             "credentials": {
                 "accessKeyId": "ACCESSKEY",
                 "secretAccessKey": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The 'deadline job cancel' command lacked unit tests.

### What was the solution? (How)

I had a hypothesis that the pattern used in https://github.com/aws-deadline/deadline-cloud/pull/825 for the 'deadline job requeue-tasks' command is something that LLM-based coding could use as a pattern to reapply. I used [Kiro](https://kiro.dev/) to test that.

* Tests created via a Kiro spec, directing it to use the 'deadline job requeue-tasks' as the model to follow.
* The LLM didn't handle the camel/snake difference in how the Deadline client was mocked. Changed the mocking to use snake instead of camel. The result is more intuitive for anyone reading the code, and consistent with boto3.

### What is the impact of this change?

Better coverage of the CLI commands.

### How was this change tested?

This is a test.

### Was this change documented?

No

### Does this PR introduce new dependencies?

No

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
