### PR TITLE
chore: Revert "chore: pin the version of click that hatch uses to <8.…

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -124,7 +124,7 @@ jobs:
           python-version: '3.9'
       - name: Install dependencies
         run: |
-          pip install --upgrade hatch "click<8.3"
+          pip install --upgrade hatch
       - name: Build
         run: hatch -v build
       # # See https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi

--- a/.github/workflows/reusable_python_build_coverage_override.yml
+++ b/.github/workflows/reusable_python_build_coverage_override.yml
@@ -70,7 +70,7 @@ jobs:
 
     - name: Install Hatch
       run: |
-        pip install --upgrade hatch "click<8.3"
+        pip install --upgrade hatch
 
     - name: Run Linting
       run: hatch -v run lint

--- a/pipeline/build.ps1
+++ b/pipeline/build.ps1
@@ -6,7 +6,7 @@ $ErrorActionPreference = "Stop"
 # Install/upgrade packages
 python -m pip install --upgrade pip
 if ($LASTEXITCODE -ne 0) { throw "Failed to update pip" }
-python -m pip install --upgrade hatch "click<8.3"
+python -m pip install --upgrade hatch
 if ($LASTEXITCODE -ne 0) { throw "Failed to update hatch" }
 python -m pip install --upgrade twine
 if ($LASTEXITCODE -ne 0) { throw "Failed to update twine" }

--- a/pipeline/build.sh
+++ b/pipeline/build.sh
@@ -4,7 +4,7 @@
 set -e
 
 pip install --upgrade pip
-pip install --upgrade hatch "click<8.3"
+pip install --upgrade hatch
 pip install --upgrade twine
 hatch -v run codebuild:lint
 hatch run codebuild:test

--- a/pipeline/build_pyinstaller_artifact.ps1
+++ b/pipeline/build_pyinstaller_artifact.ps1
@@ -4,7 +4,7 @@ $ErrorActionPreference = "Stop"
 
 pip install --upgrade pip
 if ($LASTEXITCODE -ne 0) { throw "Failed to update pip" }
-pip install --upgrade hatch "click<8.3"
+pip install --upgrade hatch
 if ($LASTEXITCODE -ne 0) { throw "Failed to update hatch" }
 
 hatch run installer:build

--- a/pipeline/e2e.sh
+++ b/pipeline/e2e.sh
@@ -4,5 +4,5 @@
 set -e
 
 pip install --upgrade pip
-pip install --upgrade hatch "click<8.3"
+pip install --upgrade hatch
 hatch run e2e:test

--- a/pipeline/integ.ps1
+++ b/pipeline/integ.ps1
@@ -3,6 +3,6 @@
 $ErrorActionPreference = "Stop"
 
 pip install --upgrade pip
-pip install --upgrade hatch "click<8.3"
+pip install --upgrade hatch
 hatch run integ:test
 if ($LASTEXITCODE -ne 0) { throw "Failed to run integration tests" }

--- a/pipeline/integ.sh
+++ b/pipeline/integ.sh
@@ -4,5 +4,5 @@
 set -e
 
 pip install --upgrade pip
-pip install --upgrade hatch "click<8.3"
+pip install --upgrade hatch
 hatch run integ:test


### PR DESCRIPTION
…3 due to Sentinel bug (#846)"

### What was the problem/requirement? (What/Why)

Hatch has fixed an issue with it's click dependency. We no longer need to pin click.
Hatch Release: https://github.com/pypa/hatch/releases/tag/hatch-v1.14.2

### What was the solution? (How)
This reverts commit d58e0387fe5a5f0fa50241b05330ad21a5bf0efc.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
