### PR TITLE
fix: concurrent job bundle submissions fail due to sqlite3 table already exists

### DIFF
--- a/src/deadline/job_attachments/caches/hash_cache.py
+++ b/src/deadline/job_attachments/caches/hash_cache.py
@@ -51,7 +51,7 @@ class HashCache(CacheDB):
 
     def __init__(self, cache_dir: Optional[str] = None) -> None:
         table_name: str = f"hashesV{self.CACHE_DB_VERSION}"
-        create_query: str = f"CREATE TABLE hashesV{self.CACHE_DB_VERSION}(file_path blob primary key, hash_algorithm text secondary key, file_hash text, last_modified_time timestamp)"
+        create_query: str = f"CREATE TABLE IF NOT EXISTS hashesV{self.CACHE_DB_VERSION}(file_path blob primary key, hash_algorithm text secondary key, file_hash text, last_modified_time timestamp)"
         super().__init__(
             cache_name=self.CACHE_NAME,
             table_name=table_name,

--- a/src/deadline/job_attachments/caches/s3_check_cache.py
+++ b/src/deadline/job_attachments/caches/s3_check_cache.py
@@ -48,7 +48,7 @@ class S3CheckCache(CacheDB):
 
     def __init__(self, cache_dir: Optional[str] = None) -> None:
         table_name: str = f"s3checkV{self.CACHE_DB_VERSION}"
-        create_query: str = f"CREATE TABLE s3checkV{self.CACHE_DB_VERSION}(s3_key text primary key, last_seen_time timestamp)"
+        create_query: str = f"CREATE TABLE IF NOT EXISTS s3checkV{self.CACHE_DB_VERSION}(s3_key text primary key, last_seen_time timestamp)"
         super().__init__(
             cache_name=self.CACHE_NAME,
             table_name=table_name,

--- a/test/unit/deadline_job_attachments/caches/test_caches.py
+++ b/test/unit/deadline_job_attachments/caches/test_caches.py
@@ -187,6 +187,76 @@ class TestHashCache:
                 )
                 assert hc.get_entry("/no/file", HashAlgorithm.XXH128) is None
 
+    def test_table_creation_idempotent(self, tmpdir):
+        """
+        Tests that creating the hash cache table multiple times doesn't cause errors
+        """
+        cache_dir = tmpdir.mkdir("cache")
+
+        # Create the cache and table first time
+        with HashCache(cache_dir) as hc1:
+            test_entry = HashCacheEntry(
+                file_path="/test/file",
+                hash_algorithm=HashAlgorithm.XXH128,
+                file_hash="abc123",
+                last_modified_time="1234.56",
+            )
+            hc1.put_entry(test_entry)
+            retrieved_entry = hc1.get_entry("/test/file", HashAlgorithm.XXH128)
+            assert retrieved_entry == test_entry
+
+        # Create the cache again with the same directory - should not fail
+        with HashCache(cache_dir) as hc2:
+            # Should be able to retrieve the previously stored entry
+            retrieved_entry = hc2.get_entry("/test/file", HashAlgorithm.XXH128)
+            assert retrieved_entry == test_entry
+
+            # Should be able to add new entries
+            new_entry = HashCacheEntry(
+                file_path="/test/file2",
+                hash_algorithm=HashAlgorithm.XXH128,
+                file_hash="def456",
+                last_modified_time="5678.91",
+            )
+            hc2.put_entry(new_entry)
+            retrieved_new_entry = hc2.get_entry("/test/file2", HashAlgorithm.XXH128)
+            assert retrieved_new_entry == new_entry
+
+    def test_table_already_exists_no_error(self, tmpdir):
+        """
+        Tests that no error is raised when trying to create a table that already exists
+        This specifically tests the 'IF NOT EXISTS' clause in the CREATE TABLE statement
+        """
+        import sqlite3
+
+        cache_dir = tmpdir.mkdir("cache")
+        db_path = os.path.join(cache_dir, "hash_cache.db")
+
+        # Create a HashCache instance to get the correct table name and schema
+        hc = HashCache(cache_dir)
+
+        with sqlite3.connect(db_path) as conn:
+            # Create the database and table first using the create query
+            conn.execute(hc.create_query)
+            # Running the same create query again to create existing table
+            # This is to simulate the case when the query runs concurrently trying to create the same table
+            conn.execute(hc.create_query)
+            conn.commit()
+
+        # Now verify normal operations work
+        with hc:
+            test_entry = HashCacheEntry(
+                file_path="/test/file",
+                hash_algorithm=HashAlgorithm.XXH128,
+                file_hash="abc123",
+                last_modified_time="1234.56",
+            )
+            hc.put_entry(test_entry)
+            retrieved_entry = hc.get_entry("/test/file", HashAlgorithm.XXH128)
+            assert retrieved_entry == test_entry
+            retrieved_entry = hc.get_entry("/test/file", HashAlgorithm.XXH128)
+            assert retrieved_entry == test_entry
+
 
 class TestS3CheckCache:
     """
@@ -312,3 +382,65 @@ class TestS3CheckCache:
             actual_entry = s3c.get_connection_entry("bucket/Data/somehash", connection)
 
             assert actual_entry is None
+
+    def test_table_creation_idempotent(self, tmpdir):
+        """
+        Tests that creating the S3 check cache table multiple times doesn't cause errors
+        """
+        cache_dir = tmpdir.mkdir("cache")
+
+        # Create the cache and table first time
+        with S3CheckCache(cache_dir) as s3c1:
+            test_entry = S3CheckCacheEntry(
+                s3_key="bucket/Data/test-hash",
+                last_seen_time=str(datetime.now().timestamp()),
+            )
+            s3c1.put_entry(test_entry)
+            retrieved_entry = s3c1.get_entry("bucket/Data/test-hash")
+            assert retrieved_entry == test_entry
+
+        # Create the cache again with the same directory - should not fail
+        with S3CheckCache(cache_dir) as s3c2:
+            # Should be able to retrieve the previously stored entry
+            retrieved_entry = s3c2.get_entry("bucket/Data/test-hash")
+            assert retrieved_entry == test_entry
+
+            # Should be able to add new entries
+            new_entry = S3CheckCacheEntry(
+                s3_key="bucket/Data/another-hash",
+                last_seen_time=str(datetime.now().timestamp()),
+            )
+            s3c2.put_entry(new_entry)
+            retrieved_new_entry = s3c2.get_entry("bucket/Data/another-hash")
+            assert retrieved_new_entry == new_entry
+
+    def test_table_already_exists_no_error(self, tmpdir):
+        """
+        Tests that no error is raised when trying to create a table that already exists
+        This specifically tests the 'IF NOT EXISTS' clause in the CREATE TABLE statement
+        """
+        import sqlite3
+
+        cache_dir = tmpdir.mkdir("cache")
+        db_path = os.path.join(cache_dir, "s3_check_cache.db")
+
+        # Create a S3CheckCache instance to get the correct table name and schema
+        s3c = S3CheckCache(cache_dir)
+
+        with sqlite3.connect(db_path) as conn:
+            # Create the database and table first using the create query
+            conn.execute(s3c.create_query)
+            # Running the same create query again to create existing table
+            # This is to simulate the case when the query runs concurrently trying to create the same table
+            conn.execute(s3c.create_query)
+            conn.commit()
+
+        # Now verify normal operations work
+        with s3c:
+            test_entry = S3CheckCacheEntry(
+                s3_key="bucket/Data/test-hash",
+                last_seen_time=str(datetime.now().timestamp()),
+            )
+            s3c.put_entry(test_entry)
+            retrieved_entry = s3c.get_entry("bucket/Data/test-hash")
+            assert retrieved_entry == test_entry


### PR DESCRIPTION
Fixes: *[821](https://github.com/aws-deadline/deadline-cloud/issues/821)*

### What was the problem/requirement? (What/Why)
When user attempt to submit two jobs in parallel on a new machine never ran this job bundle submit before, they can  get the following error:

sqlite3.OperationalError: table hashesV3 already exists

### What was the solution? (How)
Only create the table if it doesn't exist already.

### What is the impact of this change?
Concurrent initial submission wouldn't get error due to table already exists.

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- [x] Have you run the unit tests?
- [x] Have you run the integration tests?
- [N/A] Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended that you ensure that the docker-based unit tests pass.

### Was this change documented?

- Are relevant docstrings in the code base updated?
- Has the README.md been updated? If you modified CLI arguments, for instance.

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?
No


### Does this change impact security?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
