### PR TITLE
perf: speed up job bundle submission by reducing redundant stat calls

### DIFF
--- a/src/deadline/job_attachments/upload.py
+++ b/src/deadline/job_attachments/upload.py
@@ -12,9 +12,11 @@ from contextlib import contextmanager
 import errno
 import logging
 import os
+import stat
 import sys
 import time
 from datetime import datetime
+from functools import lru_cache
 from io import BufferedReader, BytesIO
 from math import trunc
 from pathlib import Path, PurePath
@@ -81,6 +83,44 @@ from ._utils import (
 )
 
 logger = logging.getLogger("deadline.job_attachments.upload")
+
+
+class _FileStatCache:
+    """Private cache for file stat results to avoid redundant filesystem calls"""
+
+    @lru_cache(maxsize=1024)
+    def _get_stat(self, path_str: str) -> Optional[os.stat_result]:
+        """Get cached stat result for a path string"""
+        try:
+            return Path(path_str).stat()
+        except (FileNotFoundError, PermissionError, OSError):
+            return None
+
+    def exists(self, path: Path) -> bool:
+        """Check if path exists, using cache when possible"""
+        stat_result = self._get_stat(str(path))
+        if stat_result is not None:
+            return True
+        # Fall back to direct exists() call if stat failed
+        return path.exists()
+
+    def is_dir(self, path: Path) -> bool:
+        """Check if path is directory, using cache when possible"""
+        stat_result = self._get_stat(str(path))
+        if stat_result is not None:
+            return stat.S_ISDIR(stat_result.st_mode)
+        # Fall back to direct is_dir() call if stat failed
+        return path.is_dir()
+
+    def get_size(self, path: Path) -> int:
+        """Get file size using cached stat"""
+        stat_result = self._get_stat(str(path))
+        if stat_result is not None:
+            return stat_result.st_size
+        # Log warning for missing files and return 0
+        logger.warning(f"Skipping file in size calculation: {path}")
+        return 0
+
 
 # The default multipart upload chunk size is 8 MB. We used this to determine the small file threshold,
 # which is the chunk size multiplied by the small file threshold multiplier.
@@ -1008,6 +1048,7 @@ class S3AssetManager:
         self.session = session
 
         self.manifest_version: ManifestVersion = asset_manifest_version
+        self._stat_cache = _FileStatCache()
 
     def _process_input_path(
         self,
@@ -1145,7 +1186,7 @@ class S3AssetManager:
         for _path in input_paths:
             # Need to use absolute to not resolve symlinks, but need normpath to get rid of relative paths, i.e. '..'
             abs_path = Path(os.path.normpath(Path(_path).absolute()))
-            if not abs_path.exists():
+            if not self._stat_cache.exists(abs_path):
                 if require_paths_exist:
                     missing_input_paths.add(abs_path)
                 else:
@@ -1154,7 +1195,7 @@ class S3AssetManager:
                     )
                     referenced_paths.add(_path)
                 continue
-            if abs_path.is_dir():
+            if self._stat_cache.is_dir(abs_path):
                 misconfigured_directories.add(abs_path)
                 continue
 
@@ -1292,11 +1333,7 @@ class S3AssetManager:
 
     def _get_total_size_of_files(self, paths: list[str]) -> int:
         def get_file_size(path_str: str) -> int:
-            try:
-                return Path(path_str).resolve().stat().st_size
-            except (FileNotFoundError, PermissionError, OSError):
-                logger.warning(f"Skipping file in size calculation: {path_str}")
-                return 0
+            return self._stat_cache.get_size(Path(path_str))
 
         with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
             sizes = list(executor.map(get_file_size, paths))

