### PR TITLE
fix: Improved job submission performance by adding optional thread local cache db connections for use without requiring additional locks

### DIFF
--- a/src/deadline/job_attachments/caches/cache_db.py
+++ b/src/deadline/job_attachments/caches/cache_db.py
@@ -6,6 +6,7 @@ Module for defining a local cache file.
 
 import logging
 import os
+import threading
 from abc import ABC
 from threading import Lock
 from typing import Optional
@@ -34,6 +35,8 @@ class CacheDB(ABC):
         self.cache_name: str = cache_name
         self.table_name: str = table_name
         self.create_query: str = create_query
+        self.local = threading.local()
+        self.local_connections: set = set()
 
         try:
             # SQLite is included in Python installers, but might not exist if building python from source.
@@ -81,8 +84,35 @@ class CacheDB(ABC):
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
         """Called when exiting the context manager."""
+
         if self.enabled:
+            import sqlite3
+
             self.db_connection.close()
+            for conn in self.local_connections:
+                try:
+                    conn.close()
+                except sqlite3.Error as e:
+                    logger.warning(f"SQLite connection failed to close with error {e}")
+
+            self.local_connections.clear()
+
+    def get_local_connection(self):
+        """Create and/or returns a thread local connection to the SQLite database."""
+        if not self.enabled:
+            return None
+        import sqlite3
+
+        if not hasattr(self.local, "connection"):
+            try:
+                self.local.connection = sqlite3.connect(self.cache_dir, check_same_thread=False)
+                self.local_connections.add(self.local.connection)
+            except sqlite3.OperationalError as oe:
+                raise JobAttachmentsError(
+                    f"Could not create connection to cache in {self.cache_dir}"
+                ) from oe
+
+        return self.local.connection
 
     @classmethod
     def get_default_cache_db_file_dir(cls) -> Optional[str]:
@@ -99,12 +129,23 @@ class CacheDB(ABC):
         """
         Removes the underlying cache contents from the file system.
         """
+
         if self.enabled:
+            import sqlite3
+
             self.db_connection.close()
+            conn_list = list(self.local_connections)
+            for conn in conn_list:
+                try:
+                    conn.close()
+                    self.local_connections.remove(conn)
+                except sqlite3.Error as e:
+                    logger.warning(f"SQLite connection failed to close with error {e}")
 
         logger.debug(f"The cache {self.cache_dir} will be removed")
         try:
             os.remove(self.cache_dir)
         except Exception as e:
             logger.error(f"Error occurred while removing the cache file {self.cache_dir}: {e}")
+
             raise e

--- a/src/deadline/job_attachments/caches/hash_cache.py
+++ b/src/deadline/job_attachments/caches/hash_cache.py
@@ -59,6 +59,32 @@ class HashCache(CacheDB):
             cache_dir=cache_dir,
         )
 
+    def get_connection_entry(
+        self, file_path_key: str, hash_algorithm: HashAlgorithm, connection
+    ) -> Optional[HashCacheEntry]:
+        """
+        Returns an entry from the hash cache, if it exists.
+        """
+        if not self.enabled:
+            return None
+
+        entry_vals = connection.execute(
+            f"SELECT * FROM {self.table_name} WHERE file_path=? AND hash_algorithm=?",
+            [
+                file_path_key.encode(encoding="utf-8", errors="surrogatepass"),
+                hash_algorithm.value,
+            ],
+        ).fetchone()
+        if entry_vals:
+            return HashCacheEntry(
+                file_path=str(entry_vals[0], encoding="utf-8", errors="surrogatepass"),
+                hash_algorithm=HashAlgorithm(entry_vals[1]),
+                file_hash=entry_vals[2],
+                last_modified_time=str(entry_vals[3]),
+            )
+        else:
+            return None
+
     def get_entry(
         self, file_path_key: str, hash_algorithm: HashAlgorithm
     ) -> Optional[HashCacheEntry]:
@@ -69,22 +95,7 @@ class HashCache(CacheDB):
             return None
 
         with self.db_lock, self.db_connection:
-            entry_vals = self.db_connection.execute(
-                f"SELECT * FROM {self.table_name} WHERE file_path=? AND hash_algorithm=?",
-                [
-                    file_path_key.encode(encoding="utf-8", errors="surrogatepass"),
-                    hash_algorithm.value,
-                ],
-            ).fetchone()
-            if entry_vals:
-                return HashCacheEntry(
-                    file_path=str(entry_vals[0], encoding="utf-8", errors="surrogatepass"),
-                    hash_algorithm=HashAlgorithm(entry_vals[1]),
-                    file_hash=entry_vals[2],
-                    last_modified_time=str(entry_vals[3]),
-                )
-            else:
-                return None
+            return self.get_connection_entry(file_path_key, hash_algorithm, self.db_connection)
 
     def put_entry(self, entry: HashCacheEntry) -> None:
         """Inserts or replaces an entry into the hash cache database after acquiring the lock."""

