### PR TITLE
feat: Add '-p' param support to 'deadline bundle gui-submit'

### DIFF
--- a/src/deadline/client/cli/_groups/bundle_group.py
+++ b/src/deadline/client/cli/_groups/bundle_group.py
@@ -98,7 +98,11 @@ def _interactive_confirmation_prompt(message: str, default_response: bool) -> bo
     "--parameter",
     multiple=True,
     callback=validate_parameters,
-    help='The values for the job template\'s parameters. Can be provided as key-value pairs, inline JSON strings, or as paths to a JSON or YAML document. If provided more than once, the values are combined in the order that they appear. Examples: --parameter MyParam=5 -p file://parameter_file.json -p \'{"MyParam": "5"}\'',
+    help=(
+        "The values for the job template's parameters. Can be provided as key-value pairs, inline JSON strings, "
+        "or as paths to a JSON or YAML document. Later values for repeated parameter names take precedence. "
+        'Examples: --parameter MyParam=5 -p file://parameter_file.json -p \'{"OtherParam": "10"}\''
+    ),
 )
 @click.option("--profile", help="The AWS profile to use.")
 @click.option("--farm-id", help="The farm to use.")
@@ -285,6 +289,17 @@ def bundle_submit(
 
 
 @cli_bundle.command(name="gui-submit")
+@click.option(
+    "-p",
+    "--parameter",
+    multiple=True,
+    callback=validate_parameters,
+    help=(
+        "Initial values in the GUI for the job template's parameters. Can be provided as key-value pairs, inline JSON strings, "
+        "or as paths to a JSON or YAML document. Later values for repeated parameter names take precedence. "
+        'Examples: --parameter MyParam=5 -p file://parameter_file.json -p \'{"OtherParam": "10"}\''
+    ),
+)
 @click.argument("job_bundle_dir", required=False)
 @click.option(
     "--browse",
@@ -321,7 +336,7 @@ def bundle_submit(
 )
 @_handle_error
 def bundle_gui_submit(
-    job_bundle_dir, browse, output, install_gui, submitter_name, known_asset_path, **args
+    parameter, job_bundle_dir, browse, output, install_gui, submitter_name, known_asset_path, **args
 ):
     """
     Opens a GUI to submit an Open Job Description job bundle.
@@ -342,6 +357,7 @@ def bundle_gui_submit(
             browse=browse,
             submitter_name=submitter_name,
             known_asset_paths=known_asset_path,
+            job_parameters=parameter,
         )
 
         if not submitter:

--- a/src/deadline/client/job_bundle/parameters.py
+++ b/src/deadline/client/job_bundle/parameters.py
@@ -249,6 +249,101 @@ def validate_job_parameter(
     return cast(JobParameter, input)
 
 
+def validate_job_parameter_value(
+    job_parameter: JobParameter,
+    value: str | int | float,
+) -> str | int | float:
+    """
+    Validates a value for the specified parameter definition, returning the value with the correct type,
+    e.g. a string "19" for an INT parameter is returned as the integer 19.
+    Raises a ValueError if validation fails.
+
+    See https://github.com/OpenJobDescription/openjd-specifications/wiki/2023-09-Template-Schemas#2-jobparameterdefinition
+
+    Args:
+        job_parameter: The parameter definition.
+        value: The value to validate.
+    Returns:
+        The value, converted to the correct type for the parameter definition.
+    """
+    name = job_parameter["name"]
+    param_type = job_parameter["type"]
+
+    # First ensure the value has the correct type
+    if param_type in ("STRING", "PATH"):
+        if not isinstance(value, str):
+            raise TypeError(
+                f"Job parameter {name!r} has type {param_type} but got value {value!r} of type {type(value)}."
+            )
+    elif param_type == "INT":
+        original_value = value
+        try:
+            if isinstance(value, str):
+                value = int(value)
+            else:
+                value = int(value)
+                # In the case of converting a float to an integer, the value gets truncated.
+                # Check if the value was modified, and raise if so.
+                if not isinstance(original_value, str) and value != original_value:
+                    value = original_value
+                    raise ValueError()
+        except ValueError:
+            raise ValueError(
+                f"Job parameter {name!r} has type INT but got value {value!r} which is not an integer."
+            )
+    elif param_type == "FLOAT":
+        try:
+            value = float(value)
+        except ValueError:
+            raise ValueError(
+                f"Job parameter {name!r} has type FLOAT but got value {value!r} which is not floating point."
+            )
+    else:
+        raise TypeError(
+            f"The definition for job parameter {name!r} has unsupported type {param_type!r}"
+        )
+
+    # Then ensure the value satisfies the constraints in the parameter definition.
+    # Assumes the parameter definition is already validated, so the existence or not
+    # of constraint fields is enough, don't need to gate by type.
+    min_length = job_parameter.get("minLength")
+    if min_length is not None:
+        if len(value) < min_length:  # type: ignore
+            raise ValueError(
+                f"Job parameter {name!r} value {value!r} is shorter than minLength {min_length}."
+            )
+
+    max_length = job_parameter.get("maxLength")
+    if max_length is not None:
+        if len(value) > max_length:  # type: ignore
+            raise ValueError(
+                f"Job parameter {name!r} value {value!r} is longer than maxLength {max_length}."
+            )
+
+    min_value = job_parameter.get("minValue")
+    if min_value is not None:
+        if value < min_value:  # type: ignore
+            raise ValueError(
+                f"Job parameter {name!r} value {value!r} is less than minValue {min_value}."
+            )
+
+    max_value = job_parameter.get("maxValue")
+    if max_value is not None:
+        if value > max_value:  # type: ignore
+            raise ValueError(
+                f"Job parameter {name!r} value {value!r} is greater than maxValue {max_value}."
+            )
+
+    allowed_values = job_parameter.get("allowedValues")
+    if allowed_values is not None:
+        if value not in allowed_values:  # type: ignore
+            raise ValueError(
+                f"Job parameter {name!r} value {value!r} is not an allowed value from {tuple(allowed_values)!r}."
+            )
+
+    return value
+
+
 def validate_user_interface_spec(input: Any, *, parameter_name: str) -> UserInterfaceSpec:
     """Validates a job parameter's "userInterface" field as defined by Open Job Description. The
     validation allows for the union of all possible parameter "type"s.

--- a/src/deadline/client/ui/job_bundle_submitter.py
+++ b/src/deadline/client/ui/job_bundle_submitter.py
@@ -10,6 +10,7 @@ from qtpy.QtWidgets import (  # pylint: disable=import-error; type: ignore
     QApplication,
     QFileDialog,
     QMainWindow,
+    QMessageBox,
 )
 
 from ..exceptions import DeadlineOperationError
@@ -25,6 +26,7 @@ from ..job_bundle.parameters import (
     apply_job_parameters,
     merge_queue_job_parameters,
     read_job_bundle_parameters,
+    validate_job_parameter_value,
 )
 from .dataclasses import JobBundleSettings
 from .dialogs.submit_job_to_deadline_dialog import (
@@ -38,6 +40,78 @@ from ..api._session import session_context
 logger = getLogger(__name__)
 
 
+def _validate_job_parameters_against_definitions(
+    job_parameters: list[dict[str, Any]],
+    job_template_parameters: list[JobParameter],
+    queue_parameters: list[dict[str, Any]],
+) -> list[str]:
+    """
+    Validate CLI parameters against available parameter definitions.
+
+    Args:
+        job_parameters: List of CLI parameters with 'name' and 'value' keys
+        job_template_parameters: List of job template parameter definitions
+        queue_parameters: List of queue parameter definitions
+
+    Returns:
+        A list of unrecognized parameter names.
+    """
+    # Create sets of recognized parameter names
+    job_template_names = {param["name"] for param in job_template_parameters}
+    queue_parameter_names = {param["name"] for param in queue_parameters}
+    all_recognized_names = job_template_names | queue_parameter_names
+
+    unrecognized_names = {param["name"] for param in job_parameters} - all_recognized_names
+
+    return sorted(unrecognized_names)
+
+
+def _validate_and_warn_about_parameters(
+    job_parameters: list[dict[str, Any]],
+    job_template_parameters: list[JobParameter],
+    queue_parameters: list[dict[str, Any]],
+    parent_widget,
+) -> bool:
+    """
+    Validate CLI parameters against job template and queue parameters.
+    Display warning dialog for unrecognized parameters.
+
+    Args:
+        job_parameters: List of CLI parameters with 'name' and 'value' keys
+        job_template_parameters: List of job template parameter definitions
+        queue_parameters: List of queue parameter definitions
+        parent_widget: Parent widget for the warning dialog
+
+    Returns:
+        True if user wants to continue, False if user wants to cancel
+    """
+    unrecognized_names = _validate_job_parameters_against_definitions(
+        job_parameters, job_template_parameters, queue_parameters
+    )
+
+    if not unrecognized_names:
+        return True
+
+    # Display warning dialog for unrecognized parameters
+    unrecognized_list = "\n".join(f"  • {name}" for name in unrecognized_names)
+    message = (
+        f"The following parameters are not recognized by the job template or queue:\n\n"
+        f"{unrecognized_list}\n\n"
+        f"These parameters will be ignored during job submission.\n\n"
+        f"Do you want to continue?"
+    )
+
+    reply = QMessageBox.question(
+        parent_widget,
+        "Unrecognized Parameters",
+        message,
+        QMessageBox.Yes | QMessageBox.No,
+        QMessageBox.No,
+    )
+
+    return reply == QMessageBox.Yes
+
+
 def show_job_bundle_submitter(
     *,
     input_job_bundle_dir: str = "",
@@ -46,6 +120,7 @@ def show_job_bundle_submitter(
     f=Qt.WindowFlags(),
     submitter_name: Optional[str] = None,
     known_asset_paths: Optional[list[str]] = None,
+    job_parameters: Optional[list[dict[str, Any]]] = None,
 ) -> Optional[SubmitJobToDeadlineDialog]:
     """
     Opens an AWS Deadline Cloud job submission dialog for the provided job bundle.
@@ -178,13 +253,33 @@ def show_job_bundle_submitter(
     initial_settings.parameters = read_job_bundle_parameters(input_job_bundle_dir)
     initial_settings.browse_enabled = browse
 
-    # Populate the initial queue parameter values based on the job template parameter values
     initial_shared_parameter_values = {}
+
+    job_parameters_dict = {param["name"]: param for param in (job_parameters or [])}
     for parameter in initial_settings.parameters:
+        # Overwrite the parameter values from the job bundle with values provided by job_parameters,
+        # e.g. from the CLI when this is called by the 'deadline bundle gui-submit' command.
+        if parameter["name"] in job_parameters_dict:
+            value = job_parameters_dict.pop(parameter["name"])["value"]
+            # Convert any path parameters to absolute
+            if parameter["type"] == "PATH":
+                value = os.path.abspath(value)
+            # Validate the value against the parameter definition and ensure it has the correct type
+            try:
+                value = validate_job_parameter_value(parameter, value)
+            except (ValueError, TypeError) as e:
+                # Convert the exception to DeadlineOperationError to avoid showing a full stack trace.
+                raise DeadlineOperationError(str(e))
+            parameter["value"] = value
+
+        # Populate the initial queue parameter values based on the job template parameter values
         if "default" in parameter or "value" in parameter:
             initial_shared_parameter_values[parameter["name"]] = parameter.get(
                 "value", parameter.get("default")
             )
+    # Put the job_parameter values that weren't for the template in the shared parameter values
+    for parameter in job_parameters_dict.values():
+        initial_shared_parameter_values[parameter["name"]] = parameter["value"]
 
     submitter_dialog = SubmitJobToDeadlineDialog(
         job_setup_widget_type=JobBundleSettingsWidget,
@@ -199,5 +294,22 @@ def show_job_bundle_submitter(
         submitter_name=submitter_name,
         known_asset_paths=known_asset_paths,
     )
+
+    if job_parameters:
+        # We want to validate the job parameters after the queue parameters are loaded.
+        # Connect a parameter validation function to the queue parameter loading completion
+        def validate_parameters_after_queue_load(refresh_id: int, queue_parameters: list):
+            """Validate CLI parameters against loaded queue parameters and set parameter values"""
+            if not _validate_and_warn_about_parameters(
+                job_parameters, initial_settings.parameters, queue_parameters, submitter_dialog
+            ):
+                # User chose to cancel, close the dialog
+                submitter_dialog.close()
+
+        # Connect to the queue parameters update signal
+        submitter_dialog.shared_job_settings._queue_parameters_update.connect(
+            validate_parameters_after_queue_load
+        )
+
     submitter_dialog.show()
     return submitter_dialog

--- a/test/unit/deadline_client/job_bundle/test_validate_job_parameter_value.py
+++ b/test/unit/deadline_client/job_bundle/test_validate_job_parameter_value.py
@@ -1,0 +1,943 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Test cases for deadline.client.job_bundle.parameters.validate_job_parameter_value"""
+
+from __future__ import annotations
+from typing import Any, Union
+
+import pytest
+
+from deadline.client.job_bundle import parameters
+
+
+# Base parameter definitions for different types
+BASE_STRING_PARAM: parameters.JobParameter = {"name": "test_string_param", "type": "STRING"}
+
+BASE_PATH_PARAM: parameters.JobParameter = {"name": "test_path_param", "type": "PATH"}
+
+BASE_INT_PARAM: parameters.JobParameter = {"name": "test_int_param", "type": "INT"}
+
+BASE_FLOAT_PARAM: parameters.JobParameter = {"name": "test_float_param", "type": "FLOAT"}
+
+# Constraint parameter definitions
+STRING_PARAM_WITH_MIN_LENGTH: parameters.JobParameter = {
+    "name": "string_with_min_length",
+    "type": "STRING",
+    "minLength": 3,
+}
+
+STRING_PARAM_WITH_MAX_LENGTH: parameters.JobParameter = {
+    "name": "string_with_max_length",
+    "type": "STRING",
+    "maxLength": 10,
+}
+
+INT_PARAM_WITH_MIN_VALUE: parameters.JobParameter = {
+    "name": "int_with_min_value",
+    "type": "INT",
+    "minValue": 5,
+}
+
+INT_PARAM_WITH_MAX_VALUE: parameters.JobParameter = {
+    "name": "int_with_max_value",
+    "type": "INT",
+    "maxValue": 100,
+}
+
+FLOAT_PARAM_WITH_MIN_VALUE: parameters.JobParameter = {
+    "name": "float_with_min_value",
+    "type": "FLOAT",
+    "minValue": 1.5,
+}
+
+FLOAT_PARAM_WITH_MAX_VALUE: parameters.JobParameter = {
+    "name": "float_with_max_value",
+    "type": "FLOAT",
+    "maxValue": 99.9,
+}
+
+STRING_PARAM_WITH_ALLOWED_VALUES: parameters.JobParameter = {
+    "name": "string_with_allowed_values",
+    "type": "STRING",
+    "allowedValues": ["option1", "option2", "option3"],
+}
+
+INT_PARAM_WITH_ALLOWED_VALUES: parameters.JobParameter = {
+    "name": "int_with_allowed_values",
+    "type": "INT",
+    "allowedValues": [1, 2, 3, 5, 8],
+}
+
+PARAM_WITH_MULTIPLE_CONSTRAINTS: parameters.JobParameter = {
+    "name": "param_with_multiple_constraints",
+    "type": "STRING",
+    "minLength": 2,
+    "maxLength": 8,
+    "allowedValues": ["short", "medium", "longer"],
+}
+
+
+class TestTypeValidationAndConversion:
+    @pytest.mark.parametrize(
+        "job_parameter,input_value,expected_output",
+        [
+            pytest.param(
+                BASE_STRING_PARAM, "hello world", "hello world", id="valid_string_unchanged"
+            ),
+            pytest.param(BASE_STRING_PARAM, "", "", id="empty_string_unchanged"),
+            pytest.param(
+                BASE_STRING_PARAM,
+                "test with spaces and symbols!@#",
+                "test with spaces and symbols!@#",
+                id="string_with_special_chars_unchanged",
+            ),
+            pytest.param(BASE_STRING_PARAM, "123", "123", id="numeric_string_unchanged"),
+        ],
+    )
+    def test_string_parameter_validation_valid_values(
+        self, job_parameter: parameters.JobParameter, input_value: str, expected_output: str
+    ) -> None:
+        """Test that valid STRING parameter values are returned unchanged."""
+        result = parameters.validate_job_parameter_value(job_parameter, input_value)
+        assert result == expected_output
+        assert isinstance(result, str)
+
+    def test_string_parameter_validation_type_mismatch_errors(self) -> None:
+        """Test that STRING parameters raise ValueError for non-string inputs."""
+        with pytest.raises(
+            TypeError,
+            match=r"Job parameter 'test_string_param' has type STRING but got value 123 of type <class 'int'>",
+        ):
+            parameters.validate_job_parameter_value(BASE_STRING_PARAM, 123)
+
+    @pytest.mark.parametrize(
+        "job_parameter,input_value,expected_output",
+        [
+            pytest.param(
+                BASE_PATH_PARAM,
+                "/absolute/path/to/file",
+                "/absolute/path/to/file",
+                id="absolute_path_unchanged",
+            ),
+            pytest.param(
+                BASE_PATH_PARAM,
+                "relative/path/to/file",
+                "relative/path/to/file",
+                id="relative_path_unchanged",
+            ),
+            pytest.param(BASE_PATH_PARAM, "", "", id="empty_path_unchanged"),
+            pytest.param(
+                BASE_PATH_PARAM,
+                "C:\\Windows\\Path",
+                "C:\\Windows\\Path",
+                id="windows_path_unchanged",
+            ),
+        ],
+    )
+    def test_path_parameter_validation_valid_values(
+        self, job_parameter: parameters.JobParameter, input_value: str, expected_output: str
+    ) -> None:
+        """Test that valid PATH parameter values are returned unchanged."""
+        result = parameters.validate_job_parameter_value(job_parameter, input_value)
+        assert result == expected_output
+        assert isinstance(result, str)
+
+    def test_path_parameter_validation_type_mismatch_errors(self) -> None:
+        """Test that PATH parameter raise ValueError for non-string input."""
+        with pytest.raises(
+            TypeError,
+            match=r"Job parameter 'test_path_param' has type PATH but got value 123 of type <class 'int'>",
+        ):
+            parameters.validate_job_parameter_value(BASE_PATH_PARAM, 123)
+
+    @pytest.mark.parametrize(
+        "job_parameter,input_value,expected_output",
+        [
+            pytest.param(BASE_INT_PARAM, 42, 42, id="int_value_unchanged"),
+            pytest.param(BASE_INT_PARAM, 0, 0, id="zero_int_unchanged"),
+            pytest.param(BASE_INT_PARAM, -15, -15, id="negative_int_unchanged"),
+            pytest.param(BASE_INT_PARAM, "123", 123, id="string_to_int_conversion"),
+            pytest.param(BASE_INT_PARAM, "0", 0, id="string_zero_to_int_conversion"),
+            pytest.param(BASE_INT_PARAM, "-456", -456, id="negative_string_to_int_conversion"),
+        ],
+    )
+    def test_int_parameter_validation_valid_values(
+        self,
+        job_parameter: parameters.JobParameter,
+        input_value: Union[int, str],
+        expected_output: int,
+    ) -> None:
+        """Test that valid INT parameter values and conversions work correctly."""
+        result = parameters.validate_job_parameter_value(job_parameter, input_value)
+        assert result == expected_output
+        assert isinstance(result, int)
+
+    @pytest.mark.parametrize(
+        "job_parameter,input_value,expected_error_pattern",
+        [
+            pytest.param(
+                BASE_INT_PARAM,
+                "not_a_number",
+                r"Job parameter 'test_int_param' has type INT but got value 'not_a_number' which is not an integer",
+                id="non_numeric_string_conversion_error",
+            ),
+            pytest.param(
+                BASE_INT_PARAM,
+                "12.5",
+                r"Job parameter 'test_int_param' has type INT but got value '12\.5' which is not an integer",
+                id="float_string_conversion_error",
+            ),
+            pytest.param(
+                BASE_INT_PARAM,
+                "abc123",
+                r"Job parameter 'test_int_param' has type INT but got value 'abc123' which is not an integer",
+                id="mixed_string_conversion_error",
+            ),
+            pytest.param(
+                BASE_INT_PARAM,
+                "",
+                r"Job parameter 'test_int_param' has type INT but got value '' which is not an integer",
+                id="empty_string_conversion_error",
+            ),
+            pytest.param(
+                BASE_INT_PARAM,
+                12.5,
+                r"Job parameter 'test_int_param' has type INT but got value 12\.5 which is not an integer",
+                id="float_input_conversion_error",
+            ),
+            pytest.param(
+                BASE_INT_PARAM,
+                None,
+                r"int.. argument must be a string, a bytes-like object or a .*number, not 'NoneType'",
+                id="none_input_conversion_error",
+            ),
+        ],
+    )
+    def test_int_parameter_validation_conversion_errors(
+        self, job_parameter: parameters.JobParameter, input_value: Any, expected_error_pattern: str
+    ) -> None:
+        """Test that INT parameters raise ValueError for non-convertible values."""
+        with pytest.raises((ValueError, TypeError), match=expected_error_pattern):
+            parameters.validate_job_parameter_value(job_parameter, input_value)
+
+    @pytest.mark.parametrize(
+        "job_parameter,input_value,expected_output",
+        [
+            pytest.param(BASE_FLOAT_PARAM, 3.14, 3.14, id="float_value_unchanged"),
+            pytest.param(BASE_FLOAT_PARAM, 0.0, 0.0, id="zero_float_unchanged"),
+            pytest.param(BASE_FLOAT_PARAM, -2.5, -2.5, id="negative_float_unchanged"),
+            pytest.param(BASE_FLOAT_PARAM, 42, 42.0, id="int_to_float_conversion"),
+            pytest.param(BASE_FLOAT_PARAM, "3.14159", 3.14159, id="string_to_float_conversion"),
+            pytest.param(BASE_FLOAT_PARAM, "0.0", 0.0, id="string_zero_to_float_conversion"),
+            pytest.param(BASE_FLOAT_PARAM, "-2.7", -2.7, id="negative_string_to_float_conversion"),
+            pytest.param(BASE_FLOAT_PARAM, "42", 42.0, id="int_string_to_float_conversion"),
+        ],
+    )
+    def test_float_parameter_validation_valid_values(
+        self,
+        job_parameter: parameters.JobParameter,
+        input_value: Union[int, float, str],
+        expected_output: float,
+    ) -> None:
+        """Test that valid FLOAT parameter values and conversions work correctly."""
+        result = parameters.validate_job_parameter_value(job_parameter, input_value)
+        assert result == expected_output
+        assert isinstance(result, float)
+
+    @pytest.mark.parametrize(
+        "job_parameter,input_value,expected_error_pattern",
+        [
+            pytest.param(
+                BASE_FLOAT_PARAM,
+                "not_a_number",
+                r"Job parameter 'test_float_param' has type FLOAT but got value 'not_a_number' which is not floating point",
+                id="non_numeric_string_conversion_error",
+            ),
+            pytest.param(
+                BASE_FLOAT_PARAM,
+                "abc123",
+                r"Job parameter 'test_float_param' has type FLOAT but got value 'abc123' which is not floating point",
+                id="mixed_string_conversion_error",
+            ),
+            pytest.param(
+                BASE_FLOAT_PARAM,
+                "",
+                r"Job parameter 'test_float_param' has type FLOAT but got value '' which is not floating point",
+                id="empty_string_conversion_error",
+            ),
+            pytest.param(
+                BASE_FLOAT_PARAM,
+                "12.5.6",
+                r"Job parameter 'test_float_param' has type FLOAT but got value '12\.5\.6' which is not floating point",
+                id="invalid_float_format_conversion_error",
+            ),
+            pytest.param(
+                BASE_FLOAT_PARAM,
+                None,
+                r"float.. argument must be a string or a .*number, not 'NoneType'",
+                id="none_input_conversion_error",
+            ),
+        ],
+    )
+    def test_float_parameter_validation_conversion_errors(
+        self, job_parameter: parameters.JobParameter, input_value: Any, expected_error_pattern: str
+    ) -> None:
+        """Test that FLOAT parameters raise ValueError for non-convertible values."""
+        with pytest.raises((ValueError, TypeError), match=expected_error_pattern):
+            parameters.validate_job_parameter_value(job_parameter, input_value)
+
+    def test_unsupported_type_error(self) -> None:
+        """Test that an incorrect type in the type definition raises a TypeError."""
+        with pytest.raises(
+            TypeError,
+            match="The definition for job parameter 'test_param' has unsupported type 'UNSUPPORTED'",
+        ):
+            job_parameter: parameters.JobParameter = {
+                "name": "test_param",
+                "type": "UNSUPPORTED",
+            }
+            parameters.validate_job_parameter_value(job_parameter, "value")
+
+
+class TestConstraintValidation:
+    @pytest.mark.parametrize(
+        "job_parameter,input_value,expected_output",
+        [
+            # minLength constraint tests - valid cases
+            pytest.param(
+                STRING_PARAM_WITH_MIN_LENGTH, "abc", "abc", id="string_exactly_at_min_length"
+            ),
+            pytest.param(
+                STRING_PARAM_WITH_MIN_LENGTH, "abcd", "abcd", id="string_above_min_length"
+            ),
+            pytest.param(
+                STRING_PARAM_WITH_MIN_LENGTH,
+                "this is a longer string",
+                "this is a longer string",
+                id="string_well_above_min_length",
+            ),
+            # maxLength constraint tests - valid cases
+            pytest.param(
+                STRING_PARAM_WITH_MAX_LENGTH, "short", "short", id="string_below_max_length"
+            ),
+            pytest.param(
+                STRING_PARAM_WITH_MAX_LENGTH,
+                "exactly10c",
+                "exactly10c",
+                id="string_exactly_at_max_length",
+            ),
+            pytest.param(STRING_PARAM_WITH_MAX_LENGTH, "", "", id="empty_string_below_max_length"),
+            # PATH parameter length constraints
+            pytest.param(
+                {"name": "path_with_min_length", "type": "PATH", "minLength": 5},
+                "/path",
+                "/path",
+                id="path_exactly_at_min_length",
+            ),
+            pytest.param(
+                {"name": "path_with_max_length", "type": "PATH", "maxLength": 15},
+                "/short/path",
+                "/short/path",
+                id="path_below_max_length",
+            ),
+        ],
+    )
+    def test_length_constraints_valid_values(
+        self, job_parameter: parameters.JobParameter, input_value: str, expected_output: str
+    ) -> None:
+        """Test that STRING/PATH parameters with length constraints accept valid values."""
+        result = parameters.validate_job_parameter_value(job_parameter, input_value)
+        assert result == expected_output
+        assert isinstance(result, str)
+
+    @pytest.mark.parametrize(
+        "job_parameter,input_value,expected_error_pattern",
+        [
+            # minLength constraint violation tests
+            pytest.param(
+                STRING_PARAM_WITH_MIN_LENGTH,
+                "ab",
+                r"Job parameter 'string_with_min_length' value 'ab' is shorter than minLength 3\.",
+                id="string_below_min_length",
+            ),
+            pytest.param(
+                STRING_PARAM_WITH_MIN_LENGTH,
+                "",
+                r"Job parameter 'string_with_min_length' value '' is shorter than minLength 3\.",
+                id="empty_string_below_min_length",
+            ),
+            pytest.param(
+                STRING_PARAM_WITH_MIN_LENGTH,
+                "x",
+                r"Job parameter 'string_with_min_length' value 'x' is shorter than minLength 3\.",
+                id="single_char_below_min_length",
+            ),
+            # maxLength constraint violation tests
+            pytest.param(
+                STRING_PARAM_WITH_MAX_LENGTH,
+                "this string is too long",
+                r"Job parameter 'string_with_max_length' value 'this string is too long' is longer than maxLength 10\.",
+                id="string_above_max_length",
+            ),
+            pytest.param(
+                STRING_PARAM_WITH_MAX_LENGTH,
+                "exactly11ch",
+                r"Job parameter 'string_with_max_length' value 'exactly11ch' is longer than maxLength 10\.",
+                id="string_one_char_above_max_length",
+            ),
+            # PATH parameter length constraint violations
+            pytest.param(
+                {"name": "path_with_min_length", "type": "PATH", "minLength": 10},
+                "/short",
+                r"Job parameter 'path_with_min_length' value '/short' is shorter than minLength 10\.",
+                id="path_below_min_length",
+            ),
+            pytest.param(
+                {"name": "path_with_max_length", "type": "PATH", "maxLength": 5},
+                "/very/long/path",
+                r"Job parameter 'path_with_max_length' value '/very/long/path' is longer than maxLength 5\.",
+                id="path_above_max_length",
+            ),
+        ],
+    )
+    def test_length_constraints_violation_errors(
+        self, job_parameter: parameters.JobParameter, input_value: str, expected_error_pattern: str
+    ) -> None:
+        """Test that STRING/PATH parameters raise ValueError for length constraint violations."""
+        with pytest.raises(ValueError, match=expected_error_pattern):
+            parameters.validate_job_parameter_value(job_parameter, input_value)
+
+    @pytest.mark.parametrize(
+        "job_parameter,input_value,expected_output",
+        [
+            # minValue constraint tests - valid cases
+            pytest.param(INT_PARAM_WITH_MIN_VALUE, 5, 5, id="int_exactly_at_min_value"),
+            pytest.param(INT_PARAM_WITH_MIN_VALUE, 10, 10, id="int_above_min_value"),
+            pytest.param(INT_PARAM_WITH_MIN_VALUE, "5", 5, id="int_string_exactly_at_min_value"),
+            pytest.param(INT_PARAM_WITH_MIN_VALUE, "15", 15, id="int_string_above_min_value"),
+            pytest.param(FLOAT_PARAM_WITH_MIN_VALUE, 1.5, 1.5, id="float_exactly_at_min_value"),
+            pytest.param(FLOAT_PARAM_WITH_MIN_VALUE, 2.0, 2.0, id="float_above_min_value"),
+            pytest.param(
+                FLOAT_PARAM_WITH_MIN_VALUE, "1.5", 1.5, id="float_string_exactly_at_min_value"
+            ),
+            # maxValue constraint tests - valid cases
+            pytest.param(INT_PARAM_WITH_MAX_VALUE, 100, 100, id="int_exactly_at_max_value"),
+            pytest.param(INT_PARAM_WITH_MAX_VALUE, 50, 50, id="int_below_max_value"),
+            pytest.param(
+                INT_PARAM_WITH_MAX_VALUE, "100", 100, id="int_string_exactly_at_max_value"
+            ),
+            pytest.param(FLOAT_PARAM_WITH_MAX_VALUE, 99.9, 99.9, id="float_exactly_at_max_value"),
+            pytest.param(FLOAT_PARAM_WITH_MAX_VALUE, 50.5, 50.5, id="float_below_max_value"),
+            pytest.param(
+                FLOAT_PARAM_WITH_MAX_VALUE, "99.9", 99.9, id="float_string_exactly_at_max_value"
+            ),
+        ],
+    )
+    def test_value_constraints_valid_values(
+        self,
+        job_parameter: parameters.JobParameter,
+        input_value: Union[str, int, float],
+        expected_output: Union[int, float],
+    ) -> None:
+        """Test that parameters with value constraints accept valid values."""
+        result = parameters.validate_job_parameter_value(job_parameter, input_value)
+        assert result == expected_output
+        assert type(result) is type(expected_output)
+
+    @pytest.mark.parametrize(
+        "job_parameter,input_value,expected_error_pattern",
+        [
+            # minValue constraint violation tests
+            pytest.param(
+                INT_PARAM_WITH_MIN_VALUE,
+                4,
+                r"Job parameter 'int_with_min_value' value 4 is less than minValue 5\.",
+                id="int_below_min_value",
+            ),
+            pytest.param(
+                INT_PARAM_WITH_MIN_VALUE,
+                "0",
+                r"Job parameter 'int_with_min_value' value 0 is less than minValue 5\.",
+                id="int_string_below_min_value",
+            ),
+            pytest.param(
+                INT_PARAM_WITH_MIN_VALUE,
+                -10,
+                r"Job parameter 'int_with_min_value' value -10 is less than minValue 5\.",
+                id="negative_int_below_min_value",
+            ),
+            pytest.param(
+                FLOAT_PARAM_WITH_MIN_VALUE,
+                1.4,
+                r"Job parameter 'float_with_min_value' value 1\.4 is less than minValue 1\.5\.",
+                id="float_below_min_value",
+            ),
+            pytest.param(
+                FLOAT_PARAM_WITH_MIN_VALUE,
+                "0.5",
+                r"Job parameter 'float_with_min_value' value 0\.5 is less than minValue 1\.5\.",
+                id="float_string_below_min_value",
+            ),
+            # maxValue constraint violation tests
+            pytest.param(
+                INT_PARAM_WITH_MAX_VALUE,
+                101,
+                r"Job parameter 'int_with_max_value' value 101 is greater than maxValue 100\.",
+                id="int_above_max_value",
+            ),
+            pytest.param(
+                INT_PARAM_WITH_MAX_VALUE,
+                "150",
+                r"Job parameter 'int_with_max_value' value 150 is greater than maxValue 100\.",
+                id="int_string_above_max_value",
+            ),
+            pytest.param(
+                FLOAT_PARAM_WITH_MAX_VALUE,
+                100.0,
+                r"Job parameter 'float_with_max_value' value 100\.0 is greater than maxValue 99\.9\.",
+                id="float_above_max_value",
+            ),
+            pytest.param(
+                FLOAT_PARAM_WITH_MAX_VALUE,
+                "200.5",
+                r"Job parameter 'float_with_max_value' value 200\.5 is greater than maxValue 99\.9\.",
+                id="float_string_above_max_value",
+            ),
+        ],
+    )
+    def test_value_constraints_violation_errors(
+        self,
+        job_parameter: parameters.JobParameter,
+        input_value: Union[str, int, float],
+        expected_error_pattern: str,
+    ) -> None:
+        """Test that parameters raise ValueError for value constraint violations."""
+        with pytest.raises(ValueError, match=expected_error_pattern):
+            parameters.validate_job_parameter_value(job_parameter, input_value)
+
+    @pytest.mark.parametrize(
+        "job_parameter,input_value,expected_output",
+        [
+            # STRING allowedValues tests - valid cases
+            pytest.param(
+                STRING_PARAM_WITH_ALLOWED_VALUES,
+                "option1",
+                "option1",
+                id="string_first_allowed_value",
+            ),
+            pytest.param(
+                STRING_PARAM_WITH_ALLOWED_VALUES,
+                "option2",
+                "option2",
+                id="string_middle_allowed_value",
+            ),
+            pytest.param(
+                STRING_PARAM_WITH_ALLOWED_VALUES,
+                "option3",
+                "option3",
+                id="string_last_allowed_value",
+            ),
+            # INT allowedValues tests - valid cases
+            pytest.param(INT_PARAM_WITH_ALLOWED_VALUES, 1, 1, id="int_first_allowed_value"),
+            pytest.param(INT_PARAM_WITH_ALLOWED_VALUES, 5, 5, id="int_middle_allowed_value"),
+            pytest.param(INT_PARAM_WITH_ALLOWED_VALUES, 8, 8, id="int_last_allowed_value"),
+            pytest.param(
+                INT_PARAM_WITH_ALLOWED_VALUES, "3", 3, id="int_string_allowed_value_with_conversion"
+            ),
+            # FLOAT allowedValues tests - valid cases
+            pytest.param(
+                {
+                    "name": "float_with_allowed_values",
+                    "type": "FLOAT",
+                    "allowedValues": [1.5, 2.7, 3.14],
+                },
+                1.5,
+                1.5,
+                id="float_first_allowed_value",
+            ),
+            pytest.param(
+                {
+                    "name": "float_with_allowed_values",
+                    "type": "FLOAT",
+                    "allowedValues": [1.5, 2.7, 3.14],
+                },
+                "2.7",
+                2.7,
+                id="float_string_allowed_value_with_conversion",
+            ),
+            # PATH allowedValues tests - valid cases
+            pytest.param(
+                {
+                    "name": "path_with_allowed_values",
+                    "type": "PATH",
+                    "allowedValues": ["/path1", "/path2", "/path3"],
+                },
+                "/path1",
+                "/path1",
+                id="path_first_allowed_value",
+            ),
+            pytest.param(
+                {
+                    "name": "path_with_allowed_values",
+                    "type": "PATH",
+                    "allowedValues": ["/path1", "/path2", "/path3"],
+                },
+                "/path3",
+                "/path3",
+                id="path_last_allowed_value",
+            ),
+        ],
+    )
+    def test_allowed_values_constraint_valid_values(
+        self,
+        job_parameter: parameters.JobParameter,
+        input_value: Union[str, int, float],
+        expected_output: Union[str, int, float],
+    ) -> None:
+        """Test that parameters with allowedValues constraints accept valid values."""
+        result = parameters.validate_job_parameter_value(job_parameter, input_value)
+        assert result == expected_output
+        assert type(result) is type(expected_output)
+
+    @pytest.mark.parametrize(
+        "job_parameter,input_value,expected_error_pattern",
+        [
+            # STRING allowedValues violation tests
+            pytest.param(
+                STRING_PARAM_WITH_ALLOWED_VALUES,
+                "invalid_option",
+                r"Job parameter 'string_with_allowed_values' value 'invalid_option' is not an allowed value from \('option1', 'option2', 'option3'\)\.",
+                id="string_invalid_allowed_value",
+            ),
+            pytest.param(
+                STRING_PARAM_WITH_ALLOWED_VALUES,
+                "Option1",
+                r"Job parameter 'string_with_allowed_values' value 'Option1' is not an allowed value from \('option1', 'option2', 'option3'\)\.",
+                id="string_case_sensitive_invalid_value",
+            ),
+            pytest.param(
+                STRING_PARAM_WITH_ALLOWED_VALUES,
+                "",
+                r"Job parameter 'string_with_allowed_values' value '' is not an allowed value from \('option1', 'option2', 'option3'\)\.",
+                id="empty_string_not_in_allowed_values",
+            ),
+            # INT allowedValues violation tests
+            pytest.param(
+                INT_PARAM_WITH_ALLOWED_VALUES,
+                4,
+                r"Job parameter 'int_with_allowed_values' value 4 is not an allowed value from \(1, 2, 3, 5, 8\)\.",
+                id="int_invalid_allowed_value",
+            ),
+            pytest.param(
+                INT_PARAM_WITH_ALLOWED_VALUES,
+                "4",
+                r"Job parameter 'int_with_allowed_values' value 4 is not an allowed value from \(1, 2, 3, 5, 8\)\.",
+                id="int_string_invalid_allowed_value",
+            ),
+            pytest.param(
+                INT_PARAM_WITH_ALLOWED_VALUES,
+                0,
+                r"Job parameter 'int_with_allowed_values' value 0 is not an allowed value from \(1, 2, 3, 5, 8\)\.",
+                id="zero_not_in_allowed_values",
+            ),
+            # FLOAT allowedValues violation tests
+            pytest.param(
+                {
+                    "name": "float_with_allowed_values",
+                    "type": "FLOAT",
+                    "allowedValues": [1.5, 2.7, 3.14],
+                },
+                2.0,
+                r"Job parameter 'float_with_allowed_values' value 2\.0 is not an allowed value from \(1\.5, 2\.7, 3\.14\)\.",
+                id="float_invalid_allowed_value",
+            ),
+            pytest.param(
+                {
+                    "name": "float_with_allowed_values",
+                    "type": "FLOAT",
+                    "allowedValues": [1.5, 2.7, 3.14],
+                },
+                "2.0",
+                r"Job parameter 'float_with_allowed_values' value 2\.0 is not an allowed value from \(1\.5, 2\.7, 3\.14\)\.",
+                id="float_string_invalid_allowed_value",
+            ),
+            # PATH allowedValues violation tests
+            pytest.param(
+                {
+                    "name": "path_with_allowed_values",
+                    "type": "PATH",
+                    "allowedValues": ["/path1", "/path2", "/path3"],
+                },
+                "/invalid/path",
+                r"Job parameter 'path_with_allowed_values' value '/invalid/path' is not an allowed value from \('/path1', '/path2', '/path3'\)\.",
+                id="path_invalid_allowed_value",
+            ),
+            pytest.param(
+                {
+                    "name": "path_with_allowed_values",
+                    "type": "PATH",
+                    "allowedValues": ["/path1", "/path2", "/path3"],
+                },
+                "/Path1",
+                r"Job parameter 'path_with_allowed_values' value '/Path1' is not an allowed value from \('/path1', '/path2', '/path3'\)\.",
+                id="path_case_sensitive_invalid_value",
+            ),
+        ],
+    )
+    def test_allowed_values_constraint_violation_errors(
+        self,
+        job_parameter: parameters.JobParameter,
+        input_value: Union[str, int, float],
+        expected_error_pattern: str,
+    ) -> None:
+        """Test that parameters raise ValueError for allowedValues constraint violations."""
+        with pytest.raises(ValueError, match=expected_error_pattern):
+            parameters.validate_job_parameter_value(job_parameter, input_value)
+
+    @pytest.mark.parametrize(
+        "job_parameter,input_value,expected_output",
+        [
+            # Multiple constraints - valid cases
+            pytest.param(
+                PARAM_WITH_MULTIPLE_CONSTRAINTS,
+                "short",
+                "short",
+                id="multiple_constraints_first_allowed_value",
+            ),
+            pytest.param(
+                PARAM_WITH_MULTIPLE_CONSTRAINTS,
+                "medium",
+                "medium",
+                id="multiple_constraints_middle_allowed_value",
+            ),
+            pytest.param(
+                PARAM_WITH_MULTIPLE_CONSTRAINTS,
+                "longer",
+                "longer",
+                id="multiple_constraints_last_allowed_value",
+            ),
+            # INT with multiple constraints
+            pytest.param(
+                {
+                    "name": "int_with_multiple_constraints",
+                    "type": "INT",
+                    "minValue": 10,
+                    "maxValue": 50,
+                    "allowedValues": [10, 20, 30, 40, 50],
+                },
+                10,
+                10,
+                id="int_multiple_constraints_min_boundary",
+            ),
+            pytest.param(
+                {
+                    "name": "int_with_multiple_constraints",
+                    "type": "INT",
+                    "minValue": 10,
+                    "maxValue": 50,
+                    "allowedValues": [10, 20, 30, 40, 50],
+                },
+                "30",
+                30,
+                id="int_multiple_constraints_middle_value_with_conversion",
+            ),
+            pytest.param(
+                {
+                    "name": "int_with_multiple_constraints",
+                    "type": "INT",
+                    "minValue": 10,
+                    "maxValue": 50,
+                    "allowedValues": [10, 20, 30, 40, 50],
+                },
+                50,
+                50,
+                id="int_multiple_constraints_max_boundary",
+            ),
+            # FLOAT with multiple constraints
+            pytest.param(
+                {
+                    "name": "float_with_multiple_constraints",
+                    "type": "FLOAT",
+                    "minValue": 1.0,
+                    "maxValue": 10.0,
+                    "allowedValues": [1.5, 5.0, 9.5],
+                },
+                1.5,
+                1.5,
+                id="float_multiple_constraints_valid_value",
+            ),
+            pytest.param(
+                {
+                    "name": "float_with_multiple_constraints",
+                    "type": "FLOAT",
+                    "minValue": 1.0,
+                    "maxValue": 10.0,
+                    "allowedValues": [1.5, 5.0, 9.5],
+                },
+                "9.5",
+                9.5,
+                id="float_multiple_constraints_with_conversion",
+            ),
+            # PATH with multiple constraints
+            pytest.param(
+                {
+                    "name": "path_with_multiple_constraints",
+                    "type": "PATH",
+                    "minLength": 5,
+                    "maxLength": 20,
+                    "allowedValues": ["/path1", "/longer/path", "/very/long/path"],
+                },
+                "/path1",
+                "/path1",
+                id="path_multiple_constraints_short_valid",
+            ),
+            pytest.param(
+                {
+                    "name": "path_with_multiple_constraints",
+                    "type": "PATH",
+                    "minLength": 5,
+                    "maxLength": 20,
+                    "allowedValues": ["/path1", "/longer/path", "/very/long/path"],
+                },
+                "/very/long/path",
+                "/very/long/path",
+                id="path_multiple_constraints_long_valid",
+            ),
+        ],
+    )
+    def test_multiple_constraints_valid_values(
+        self,
+        job_parameter: parameters.JobParameter,
+        input_value: Union[str, int, float],
+        expected_output: Union[str, int, float],
+    ) -> None:
+        """Test that parameters with multiple constraints accept values that satisfy all constraints."""
+        result = parameters.validate_job_parameter_value(job_parameter, input_value)
+        assert result == expected_output
+        assert type(result) is type(expected_output)
+
+    @pytest.mark.parametrize(
+        "job_parameter,input_value,expected_error_pattern",
+        [
+            # Multiple constraints - length violation
+            pytest.param(
+                PARAM_WITH_MULTIPLE_CONSTRAINTS,
+                "x",
+                r"Job parameter 'param_with_multiple_constraints' value 'x' is shorter than minLength 2\.",
+                id="multiple_constraints_min_length_violation",
+            ),
+            pytest.param(
+                PARAM_WITH_MULTIPLE_CONSTRAINTS,
+                "toolongstring",
+                r"Job parameter 'param_with_multiple_constraints' value 'toolongstring' is longer than maxLength 8\.",
+                id="multiple_constraints_max_length_violation",
+            ),
+            # Multiple constraints - allowedValues violation (but satisfies length)
+            pytest.param(
+                PARAM_WITH_MULTIPLE_CONSTRAINTS,
+                "valid",
+                r"Job parameter 'param_with_multiple_constraints' value 'valid' is not an allowed value from \('short', 'medium', 'longer'\)\.",
+                id="multiple_constraints_allowed_values_violation",
+            ),
+            # INT with multiple constraints - minValue violation
+            pytest.param(
+                {
+                    "name": "int_with_multiple_constraints",
+                    "type": "INT",
+                    "minValue": 10,
+                    "maxValue": 50,
+                    "allowedValues": [10, 20, 30, 40, 50],
+                },
+                5,
+                r"Job parameter 'int_with_multiple_constraints' value 5 is less than minValue 10\.",
+                id="int_multiple_constraints_min_value_violation",
+            ),
+            # INT with multiple constraints - maxValue violation
+            pytest.param(
+                {
+                    "name": "int_with_multiple_constraints",
+                    "type": "INT",
+                    "minValue": 10,
+                    "maxValue": 50,
+                    "allowedValues": [10, 20, 30, 40, 50],
+                },
+                60,
+                r"Job parameter 'int_with_multiple_constraints' value 60 is greater than maxValue 50\.",
+                id="int_multiple_constraints_max_value_violation",
+            ),
+            # INT with multiple constraints - allowedValues violation (but satisfies min/max)
+            pytest.param(
+                {
+                    "name": "int_with_multiple_constraints",
+                    "type": "INT",
+                    "minValue": 10,
+                    "maxValue": 50,
+                    "allowedValues": [10, 20, 30, 40, 50],
+                },
+                25,
+                r"Job parameter 'int_with_multiple_constraints' value 25 is not an allowed value from \(10, 20, 30, 40, 50\)\.",
+                id="int_multiple_constraints_allowed_values_violation",
+            ),
+            # FLOAT with multiple constraints - minValue violation
+            pytest.param(
+                {
+                    "name": "float_with_multiple_constraints",
+                    "type": "FLOAT",
+                    "minValue": 1.0,
+                    "maxValue": 10.0,
+                    "allowedValues": [1.5, 5.0, 9.5],
+                },
+                0.5,
+                r"Job parameter 'float_with_multiple_constraints' value 0\.5 is less than minValue 1\.0\.",
+                id="float_multiple_constraints_min_value_violation",
+            ),
+            # FLOAT with multiple constraints - allowedValues violation (but satisfies min/max)
+            pytest.param(
+                {
+                    "name": "float_with_multiple_constraints",
+                    "type": "FLOAT",
+                    "minValue": 1.0,
+                    "maxValue": 10.0,
+                    "allowedValues": [1.5, 5.0, 9.5],
+                },
+                7.5,
+                r"Job parameter 'float_with_multiple_constraints' value 7\.5 is not an allowed value from \(1\.5, 5\.0, 9\.5\)\.",
+                id="float_multiple_constraints_allowed_values_violation",
+            ),
+            # PATH with multiple constraints - length violation
+            pytest.param(
+                {
+                    "name": "path_with_multiple_constraints",
+                    "type": "PATH",
+                    "minLength": 5,
+                    "maxLength": 20,
+                    "allowedValues": ["/path1", "/longer/path", "/very/long/path"],
+                },
+                "/x",
+                r"Job parameter 'path_with_multiple_constraints' value '/x' is shorter than minLength 5\.",
+                id="path_multiple_constraints_min_length_violation",
+            ),
+            # PATH with multiple constraints - allowedValues violation (but satisfies length)
+            pytest.param(
+                {
+                    "name": "path_with_multiple_constraints",
+                    "type": "PATH",
+                    "minLength": 5,
+                    "maxLength": 20,
+                    "allowedValues": ["/path1", "/longer/path", "/very/long/path"],
+                },
+                "/other/path",
+                r"Job parameter 'path_with_multiple_constraints' value '/other/path' is not an allowed value from \('/path1', '/longer/path', '/very/long/path'\)\.",
+                id="path_multiple_constraints_allowed_values_violation",
+            ),
+        ],
+    )
+    def test_multiple_constraints_violation_errors(
+        self,
+        job_parameter: parameters.JobParameter,
+        input_value: Union[str, int, float],
+        expected_error_pattern: str,
+    ) -> None:
+        """Test that parameters with multiple constraints raise ValueError when any constraint is violated."""
+        with pytest.raises(ValueError, match=expected_error_pattern):
+            parameters.validate_job_parameter_value(job_parameter, input_value)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Sometimes, when you've got a job submission command like:

```
deadline bundle submit my_bundle -p MyParam=12
```

you want to start from there and instead use the GUI to edit more parameters instead of adding more `-p` options. This change adds support for that, so the following will work:

```
deadline bundle gui-submit my_bundle -p MyParam=12
```

### What was the solution? (How)

Implement support for the `-p` / `--parameter` option to `deadline bundle gui-submit`.

### What is the impact of this change?

You can pass parameter values to `deadline bundle gui-submit` to set the GUI controls for those parameters.

### How was this change tested?

Manually tested different cases of job parameters vs queue parameters, and different parameter types. The GUI code doesn't have a testing framework to add unit tests in, so this change does not include unit tests.

### Was this change documented?

The help output of the Deadline CLI includes this command.

### Does this PR introduce new dependencies?

No

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