--- a/test/unit/deadline/job_attachments/test_file_stat_cache.py
+++ b/test/unit/deadline/job_attachments/test_file_stat_cache.py
@@ -1,0 +1,111 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import stat
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+from deadline.job_attachments.upload import _FileStatCache
+
+
+class TestFileStatCache:
+    def test_get_stat_caches_result(self, tmp_path):
+        """Test that stat results are cached and not called multiple times"""
+        cache = _FileStatCache()
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("test")
+
+        with patch.object(Path, "stat") as mock_stat:
+            mock_stat.return_value = MagicMock()
+
+            # First call should invoke stat
+            result1 = cache._get_stat(test_file)
+            assert mock_stat.call_count == 1
+
+            # Second call should use cache
+            result2 = cache._get_stat(test_file)
+            assert mock_stat.call_count == 1
+            assert result1 is result2
+
+    def test_get_stat_handles_missing_file(self, tmp_path):
+        """Test that missing files return None and are cached"""
+        cache = _FileStatCache()
+        missing_file = tmp_path / "missing.txt"
+
+        result1 = cache._get_stat(missing_file)
+        result2 = cache._get_stat(missing_file)
+
+        assert result1 is None
+        assert result2 is None
+
+    def test_exists_with_existing_file(self, tmp_path):
+        """Test exists() returns True for existing files"""
+        cache = _FileStatCache()
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("test")
+
+        assert cache.exists(test_file) is True
+
+    def test_exists_with_missing_file(self, tmp_path):
+        """Test exists() returns False for missing files"""
+        cache = _FileStatCache()
+        missing_file = tmp_path / "missing.txt"
+
+        assert cache.exists(missing_file) is False
+
+    def test_is_dir_with_directory(self, tmp_path):
+        """Test is_dir() returns True for directories"""
+        cache = _FileStatCache()
+        test_dir = tmp_path / "testdir"
+        test_dir.mkdir()
+
+        assert cache.is_dir(test_dir) is True
+
+    def test_is_dir_with_file(self, tmp_path):
+        """Test is_dir() returns False for files"""
+        cache = _FileStatCache()
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("test")
+
+        assert cache.is_dir(test_file) is False
+
+    def test_is_dir_with_missing_path(self, tmp_path):
+        """Test is_dir() returns False for missing paths"""
+        cache = _FileStatCache()
+        missing_path = tmp_path / "missing"
+
+        assert cache.is_dir(missing_path) is False
+
+    def test_get_size_with_file(self, tmp_path):
+        """Test get_size() returns correct file size"""
+        cache = _FileStatCache()
+        test_file = tmp_path / "test.txt"
+        content = "test content"
+        test_file.write_text(content)
+
+        size = cache.get_size(test_file)
+        assert size == len(content.encode())
+
+    def test_get_size_with_missing_file(self, tmp_path, caplog):
+        """Test get_size() returns 0 for missing files and emits the expected message"""
+        cache = _FileStatCache()
+        missing_file = tmp_path / "missing.txt"
+
+        assert cache.get_size(missing_file) == 0
+        assert "Skipping file in size calculation" in caplog.text
+
+    def test_cache_reuse_across_methods(self, tmp_path):
+        """Test that cache is shared across different methods"""
+        cache = _FileStatCache()
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("test")
+
+        with patch.object(Path, "stat") as mock_stat:
+            mock_stat.return_value = MagicMock(st_mode=stat.S_IFREG, st_size=4)
+
+            # Call different methods
+            cache.exists(test_file)
+            cache.is_dir(test_file)
+            cache.get_size(test_file)
+
+            # Should only call stat once
+            assert mock_stat.call_count == 1


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
When creating and uploading a job bundle performance is reduced by repeated stat calls to the same files

### What was the solution? (How)
Add a stat cache of previously retrieved stat results

### What is the impact of this change?
Faster job bundle creation.  In my own testing with Meerkat on top of the previously committed improvements I saw another ~20-28% improvement - reducing the creation time to 16-16.5 seconds.

### How was this change tested?
New unit tests added which pass
Integration tests pass
Manual testing

### Was this change documented?
Yes

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatibilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [ X] This PR does not add any new dependencies.

### Is this a breaking change?
No

### Does this change impact security?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
