### PR TITLE
ci: add manual PyPI publish workflow

### DIFF
--- a/.github/workflows/manual_pypi_release.yml
+++ b/.github/workflows/manual_pypi_release.yml
@@ -1,0 +1,61 @@
+# Perform a manual PyPI release outside of the regular release process
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        required: true
+        default: ""
+        type: string
+
+jobs:
+  ValidateTag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate semantic versioning
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          if ! [[ "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: Tag '$TAG' does not follow semantic versioning format (X.Y.Z)"
+            exit 1
+          fi
+          echo "Tag validation successful"
+                
+  UnitTests:
+    name: Unit Tests
+    uses: ./.github/workflows/code_quality.yml
+    with:
+      tag: ${{ inputs.tag }}
+      
+  PublishToPyPI:
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
+          fetch-depth: 0
+      - name: Validate semantic versioning
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          if ! [[ "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?(\+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?$ ]]; then
+            echo "Error: Tag '$TAG' does not follow semantic versioning format (X.Y.Z)"
+            exit 1
+          fi
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+      - name: Install dependencies
+        run: |
+          pip install --upgrade hatch "click<8.3"
+      - name: Build
+        run: hatch -v build
+      # # See https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

In attempting to release `deadline` version `0.53.0`, the `Release: Publish` GitHub actions workflow failed (https://github.com/aws-deadline/deadline-cloud/actions/runs/17748760805).

This was caused by a bug in click 8.3 (pallets/click#3065) that blocks our CI from running.

The release process is mostly complete. All that remains is to publish the package to PyPI.

### What was the solution? (How)

To complete the release, this PR introduces a manual GitHub actions workflow that can be ran to publish a semantically versioned tag of the format `X.Y.Z` (e.g. `0.53.0`) to PyPI.

### What is the impact of this change?

Maintainers can manually initiate a GitHub actions workflow to publish a tag to PyPI.

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests?
   *N/A*
- Have you run the integration tests?
   *N/A*
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass.
  *N/A*

### Was this change documented?

-  Are relevant docstrings in the code base updated?
   *N/A*
-  Has the README.md been updated? If you modified CLI arguments, for instance.
    *N/A*

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?

A breaking change is one that modifies a public contract in a way that is not backwards compatible. See the 
[Public Contracts](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#public-contracts) section
of the DEVELOPMENT.md for more information on the public contracts.

If so, then please describe the changes that users of this package must make to update their scripts, or Python applications.

No

### Does this change impact security?

- Does the change need to be threat modeled? For example, does it create or modify files/directories that must only be readable by the process owner?
    - If so, then please label this pull request with the "security" label. We'll work with you to analyze the threats.

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
