### PR TITLE
feat: Add detailed tooltips to grayed-out submit button

### DIFF
--- a/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
@@ -229,19 +229,35 @@ class SubmitJobToDeadlineDialog(QDialog):
     def _set_submit_button_state(self):
         # Enable/disable the Submit button based on whether the
         # AWS Deadline Cloud API is accessible and the farm+queue are configured.
-        enable = (
-            self.deadline_authentication_status.api_availability is True
-            and get_setting("defaults.farm_id") != ""
-            and get_setting("defaults.queue_id") != ""
-            and self.shared_job_settings.is_queue_valid()
-        )
+        api_available = self.deadline_authentication_status.api_availability is True
+        farm_configured = get_setting("defaults.farm_id") != ""
+        queue_configured = get_setting("defaults.queue_id") != ""
+        queue_valid = self.shared_job_settings.is_queue_valid()
+
+        enable = api_available and farm_configured and queue_configured and queue_valid
 
         self.submit_button.setEnabled(enable)
 
         if not enable:
-            self.submit_button.setToolTip(
-                "Cannot submit job to Deadline Cloud. Nonvalid credentials or queue parameters."
-            )
+            issues = []
+            if not api_available:
+                issues.append(
+                    "AWS Deadline Cloud API is not accessible. Check your authentication status."
+                )
+            if not farm_configured:
+                issues.append(
+                    "No farm is configured. Click Settings to select a farm for job submission."
+                )
+            if not queue_configured:
+                issues.append(
+                    "No queue is configured. Click Settings to select a queue within your farm."
+                )
+            if farm_configured and queue_configured and not queue_valid:
+                issues.append(
+                    "Queue parameters are not valid. Check Shared job settings tab for details."
+                )
+
+            self.submit_button.setToolTip("Cannot submit job:\n\n• " + "\n\n• ".join(issues))
         else:
             self.submit_button.setToolTip("")
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The tooltip wasn't clear enough on why the submit button was disabled, making it hard for users to figure out what to fix.

### What was the solution? (How)
Updated the tooltip to show specific reasons why submit is disabled and where to go fix each issue.

### What is the impact of this change?
Users can now see specific reasons why submit is disabled.

### How was this change tested?
<img width="1009" height="839" alt="Screenshot 2025-09-11 at 09 58 51" src="https://github.com/user-attachments/assets/a9219183-1961-44a0-8b26-34c973fd7d64" />
<img width="926" height="350" alt="Screenshot 2025-09-11 at 11 06 57" src="https://github.com/user-attachments/assets/9953361b-386f-4268-a733-6535ac72f75c" />


- Have you run the unit tests?
    - ========================== 1751 passed, 63 skipped, 1 xfailed in 23.91s =======================
- Have you run the integration tests?
    - No
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass.
    - No
### Was this change documented?
No

- Are relevant docstrings in the code base updated? No
- Has the README.md been updated? If you modified CLI arguments, for instance. No

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?
No

### Does this change impact security?
No


----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
