### PR TITLE
test(docker): upgrade base image and match required coverage to what is tested

### DIFF
--- a/testing_containers/localuser_sudo_environment/Dockerfile
+++ b/testing_containers/localuser_sudo_environment/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
-FROM python:3.9-buster
+FROM python:3.13-bullseye
 
 # Set environment variables, and let our tests know that we are in an
 # environment that can run the sudo tests

--- a/testing_containers/localuser_sudo_environment/run_tests.sh
+++ b/testing_containers/localuser_sudo_environment/run_tests.sh
@@ -11,5 +11,4 @@ cd code
 python -m venv .venv
 source .venv/bin/activate
 pip install hatch
-# Use the codebuild env so that PIP_INDEX_URL isn't set in the hatch config files.
-hatch run codebuild:test -m docker
+hatch run pytest --cov=src/deadline --cov-report=html:build/coverage --cov-report=xml:build/coverage/coverage.xml --cov-report=term-missing --cov-fail-under=25 -m docker


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The Docker tests were not working due to using an obsolete base image and the coverage for the default pytest configuration is too high

### What was the solution? (How)
- Change the base Docker image to `python:3.9-bullseye`
- Update the test script to have a minimum coverage that reflects what is actually being tested by the docker tests.

### What is the impact of this change?
Docker tests are passing again

### How was this change tested?

Ran the Docker tests following its README.md

### Was this change documented?

N/A

### Does this PR introduce new dependencies?
No

### Is this a breaking change?
No

### Does this change impact security?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