--- a/src/deadline/job_attachments/caches/s3_check_cache.py
+++ b/src/deadline/job_attachments/caches/s3_check_cache.py
@@ -56,6 +56,29 @@ class S3CheckCache(CacheDB):
             cache_dir=cache_dir,
         )
 
+    def get_connection_entry(self, s3_key: str, connection) -> Optional[S3CheckCacheEntry]:
+        """
+        Checks if an entry exists in the cache, and returns it if it hasn't expired.
+        """
+
+        entry_vals = connection.execute(
+            f"SELECT * FROM {self.table_name} WHERE s3_key=?",
+            [s3_key],
+        ).fetchone()
+        if entry_vals:
+            entry = S3CheckCacheEntry(
+                s3_key=entry_vals[0],
+                last_seen_time=str(entry_vals[1]),
+            )
+            try:
+                last_seen = datetime.fromtimestamp(float(entry.last_seen_time))
+                if (datetime.now() - last_seen).days < self.ENTRY_EXPIRY_DAYS:
+                    return entry
+            except ValueError:
+                logger.warning(f"Timestamp for S3 key {s3_key} is not valid. Ignoring.")
+
+        return None
+
     def get_entry(self, s3_key: str) -> Optional[S3CheckCacheEntry]:
         """
         Checks if an entry exists in the cache, and returns it if it hasn't expired.
@@ -64,23 +87,7 @@ class S3CheckCache(CacheDB):
             return None
 
         with self.db_lock, self.db_connection:
-            entry_vals = self.db_connection.execute(
-                f"SELECT * FROM {self.table_name} WHERE s3_key=?",
-                [s3_key],
-            ).fetchone()
-            if entry_vals:
-                entry = S3CheckCacheEntry(
-                    s3_key=entry_vals[0],
-                    last_seen_time=str(entry_vals[1]),
-                )
-                try:
-                    last_seen = datetime.fromtimestamp(float(entry.last_seen_time))
-                    if (datetime.now() - last_seen).days < self.ENTRY_EXPIRY_DAYS:
-                        return entry
-                except ValueError:
-                    logger.warning(f"Timestamp for S3 key {s3_key} is not valid. Ignoring.")
-
-            return None
+            return self.get_connection_entry(s3_key, self.db_connection)
 
     def put_entry(self, entry: S3CheckCacheEntry) -> None:
         """Inserts or replaces an entry into the cache database."""

--- a/src/deadline/job_attachments/upload.py
+++ b/src/deadline/job_attachments/upload.py
@@ -553,8 +553,11 @@ class S3AssetUploader:
         random.shuffle(s3_upload_keys)
         sampled_cache_entries: List[S3CheckCacheEntry] = []
         with S3CheckCache(s3_check_cache_dir) as s3_cache:
+            local_connection = s3_cache.get_local_connection()
             for upload_key in s3_upload_keys:
-                this_entry = s3_cache.get_entry(s3_key=f"{s3_bucket}/{upload_key}")
+                this_entry = s3_cache.get_connection_entry(
+                    s3_key=f"{s3_bucket}/{upload_key}", connection=local_connection
+                )
                 if this_entry is not None:
                     sampled_cache_entries.append(this_entry)
                     if len(sampled_cache_entries) >= 30:
@@ -611,7 +614,9 @@ class S3AssetUploader:
         s3_upload_key = self._generate_s3_upload_key(file, hash_algorithm, s3_cas_prefix)
         is_uploaded = False
 
-        if s3_check_cache.get_entry(s3_key=f"{s3_bucket}/{s3_upload_key}"):
+        if s3_check_cache.get_connection_entry(
+            s3_key=f"{s3_bucket}/{s3_upload_key}", connection=s3_check_cache.get_local_connection()
+        ):
             logger.debug(
                 f"skipping {local_path} because {s3_bucket}/{s3_upload_key} exists in the cache"
             )
@@ -1027,7 +1032,9 @@ class S3AssetManager:
         file_status: FileStatus = FileStatus.UNCHANGED
         actual_modified_time = str(datetime.fromtimestamp(path.stat().st_mtime))
 
-        entry: Optional[HashCacheEntry] = hash_cache.get_entry(full_path, hash_alg)
+        entry: Optional[HashCacheEntry] = hash_cache.get_connection_entry(
+            full_path, hash_alg, connection=hash_cache.get_local_connection()
+        )
         if entry is not None:
             # If the file was modified, we need to rehash it
             if actual_modified_time != entry.last_modified_time:

--- a/test/unit/deadline_job_attachments/caches/test_caches.py
+++ b/test/unit/deadline_job_attachments/caches/test_caches.py
@@ -1,6 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 import os
+import threading
 from datetime import datetime
 from sqlite3 import OperationalError
 from unittest.mock import patch
@@ -68,6 +69,54 @@ class TestCacheDB:
         """Tests that a JobAttachmentsError is raised if init args are empty"""
         with pytest.raises(JobAttachmentsError):
             CacheDB(cache_name, table_name, create_query)
+
+    def test_get_local_connection_same_thread(self, tmpdir):
+        """Tests that get_local_connection returns the same connection for a single thread"""
+        cache_dir = tmpdir.mkdir("cache")
+
+        with CacheDB(
+            "test", "test_table", "CREATE TABLE test_table (id INTEGER)", cache_dir
+        ) as cdb:
+            # Get connection from main thread
+            conn1 = cdb.get_local_connection()
+            conn2 = cdb.get_local_connection()
+
+            # Should return same connection for same thread
+            assert conn1 is conn2
+
+    def test_get_local_connection_different_threads(self, tmpdir):
+        """Tests that get_local_connection creates separate connections for different threads"""
+        cache_dir = tmpdir.mkdir("cache")
+        connections = {}
+
+        # Create the cache and table first
+        with CacheDB(
+            "test", "test_table", "CREATE TABLE test_table (id INTEGER)", cache_dir
+        ) as cdb:
+
+            def get_connection(thread_id):
+                connections[thread_id] = cdb.get_local_connection()
+
+            # Create connections from different threads
+            thread1 = threading.Thread(target=get_connection, args=(1,))
+            thread2 = threading.Thread(target=get_connection, args=(2,))
+
+            thread1.start()
+            thread2.start()
+            thread1.join()
+            thread2.join()
+
+            # Connections should be different for different threads
+            assert connections[1] is not connections[2]
+
+    def test_get_local_connection_handles_sqlite_error(self, tmpdir):
+        """Tests that get_local_connection raises JobAttachmentsError on SQLite errors"""
+        with CacheDB("test", "test_table", "CREATE TABLE test_table (id INTEGER)", tmpdir) as cdb:
+            # Mock sqlite3.connect to raise OperationalError
+            with patch("sqlite3.connect", side_effect=OperationalError("test error")):
+                with pytest.raises(JobAttachmentsError) as exc_info:
+                    cdb.get_local_connection()
+                assert "Could not create connection to cache" in str(exc_info.value)
 
 
 class TestHashCache:
@@ -223,3 +272,43 @@ class TestS3CheckCache:
 
             # Test if the cache file was deleted
             assert not os.path.exists(file_name)
+
+    def test_get_connection_entry_returns_valid_entry(self, tmpdir):
+        """Tests that get_connection_entry returns a valid entry with provided connection"""
+        cache_dir = tmpdir.mkdir("cache")
+        expected_entry = S3CheckCacheEntry(
+            s3_key="bucket/Data/somehash",
+            last_seen_time=str(datetime.now().timestamp()),
+        )
+
+        with S3CheckCache(cache_dir) as s3c:
+            s3c.put_entry(expected_entry)
+            connection = s3c.get_local_connection()
+            actual_entry = s3c.get_connection_entry("bucket/Data/somehash", connection)
+
+            assert actual_entry == expected_entry
+
+    def test_get_connection_entry_returns_none_for_nonexistent_key(self, tmpdir):
+        """Tests that get_connection_entry returns None for non-existent key"""
+        cache_dir = tmpdir.mkdir("cache")
+
+        with S3CheckCache(cache_dir) as s3c:
+            connection = s3c.get_local_connection()
+            actual_entry = s3c.get_connection_entry("nonexistent/key", connection)
+
+            assert actual_entry is None
+
+    def test_get_connection_entry_returns_none_for_expired_entry(self, tmpdir):
+        """Tests that get_connection_entry returns None for expired entries"""
+        cache_dir = tmpdir.mkdir("cache")
+        expired_entry = S3CheckCacheEntry(
+            s3_key="bucket/Data/somehash",
+            last_seen_time="123.456",  # very old timestamp
+        )
+
+        with S3CheckCache(cache_dir) as s3c:
+            s3c.put_entry(expired_entry)
+            connection = s3c.get_local_connection()
+            actual_entry = s3c.get_connection_entry("bucket/Data/somehash", connection)
+
+            assert actual_entry is None

--- a/test/unit/deadline_job_attachments/test_upload.py
+++ b/test/unit/deadline_job_attachments/test_upload.py
@@ -1582,7 +1582,7 @@ class TestUpload:
         # WHEN
         test_entry = HashCacheEntry(test_file, HashAlgorithm.XXH128, "a", "123.45")
         hash_cache = MagicMock()
-        hash_cache.get_entry.return_value = test_entry
+        hash_cache.get_connection_entry.return_value = test_entry
 
         with patch(f"{deadline.__package__}.job_attachments.upload.hash_file", side_effect=["b"]):
             asset_manager = S3AssetManager(
@@ -1616,7 +1616,7 @@ class TestUpload:
         # WHEN
         test_entry = HashCacheEntry(test_file, HashAlgorithm.XXH128, "a", file_time)
         hash_cache = MagicMock()
-        hash_cache.get_entry.return_value = test_entry
+        hash_cache.get_connection_entry.return_value = test_entry
 
         with patch(f"{deadline.__package__}.job_attachments.upload.hash_file", side_effect=["a"]):
             asset_manager = S3AssetManager(
@@ -2491,7 +2491,7 @@ class TestUpload:
     def test_verify_hash_cache_integrity_returns_true_when_cache_and_s3_match(self, cache_entry):
         # Given
         mock_s3_check_cache_impl = MagicMock()
-        mock_s3_check_cache_impl.get_entry.return_value = cache_entry
+        mock_s3_check_cache_impl.get_connection_entry.return_value = cache_entry
         mock_s3_check_cache = MagicMock()
         mock_s3_check_cache.__enter__.return_value = mock_s3_check_cache_impl
 
@@ -2537,7 +2537,7 @@ class TestUpload:
     def test_verify_hash_cache_integrity_returns_false_when_cache_and_s3_mismatch(self):
         # Given
         mock_s3_check_cache_impl = MagicMock()
-        mock_s3_check_cache_impl.get_entry.return_value = S3CheckCacheEntry(
+        mock_s3_check_cache_impl.get_connection_entry.return_value = S3CheckCacheEntry(
             s3_key="bucket/Data/test-hash",
             last_seen_time=str(datetime.now().timestamp()),
         )
@@ -2629,7 +2629,7 @@ class TestUpload:
         s3_key = f"{default_job_attachment_s3_settings.s3BucketName}/prefix/test-hash.xxh128"
         test_entry = S3CheckCacheEntry(s3_key, "123.45")
         s3_cache = MagicMock()
-        s3_cache.get_entry.return_value = test_entry
+        s3_cache.get_connection_entry.return_value = test_entry
 
         # When
         with patch.object(
@@ -2716,7 +2716,7 @@ class TestUpload:
         )
         s3_key = f"{default_job_attachment_s3_settings.s3BucketName}/prefix/test-hash.xxh128"
         s3_cache = MagicMock()
-        s3_cache.get_entry.return_value = None
+        s3_cache.get_connection_entry.return_value = None
         expected_new_entry = S3CheckCacheEntry(s3_key, "345.67")
 
         # When


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Our S3 cache was using a connection shared across threads which required a lock for all access, creating a bottleneck when attempting to divide up work across threads.

### What was the solution? (How)
Add a thread local connection which can be used in cases where we can expect to benefit from reuse and lack of locking.  Use in upload_object_to_cas, verify_hash_cache_integrity, and _process_input_path.

### What is the impact of this change?
In my testing on top of https://github.com/aws-deadline/deadline-cloud/pull/847 I was able to cut about an additional 15 seconds of my EC2 test machine time with Meerkat submissions, reducing the total time from about 40.5 seconds to around 25 seconds.  With the already uploaded Meerkat including a local cache, upload_input_files went from taking about 11 seconds to about 4 seconds.

### How was this change tested?
Local testing

- Have you run the unit tests? 
   Yes, existing unit tests pass, new unit tests added which pass
- Have you run the integration tests?
   Yes
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass.
   No

### Was this change documented?
Yes

### Does this PR introduce new dependencies?
No

### Is this a breaking change?
No

### Does this change impact security?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
