### PR TITLE
fix: Changing wait_for_create_job_to_complete to use a short initial …

### DIFF
--- a/src/deadline/client/api/_submit_job_bundle.py
+++ b/src/deadline/client/api/_submit_job_bundle.py
@@ -848,18 +848,21 @@ def wait_for_create_job_to_complete(
     Wait until a job exits the CREATE_IN_PROGRESS state.
     """
 
-    delay_sec = 5  # Time to wait between checks in seconds.
-    max_attempts = 60
+    initial_delay = 0.3
+    max_delay = 5.0
+    timeout_seconds = 300
     creating_statuses = {
         "CREATE_IN_PROGRESS",
     }
     failure_statuses = {"CREATE_FAILED"}
 
-    for attempt in range(max_attempts):
-        logger.debug(
-            f"Waiting for creation of {job_id} to complete...attempt {attempt} of {max_attempts}"
-        )
+    start_time = time.time()
+    delay = initial_delay
 
+    # Initial wait before first attempt
+    time.sleep(initial_delay)
+
+    while time.time() - start_time < timeout_seconds:
         if not continue_callback():
             raise CreateJobWaiterCanceled()
 
@@ -867,12 +870,13 @@ def wait_for_create_job_to_complete(
 
         current_status = job["lifecycleStatus"] if "lifecycleStatus" in job else job["state"]
         if current_status in creating_statuses:
-            time.sleep(delay_sec)
+            time.sleep(delay)
+            delay = min(delay * 2, max_delay)
         elif current_status in failure_statuses:
             return False, job["lifecycleStatusMessage"]
         else:
             return True, job["lifecycleStatusMessage"]
 
     raise TimeoutError(
-        f"Timed out after {delay_sec * max_attempts} seconds while waiting for Job to be created: {job_id}"
+        f"Timed out after {timeout_seconds} seconds while waiting for Job to be created: {job_id}"
     )

--- a/test/unit/deadline_client/api/test_job_bundle_submission.py
+++ b/test/unit/deadline_client/api/test_job_bundle_submission.py
@@ -1039,7 +1039,23 @@ def test_wait_for_create_job_to_complete_timeout():
         "lifecycleStatusMessage": MOCK_STATUS_MESSAGE,
     }
 
-    with pytest.raises(TimeoutError), patch.object(time, "sleep"):
+    # Mock time.time to simulate timeout after a few iterations
+    mock_times = [
+        0,
+        0.5,
+        1.5,
+        3.5,
+        7.5,
+        12.5,
+        17.5,
+        22.5,
+        27.5,
+        32.5,
+        301,
+    ]  # Last value exceeds 300s timeout
+    with pytest.raises(TimeoutError), patch.object(time, "sleep"), patch.object(
+        time, "time", side_effect=mock_times
+    ):
         api.wait_for_create_job_to_complete(
             farm_id=MOCK_FARM_ID,
             queue_id=MOCK_QUEUE_ID,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
When creating a job bundle the wait_for_create_job_to_complete would attempt to get the job immediately which would fail to find the job had been created due to the asynchronous job processing which had to take place, then wait a full 5 seconds before checking again.  Jobs generally should be expected to be ready much faster than 5 seconds.

### What was the solution? (How)
Add an initial wait of .3 seconds, then start waiting .3 seconds with exponential backoff up to 5 seconds max wait time, keeping a 300 second absolute max wait time.

### What is the impact of this change?
Faster job creation from the submitter's perspective.  In my own testing this takes off about 4-5 additional seconds.

### How was this change tested?
Local testing

- Have you run the unit tests? 
Yes
- Have you run the integration tests? 
Yes
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass.
No

### Was this change documented?
Yes

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [X ] This PR does not add any new dependencies.

### Is this a breaking change?
No

### Does this change impact security?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
