### PR TITLE
fix: authentication status text not visible in light mode

### DIFF
--- a/src/deadline/client/ui/widgets/deadline_authentication_status_widget.py
+++ b/src/deadline/client/ui/widgets/deadline_authentication_status_widget.py
@@ -16,13 +16,12 @@ from qtpy.QtCore import Signal
 from qtpy.QtWidgets import (  # pylint: disable=import-error; type: ignore
     QHBoxLayout,
     QLabel,
-    QWidget,
     QApplication,
     QStyle,
-    QFrame,
     QMenu,
     QPushButton,
     QMessageBox,
+    QGroupBox,
 )
 
 from ... import api
@@ -103,9 +102,9 @@ class AuthenticationState(enum.Enum):
     UNEXPECTED_ERROR = enum.auto()
 
 
-class DeadlineAuthenticationStatusWidget(QWidget):
+class DeadlineAuthenticationStatusWidget(QGroupBox):
     """
-    A Qt widget that displays the current AWS Deadline Cloud authentication status.
+    A Qt GroupBox widget that displays the current AWS Deadline Cloud authentication status.
 
     This widget provides a visual indicator of the authentication status, showing an appropriate
     icon, profile name, and relevant action buttons based on the current authentication status.
@@ -154,19 +153,12 @@ class DeadlineAuthenticationStatusWidget(QWidget):
             show_profile_switch (bool): Whether to enable profile switching functionality.
                 Defaults to True.
         """
-        main_layout = QHBoxLayout(self)
-        main_layout.setContentsMargins(0, 0, 0, 0)
 
-        frame = QFrame(self)
-        frame.setStyleSheet("QFrame {background-color: palette(base); border-radius: 4px;}")
-        frame.setFrameShape(QFrame.StyledPanel)
-        main_layout.addWidget(frame)
-
-        frame_layout = QHBoxLayout(frame)
-        frame_layout.setContentsMargins(5, 5, 5, 5)
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(5, 5, 5, 5)
 
         self._status_icon = QLabel()
-        frame_layout.addWidget(self._status_icon)
+        layout.addWidget(self._status_icon)
 
         self._profile_button = QPushButton()
         self._profile_button.setStyleSheet("""
@@ -186,21 +178,23 @@ class DeadlineAuthenticationStatusWidget(QWidget):
         )
         self._logout_menu_action = self._auth_menu.addAction("Log out", self.logout_clicked.emit)
 
-        frame_layout.addWidget(self._profile_button)
+        layout.addWidget(self._profile_button)
 
-        frame_layout.addStretch()
+        layout.addStretch()
 
         self._switch_profile_button = QPushButton("Switch profile")
         self._switch_profile_button.clicked.connect(self.switch_profile_clicked.emit)
-        frame_layout.addWidget(self._switch_profile_button)
+        layout.addWidget(self._switch_profile_button)
 
         self._login_button = QPushButton("Log in")
         self._login_button.clicked.connect(self.login_clicked.emit)
-        frame_layout.addWidget(self._login_button)
+        layout.addWidget(self._login_button)
 
         self._more_info_button = QPushButton("More info")
         self._more_info_button.clicked.connect(self._show_more_info)
-        frame_layout.addWidget(self._more_info_button)
+        layout.addWidget(self._more_info_button)
+
+        self.setLayout(layout)
 
     def _get_profile_name(self) -> str:
         """


### PR DESCRIPTION
Fixes: #840 

### What was the problem/requirement? (What/Why)
With certain stylesheets the new authentication status dialog text can become unreadable. This has happened in Blender when using their provided stylesheet.

### What was the solution? (How)
Swap from setting the QFrame background colour to palette(base) which seems to be determined based on the system appearance setting when using some stylesheets despite the text colour not also following the system setting. Instead the widget is now a QGroupBox without a title. This means that the background colour now also matches all of the other QGroupBox sections in the rest of the submission window.

### What is the impact of this change?
Better UX and the text should always be readable now

### How was this change tested?
Manually tested doing a `deadline bundle gui-submit` on MacOs with pyside2 and pyside6. Also tested in Blender 4.5 with and without the stylesheet installed.

<img width="551" height="740" alt="image" src="https://github.com/user-attachments/assets/27b4b65d-11ac-4450-921e-65ebc48996f5" />

- Have you run the unit tests?
  - Yes
- Have you run the integration tests? 
  - N/A  

### Was this change documented?

See #840 

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [X] This PR does not add any new dependencies.

### Is this a breaking change?

No

### Does this change impact security?

No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
