### PR TITLE
ci: add changelog section for performance improvements

### DIFF
--- a/.semantic_release/CHANGELOG.md.j2
+++ b/.semantic_release/CHANGELOG.md.j2
@@ -22,4 +22,11 @@
         {% endfor %}
     {% endif %}
 
+    {% if "performance improvements" in release["elements"] %}
+### Performance Improvements
+        {% for commit in release["elements"]["performance improvements"] %}
+* {% if commit.scope %}**{{ commit.scope }}**: {% endif %}{{ commit.commit.summary[commit.commit.summary.find(":")+1:].strip() }} ([`{{ commit.short_hash }}`]({{ commit.commit.hexsha | commit_hash_url }}))
+        {% endfor %}
+    {% endif %}
+
 {% endfor %}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,6 +98,7 @@ We ask that you use these commit types in your commit titles:
 * `refactor` - When the pull request is implementing only a refactor of existing code;
 * `ci` - When the pull request is implementing a change to the CI infrastructure of the packge;
 * `chore` - When the pull request is a generic maintenance task.
+* `perf` - When the pull request is a performance improvement.
 
 We also require that the type in your conventional commit title end in an exclaimation point (e.g. `feat!` or `fix!`)
 if the pull request should be considered to be a breaking change in some way. Please also include a "BREAKING CHANGE" footer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,7 +209,7 @@ allowed_tags = [
   "revert",
 ]
 minor_tags = []
-patch_tags = ["chore", "feat", "fix", "refactor"]
+patch_tags = ["chore", "feat", "fix", "refactor", "perf"]
 
 [tool.semantic_release.publish]
 upload_to_vcs_release = false


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

In the `0.53.1` release underway, we observed multiple performance improvement changes that were merged, but they ended up being classified as bug fixes.

[Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#specification) recommends using `perf:` for such commit changes.

`deadline-cloud` uses `python-semantic-release` to parse commits and generate our changelogs. Currently, configuration allows `perf:` commits, but they are excluded from the changelog. 

### What was the solution? (How)

*   Modify the changelog template to include performance improvements in their own section.
*   Include `perf:` commit types as one that warrants a patch bump

### What is the impact of this change?

Change authors can use the `perf:` conventional commit type to classify performance improvement changes and they wil be automatically added in a relevant changelog section for the release.

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests?
   No, the change does not impact unit tests
- Have you run the integration tests?
   No, the change does not impact integration tests
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
    No

To test the generated changelog:

1.  Updated my local `mainline` to this commit
2.  Committed a `perf: improved performance` to my local `mainline` branch
3.  Ran `hatch run release:bump`
4.  Inspected the generated changelog and confirmed the new "Performance Improvements" section included the commit

>   ## 0.53.2 (2025-10-02)
>   
>   ### Performance Improvements
>   * improved performance ([`9d54c96`](https://github.com/aws-deadline/deadline-cloud/commit/9d54c96fa638284a8e985d725f79d1652af77b09))

### Was this change documented?

- Are relevant docstrings in the code base updated?
    Yes, I modified `CONTRIBUTING.md` to include the `perf:` commit type
- Has the README.md been updated? If you modified CLI arguments, for instance.
    N/A

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?

A breaking change is one that modifies a public contract in a way that is not backwards compatible. See the 
[Public Contracts](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#public-contracts) section
of the DEVELOPMENT.md for more information on the public contracts.

No

### Does this change impact security?

- Does the change need to be threat modeled? For example, does it create or modify files/directories that must only be readable by the process owner?
    - If so, then please label this pull request with the "security" label. We'll work with you to analyze the threats.

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
