### PR TITLE
fix: Job submission warning dialogs are too long

### DIFF
--- a/src/deadline/client/api/_submit_job_bundle.py
+++ b/src/deadline/client/api/_submit_job_bundle.py
@@ -136,8 +136,8 @@ def _generate_message_for_asset_paths(
         warning_messages.append("\n")
         warning_messages.extend(unknown_path_warnings)
         warning_messages.append(
-            "\nTo enable submission without user input, add directory locations containing the unknown paths to either "
-            + "1. The list of known asset paths in the local Deadline Cloud configuration. "
+            "\nTo enable submission without user input, add directory locations containing the unknown paths to either \n"
+            + "1. The list of known asset paths in the local Deadline Cloud configuration. \n"
         )
         if storage_profile:
             warning_messages.append(

--- a/src/deadline/client/ui/dialogs/submit_job_progress_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_progress_dialog.py
@@ -12,21 +12,23 @@ from typing import Any, Optional
 from functools import partial
 import time
 
-from qtpy.QtCore import Qt, Signal
-from qtpy.QtGui import QCloseEvent
+from qtpy.QtCore import Qt, Signal, QSize
+from qtpy.QtGui import QCloseEvent, QFontMetrics
 from qtpy.QtWidgets import (  # pylint: disable=import-error; type: ignore
     QApplication,
     QDialog,
     QDialogButtonBox,
     QFormLayout,
     QGroupBox,
+    QHBoxLayout,
     QLabel,
-    QMessageBox,
     QPushButton,
     QProgressBar,
+    QStyle,
     QTextEdit,
     QVBoxLayout,
     QWidget,
+    QSizePolicy,
 )
 
 from .. import CancelationFlag
@@ -230,26 +232,20 @@ class SubmitJobProgressDialog(QDialog):
         self.button_box.rejected.connect(self.close)
 
     def handle_request_warning_dialog(self, message: str, default_response: bool):
+        """Presents a dialog with the provided message.
+
+        Args:
+            message (str): The message to present to the user.
+            default_response (bool):
+                True if the default is to continue. This adds a "Do not ask again" button as well.
+                False if the default is to Cancel.
+        """
         # Build the UI for user confirmation
-        message_box = QMessageBox(self)
-        if not default_response:
-            message_box.setIcon(QMessageBox.Warning)
+        dialog = _JobSumissionWarningDialog(message, default_response)
 
-        self.submission_log.append(f"{message}\n")
-        message_box.setText(message)
-        message_box.setStandardButtons(QMessageBox.Ok | QMessageBox.Cancel)
-        message_box.setDefaultButton(QMessageBox.Ok if default_response else QMessageBox.Cancel)
+        selection = dialog.exec()
 
-        if default_response:
-            # If the default response is to continue, add the "Do not ask again" button
-            dont_ask_button = QPushButton("Do not ask again", self)
-            dont_ask_button.clicked.connect(lambda: set_setting("settings.auto_accept", "true"))
-            message_box.addButton(dont_ask_button, QMessageBox.ActionRole)
-
-        message_box.setWindowTitle("Job attachments file upload confirmation")
-        selection = message_box.exec()
-
-        if selection == QMessageBox.Cancel:
+        if selection == QDialog.Rejected:
             self._warning_dialog_canceled = True
 
         self._warning_dialog_completed = True
@@ -361,3 +357,122 @@ class JobAttachmentsProgressWidget(QGroupBox):
 
         self.layout.addWidget(self.progress_bar)
         self.layout.addWidget(self.progress_message)
+
+
+class _JobSumissionWarningDialog(QDialog):
+    """
+    Simple Dialog which functions similar to a QMessageBox, but with a scrollable text area.
+    """
+
+    def __init__(self, message: str, default_response: bool = False):
+        """
+        Simple Dialog which functions similar to a QMessageBox, but with a scrollable text area.
+
+        Args:
+            message (str): The message to present to the user.
+            default_response (bool):
+                True if the default response should be to continue.
+                    - This also adds a "Do not ask again" button which will set settings.auto_accept to True.
+                False if the default response should be to Cancel.
+        """
+        super().__init__()
+        self.setWindowTitle("Job Submission Confirmation")
+        self.message = message
+        self.default_response = default_response
+        self.buttons = None
+        layout = QVBoxLayout(self)
+
+        # Top section with icon and title
+        top_layout = QHBoxLayout()
+        icon_label = QLabel()
+        icon_label.setPixmap(
+            self.style()
+            .standardIcon(QStyle.SP_DirIcon if default_response else QStyle.SP_MessageBoxWarning)
+            .pixmap(32, 32)
+        )
+        top_layout.addWidget(icon_label)
+        title_label = QLabel("Job submission confirmation")
+        title_label.setStyleSheet("font-weight: bold;")
+        top_layout.addWidget(title_label)
+        top_layout.addStretch()
+        layout.addLayout(top_layout, 0)  # No stretch for title section
+
+        # Scrollable Text Area
+        self.text_edit = QTextEdit()
+        self.text_edit.setPlainText(message)
+        self.text_edit.setReadOnly(True)
+        self.text_edit.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        layout.addWidget(self.text_edit, 1)  # Stretch factor 1 for text area
+
+        # Set minimum width and calculate optimal height
+        self.text_edit.setMinimumWidth(500)
+        self._calculate_optimal_size()
+
+        self.buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        self.buttons.accepted.connect(self.accept)
+        self.buttons.rejected.connect(self.reject)
+
+        if default_response:
+            # If the default response is to continue, add the "Do not ask again" button
+            dont_ask_button = QPushButton("Do not ask again", self)
+            dont_ask_button.clicked.connect(lambda: set_setting("settings.auto_accept", "true"))
+            dont_ask_button.clicked.connect(self.accept)
+            self.buttons.addButton(dont_ask_button, QDialogButtonBox.ActionRole)
+
+        layout.addWidget(self.buttons)
+
+    def _calculate_optimal_size(self):
+        """Calculate optimal height based on text content and font metrics."""
+        # Get font metrics for the text edit
+        font_metrics = QFontMetrics(self.text_edit.font())
+
+        # Calculate text width accounting for margins and scrollbar
+        text_width = self.text_edit.minimumWidth() - 40  # Account for margins and scrollbar
+
+        # Calculate the height needed for the text
+        text_rect = font_metrics.boundingRect(0, 0, text_width, 0, Qt.TextWordWrap, self.message)
+        text_height = text_rect.height()
+
+        # Add some padding for better appearance
+        padding = 20
+        optimal_height = text_height + padding
+
+        # Set reasonable bounds
+        min_height = 100
+        max_height = 500
+
+        # Clamp the height to reasonable bounds
+        final_height = max(min_height, min(optimal_height, max_height))
+
+        self.text_edit.setMinimumHeight(min_height)
+        # Set dialog's initial size based on content
+        dialog_height = final_height + 120  # Add space for title and buttons
+        self.resize(500, dialog_height)
+
+    def showEvent(self, event):
+        """Override showEvent to set the default button after the dialog is shown."""
+        super().showEvent(event)
+
+        # Set the default button after the dialog is fully shown
+        if self.buttons is not None:  # This type check is to make linting pass
+            if self.default_response:
+                ok_button = self.buttons.button(QDialogButtonBox.Ok)
+                if ok_button:
+                    ok_button.setDefault(True)
+                    ok_button.setAutoDefault(True)
+                    ok_button.setFocus()
+            else:
+                cancel_button = self.buttons.button(QDialogButtonBox.Cancel)
+                if cancel_button:
+                    cancel_button.setDefault(True)
+                    cancel_button.setAutoDefault(True)
+                    cancel_button.setFocus()
+
+    def sizeHint(self):
+        """Return size hint based on content."""
+        # Calculate total dialog height including other widgets
+        base_height = 50  # Height for title, buttons, and margins
+        text_height = self.text_edit.minimumHeight()
+        total_height = base_height + text_height
+
+        return QSize(500, total_height)


### PR DESCRIPTION
Fixes: #785 

### What was the problem/requirement? (What/Why)

For scenes with numerous attachments, the job attachments upload summary dialog box was too long, causing the "Do you wish to proceed?" question and accompanying buttons to be hidden from view. This issue prevents users from submitting jobs.

### What was the solution? (How)

It is not possible to implement scroll bars in a QMessageBox, so I needed to create a new QDialog class which I could add a scrollable text section to. The new dialog maintains the existing interface in `handle_request_warning_dialog()` and automatically resizes depending on the length of the content. 

### What is the impact of this change?

If the length of the warnings passed to `handle_request_warning_dialog()`  is extremely long, the dialog will appropriately scale and provide a scrollable area if applicable. 

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests?
    - yes
- Have you run the integration tests?
   -  yes
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass.
  - no
  
  
  I tested this against two modes of this dialog which is 
  1) With provides default option of accepting which then presents a `Do not ask again` button and sets the default button to `OK`

        - <details>
          <summary>Original Dialog with Default</summary>
          <img width="2108" height="1164" alt="original info" src="https://github.com/user-attachments/assets/32535fb5-f4a2-45ce-aab6-551868b3a65d" />
          </details>

        - <details>
          <summary>New Dialog with Default</summary>
          <img width="1980" height="1297" alt="new info" src="https://github.com/user-attachments/assets/8caea3c8-8761-4002-b15f-521ea31c1e17" />
          </details>

  2) Without a default option which only yields the `Cancel`/`OK` buttons and sets the default option to `Cancel`. This is the mode which can be extremely long.
 
        - <details>
          <summary>Original Dialog without Default</summary>
          <img width="1416" height="2342" alt="warning original" src="https://github.com/user-attachments/assets/ae597ce6-4de9-4f7e-a0e0-f61f45583f2b" />
          </details>

        - <details>
          <summary>New Dialog without Default</summary>
          <img width="1420" height="1659" alt="warning new" src="https://github.com/user-attachments/assets/a57b68dc-83ff-4b99-9807-0abd268e6aad" />
          </details>

### Was this change documented?

Yes through the commit title.

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.


### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
