### PR TITLE
fix: Improved job submission performance by multithreading syscalls to stat() and…

### DIFF
--- a/src/deadline/job_attachments/upload.py
+++ b/src/deadline/job_attachments/upload.py
@@ -532,13 +532,6 @@ class S3AssetUploader:
         # Otherwise all hashes exist in S3
         return True
 
-    def _sample_cache_entries_with_limit(
-        self, cache_entries: List[S3CheckCacheEntry], limit: int = 30
-    ):
-        sampled_count: int = min(len(cache_entries), limit)
-        random.shuffle(cache_entries)
-        return cache_entries[:sampled_count]
-
     def verify_hash_cache_integrity(
         self,
         s3_check_cache_dir: Optional[str],
@@ -551,22 +544,22 @@ class S3AssetUploader:
         verifies if the cached assets exist in S3. Returns True if all sampled cached assets exist in S3, False
         otherwise.
         """
-
         # Find the list of s3 upload keys that have been cached
         s3_upload_keys: List[str] = [
             self._generate_s3_upload_key(file, manifest.hashAlg, s3_cas_prefix)
             for file in manifest.paths
         ]
-        with S3CheckCache(s3_check_cache_dir) as s3_cache:
-            cache_entries = [
-                s3_cache.get_entry(s3_key=f"{s3_bucket}/{upload_key}")
-                for upload_key in s3_upload_keys
-                if s3_cache.get_entry(s3_key=f"{s3_bucket}/{upload_key}") is not None
-            ]
 
-            # verify that a sample of the cached entries still exist in S3
-            sampled_cache_entries = self._sample_cache_entries_with_limit(cache_entries)
-            return self._check_hashes_exist_in_s3(sampled_cache_entries)
+        random.shuffle(s3_upload_keys)
+        sampled_cache_entries: List[S3CheckCacheEntry] = []
+        with S3CheckCache(s3_check_cache_dir) as s3_cache:
+            for upload_key in s3_upload_keys:
+                this_entry = s3_cache.get_entry(s3_key=f"{s3_bucket}/{upload_key}")
+                if this_entry is not None:
+                    sampled_cache_entries.append(this_entry)
+                    if len(sampled_cache_entries) >= 30:
+                        break
+        return self._check_hashes_exist_in_s3(sampled_cache_entries)
 
     def _separate_files_by_size(
         self,
@@ -617,13 +610,12 @@ class S3AssetUploader:
         local_path = source_root.joinpath(file.path)
         s3_upload_key = self._generate_s3_upload_key(file, hash_algorithm, s3_cas_prefix)
         is_uploaded = False
-        file_size = local_path.resolve().stat().st_size
 
         if s3_check_cache.get_entry(s3_key=f"{s3_bucket}/{s3_upload_key}"):
             logger.debug(
                 f"skipping {local_path} because {s3_bucket}/{s3_upload_key} exists in the cache"
             )
-            return (is_uploaded, file_size)
+            return (is_uploaded, file.size)
 
         if self.file_already_uploaded(s3_bucket, s3_upload_key):
             logger.debug(
@@ -645,7 +637,7 @@ class S3AssetUploader:
             )
         )
 
-        return (is_uploaded, file_size)
+        return (is_uploaded, file.size)
 
     def _snapshot_object_to_cas(
         self,
@@ -1292,15 +1284,17 @@ class S3AssetManager:
             return top_directory
 
     def _get_total_size_of_files(self, paths: list[str]) -> int:
-        total_bytes = 0
-        try:
-            for path in paths:
-                total_bytes += Path(path).resolve().stat().st_size
-        except FileNotFoundError:
-            logger.warning(
-                f"Skipping the input from total size calculation as it doesn't exist: {path}"
-            )
-        return total_bytes
+        def get_file_size(path_str: str) -> int:
+            try:
+                return Path(path_str).resolve().stat().st_size
+            except (FileNotFoundError, PermissionError, OSError):
+                logger.warning(f"Skipping file in size calculation: {path_str}")
+                return 0
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
+            sizes = list(executor.map(get_file_size, paths))
+
+        return sum(sizes)
 
     def _get_total_input_size_from_manifests(
         self, manifests: list[AssetRootManifest]
@@ -1309,14 +1303,9 @@ class S3AssetManager:
         total_bytes = 0
         for asset_root_manifest in manifests:
             if asset_root_manifest.asset_manifest:
-                input_paths = asset_root_manifest.asset_manifest.paths
-                input_paths_str = [
-                    str(Path(asset_root_manifest.root_path).joinpath(path.path))
-                    for path in input_paths
-                ]
-                total_files += len(input_paths)
-                total_bytes += self._get_total_size_of_files(input_paths_str)
-
+                total_files += len(asset_root_manifest.asset_manifest.paths)
+                for path in asset_root_manifest.asset_manifest.paths:
+                    total_bytes += path.size
         return (total_files, total_bytes)
 
     def _get_total_input_size_from_asset_group(

--- a/test/unit/deadline_job_attachments/test_upload.py
+++ b/test/unit/deadline_job_attachments/test_upload.py
@@ -2787,6 +2787,157 @@ class TestUpload:
         assert hash_alg == HashAlgorithm.XXH128
         assert manifest_name == "da20652d1ff9f1dc55050b28b3ab6d36_suffix"
 
+    def test_get_total_size_of_files_with_valid_files(self, tmp_path: Path):
+        """Test that _get_total_size_of_files correctly calculates total size for valid files."""
+        # Create test files with known sizes
+        file1 = tmp_path / "file1.txt"
+        file2 = tmp_path / "file2.txt"
+        file1.write_text("hello")  # 5 bytes
+        file2.write_text("world!")  # 6 bytes
+
+        manager = S3AssetManager(
+            farm_id="farm-123",
+            queue_id="queue-456",
+            job_attachment_settings=JobAttachmentS3Settings(
+                s3BucketName="test-bucket", rootPrefix="test-prefix"
+            ),
+        )
+
+        total_size = manager._get_total_size_of_files([str(file1), str(file2)])
+        assert total_size == 11
+
+    def test_get_total_size_of_files_with_missing_files(self, tmp_path: Path, caplog):
+        """Test that _get_total_size_of_files handles missing files gracefully."""
+        # Create one real file and reference non-existent files
+        real_file = tmp_path / "real.txt"
+        real_file.write_text("content")  # 7 bytes
+        missing_file = tmp_path / "missing.txt"
+
+        manager = S3AssetManager(
+            farm_id="farm-123",
+            queue_id="queue-456",
+            job_attachment_settings=JobAttachmentS3Settings(
+                s3BucketName="test-bucket", rootPrefix="test-prefix"
+            ),
+        )
+
+        total_size = manager._get_total_size_of_files([str(real_file), str(missing_file)])
+        assert total_size == 7
+        assert "Skipping file in size calculation" in caplog.text
+
+    def test_get_total_size_of_files_uses_threadpool(self, tmp_path: Path):
+        """Test that _get_total_size_of_files uses ThreadPoolExecutor with correct configuration."""
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("test")
+
+        manager = S3AssetManager(
+            farm_id="farm-123",
+            queue_id="queue-456",
+            job_attachment_settings=JobAttachmentS3Settings(
+                s3BucketName="test-bucket", rootPrefix="test-prefix"
+            ),
+        )
+
+        with patch(
+            "deadline.job_attachments.upload.concurrent.futures.ThreadPoolExecutor"
+        ) as mock_executor:
+            mock_executor.return_value.__enter__.return_value.map.return_value = [4]
+
+            manager._get_total_size_of_files([str(test_file)])
+
+            mock_executor.assert_called_once_with(max_workers=8)
+
+    def test_get_total_size_of_files_empty_list(self):
+        """Test that _get_total_size_of_files returns 0 for empty file list."""
+        manager = S3AssetManager(
+            farm_id="farm-123",
+            queue_id="queue-456",
+            job_attachment_settings=JobAttachmentS3Settings(
+                s3BucketName="test-bucket", rootPrefix="test-prefix"
+            ),
+        )
+
+        total_size = manager._get_total_size_of_files([])
+        assert total_size == 0
+
+    def test_get_total_input_size_from_manifests_uses_manifest_sizes(self):
+        """Test that _get_total_input_size_from_manifests uses manifest path sizes directly."""
+        from deadline.job_attachments.models import AssetRootManifest
+
+        manager = S3AssetManager(
+            farm_id="farm-123",
+            queue_id="queue-456",
+            job_attachment_settings=JobAttachmentS3Settings(
+                s3BucketName="test-bucket", rootPrefix="test-prefix"
+            ),
+        )
+
+        # Create manifests with known file sizes
+        manifest1 = AssetManifest(
+            hash_alg=HashAlgorithm.XXH128,
+            total_size=150,
+            paths=[
+                BaseManifestPath(path="file1.txt", hash="hash1", size=100, mtime=1234567890),
+                BaseManifestPath(path="file2.txt", hash="hash2", size=50, mtime=1234567891),
+            ],
+        )
+
+        manifest2 = AssetManifest(
+            hash_alg=HashAlgorithm.XXH128,
+            total_size=75,
+            paths=[
+                BaseManifestPath(path="file3.txt", hash="hash3", size=75, mtime=1234567892),
+            ],
+        )
+
+        root_manifests = [
+            AssetRootManifest(root_path="/path1", asset_manifest=manifest1),
+            AssetRootManifest(root_path="/path2", asset_manifest=manifest2),
+            AssetRootManifest(root_path="/path3", asset_manifest=None),  # No manifest
+        ]
+
+        total_files, total_bytes = manager._get_total_input_size_from_manifests(root_manifests)
+
+        assert total_files == 3  # 2 files from manifest1 + 1 file from manifest2
+        assert total_bytes == 225  # 100 + 50 + 75
+
+    def test_get_total_input_size_from_manifests_empty_manifests(self):
+        """Test that _get_total_input_size_from_manifests handles empty manifest list."""
+        manager = S3AssetManager(
+            farm_id="farm-123",
+            queue_id="queue-456",
+            job_attachment_settings=JobAttachmentS3Settings(
+                s3BucketName="test-bucket", rootPrefix="test-prefix"
+            ),
+        )
+
+        total_files, total_bytes = manager._get_total_input_size_from_manifests([])
+
+        assert total_files == 0
+        assert total_bytes == 0
+
+    def test_get_total_input_size_from_manifests_no_asset_manifests(self):
+        """Test that _get_total_input_size_from_manifests handles root manifests with no asset manifests."""
+        from deadline.job_attachments.models import AssetRootManifest
+
+        manager = S3AssetManager(
+            farm_id="farm-123",
+            queue_id="queue-456",
+            job_attachment_settings=JobAttachmentS3Settings(
+                s3BucketName="test-bucket", rootPrefix="test-prefix"
+            ),
+        )
+
+        root_manifests = [
+            AssetRootManifest(root_path="/path1", asset_manifest=None),
+            AssetRootManifest(root_path="/path2", asset_manifest=None),
+        ]
+
+        total_files, total_bytes = manager._get_total_input_size_from_manifests(root_manifests)
+
+        assert total_files == 0
+        assert total_bytes == 0
+
 
 def assert_progress_report_last_callback(
     num_input_files: int,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Job submission could encounter significant performance bottlenecking in stat calls when a bundle includes many files which were not cached by the OS.

Job submission encountered additional overhead by repeating this routine when calculating file sizes from manifest and when uploading objects to cas rather than using the already cached file sizes in the manifest.

verify_hash_cache_integrity method was not optimized

### What was the solution? (How)
- Parallelize OS stat calls
- Calculate manifest input size using manifest
- Remove unnecessary stat calls from upload_object_to_cas
- Optimize verify_hash_cache_integrity

### What is the impact of this change?
- Testing submitting a previously submitted Unreal Meerkat scene resulted in a ~48% submission speed improvement
- On my Windows test machine in Ec2 this saved ~36 seconds (76 -> 40.5)
- On my Windows laptop it saved about 26 seconds (~56 -> 30).

- ### How was this change tested?
Local testing and timing
Added unit tests, new unit tests pass
All integration tests pass

### Was this change documented?
Yes

### Does this PR introduce new dependencies?

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [X ] This PR does not add any new dependencies.

### Is this a breaking change?
No

### Does this change impact security?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
