### PR TITLE
feat: download outputs from chunked session actions

### DIFF
--- a/src/deadline/client/cli/_groups/job_group.py
+++ b/src/deadline/client/cli/_groups/job_group.py
@@ -436,6 +436,7 @@ def _download_job_output(
     job = deadline.get_job(farmId=farm_id, queueId=queue_id, jobId=job_id)
     step = {}
     task = {}
+    session_action_id = None
     if step_id:
         step = deadline.get_step(farmId=farm_id, queueId=queue_id, jobId=job_id, stepId=step_id)
     if task_id:
@@ -446,6 +447,7 @@ def _download_job_output(
             stepId=step_id,
             taskId=task_id,
         )
+        session_action_id = task.get("latestSessionActionId")
 
     click.echo(
         _get_start_message(job["name"], step.get("name"), task.get("parameters"), is_json_format)
@@ -476,6 +478,7 @@ def _download_job_output(
         job_id=job_id,
         step_id=step_id,
         task_id=task_id,
+        session_action_id=session_action_id,
         session=queue_role_session,
     )
 

--- a/src/deadline/job_attachments/download.py
+++ b/src/deadline/job_attachments/download.py
@@ -172,20 +172,11 @@ def _get_output_manifest_prefix(
     job_id: str,
     step_id: Optional[str] = None,
     task_id: Optional[str] = None,
-    session_action_id: Optional[str] = None,
 ) -> str:
     """
     Get full prefix for output manifest with given farm id, queue id, job id, step id and task id
     """
     manifest_prefix: str
-    if session_action_id:
-        if not task_id or not step_id:
-            raise JobAttachmentsError(
-                "Session Action ID specified, but no Task ID or Step ID. Job, Step, and Task ID are required to retrieve task outputs."
-            )
-        manifest_prefix = s3_settings.full_output_prefix(
-            farm_id, queue_id, job_id, step_id, task_id, session_action_id
-        )
     if task_id:
         if not step_id:
             raise JobAttachmentsError(
@@ -203,19 +194,18 @@ def _get_output_manifest_prefix(
     return f"{manifest_prefix}/"
 
 
-def _get_tasks_manifests_keys_from_s3(
-    manifest_prefix: str,
+def _list_s3_objects_with_error_handling(
     s3_bucket: str,
+    manifest_prefix: str,
     session: Optional[boto3.Session] = None,
-    *,
-    select_latest_per_task=True,
-) -> List[str]:
+) -> List[dict]:
     """
-    Returns the keys of all output manifests from the given s3 prefix.
-    (Only the manifests that end with the prefix pattern task-*/*_output)
+    List S3 objects with standardized error handling for job attachments.
+    Returns a list of all S3 object contents under the given prefix.
     """
-    manifests_keys: List[str] = []
     s3_client = get_s3_client(session=session)
+    all_contents = []
+
     try:
         paginator = s3_client.get_paginator("list_objects_v2")
         page_iterator = paginator.paginate(
@@ -223,21 +213,15 @@ def _get_tasks_manifests_keys_from_s3(
             Prefix=manifest_prefix,
         )
 
-        # 1. Find all files that match the pattern: task-{any}/{any}/{any}output{any}
-        task_prefixes = defaultdict(list)
         for page in page_iterator:
             contents = page.get("Contents", None)
             if contents is None:
                 raise JobAttachmentsError(
                     f"Unable to find asset manifest in s3://{s3_bucket}/{manifest_prefix}"
                 )
-            for content in contents:
-                if re.search(r"task-.*/.*/.*output.*", content["Key"]):
-                    parts = content["Key"].split("/")
-                    for i, part in enumerate(parts):
-                        if "task-" in part:
-                            task_folder = "/".join(parts[: i + 1])
-                            task_prefixes[task_folder].append(content["Key"])
+            all_contents.extend(contents)
+
+        return all_contents
 
     except ClientError as exc:
         status_code = int(exc.response["ResponseMetadata"]["HTTPStatusCode"])
@@ -266,8 +250,52 @@ def _get_tasks_manifests_keys_from_s3(
     except Exception as e:
         raise AssetSyncError(e) from e
 
+
+def _get_tasks_manifests_keys_from_s3(
+    manifest_prefix: str,
+    s3_bucket: str,
+    session: Optional[boto3.Session] = None,
+    *,
+    select_latest_per_task=True,
+) -> List[str]:
+    """
+    Retrieves manifest keys from S3 by listing objects in a given S3 prefix, usually job or step folders.
+
+    Searches for manifest files matching the regex pattern that captures both:
+    - Chunked step manifests: .../job_id/step_id/timestamp_sessionaction_id/
+    - Task-based manifests: .../job_id/step_id/task_id/timestamp_sessionaction_id/
+
+    For chunked steps (no task ID), all manifests are included.
+    For task-based manifests, behavior depends on select_latest_per_task:
+    - If True: selects only the latest session action per task (by timestamp_sessionaction_id alphabetical order)
+    - If False: includes all manifests
+    """
+    manifests_keys = []
+
+    # Separate tracking for task-based vs chunked manifests
+    task_prefixes: dict[str, list] = defaultdict(list)
+
+    all_contents = _list_s3_objects_with_error_handling(s3_bucket, manifest_prefix, session)
+
+    step_pattern = re.compile(r"step-.*/.*/.*output.*")
+    for content in all_contents:
+        key = content["Key"]
+        if step_pattern.search(key):
+            if "task-" in key:
+                parts = key.split("/")
+                for i, part in enumerate(parts):
+                    if "task-" in part:
+                        task_folder = "/".join(parts[: i + 1])
+                        task_prefixes[task_folder].append(key)
+                        break
+            else:
+                manifests_keys.append(key)
+
+    # Handle task-based steps
     if select_latest_per_task:
-        # 2. Select all files in the last subfolder (alphabetically) under each "task-{any}" folder.
+        # TODO: Select all files in the last subfolder (alphabetically) under each "task-{any}" folder.
+        # This sorts by timestamp_sessionaction_id, but timestamp comes from WorkerAgent and shouldn't be relied on.
+        # Should use S3 LastModified instead.
         for task_folder, files in task_prefixes.items():
             last_subfolder = sorted(
                 set(f.split("/")[len(task_folder.split("/"))] for f in files), reverse=True
@@ -275,9 +303,8 @@ def _get_tasks_manifests_keys_from_s3(
             manifests_keys += [f for f in files if f.startswith(f"{task_folder}/{last_subfolder}/")]
     else:
         # Include all the keys, not just the latest per task
-        manifests_keys = [f for _, files in task_prefixes.items() for f in files]
+        manifests_keys += [f for _, files in task_prefixes.items() for f in files]
 
-    # Now `manifests_keys` is a list of the keys of files in the last folder (alphabetically) under each "task-" folder.
     return manifests_keys
 
 
@@ -738,12 +765,29 @@ def get_output_manifests_by_asset_root(
     session: Optional[boto3.Session] = None,
 ) -> dict[str, list[BaseAssetManifest]]:
     """
-    For a given job/step/task, gets a map from each root path to a corresponding list of
-    output manifests.
+    Gets output manifests grouped by asset root for job, step, or task outputs, handling both chunked and non-chunked steps.
+
+    When session_action_id is provided, retrieves outputs for that specific session action
+    by searching S3 paths containing the session action ID. Session action ID is typically
+    provided with task ID but is not required.
+
+    When session_action_id is not provided, retrieves all output manifests for the specified
+    scope (job, step, or task) and merges them chronologically by asset root. This is used
+    for downloading complete job/step/task outputs or syncing step dependencies by WorkerAgent.
     """
+    # Handle specific session action ID requests
+    if session_action_id:
+        if not step_id or not task_id:
+            raise JobAttachmentsError(
+                "Session Action ID specified, but missing Step ID or Task ID. Job, Step, and Task ID are required to retrieve session action outputs."
+            )
+        return _get_manifests_by_session_action_id(
+            s3_settings, farm_id, queue_id, job_id, step_id, task_id, session_action_id, session
+        )
+
     outputs: DefaultDict[str, list[BaseAssetManifest]] = DefaultDict(list)
     manifest_prefix: str = _get_output_manifest_prefix(
-        s3_settings, farm_id, queue_id, job_id, step_id, task_id, session_action_id
+        s3_settings, farm_id, queue_id, job_id, step_id, task_id
     )
     try:
         manifests_keys: list[str] = _get_tasks_manifests_keys_from_s3(
@@ -752,20 +796,39 @@ def get_output_manifests_by_asset_root(
     except JobAttachmentsError:
         return outputs
 
-    with concurrent.futures.ThreadPoolExecutor(max_workers=S3_DOWNLOAD_MAX_CONCURRENCY) as executor:
-        futures = [
-            executor.submit(
-                get_asset_root_and_manifest_from_s3, key, s3_settings.s3BucketName, session
-            )
-            for key in manifests_keys
-        ]
-        for key, future in zip(manifests_keys, futures):
-            asset_root, asset_manifest = future.result()
-            if not asset_root:
-                raise MissingAssetRootError(
-                    f"Failed to get asset root from metadata of output manifest: {key}"
+    # Collect all manifests grouped by asset root
+    by_root: defaultdict[str, list[Tuple[datetime, BaseAssetManifest]]] = defaultdict(list)
+
+    if manifests_keys:
+        # Download manifests with timestamps for chronological merging
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=S3_DOWNLOAD_MAX_CONCURRENCY
+        ) as executor:
+            futures = []
+            for manifest_key in manifests_keys:
+                future = executor.submit(
+                    _get_asset_root_and_manifest_from_s3_with_last_modified,
+                    manifest_key,
+                    s3_settings.s3BucketName,
+                    session,
                 )
-            outputs[asset_root].append(asset_manifest)
+                futures.append(future)
+
+            for i, future in enumerate(futures):
+                asset_root, last_modified, manifest = future.result()
+                if not asset_root:
+                    raise MissingAssetRootError(
+                        f"Failed to get asset root from metadata of output manifest: {manifests_keys[i]}"
+                    )
+                by_root[asset_root].append((last_modified, manifest))
+
+    # Merge each asset root chronologically
+    # We must merge here while we have LastModified timestamps, since the returned manifests
+    # lose this metadata and downstream callers can't merge chronologically.
+    for asset_root, manifest_list in by_root.items():
+        merged_manifest = _merge_asset_manifests_sorted_asc_by_last_modified(manifest_list)
+        if merged_manifest:
+            outputs[asset_root].append(merged_manifest)
 
     return outputs
 
@@ -999,7 +1062,9 @@ def _merge_asset_manifests_sorted_asc_by_last_modified(
         return None
 
     # Sort manifests by timestamp (oldest first)
-    sorted_manifests_with_timestamps = sorted(manifests_with_last_modified_timestamps)
+    sorted_manifests_with_timestamps = sorted(
+        manifests_with_last_modified_timestamps, key=lambda x: x[0]
+    )
 
     # Extract just the manifests in the sorted order
     sorted_manifests = [manifest for _, manifest in sorted_manifests_with_timestamps]
@@ -1313,3 +1378,78 @@ class OutputDownloader:
         progress_tracker.total_time = time.perf_counter() - start_time
 
         return progress_tracker.get_download_summary_statistics(downloaded_files_paths_by_root)
+
+
+def _get_manifests_by_session_action_id(
+    s3_settings: JobAttachmentS3Settings,
+    farm_id: str,
+    queue_id: str,
+    job_id: str,
+    step_id: str,
+    task_id: str,
+    session_action_id: str,
+    session: Optional[boto3.Session],
+) -> dict[str, list[BaseAssetManifest]]:
+    """
+    Get manifests for a specific session action ID by searching S3 paths containing the session action ID.
+
+    When session action ID is known, we don't need to search for the "latest" session action based on
+    timestamp prefix (which comes from WorkerAgent and can't be trusted). However, we still can't
+    directly access the outputs because the S3 path contains an unknown timestamp prefix before the
+    session action ID (e.g., .../step_id/task_id/20241225T120000_sessionaction_id/).
+
+    For task-based paths, searches in the task folder first (...job_id/step_id/task_id/) for efficiency.
+    This approach is more correct than searching by timestamp prefix since latestSessionActionId is
+    typically obtained from GetTask API, guaranteeing the latest outputs.
+    For chunked steps, when no task-based manifests found, falls back to step folder (...job_id/step_id/).
+    """
+    outputs: dict[str, list[BaseAssetManifest]] = defaultdict(list)
+
+    def get_manifests_by_regex(manifest_prefix: str) -> List[str]:
+        """Get manifest keys matching the session action ID using regex search."""
+        all_contents = _list_s3_objects_with_error_handling(
+            s3_settings.s3BucketName, manifest_prefix, session
+        )
+        manifests_keys = []
+        regex_pattern = re.compile(rf".*{re.escape(session_action_id)}.*output.*")
+        for content in all_contents:
+            if regex_pattern.search(content["Key"]):
+                manifests_keys.append(content["Key"])
+        return manifests_keys
+
+    # Try task-specific prefix first for efficiency
+    task_prefix = _get_output_manifest_prefix(
+        s3_settings, farm_id, queue_id, job_id, step_id, task_id
+    )
+
+    manifests_keys: Optional[List[str]] = None
+    try:
+        manifests_keys = get_manifests_by_regex(task_prefix)
+    except JobAttachmentsError:
+        pass  # Unable to find manifests under task prefix.
+
+    # If no manifests found at task level, fall back to step level
+    if not manifests_keys:
+        step_prefix = _get_output_manifest_prefix(s3_settings, farm_id, queue_id, job_id, step_id)
+        try:
+            manifests_keys = get_manifests_by_regex(step_prefix)
+        except JobAttachmentsError:
+            return outputs
+
+    # Download all found manifests
+    with concurrent.futures.ThreadPoolExecutor(max_workers=S3_DOWNLOAD_MAX_CONCURRENCY) as executor:
+        futures = [
+            executor.submit(
+                get_asset_root_and_manifest_from_s3, key, s3_settings.s3BucketName, session
+            )
+            for key in manifests_keys
+        ]
+        for i, future in enumerate(futures):
+            asset_root, manifest = future.result()
+            if not asset_root:
+                raise MissingAssetRootError(
+                    f"Failed to get asset root from metadata of output manifest: {manifests_keys[i]}"
+                )
+            outputs[asset_root].append(manifest)
+
+    return outputs

--- a/src/deadline/job_attachments/models.py
+++ b/src/deadline/job_attachments/models.py
@@ -373,6 +373,30 @@ class JobAttachmentS3Settings:
             f"{_float_to_iso_datetime_string(time)}_{session_action_id}",
         )
 
+    @staticmethod
+    def partial_session_action_manifest_prefix_without_task(
+        farm_id: str,
+        queue_id: str,
+        job_id: str,
+        step_id: str,
+        session_action_id: str,
+        time: float,
+    ) -> str:
+        """
+        Constructs the partial S3 prefix for storing session action output manifests.
+
+        This method creates a hierarchical path structure for organizing output manifests in S3,
+        following the pattern: farm_id/queue_id/job_id/step_id/timestamp_session_action_id.
+        The timestamp is converted from a float to an ISO datetime string format.
+        """
+        return _join_s3_paths(
+            farm_id,
+            queue_id,
+            job_id,
+            step_id,
+            f"{_float_to_iso_datetime_string(time)}_{session_action_id}",
+        )
+
     def partial_manifest_prefix(self, farm_id, queue_id) -> str:
         guid = _generate_random_guid()
         return _join_s3_paths(

--- a/test/unit/deadline_client/cli/test_cli_handle_web_url.py
+++ b/test/unit/deadline_client/cli/test_cli_handle_web_url.py
@@ -38,6 +38,7 @@ from ..shared_constants import (
     MOCK_FARM_ID,
     MOCK_JOB_ID,
     MOCK_QUEUE_ID,
+    MOCK_SESSION_ACTION_ID,
     MOCK_STEP_ID,
     MOCK_TASK_ID,
     MOCK_PROFILE_NAME,
@@ -300,6 +301,7 @@ def test_cli_handle_web_url_download_output_only_required_input(fresh_deadline_c
             job_id=MOCK_JOB_ID,
             step_id=None,
             task_id=None,
+            session_action_id=None,
             session=ANY,
         )
         mock_download.assert_called_once_with(
@@ -349,6 +351,10 @@ def test_cli_handle_web_url_download_output_with_optional_input(fresh_deadline_c
             + f"&step-id={MOCK_STEP_ID}&task-id={MOCK_TASK_ID}&profile={MOCK_PROFILE_NAME}"
         )
 
+        boto3_client_mock().get_task.return_value = {
+            "latestSessionActionId": MOCK_SESSION_ACTION_ID,
+        }
+
         runner = CliRunner()
         result = runner.invoke(main, ["handle-web-url", web_url])
         assert result.exit_code == 0, result.output
@@ -360,6 +366,7 @@ def test_cli_handle_web_url_download_output_with_optional_input(fresh_deadline_c
             job_id=MOCK_JOB_ID,
             step_id=MOCK_STEP_ID,
             task_id=MOCK_TASK_ID,
+            session_action_id=MOCK_SESSION_ACTION_ID,
             session=ANY,
         )
         mock_download.assert_called_once_with(

--- a/test/unit/deadline_client/cli/test_cli_job.py
+++ b/test/unit/deadline_client/cli/test_cli_job.py
@@ -42,6 +42,9 @@ from ..shared_constants import (
     MOCK_FARM_ID,
     MOCK_JOB_ID,
     MOCK_QUEUE_ID,
+    MOCK_SESSION_ACTION_ID,
+    MOCK_STEP_ID,
+    MOCK_TASK_ID,
     MOCK_FLEET_ID,
     MOCK_WORKER_ID,
 )
@@ -421,6 +424,7 @@ def test_cli_job_download_output_stdout_with_only_required_input(
             job_id=MOCK_JOB_ID,
             step_id=None,
             task_id=None,
+            session_action_id=None,
             session=ANY,
         )
 
@@ -529,6 +533,7 @@ def test_cli_job_download_output_stdout_with_mismatching_path_format(
             job_id=MOCK_JOB_ID,
             step_id=None,
             task_id=None,
+            session_action_id=None,
             session=ANY,
         )
 
@@ -624,6 +629,7 @@ def test_cli_job_download_output_handles_unc_path_on_windows(fresh_deadline_conf
             job_id=MOCK_JOB_ID,
             step_id=None,
             task_id=None,
+            session_action_id=None,
             session=ANY,
         )
 
@@ -706,6 +712,7 @@ def test_cli_job_download_no_output_stdout(fresh_deadline_config, tmp_path: Path
             job_id=MOCK_JOB_ID,
             step_id=None,
             task_id=None,
+            session_action_id=None,
             session=ANY,
         )
 
@@ -797,6 +804,7 @@ def test_cli_job_download_output_stdout_with_json_format(
             job_id=MOCK_JOB_ID,
             step_id=None,
             task_id=None,
+            session_action_id=None,
             session=ANY,
         )
 
@@ -1356,6 +1364,10 @@ def test_cli_job_download_output_handle_web_url_with_optional_input(fresh_deadli
         }
         boto3_client_mock().get_queue.side_effect = [MOCK_GET_QUEUE_RESPONSE]
 
+        boto3_client_mock().get_task.return_value = {
+            "latestSessionActionId": MOCK_SESSION_ACTION_ID,
+        }
+
         runner = CliRunner()
         result = runner.invoke(
             main,
@@ -1382,6 +1394,7 @@ def test_cli_job_download_output_handle_web_url_with_optional_input(fresh_deadli
             job_id=MOCK_JOB_ID,
             step_id="step-1",
             task_id="task-2",
+            session_action_id=MOCK_SESSION_ACTION_ID,
             session=ANY,
         )
         mock_download.assert_called_once_with(
@@ -1524,6 +1537,7 @@ def test_cli_job_download_output_with_different_asset_root_path_format_than_job(
             job_id=MOCK_JOB_ID,
             step_id=None,
             task_id=None,
+            session_action_id=None,
             session=ANY,
         )
 
@@ -1641,3 +1655,73 @@ class TestJsonLineHelpers:
         assert "Download Summary:" in result
         assert "Downloaded 2 files totaling" in result
         assert not result.startswith('{"messageType":')
+
+
+def test_cli_job_download_output_with_session_action_id(fresh_deadline_config):
+    config.set_setting("settings.auto_accept", "true")
+
+    with patch.object(api, "get_boto3_client") as boto3_client_mock, patch.object(
+        job_group, "OutputDownloader"
+    ) as MockOutputDownloader, patch.object(
+        job_group, "_get_conflicting_filenames", return_value=[]
+    ), patch.object(job_group, "round", return_value=0), patch.object(
+        api, "get_queue_user_boto3_session"
+    ):
+        mock_download = MagicMock()
+        mock_download.return_value = DownloadSummaryStatistics(
+            total_time=12,
+            processed_files=3,
+            processed_bytes=1024,
+        )
+        MockOutputDownloader.return_value.download_job_output = mock_download
+        MockOutputDownloader.return_value.get_output_paths_by_root.return_value = {}
+
+        mock_host_path_format_name = PathFormat.get_host_path_format_string()
+        boto3_client_mock().get_job.return_value = {
+            "name": "Test Job",
+            "attachments": {
+                "manifests": [
+                    {
+                        "rootPath": "/root/path",
+                        "rootPathFormat": PathFormat(mock_host_path_format_name),
+                        "outputRelativeDirectories": ["."],
+                    },
+                ],
+            },
+        }
+        boto3_client_mock().get_step.return_value = {"name": "Test Step"}
+        boto3_client_mock().get_task.return_value = {
+            "latestSessionActionId": MOCK_SESSION_ACTION_ID,
+        }
+        boto3_client_mock().get_queue.return_value = MOCK_GET_QUEUE_RESPONSE
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "job",
+                "download-output",
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--job-id",
+                MOCK_JOB_ID,
+                "--step-id",
+                MOCK_STEP_ID,
+                "--task-id",
+                MOCK_TASK_ID,
+            ],
+        )
+
+        assert result.exit_code == 0, f"CLI failed with output: {result.output}"
+        MockOutputDownloader.assert_called_once_with(
+            s3_settings=ANY,
+            farm_id=MOCK_FARM_ID,
+            queue_id=MOCK_QUEUE_ID,
+            job_id=MOCK_JOB_ID,
+            step_id=MOCK_STEP_ID,
+            task_id=MOCK_TASK_ID,
+            session_action_id=MOCK_SESSION_ACTION_ID,
+            session=ANY,
+        )

--- a/test/unit/deadline_client/shared_constants.py
+++ b/test/unit/deadline_client/shared_constants.py
@@ -9,6 +9,7 @@ MOCK_STORAGE_PROFILE_ID = "sp-0123456789abcdefabcdefabcdefabcd"
 MOCK_JOB_ID = "job-0123456789abcdefabcdefabcdefabcd"
 MOCK_STEP_ID = "step-0123456789abcdefabcdefabcdefabcd"
 MOCK_TASK_ID = "task-0123456789abcdefabcdefabcdefabcd-99"
+MOCK_SESSION_ACTION_ID = "sessionaction-0123456789abcdefabcdefabcdefabcd-0"
 MOCK_PROFILE_NAME = "my-monitor-profile"
 MOCK_QUEUES_LIST = [
     {

--- a/test/unit/deadline_job_attachments/test_download.py
+++ b/test/unit/deadline_job_attachments/test_download.py
@@ -9,6 +9,7 @@ import shutil
 
 from collections import Counter
 from dataclasses import dataclass, fields
+from datetime import datetime
 from io import BytesIO
 import json
 from pathlib import Path
@@ -42,14 +43,18 @@ from deadline.job_attachments.download import (
     get_job_input_output_paths_by_asset_root,
     get_job_input_paths_by_asset_root,
     get_job_output_paths_by_asset_root,
+    get_output_manifests_by_asset_root,
     get_manifest_from_s3,
     handle_existing_vfs,
     mount_vfs_from_manifests,
     merge_asset_manifests,
     _ensure_paths_within_directory,
     _get_asset_root_from_metadata,
+    _get_manifests_by_session_action_id,
     _get_new_copy_file_path,
     _get_tasks_manifests_keys_from_s3,
+    _list_s3_objects_with_error_handling,
+    _merge_asset_manifests_sorted_asc_by_last_modified,
     VFS_CACHE_REL_PATH_IN_SESSION,
     VFS_MANIFEST_FOLDER_IN_SESSION,
     VFS_MANIFEST_FOLDER_PERMISSIONS,
@@ -98,14 +103,14 @@ class Manifest:
 
 MANIFESTS_v2022_03_03: List[Manifest] = [
     Manifest(
-        "job-1/step-1/task-1-1/session-action-9/manifest1v2023-03-03_output",
+        "job-1/step-1/task-1-1/sessionaction-9-9/manifest1v2023-03-03_output",
         b'{"hashAlg":"xxh128","manifestVersion":"2023-03-03",'
         b'"paths":[{"hash":"test1","mtime":1234000000,"path":"test1.txt","size":1},'
         b'{"hash":"test2","mtime":1234000000,"path":"test/test2.txt","size":1}],'
         b'"totalSize":2}',
     ),
     Manifest(
-        "job-1/step-1/task-1-1/session-action-9/manifest2v2023-03-03_output",
+        "job-1/step-1/task-1-1/sessionaction-9-9/manifest2v2023-03-03_output",
         b'{"hashAlg":"xxh128","manifestVersion":"2023-03-03",'
         b'"paths":[{"hash":"test3","mtime":1234000000,"path":"test/test3.txt","size":1},'
         b'{"hash":"test4","mtime":1234000000,"path":"test4.txt","size":1}],'
@@ -210,6 +215,7 @@ def assert_download_task_output(
             job_id="job-1",
             step_id="step-1",
             task_id="task-1-1",
+            session_action_id="sessionaction-9-9",
         )
 
         summary_statistics = output_downloader.download_job_output(
@@ -1249,6 +1255,7 @@ class TestFullDownload:
                 job_id="job-1",
                 step_id="step-1",
                 task_id="task-1-1",
+                session_action_id="sessionaction-9-9",
             )
 
         target_path = tmp_path / "target"
@@ -2649,6 +2656,418 @@ def test_mount_vfs_from_manifests(
         mock_vfs_start.assert_has_calls(
             [call(session_dir=temp_dir_path), call(session_dir=temp_dir_path)]
         )
+
+
+def test_get_manifests_by_session_action_id_task_based():
+    s3_settings = JobAttachmentS3Settings(s3BucketName="test-bucket", rootPrefix="root")
+
+    with patch(
+        "deadline.job_attachments.download._list_s3_objects_with_error_handling"
+    ) as mock_list:
+        mock_list.return_value = [
+            {
+                "Key": "farm-0/queue-0/job-0/step-0/task-0/2025-05-06T02:58:03.824934Z_sessionaction-0-0/0_output"
+            }
+        ]
+
+        with patch(
+            "deadline.job_attachments.download.get_asset_root_and_manifest_from_s3"
+        ) as mock_get:
+            mock_get.return_value = ("/test/root", MagicMock())
+
+            result = _get_manifests_by_session_action_id(
+                s3_settings,
+                "farm-0",
+                "queue-0",
+                "job-0",
+                "step-0",
+                "task-0",
+                "sessionaction-0-0",
+                None,
+            )
+
+            assert "/test/root" in result
+            mock_list.assert_called_once()
+
+
+def test_get_manifests_by_session_action_id_chunked_fallback():
+    s3_settings = JobAttachmentS3Settings(s3BucketName="test-bucket", rootPrefix="root")
+
+    with patch(
+        "deadline.job_attachments.download._list_s3_objects_with_error_handling"
+    ) as mock_list:
+        mock_list.side_effect = [
+            [],  # Empty first call (task prefix)
+            [
+                {
+                    "Key": "farm-0/queue-0/job-0/step-0/2025-05-06T02:58:03.824934Z_sessionaction-0-0/0_output"
+                }
+            ],  # Found on fallback (step prefix)
+        ]
+
+        with patch(
+            "deadline.job_attachments.download.get_asset_root_and_manifest_from_s3"
+        ) as mock_get:
+            mock_get.return_value = ("/test/root", MagicMock())
+
+            result = _get_manifests_by_session_action_id(
+                s3_settings,
+                "farm-0",
+                "queue-0",
+                "job-0",
+                "step-0",
+                "task-0",
+                "sessionaction-0-0",
+                None,
+            )
+
+            assert "/test/root" in result
+            assert mock_list.call_count == 2
+
+
+def test_get_manifests_by_session_action_id_no_manifests_found():
+    """Test _get_manifests_by_session_action_id when no manifests are found in either task or step prefix."""
+    s3_settings = JobAttachmentS3Settings(s3BucketName="test-bucket", rootPrefix="root")
+
+    with patch(
+        "deadline.job_attachments.download._list_s3_objects_with_error_handling"
+    ) as mock_list:
+        mock_list.side_effect = [JobAttachmentsError("Not found"), JobAttachmentsError("Not found")]
+
+        result = _get_manifests_by_session_action_id(
+            s3_settings, "farm-0", "queue-0", "job-0", "step-0", "task-0", "sessionaction-0-0", None
+        )
+
+        assert result == {}
+        assert mock_list.call_count == 2
+
+
+def test_get_tasks_manifests_keys_chunked_and_task_based_with_latest():
+    mock_s3_client = MagicMock()
+    mock_paginator = MagicMock()
+    mock_s3_client.get_paginator.return_value = mock_paginator
+    mock_paginator.paginate.return_value = [
+        {
+            "Contents": [
+                {"Key": "step-0/2025-05-06T02:58:03.824934Z_sessionaction-0-0/0_output"},  # Chunked
+                {
+                    "Key": "step-0/task-0/2025-05-06T02:58:03.824934Z_sessionaction-0-1/0_output"
+                },  # Newer task-based
+                {
+                    "Key": "step-0/task-0/2024-05-06T02:58:03.824934Z_sessionaction-1-1/0_output"
+                },  # Older task-based
+            ]
+        }
+    ]
+
+    with patch("deadline.job_attachments.download.get_s3_client", return_value=mock_s3_client):
+        result = _get_tasks_manifests_keys_from_s3(
+            "prefix/", "bucket", None, select_latest_per_task=True
+        )
+
+        assert len(result) == 2
+        assert "step-0/2025-05-06T02:58:03.824934Z_sessionaction-0-0/0_output" in result
+        assert "step-0/task-0/2025-05-06T02:58:03.824934Z_sessionaction-0-1/0_output" in result
+
+
+def test_get_manifests_by_session_action_id_regex_matching():
+    """Test that _get_manifests_by_session_action_id correctly matches session action IDs using regex."""
+    s3_settings = JobAttachmentS3Settings(s3BucketName="test-bucket", rootPrefix="root")
+
+    with patch(
+        "deadline.job_attachments.download._list_s3_objects_with_error_handling"
+    ) as mock_list:
+        # Mock S3 contents with various files, only one should match the session action ID
+        mock_list.return_value = [
+            {"Key": "prefix/20241225T120000_sessionaction-1-0/manifest_output"},  # Should match
+            {"Key": "prefix/other_file"},  # Should not match
+            {"Key": "prefix/20241225T130000_sessionaction-2-0/manifest_output"},  # Should not match
+            {"Key": "prefix/no_output_suffix"},  # Should not match
+        ]
+
+        with patch(
+            "deadline.job_attachments.download.get_asset_root_and_manifest_from_s3"
+        ) as mock_get:
+            mock_get.return_value = ("/test/root", MagicMock())
+
+            result = _get_manifests_by_session_action_id(
+                s3_settings,
+                "farm-0",
+                "queue-0",
+                "job-0",
+                "step-0",
+                "task-0",
+                "sessionaction-1-0",  # This should only match the first file
+                None,
+            )
+
+            assert "/test/root" in result
+            # Should only call get_asset_root_and_manifest_from_s3 once for the matching file
+            mock_get.assert_called_once_with(
+                "prefix/20241225T120000_sessionaction-1-0/manifest_output", "test-bucket", None
+            )
+
+
+def test_get_tasks_manifests_keys_chunked_and_task_based_without_latest():
+    mock_s3_client = MagicMock()
+    mock_paginator = MagicMock()
+    mock_s3_client.get_paginator.return_value = mock_paginator
+    mock_paginator.paginate.return_value = [
+        {
+            "Contents": [
+                {"Key": "step-0/2025-05-06T02:58:03.824934Z_sessionaction-0-0/0_output"},  # Chunked
+                {
+                    "Key": "step-0/task-0/2025-05-06T02:58:03.824934Z_sessionaction-0-1/0_output"
+                },  # Newer task-based
+                {
+                    "Key": "step-0/task-0/2024-05-06T02:58:03.824934Z_sessionaction-1-1/0_output"
+                },  # Older task-based
+            ]
+        }
+    ]
+
+    with patch("deadline.job_attachments.download.get_s3_client", return_value=mock_s3_client):
+        result = _get_tasks_manifests_keys_from_s3(
+            "prefix/", "bucket", None, select_latest_per_task=False
+        )
+
+        assert len(result) == 3
+        assert "step-0/2025-05-06T02:58:03.824934Z_sessionaction-0-0/0_output" in result
+        assert "step-0/task-0/2025-05-06T02:58:03.824934Z_sessionaction-0-1/0_output" in result
+        assert "step-0/task-0/2024-05-06T02:58:03.824934Z_sessionaction-1-1/0_output" in result
+
+
+def test_get_output_manifests_by_asset_root_with_session_action_id():
+    s3_settings = JobAttachmentS3Settings(s3BucketName="test-bucket", rootPrefix="root")
+
+    with patch("deadline.job_attachments.download._get_manifests_by_session_action_id") as mock_get:
+        mock_get.return_value = {"/test/root": [MagicMock()]}
+
+        result = get_output_manifests_by_asset_root(
+            s3_settings, "farm-1", "queue-1", "job-1", "step-1", "task-1", "session-1", None
+        )
+
+        assert "/test/root" in result
+        mock_get.assert_called_once_with(
+            s3_settings, "farm-1", "queue-1", "job-1", "step-1", "task-1", "session-1", None
+        )
+
+
+def test_get_output_manifests_by_asset_root_chronological_merge_chunked():
+    """Test chronological merging of manifests for chunked-based paths with different timestamps."""
+    s3_settings = JobAttachmentS3Settings(s3BucketName="test-bucket", rootPrefix="root")
+
+    # Create two manifests with different content for the same asset root
+    older_manifest_dict = {
+        "hashAlg": "xxh128",
+        "manifestVersion": "2023-03-03",
+        "paths": [
+            {
+                "hash": "a96ddfc33590cd7d2391f1972f66a72a",
+                "mtime": 1111111111111111,
+                "path": "file.txt",
+                "size": 10,
+            }
+        ],
+        "totalSize": 10,
+    }
+    newer_manifest_dict = {
+        "hashAlg": "xxh128",
+        "manifestVersion": "2023-03-03",
+        "paths": [
+            {
+                "hash": "b96ddfc33590cd7d2391f1972f66a72b",
+                "mtime": 2222222222222222,
+                "path": "file.txt",
+                "size": 20,
+            }
+        ],
+        "totalSize": 20,
+    }
+
+    older_manifest = decode_manifest(json.dumps(older_manifest_dict))
+    newer_manifest = decode_manifest(json.dumps(newer_manifest_dict))
+
+    # Mock the S3 calls
+    with patch(
+        "deadline.job_attachments.download._get_tasks_manifests_keys_from_s3"
+    ) as mock_keys, patch(
+        "deadline.job_attachments.download._get_asset_root_and_manifest_from_s3_with_last_modified"
+    ) as mock_get_manifest:
+        # Two chunked session actions under same step with different timestamps
+        mock_keys.return_value = [
+            "step-0/2024-05-06T02:58:03.824934Z_sessionaction-0-0/0_output",  # Older
+            "step-0/2025-05-06T02:58:03.824934Z_sessionaction-1-0/0_output",  # Newer
+        ]
+
+        # Return manifests with timestamps - older first, then newer
+        mock_get_manifest.side_effect = [
+            ("/test/root", datetime(2024, 5, 6, 2, 58, 3), older_manifest),
+            ("/test/root", datetime(2025, 5, 6, 2, 58, 3), newer_manifest),
+        ]
+
+        result = get_output_manifests_by_asset_root(
+            s3_settings, "farm-1", "queue-1", "job-1", "step-1"
+        )
+
+        # Should have one asset root with one merged manifest
+        assert len(result) == 1
+        assert "/test/root" in result
+        assert len(result["/test/root"]) == 1
+
+        # The merged manifest should contain the newer file (newer overwrites older)
+        merged_manifest = result["/test/root"][0]
+        assert len(merged_manifest.paths) == 1
+        assert merged_manifest.paths[0].hash == "b96ddfc33590cd7d2391f1972f66a72b"
+        assert merged_manifest.paths[0].size == 20
+
+
+def test_get_output_manifests_by_asset_root_multiple_asset_roots():
+    """Test chronological merging with multiple asset roots."""
+    s3_settings = JobAttachmentS3Settings(s3BucketName="test-bucket", rootPrefix="root")
+
+    # Create manifests for different asset roots
+    manifest_root1 = decode_manifest(
+        json.dumps(
+            {
+                "hashAlg": "xxh128",
+                "manifestVersion": "2023-03-03",
+                "paths": [
+                    {
+                        "hash": "a96ddfc33590cd7d2391f1972f66a72a",
+                        "mtime": 1111111111111111,
+                        "path": "file1.txt",
+                        "size": 10,
+                    }
+                ],
+                "totalSize": 10,
+            }
+        )
+    )
+    manifest_root2 = decode_manifest(
+        json.dumps(
+            {
+                "hashAlg": "xxh128",
+                "manifestVersion": "2023-03-03",
+                "paths": [
+                    {
+                        "hash": "b96ddfc33590cd7d2391f1972f66a72b",
+                        "mtime": 2222222222222222,
+                        "path": "file2.txt",
+                        "size": 20,
+                    }
+                ],
+                "totalSize": 20,
+            }
+        )
+    )
+
+    with patch(
+        "deadline.job_attachments.download._get_tasks_manifests_keys_from_s3"
+    ) as mock_keys, patch(
+        "deadline.job_attachments.download._get_asset_root_and_manifest_from_s3_with_last_modified"
+    ) as mock_get_manifest:
+        mock_keys.return_value = ["manifest1", "manifest2"]
+        mock_get_manifest.side_effect = [
+            ("/root1", datetime(2024, 5, 6), manifest_root1),
+            ("/root2", datetime(2024, 5, 7), manifest_root2),
+        ]
+
+        result = get_output_manifests_by_asset_root(s3_settings, "farm-1", "queue-1", "job-1")
+
+        assert len(result) == 2
+        assert "/root1" in result
+        assert "/root2" in result
+        assert len(result["/root1"]) == 1
+        assert len(result["/root2"]) == 1
+
+
+def test_list_s3_objects_with_error_handling_no_contents():
+    """Test _list_s3_objects_with_error_handling when S3 returns no Contents."""
+    mock_s3_client = MagicMock()
+    mock_paginator = MagicMock()
+    mock_s3_client.get_paginator.return_value = mock_paginator
+    mock_paginator.paginate.return_value = [{}]  # No Contents key
+
+    with patch("deadline.job_attachments.download.get_s3_client", return_value=mock_s3_client):
+        with pytest.raises(JobAttachmentsError, match="Unable to find asset manifest"):
+            _list_s3_objects_with_error_handling("bucket", "prefix/", None)
+
+
+def test_get_tasks_manifests_keys_chunked_only():
+    """Test _get_tasks_manifests_keys_from_s3 with only chunked manifests (no task-based)."""
+    mock_s3_client = MagicMock()
+    mock_paginator = MagicMock()
+    mock_s3_client.get_paginator.return_value = mock_paginator
+    mock_paginator.paginate.return_value = [
+        {
+            "Contents": [
+                {"Key": "step-0/2025-05-06T02:58:03.824934Z_sessionaction-0-0/0_output"},
+                {"Key": "step-0/2025-05-06T03:58:03.824934Z_sessionaction-1-0/0_output"},
+            ]
+        }
+    ]
+
+    with patch("deadline.job_attachments.download.get_s3_client", return_value=mock_s3_client):
+        result = _get_tasks_manifests_keys_from_s3(
+            "prefix/", "bucket", None, select_latest_per_task=True
+        )
+
+        assert len(result) == 2
+        assert all("task-" not in key for key in result)
+
+
+def test_merge_asset_manifests_sorted_same_timestamp():
+    """Test _merge_asset_manifests_sorted_asc_by_last_modified with manifests having same timestamp."""
+    # Create two manifests with same timestamp but different content
+    manifest1 = decode_manifest(
+        json.dumps(
+            {
+                "hashAlg": "xxh128",
+                "manifestVersion": "2023-03-03",
+                "paths": [
+                    {
+                        "hash": "a96ddfc33590cd7d2391f1972f66a72a",
+                        "mtime": 1111111111111111,
+                        "path": "file.txt",
+                        "size": 10,
+                    }
+                ],
+                "totalSize": 10,
+            }
+        )
+    )
+    manifest2 = decode_manifest(
+        json.dumps(
+            {
+                "hashAlg": "xxh128",
+                "manifestVersion": "2023-03-03",
+                "paths": [
+                    {
+                        "hash": "b96ddfc33590cd7d2391f1972f66a72b",
+                        "mtime": 2222222222222222,
+                        "path": "file.txt",
+                        "size": 20,
+                    }
+                ],
+                "totalSize": 20,
+            }
+        )
+    )
+
+    same_timestamp = datetime(2024, 5, 6, 2, 58, 3)
+    manifests_with_timestamps = [
+        (same_timestamp, manifest1),
+        (same_timestamp, manifest2),
+    ]
+
+    result = _merge_asset_manifests_sorted_asc_by_last_modified(manifests_with_timestamps)
+
+    # Should merge successfully even with same timestamps
+    assert result is not None
+    assert len(result.paths) == 1
+    # The second manifest should overwrite the first (stable sort behavior)
+    assert result.paths[0].hash == "b96ddfc33590cd7d2391f1972f66a72b"
 
 
 def test_get_new_copy_file_path_file_collisions(tmp_path: Path) -> None:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Job attachments need to support downloading outputs from chunked session actions in addition to the existing task-based output downloads. 

Some session actions no longer have `taskId` because they represent a "chunk" of tasks (e.g., frame range 0-20 corresponding to 20 tasks). Previously, WorkerAgent stored manifests at S3 path `.../job_id/step_id/task_id/timestamp_sessionaction_id/` but outputs for chunked session actions are stored at `.../job_id/step_id/timestamp_sessionaction_id/` (omitting task_id).

The existing download functionality only handles task-based outputs with the pattern `task-*/*_output`, but chunked session actions generate outputs with different S3 key patterns that aren't being captured.

### What was the solution? (How)

- **Implemented chunked manifest handling**: Added logic to detect and process chunked session action outputs alongside traditional task outputs in `_get_tasks_manifests_keys_from_s3()` to handle both task-based (`step_id/task_id`) and chunked (`step_id/session_action_id`) output patterns. Also,  updated `get_output_manifests_by_asset_root()` to chronologically merge manifests from chunked sources.
- **Added session action ID support**: Updated the CLI to extract and pass `latestSessionActionId` from task metadata to the download functions and added session action-specific retrieval with `_get_manifests_by_session_action_id()` and `_get_manifests_by_session_action_regex()` functions.

### What is the impact of this change?

- Users can now download outputs from chunked session actions using the existing CLI commands
- WorkerAgent can sync step-step dependencies for both task-based and chunked outputs
- The system maintains backward compatibility with existing task-based downloads

### How was this change tested?

* [x] Have you run the unit tests?
* [x] Have you run the integration tests?
```
49 passed, 4 skipped, 2 xfailed, 4 xpassed in 3528.71s (0:58:48)
```

* [x] Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass.
```
32 passed, 13 skipped in 19.15s
```
* [x] Manually tested downloading of job/step/task outputs from `dep_chain_ja_output_test`. Also, used the same job outputs but moved manifests from `task-` folders directly into `step-` folders and confirmed that handling "chunked" paths works as expected. Got the correct output in both cases.
```
Step A is correct
Step B is correct
Step C is correct
Step D is correct
Step E is correct
Step F is correct
Step G is correct
Step H is correct
Step I is correct
Step J is correct
Step K is correct
Step L is correct
Step M is correct
Step N is correct
Step O is correct
Step P is correct
Step Q is correct
Step R is correct
Step S is correct
Step T is correct
Step U is correct
Step V is correct
Step W is correct
Step X is correct
Step Y is correct
Step Z is correct
```

* [x] Ran a small benchmarking test to compare `re.compile` vs `re.search`
```
Summary over 10 runs with 30,000 paths:

• **re.search**: avg=0.0185s, min=0.0177s, max=0.0225s
• **compiled**: avg=0.0102s, min=0.0097s, max=0.0110s  
• **Improvement: 45.1%**

The results are consistent across 10 runs, showing the compiled regex is reliably ~45% faster. The performance is stable with minimal variance.
```

### Was this change documented?

* [x] Are relevant docstrings in the code base updated?

### Does this PR introduce new dependencies?
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?
No, this is not a breaking change. The modifications extend existing functionality while maintaining backward compatibility with existing task-based downloads.

### Does this change impact security?
No security impact. The change only modifies how S3 manifest keys are discovered and processed, using the same existing S3 permissions and download mechanisms.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*