### PR TITLE
fix: Added some verbose logging for incremental download tests to det…

### DIFF
--- a/test/integ/cli/test_cli_incremental_download.py
+++ b/test/integ/cli/test_cli_incremental_download.py
@@ -143,7 +143,17 @@ class IncrementalDownloadTest:
 
         # Run from the specified output directory so files are downloaded to their manifest paths
         # The CLI will create the necessary directory structure based on job manifests
-        return subprocess.run(cmd, capture_output=True, text=True, check=False, cwd=output_dir)
+        result = subprocess.run(cmd, capture_output=True, text=True, check=False, cwd=output_dir)
+
+        # Print CLI output for debugging
+        if result.stdout:
+            print(f"[sync-output] STDOUT:\n{result.stdout}")
+        if result.stderr:
+            print(f"[sync-output] STDERR:\n{result.stderr}")
+        if result.returncode != 0:
+            print(f"[sync-output] Exit code: {result.returncode}")
+
+        return result
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The incremental download command ``sync-output`` tests fail sometimes. I investigated and the tests pass on dev - there could be an edge case in the CLI but we need more verbose logging to confirm & root cause.

### What was the solution? (How)
Added some verbose logging to debug and find out the root cause of failing tests. My hunch is there is an edge case in the CLI getting exposed by the tests

### What is the impact of this change?
More logging to debug

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests? yes
- Have you run the integration tests? yes
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass. N/A

```
test/integ/cli/test_cli_incremental_download.py::test_incremental_download_many_small_files 
[gw0] [ 16%] PASSED test/integ/cli/test_cli_incremental_download.py::test_incremental_download_many_small_files 
test/integ/cli/test_cli_incremental_download.py::test_incremental_download_dep_data_flow 
[gw0] [ 33%] PASSED test/integ/cli/test_cli_incremental_download.py::test_incremental_download_dep_data_flow 
test/integ/cli/test_cli_incremental_download.py::test_incremental_download_dependency_chain 
[gw0] [ 50%] XPASS test/integ/cli/test_cli_incremental_download.py::test_incremental_download_dependency_chain 
test/integ/cli/test_cli_incremental_download.py::test_conflict_resolution_with_requeue[job] 
[gw0] [ 66%] PASSED test/integ/cli/test_cli_incremental_download.py::test_conflict_resolution_with_requeue[job] 
test/integ/cli/test_cli_incremental_download.py::test_conflict_resolution_with_requeue[step] 
[gw0] [ 83%] PASSED test/integ/cli/test_cli_incremental_download.py::test_conflict_resolution_with_requeue[step] 
test/integ/cli/test_cli_incremental_download.py::test_conflict_resolution_with_requeue[task] 
[gw0] [100%] PASSED test/integ/cli/test_cli_incremental_download.py::test_conflict_resolution_with_requeue[task] 

================================================================================ slowest 5 durations ================================================================================
554.07s call     test/integ/cli/test_cli_incremental_download.py::test_incremental_download_dependency_chain
512.29s call     test/integ/cli/test_cli_incremental_download.py::test_incremental_download_dep_data_flow
394.36s call     test/integ/cli/test_cli_incremental_download.py::test_conflict_resolution_with_requeue[job]
297.41s call     test/integ/cli/test_cli_incremental_download.py::test_conflict_resolution_with_requeue[task]
293.44s call     test/integ/cli/test_cli_incremental_download.py::test_conflict_resolution_with_requeue[step]
===================================================================== 5 passed, 1 xpassed in 2325.17s (0:38:45) =====================================================================
(base) sakshie@c889f3b5520c deadline-cloud % hatch run integ:test -- test/integ/cli/test_cli_incremental_download.py::test_conflict_resolution_with_requeue 
================================================================================ test session starts ================================================================================

```

debug logs:
```
[sync-output] STDOUT:
Ignoring all storage profiles.
Started incremental download for queue: DeadlineCloudLinuxQueue
Checkpoint: /private/var/folders/k9/0q9dw35d3b12jwsq_zh3l1pc0000gr/T/pytest-of-sakshie/pytest-159/popen-gw2/test_conflict_resolution_with_0/checkpoints_requeue_task/queue-d3880b52484d4189959c083775fa7c8b_ignore-storage-profiles_download_checkpoint.json

Bootstrap forced, lookback is 1.0 minutes
Initializing from: 2025-09-12T14:26:36.134361-07:00

Updating download state across time interval:
    From: 2025-09-12T14:26:36.134361-07:00
      To: 2025-09-12T14:27:36.134721-07:00
  Length: 0:01:00.000360

Retrieving updated data from Deadline Cloud...
DEBUG: Got 2 active jobs
DEBUG: Filtered down to 0 active jobs based on SUCCEEDED task filter
DEBUG: Got 0 jobs with job[endedAt] >= 2025-09-12T14:26:36.134361-07:00
DEBUG: Filtered down to 0 jobs based on SUCCEEDED task filter
...retrieval completed in 0:00:01.012323

Categorizing 0 checkpoint jobs against 0 download candidate jobs...
...categorization completed in 0:00:00.000032

Retrieving sessions for 0 jobs...

```
### Was this change documented?

- Are relevant docstrings in the code base updated? No
- Has the README.md been updated? If you modified CLI arguments, for instance. No

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?
No
### Does this change impact security?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
