### PR TITLE
chore: pin the version of click that hatch uses to <8.3 due to Sentinel bug

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -124,7 +124,7 @@ jobs:
           python-version: '3.9'
       - name: Install dependencies
         run: |
-          pip install --upgrade hatch
+          pip install --upgrade hatch "click<8.3"
       - name: Build
         run: hatch -v build
       # # See https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi

--- a/.github/workflows/reusable_python_build_coverage_override.yml
+++ b/.github/workflows/reusable_python_build_coverage_override.yml
@@ -70,7 +70,7 @@ jobs:
 
     - name: Install Hatch
       run: |
-        pip install --upgrade hatch
+        pip install --upgrade hatch "click<8.3"
 
     - name: Run Linting
       run: hatch -v run lint

--- a/pipeline/build.ps1
+++ b/pipeline/build.ps1
@@ -6,7 +6,7 @@ $ErrorActionPreference = "Stop"
 # Install/upgrade packages
 python -m pip install --upgrade pip
 if ($LASTEXITCODE -ne 0) { throw "Failed to update pip" }
-python -m pip install --upgrade hatch
+python -m pip install --upgrade hatch "click<8.3"
 if ($LASTEXITCODE -ne 0) { throw "Failed to update hatch" }
 python -m pip install --upgrade twine
 if ($LASTEXITCODE -ne 0) { throw "Failed to update twine" }

--- a/pipeline/build.sh
+++ b/pipeline/build.sh
@@ -4,7 +4,7 @@
 set -e
 
 pip install --upgrade pip
-pip install --upgrade hatch
+pip install --upgrade hatch "click<8.3"
 pip install --upgrade twine
 hatch -v run codebuild:lint
 hatch run codebuild:test

--- a/pipeline/build_pyinstaller_artifact.ps1
+++ b/pipeline/build_pyinstaller_artifact.ps1
@@ -4,7 +4,7 @@ $ErrorActionPreference = "Stop"
 
 pip install --upgrade pip
 if ($LASTEXITCODE -ne 0) { throw "Failed to update pip" }
-pip install --upgrade hatch
+pip install --upgrade hatch "click<8.3"
 if ($LASTEXITCODE -ne 0) { throw "Failed to update hatch" }
 
 hatch run installer:build

--- a/pipeline/e2e.sh
+++ b/pipeline/e2e.sh
@@ -4,5 +4,5 @@
 set -e
 
 pip install --upgrade pip
-pip install --upgrade hatch
+pip install --upgrade hatch "click<8.3"
 hatch run e2e:test

--- a/pipeline/integ.ps1
+++ b/pipeline/integ.ps1
@@ -3,6 +3,6 @@
 $ErrorActionPreference = "Stop"
 
 pip install --upgrade pip
-pip install --upgrade hatch
+pip install --upgrade hatch "click<8.3"
 hatch run integ:test
 if ($LASTEXITCODE -ne 0) { throw "Failed to run integration tests" }

--- a/pipeline/integ.sh
+++ b/pipeline/integ.sh
@@ -4,5 +4,5 @@
 set -e
 
 pip install --upgrade pip
-pip install --upgrade hatch
+pip install --upgrade hatch "click<8.3"
 hatch run integ:test


### PR DESCRIPTION
related: aws-deadline/.github#56

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
