### PR TITLE
fix: Remove default value requirement for hidden parameters in GUI

### DIFF
--- a/src/deadline/client/job_bundle/parameters.py
+++ b/src/deadline/client/job_bundle/parameters.py
@@ -808,10 +808,24 @@ def read_job_bundle_parameters(bundle_dir: str) -> list[JobParameter]:
                 parameter["value"] = default_absolute
 
     # Rearrange the dict from the template into a list
-    return [
+    parameters = [
         validate_job_parameter({"name": name, **values})
         for name, values in template_parameters.items()
     ]
+
+    # Validate hidden parameters have values
+    for param in parameters:
+        if param.get("userInterface", {}).get("control") == "HIDDEN":
+            parameter_value = param.get("value")
+            if parameter_value is None or parameter_value == "":
+                parameter_value = param.get("default")
+            if parameter_value is None or parameter_value == "":
+                raise DeadlineOperationError(
+                    f'Job bundle validation failed:\nHidden parameter "{param["name"]}" is missing a value. '
+                    f"Hidden parameters must have either a default value in the template or a value in parameter_values.yaml."
+                )
+
+    return parameters
 
 
 _SUPPORTED_CONTROLS_FOR_TYPE = {

--- a/src/deadline/client/ui/widgets/openjd_parameters_widget.py
+++ b/src/deadline/client/ui/widgets/openjd_parameters_widget.py
@@ -803,8 +803,9 @@ class _JobTemplateHiddenWidget(_JobTemplateWidget):
         "FLOAT",
         "STRING",
     ]
-    OPENJD_DEFAULT_VALUE: str = ""  # All hidden fields require a default value to be provided
-    OPENJD_REQUIRED_PARAMETER_FIELDS: List[str] = ["default"]
+
+    OPENJD_DEFAULT_VALUE: str = ""  # Hidden parameters do not require defaults
+    OPENJD_REQUIRED_PARAMETER_FIELDS: List[str] = []
     OPENJD_DISALLOWED_PARAMETER_FIELDS: List[str] = []
 
     def __init__(self, parent: QWidget, parameter: Dict[str, Any]):


### PR DESCRIPTION
Fixes: *<https://github.com/aws-deadline/deadline-cloud/issues/343>*

### What was the problem/requirement? (What/Why)
Hidden parameters in OpenJD job templates were incorrectly required to have default values in the GUI validation. This prevented job bundle submission when templates contained hidden parameters without defaults, even though the OpenJD specification doesn't require hidden parameters to have defaults.

### What was the solution? (How)
Removed the default value requirement for hidden parameters. Hidden parameters get their values from parameter_values.yaml, so they don't need defaults defined in the template.

### What is the impact of this change?
This change allows job bundles with hidden parameters to be submitted through the GUI without requiring default values in the template. 

### How was this change tested?

1. Created test job bundles with hidden parameters of different types (PATH, INT, FLOAT, STRING) without default value
2. Verified that job submission works correctly through the GUI when parameter values are provided in parameter_values.yaml
3. Confirmed that hidden parameters are passed correctly


- Have you run the unit tests?
-============================== 1866 passed, 63 skipped, 1 xfailed in 24.09s ================================
- Have you run the integration tests?
- No
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass.
No

### Was this change documented?
No
- Are relevant docstrings in the code base updated? No
- Has the README.md been updated? If you modified CLI arguments, for instance. No

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?

A breaking change is one that modifies a public contract in a way that is not backwards compatible. See the 
[Public Contracts](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#public-contracts) section
of the DEVELOPMENT.md for more information on the public contracts.

If so, then please describe the changes that users of this package must make to update their scripts, or Python applications.

No

### Does this change impact security?
No
- Does the change need to be threat modeled? For example, does it create or modify files/directories that must only be readable by the process owner?
    - If so, then please label this pull request with the "security" label. We'll work with you to analyze the threats.


### New changes:
Added validation for hidden parameters during job bundle loading. Since hidden parameters cannot be modified after the GUI launches, the validation now checks that all hidden parameters have either a default value in the template or a value in parameter_values.yaml when the bundle is first loaded. 
<img width="303" height="315" alt="Screenshot 2025-09-18 at 16 13 31" src="https://github.com/user-attachments/assets/6156a01f-d8f2-468c-b174-78f863b5aa0c" />


----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
