### PR TITLE
test(integ): add deadline-cloud-test-fixtures logging for integration tests

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -149,6 +149,7 @@ export AWS_DEFAULT_REGION=xx-yyyy-nn
 export FARM_ID=farm-00112233445566778899aabbccddeeff
 # Replace with the ID of your AWS Deadline Cloud Queue that is configured with a
 # Job Attachments bucket.
+# IMPORTANT: The queue must be associated with a fleet with workers that can run bash scripts (e.g. Linux SMF)
 export QUEUE_ID=queue-00112233445566778899aabbccddeeff
 
 export JOB_ATTACHMENTS_BUCKET=$(

--- a/hatch.toml
+++ b/hatch.toml
@@ -31,7 +31,7 @@ pre-install-commands = [
 ]
 
 [envs.integ.scripts]
-test = "pytest --xfail-tb --no-cov -vvv --numprocesses=1 {args:test/integ}"
+test = "pytest --xfail-tb --no-cov -vvv --numprocesses=0 {args:test/integ}"
 
 [envs.installer.env-vars]
 SKIP_BOOTSTRAP_TEST_RESOURCES = "True"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,7 +155,10 @@ markers = [
 ]
 # looponfailroots is deprecated, this removes the deprecation from the test output
 filterwarnings = ["ignore::DeprecationWarning"]
-
+# Print live logs during test run. This will only take effect if tests are not run
+# concurrently, since pytest-xdist does not support live logging.
+log_cli = true
+log_cli_level = "INFO"
 
 [tool.coverage.run]
 disable_warnings = ["module-not-measured"]

--- a/test/integ/conftest.py
+++ b/test/integ/conftest.py
@@ -4,6 +4,8 @@ import json
 import os
 import pytest
 
+pytest_plugins = ["deadline_test_fixtures.pytest_hooks"]
+
 
 @pytest.fixture()
 def external_bucket() -> str:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The Job Attachment integration tests setup and cleanup resources using [deadline-cloud-test-fixtures](https://github.com/aws-deadline/deadline-cloud-test-fixtures), but there are no logs showing what resources the fixtures are setting up. This makes it difficult to debug issues related to resource setup/teardown.

### What was the solution? (How)

We can get these logs by doing a couple things:
1. For integration tests, turn off pytest-xdist (i.e. set `--numprocesses=0`) since pytest-xdist does not support live logging. This will allow the logs from `deadlline-cloud-test-fixtures` to appear in integ test run logs
2. Add `deadline-cloud-test-fixtures` as a pytest plugin to format the logs nicely (prefix with current test name rather than filepath)

Also clarified that a Fleet with workers must be associated to the provided `QUEUE_ID` in the instructions for running integration tests since we now have tests that require real jobs to run.

### What is the impact of this change?

We have logs for resources setup by the fixtures like this: (a temporary test case I wrote while addressing a separate resource cleanup issue)

```
$ hatch run integ:test test/integ/deadline_job_attachments/test_crash.py 2>&1 | tee -a integ-crash3.log
============================= test session starts ==============================
platform linux -- Python 3.11.7, pytest-8.4.2, pluggy-1.6.0 -- /local/home/jericht/.local/share/hatch/env/virtual/deadline/GfaSvYFq/integ/bin/python
cachedir: .pytest_cache
rootdir: /local/home/jericht/repositories/github/deadline-cloud
configfile: pyproject.toml
plugins: asyncio-1.2.0, timeout-2.4.0, xdist-3.8.0, anyio-4.11.0, deadline-cloud-test-fixtures-0.18.4, cov-7.0.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ... collected 1 item

test/integ/deadline_job_attachments/test_crash.py::test_crash_worker 
-------------------------------- live log setup --------------------------------
[2025-10-03 21:55:03,899] [test/integ/deadline_job_attachments/test_crash.py::test_crash_worker] Found credentials in shared credentials file: ~/.aws/credentials
[2025-10-03 21:55:04,007] [test/integ/deadline_job_attachments/test_crash.py::test_crash_worker] About to call API (Create queue job_attachments_test_queue in farm farm-3668bdc1c58345b8b29ce1526eef1588)
[2025-10-03 21:55:04,513] [test/integ/deadline_job_attachments/test_crash.py::test_crash_worker] API call succeeded (Create queue job_attachments_test_queue in farm farm-3668bdc1c58345b8b29ce1526eef1588)
[2025-10-03 21:55:04,513] [test/integ/deadline_job_attachments/test_crash.py::test_crash_worker] Created queue: queue-d125e3cf72bc4d08a7d0e398c78cf704
[2025-10-03 21:55:04,513] [test/integ/deadline_job_attachments/test_crash.py::test_crash_worker] About to call API (Create queue job_attachments_test_no_settings_queue in farm farm-3668bdc1c58345b8b29ce1526eef1588)
[2025-10-03 21:55:04,904] [test/integ/deadline_job_attachments/test_crash.py::test_crash_worker] API call succeeded (Create queue job_attachments_test_no_settings_queue in farm farm-3668bdc1c58345b8b29ce1526eef1588)
[2025-10-03 21:55:04,904] [test/integ/deadline_job_attachments/test_crash.py::test_crash_worker] Created queue: queue-ab2ce0c699cf44e2aab1f8595c4df54b
```

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests?
    - Yes
- Have you run the integration tests?
    - Yes
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass.
    - No

### Was this change documented?

- Are relevant docstrings in the code base updated?
    - Yes 
- Has the README.md been updated? If you modified CLI arguments, for instance.
    - Yes

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?
No

### Does this change impact security?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
