### PR TITLE
test: mock AWS_PROFILE env var to isolate tests from local config

### DIFF
--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -62,6 +62,7 @@ def aws_config(monkeypatch):
         temp_file_path = temp_dir_path / "aws_config"
         monkeypatch.setenv("AWS_CONFIG_FILE", str(temp_file_path))
         monkeypatch.delenv("AWS_DEFAULT_PROFILE", raising=False)
+        monkeypatch.delenv("AWS_PROFILE", raising=False)
 
         yield temp_file_path
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

When running the unit tests (`hatch run test`) with the `AWS_PROFILE` environment variable set, the tests would error. For example, with the following environment setup:

```
export AWS_PROFILE=default
```

The tests would error with:

```
>           raise ProfileNotFound(profile=profile_name)
E           botocore.exceptions.ProfileNotFound: The config profile (default) could not be found

../../../.local/share/hatch/env/virtual/deadline/Lgy_KhBZ/deadline/lib/python3.13/site-packages/botocore/session.py:424: ProfileNotFound
```

### What was the solution? (How)

Add `AWS_PROFILE` to the set of environment variables monkey-patched in `test/unit/conftest.py`. This is the same approach taken by #740.

### What is the impact of this change?

Tests will now succeed independent of the `AWS_PROFILE` environment variable on the development / build machine.

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests?
    *   yes, passing
- Have you run the integration tests?
    *   Not applicable
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass.
    *   No

### Was this change documented?

- Are relevant docstrings in the code base updated?
    *   N/A
- Has the README.md been updated? If you modified CLI arguments, for instance.
    *   N/A

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?

A breaking change is one that modifies a public contract in a way that is not backwards compatible. See the 
[Public Contracts](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#public-contracts) section
of the DEVELOPMENT.md for more information on the public contracts.

If so, then please describe the changes that users of this package must make to update their scripts, or Python applications.

No

### Does this change impact security?

- Does the change need to be threat modeled? For example, does it create or modify files/directories that must only be readable by the process owner?
    - If so, then please label this pull request with the "security" label. We'll work with you to analyze the threats.

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
