### PR TITLE
test: fix cli manifest download integration test

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -31,7 +31,7 @@ pre-install-commands = [
 ]
 
 [envs.integ.scripts]
-test = "pytest --xfail-tb --no-cov {args:test/integ} -vvv --numprocesses=1"
+test = "pytest --xfail-tb --no-cov -vvv --numprocesses=1 {args:test/integ}"
 
 [envs.installer.env-vars]
 SKIP_BOOTSTRAP_TEST_RESOURCES = "True"

--- a/test/integ/cli/test_cli_manifest_download.py
+++ b/test/integ/cli/test_cli_manifest_download.py
@@ -281,7 +281,7 @@ class TestManifestDownload:
         ],
     )
     @pytest.mark.parametrize(
-        "asset_type", [AssetType.INPUT.value, AssetType.OUTPUT.value, AssetType.ALL.value, None]
+        "asset_type", [AssetType.INPUT.value, AssetType.OUTPUT.value, AssetType.ALL.value]
     )
     def test_manifest_download_asset_type_with_job_step_dependency(
         self,
@@ -351,7 +351,7 @@ class TestManifestDownload:
                     self._assert_output_manifests_exist(files)
                     self._assert_dependent_step_output_exist(files)
 
-                if asset_type == AssetType.ALL or asset_type is None:
+                if asset_type == AssetType.ALL:
                     self._assert_input_mainfests_exist(files)
                     self._assert_dependent_step_output_exist(files)
                     self._assert_output_manifests_exist(files)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
mainline integration tests are failing due to a CLI manifest download test case: https://github.com/aws-deadline/deadline-cloud/actions/runs/17921280403/job/50956637896

### What was the solution? (How)
Remove the `asset_type` = `None` test case, it was not a valid test case.

### What is the impact of this change?
Integration tests pass again

### How was this change tested?

- Have you run the unit tests? CI did
- Have you run the integration tests? Yes, the affected ones and they pass
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass. No

### Was this change documented?
No

### Does this PR introduce new dependencies?

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?
No

### Does this change impact security?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
