### PR TITLE
fix: manifest snapshot run on empty dir throws exception and circular dependency importing manifest and attachment

### DIFF
--- a/src/deadline/client/cli/_groups/attachment_group.py
+++ b/src/deadline/client/cli/_groups/attachment_group.py
@@ -129,7 +129,7 @@ def attachment_download(
         s3_root_uri=s3_root_uri,
         boto3_session=boto3_session,
         path_mapping_rules=path_mapping_rules,
-        logger=logger,
+        print_function_callback=logger.echo,
         conflict_resolution=conflict_resolution,
     )
 
@@ -214,5 +214,5 @@ def attachment_upload(
         boto3_session=boto3_session,
         path_mapping_rules=path_mapping_rules,
         upload_manifest_path=upload_manifest_path,
-        logger=logger,
+        print_function_callback=logger.echo,
     )

--- a/src/deadline/client/cli/_groups/manifest_group.py
+++ b/src/deadline/client/cli/_groups/manifest_group.py
@@ -134,7 +134,7 @@ def manifest_snapshot(
         include_exclude_config=include_exclude_config,
         diff=diff,
         force_rehash=force_rehash,
-        logger=logger,
+        print_function_callback=logger.echo,
     )
     if manifest_out:
         if (
@@ -223,7 +223,7 @@ def manifest_diff(
         exclude=exclude,
         include_exclude_config=include_exclude_config,
         force_rehash=force_rehash,
-        logger=logger,
+        print_function_callback=logger.echo,
     )
 
     # Print results to console.
@@ -298,7 +298,7 @@ def manifest_download(
         step_id=step_id,
         asset_type=AssetType(asset_type),
         boto3_session=boto3_session,
-        logger=logger,
+        print_function_callback=logger.echo,
     )
     logger.json(dataclasses.asdict(output))
 
@@ -385,6 +385,6 @@ def manifest_upload(
         s3_cas_prefix=cas_path,
         s3_key_prefix=s3_manifest_prefix,
         boto_session=session,
-        logger=logger,
+        print_function_callback=logger.echo,
     )
     logger.echo("Uploading successful!")

--- a/src/deadline/client/cli/_incremental_download.py
+++ b/src/deadline/client/cli/_incremental_download.py
@@ -72,7 +72,7 @@ def _get_download_candidate_jobs(
     farm_id: str,
     queue_id: str,
     starting_timestamp: datetime,
-    print_function_callback: Callable[[str], None] = lambda msg: None,
+    print_function_callback: Callable[[Any], None] = lambda msg: None,
 ) -> dict[str, dict[str, Any]]:
     """
     Uses deadline:SearchJobs queries to get a dict {job_id: job} of download candidates for the queue.
@@ -223,7 +223,7 @@ def _categorize_jobs_in_checkpoint(
     checkpoint: IncrementalDownloadState,
     download_candidate_jobs: dict[str, dict[str, Any]],
     new_completed_timestamp: datetime,
-    print_function_callback: Callable[[str], None] = lambda msg: None,
+    print_function_callback: Callable[[Any], None] = lambda msg: None,
 ) -> CategorizedJobIds:
     """
     Categorizes the provided download candidate jobs by id into a CategorizedJobIds object,
@@ -539,7 +539,7 @@ def _get_job_sessions(
     categorized_job_ids: CategorizedJobIds,
     checkpoint: IncrementalDownloadState,
     download_candidate_jobs: dict[str, dict[str, Any]],
-    print_function_callback: Callable[[str], None] = lambda msg: None,
+    print_function_callback: Callable[[Any], None] = lambda msg: None,
 ) -> dict[str, list]:
     """
     This function gets all the job sessions and session actions from the completed, added, and updated jobs.
@@ -734,7 +734,7 @@ def _create_path_mapping_rule_appliers(
     storage_profiles: dict[str, dict[str, Any]],
     checkpoint: IncrementalDownloadState,
     download_candidate_jobs: dict[str, dict[str, Any]],
-    print_function_callback: Callable[[str], None] = lambda msg: None,
+    print_function_callback: Callable[[Any], None] = lambda msg: None,
 ) -> dict[str, Optional[_PathMappingRuleApplier]]:
     """
     Retrieves all the needed storage profiles and constructs path mapping rule applies for them.
@@ -833,7 +833,7 @@ def _add_missing_output_manifests_to_job_sessions(
 def _filter_session_actions_without_manifests_from_job_sessions(
     job_sessions: dict[str, list],
     download_candidate_jobs: dict[str, dict[str, Any]],
-    print_function_callback: Callable[[str], None] = lambda msg: None,
+    print_function_callback: Callable[[Any], None] = lambda msg: None,
 ):
     """
     Modify job_sessions in place to filter out any session actions that lack any output manifests.
@@ -995,7 +995,7 @@ def _incremental_output_download(
     checkpoint: IncrementalDownloadState,
     file_conflict_resolution: FileConflictResolution,
     config: Optional[ConfigParser] = None,
-    print_function_callback: Callable[[str], None] = lambda msg: None,
+    print_function_callback: Callable[[Any], None] = lambda msg: None,
     *,
     dry_run: bool = False,
 ) -> IncrementalDownloadState:

--- a/src/deadline/job_attachments/_diff.py
+++ b/src/deadline/job_attachments/_diff.py
@@ -4,7 +4,7 @@ import concurrent.futures
 import logging
 import os
 from pathlib import Path, PurePosixPath
-from typing import Callable, Dict, List, Tuple
+from typing import Any, Callable, Dict, List, Tuple
 from math import trunc
 from deadline.client.config import config_file
 from deadline.client.exceptions import NonValidInputError
@@ -121,7 +121,7 @@ def _fast_file_list_to_manifest_diff(
     root: str,
     current_files: List[str],
     diff_manifest: BaseAssetManifest,
-    print_function_callback: Callable[[str], None] = lambda msg: None,
+    print_function_callback: Callable[[Any], None] = lambda msg: None,
     return_root_relative_path: bool = True,
 ) -> List[Tuple[str, FileStatus]]:
     """

--- a/src/deadline/job_attachments/_diff.py
+++ b/src/deadline/job_attachments/_diff.py
@@ -4,9 +4,8 @@ import concurrent.futures
 import logging
 import os
 from pathlib import Path, PurePosixPath
-from typing import Dict, List, Tuple
+from typing import Callable, Dict, List, Tuple
 from math import trunc
-from deadline.client.cli._groups.click_logger import ClickLogger
 from deadline.client.config import config_file
 from deadline.client.exceptions import NonValidInputError
 from deadline.job_attachments.asset_manifests.base_manifest import (
@@ -122,7 +121,7 @@ def _fast_file_list_to_manifest_diff(
     root: str,
     current_files: List[str],
     diff_manifest: BaseAssetManifest,
-    logger: ClickLogger,
+    print_function_callback: Callable[[str], None] = lambda msg: None,
     return_root_relative_path: bool = True,
 ) -> List[Tuple[str, FileStatus]]:
     """
@@ -166,7 +165,9 @@ def _fast_file_list_to_manifest_diff(
         )
         if root_relative_path not in input_files_map:
             # This is a new file
-            logger.echo(f"Found difference at: {root_relative_path}, Status: FileStatus.NEW")
+            print_function_callback(
+                f"Found difference at: {root_relative_path}, Status: FileStatus.NEW"
+            )
             changed_paths.append((return_path, FileStatus.NEW))
         else:
             # This is a modified file, compare with manifest relative timestamp.
@@ -174,14 +175,14 @@ def _fast_file_list_to_manifest_diff(
             # Check file size first as it is easier to test. Usually modified files will also have size diff.
             if file_stat.st_size != input_file.size:
                 changed_paths.append((return_path, FileStatus.MODIFIED))
-                logger.echo(
+                print_function_callback(
                     f"Found size difference at: {root_relative_path}, Status: FileStatus.MODIFIED"
                 )
             # Check file mtime, allow 1 microsecond diff to prevent false positive
             # utime set from microsecond to nanosecond conversion could create 1 microsecond diff upon division
             elif abs(trunc(file_stat.st_mtime_ns / 1000) - input_file.mtime) > 1:
                 changed_paths.append((return_path, FileStatus.MODIFIED))
-                logger.echo(
+                print_function_callback(
                     f"Found time difference at: {root_relative_path}, Status: FileStatus.MODIFIED"
                 )
 

--- a/src/deadline/job_attachments/_incremental_downloads/_manifest_s3_downloads.py
+++ b/src/deadline/job_attachments/_incremental_downloads/_manifest_s3_downloads.py
@@ -306,7 +306,7 @@ def _download_all_manifests_with_absolute_paths(
     path_mapping_rule_appliers: dict[str, Optional[_PathMappingRuleApplier]],
     output_unmapped_paths: dict[str, list[str]],
     boto3_session_for_s3: boto3.Session,
-    print_function_callback: Callable[[str], None] = lambda msg: None,
+    print_function_callback: Callable[[Any], None] = lambda msg: None,
 ) -> list[tuple[datetime, BaseAssetManifest]]:
     """
     Downloads all the manifest files that are in the session_actions of job_sessions, and uses the rootPath
@@ -604,7 +604,7 @@ def _download_manifest_paths(
     boto3_session_for_s3: boto3.Session,
     file_conflict_resolution: FileConflictResolution,
     on_downloading_files: Optional[Callable[[ProgressReportMetadata], bool]],
-    print_function_callback: Callable[[str], None] = lambda msg: None,
+    print_function_callback: Callable[[Any], None] = lambda msg: None,
 ) -> None:
     """
     Downloads all files from the S3 bucket in the Job Attachment settings to the specified directory.

--- a/src/deadline/job_attachments/api/attachment.py
+++ b/src/deadline/job_attachments/api/attachment.py
@@ -4,7 +4,7 @@ import os
 import boto3
 import json
 
-from typing import Optional, List, Dict, Callable
+from typing import Any, Optional, List, Dict, Callable
 from pathlib import Path
 from dataclasses import asdict
 
@@ -29,7 +29,7 @@ def _attachment_download(
     s3_root_uri: str,
     boto3_session: boto3.Session,
     path_mapping_rules: Optional[str] = None,
-    print_function_callback: Callable[[str], None] = lambda msg: None,
+    print_function_callback: Callable[[Any], None] = lambda msg: None,
     conflict_resolution: FileConflictResolution = FileConflictResolution.CREATE_COPY,
 ):
     """
@@ -98,7 +98,7 @@ def _attachment_upload(
     path_mapping_rules: Optional[str] = None,
     manifest_path_mapping: Optional[Dict[str, str]] = None,
     upload_manifest_path: Optional[str] = None,
-    print_function_callback: Callable[[str], None] = lambda msg: None,
+    print_function_callback: Callable[[Any], None] = lambda msg: None,
 ) -> List[UploadManifestInfo]:
     """
     BETA API - This API is still evolving.

--- a/src/deadline/job_attachments/api/attachment.py
+++ b/src/deadline/job_attachments/api/attachment.py
@@ -4,7 +4,7 @@ import os
 import boto3
 import json
 
-from typing import Optional, List, Dict
+from typing import Optional, List, Dict, Callable
 from pathlib import Path
 from dataclasses import asdict
 
@@ -19,7 +19,7 @@ from deadline.job_attachments.models import (
 )
 from deadline.job_attachments.progress_tracker import DownloadSummaryStatistics
 from deadline.job_attachments.upload import S3AssetUploader
-from deadline.client.cli._groups.click_logger import ClickLogger
+
 from deadline.client.config import config_file
 from deadline.client.exceptions import NonValidInputError
 
@@ -29,7 +29,7 @@ def _attachment_download(
     s3_root_uri: str,
     boto3_session: boto3.Session,
     path_mapping_rules: Optional[str] = None,
-    logger: ClickLogger = ClickLogger(False),
+    print_function_callback: Callable[[str], None] = lambda msg: None,
     conflict_resolution: FileConflictResolution = FileConflictResolution.CREATE_COPY,
 ):
     """
@@ -43,7 +43,7 @@ def _attachment_download(
         s3_root_uri (str): S3 root uri including bucket name and root prefix.
         boto3_session (boto3.Session): Boto3 session for interacting with customer s3.
         path_mapping_rules (Optional[str], optional): Optional file path to a JSON file contains list of path mapping. Defaults to None.
-        logger (ClickLogger, optional): Logger to provide visibility. Defaults to ClickLogger(False).
+        print_function_callback (Callable[[str], None], optional): Callback function to provide visibility. Defaults to lambda msg: None.
 
     Raises:
         NonValidInputError: raise when any of the input is not valid.
@@ -87,8 +87,7 @@ def _attachment_download(
         session=boto3_session,
         conflict_resolution=conflict_resolution,
     )
-    logger.echo(download_summary)
-    logger.json(asdict(download_summary.convert_to_summary_statistics()))
+    print_function_callback(json.dumps(asdict(download_summary.convert_to_summary_statistics())))
 
 
 def _attachment_upload(
@@ -99,7 +98,7 @@ def _attachment_upload(
     path_mapping_rules: Optional[str] = None,
     manifest_path_mapping: Optional[Dict[str, str]] = None,
     upload_manifest_path: Optional[str] = None,
-    logger: ClickLogger = ClickLogger(False),
+    print_function_callback: Callable[[str], None] = lambda msg: None,
 ) -> List[UploadManifestInfo]:
     """
     BETA API - This API is still evolving.
@@ -114,7 +113,7 @@ def _attachment_upload(
         root_dirs (List[str]): List of root directories holding attachments. Defaults to empty.
         path_mapping_rules (Optional[str], optional): Optional file path to a JSON file contains list of path mapping. Defaults to None.
         upload_manifest_path (Optional[str], optional): Optional path prefix for uploading given manifests. Defaults to None.
-        logger (ClickLogger, optional): Logger to provide visibility. Defaults to ClickLogger(False).
+        print_function_callback (Callable[[str], None], optional): Callback function to provide visibility. Defaults to lambda msg: None.
 
     Returns:
         List[UploadManifestInfo]: A list of UploadManifestInfo objects corresponding to the input manifests
@@ -187,7 +186,7 @@ def _attachment_upload(
             asset_root=Path(rule.destination_path),
             s3_check_cache_dir=config_file.get_cache_directory(),
         )
-        logger.echo(
+        print_function_callback(
             f"Uploaded assets from {rule.destination_path}, to {s3_settings.to_s3_root_uri()}/Manifests/{key}, hashed data {data}"
         )
 

--- a/src/deadline/job_attachments/api/manifest.py
+++ b/src/deadline/job_attachments/api/manifest.py
@@ -4,12 +4,11 @@ import datetime
 from io import BytesIO
 import os
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import boto3
 
 from deadline.client.api._session import _get_queue_user_boto3_session, get_default_client_config
-from deadline.client.cli._groups.click_logger import ClickLogger
 from deadline.job_attachments._diff import _fast_file_list_to_manifest_diff, compare_manifest
 from deadline.job_attachments._glob import _process_glob_inputs, _glob_paths
 from deadline.job_attachments.api._utils import _read_manifests
@@ -92,7 +91,7 @@ def _manifest_snapshot(
     include_exclude_config: Optional[str] = None,
     diff: Optional[str] = None,
     force_rehash: bool = False,
-    logger: ClickLogger = ClickLogger(False),
+    print_function_callback: Callable[[str], None] = lambda msg: None,
 ) -> Optional[ManifestSnapshot]:
     # Get all files in the root.
     glob_config: GlobConfig
@@ -113,7 +112,7 @@ def _manifest_snapshot(
     # Compute the output manifest immediately and hash.
     if not diff:
         output_manifest = _create_manifest_for_single_root(
-            files=current_files, root=root, logger=logger
+            files=current_files, root=root, print_function_callback=print_function_callback
         )
         if not output_manifest:
             return None
@@ -134,7 +133,7 @@ def _manifest_snapshot(
                 root=root,
                 current_files=current_files,
                 diff_manifest=source_manifest,
-                logger=logger,
+                print_function_callback=print_function_callback,
                 return_root_relative_path=False,
             )
             for diff_file in diff_list:
@@ -144,7 +143,7 @@ def _manifest_snapshot(
         else:
             # In "slow / thorough" mode, we check by hash, which is definitive.
             output_manifest = _create_manifest_for_single_root(
-                files=current_files, root=root, logger=logger
+                files=current_files, root=root, print_function_callback=print_function_callback
             )
             if not output_manifest:
                 return None
@@ -155,7 +154,9 @@ def _manifest_snapshot(
                 if diff_item[0] == FileStatus.MODIFIED or diff_item[0] == FileStatus.NEW:
                     full_diff_path = f"{root}/{diff_item[1].path}"
                     changed_paths.append(full_diff_path)
-                    logger.echo(f"Found difference at: {full_diff_path}, Status: {diff_item[0]}")
+                    print_function_callback(
+                        f"Found difference at: {full_diff_path}, Status: {diff_item[0]}"
+                    )
 
         # If there were no files diffed, return None, there was nothing to snapshot.
         if len(changed_paths) == 0:
@@ -163,7 +164,7 @@ def _manifest_snapshot(
 
         # Since the files are already hashed, we can easily re-use has_attachments to remake a diff manifest.
         output_manifest = _create_manifest_for_single_root(
-            files=changed_paths, root=root, logger=logger
+            files=changed_paths, root=root, print_function_callback=print_function_callback
         )
         if not output_manifest:
             return None
@@ -177,11 +178,11 @@ def _manifest_snapshot(
             name=name,
         )
         # Output results.
-        logger.echo(f"Manifest generated at {local_manifest_file}")
+        print_function_callback(f"Manifest generated at {local_manifest_file}")
         return ManifestSnapshot(root=root, manifest=local_manifest_file)
     else:
         # No manifest generated.
-        logger.echo("No manifest generated")
+        print_function_callback("No manifest generated")
         return None
 
 
@@ -220,7 +221,7 @@ def _manifest_diff(
     exclude: Optional[List[str]] = None,
     include_exclude_config: Optional[str] = None,
     force_rehash=False,
-    logger: ClickLogger = ClickLogger(False),
+    print_function_callback: Callable[[str], None] = lambda msg: None,
 ) -> ManifestDiff:
     """
     BETA API - This API is still evolving but will be made public in the near future.
@@ -230,7 +231,7 @@ def _manifest_diff(
     :param include: Include glob to look for files to add to the manifest.
     :param exclude: Exclude glob to exclude files from the manifest.
     :param include_exclude_config: Config JSON or file containeing input and exclude config.
-    :param logger: Click Logger instance to print to CLI as text or JSON.
+    :param print_function_callback: Click Logger instance to print to CLI as text or JSON.
     :returns: ManifestDiff object containing all new changed, deleted files.
     """
 
@@ -279,7 +280,10 @@ def _manifest_diff(
     else:
         # File based comparisons.
         fast_diff: List[Tuple[str, FileStatus]] = _fast_file_list_to_manifest_diff(
-            root=root, current_files=input_files, diff_manifest=local_manifest_object, logger=logger
+            root=root,
+            current_files=input_files,
+            diff_manifest=local_manifest_object,
+            print_function_callback=print_function_callback,
         )
         for fast_diff_item in fast_diff:
             process_output(fast_diff_item[1], fast_diff_item[0], output)
@@ -293,7 +297,7 @@ def _manifest_upload(
     s3_cas_prefix: str,
     boto_session: boto3.Session,
     s3_key_prefix: Optional[str] = None,
-    logger: ClickLogger = ClickLogger(False),
+    print_function_callback: Callable[[str], None] = lambda msg: None,
 ):
     """
     BETA API - This API is still evolving but will be made public in the near future.
@@ -304,7 +308,7 @@ def _manifest_upload(
     boto_session: S3 Content Addressable Storage prefix.
     s3_key_prefix: [Optional] S3 prefix path to the Content Addressable Storge.
     boto_session: Boto3 session.
-    logger: Click Logger instance to print to CLI as text or JSON.
+    print_function_callback: Click Logger instance to print to CLI as text or JSON.
     """
     # S3 metadata
 
@@ -329,7 +333,6 @@ def _manifest_upload(
             bytes=BytesIO(manifest.read().encode("utf-8")),
             bucket=s3_bucket_name,
             key=manifest_path,
-            progress_handler=logger.echo,
             extra_args=s3_metadata,
         )
 
@@ -342,7 +345,7 @@ def _manifest_download(
     boto3_session: boto3.Session,
     step_id: Optional[str] = None,
     asset_type: AssetType = AssetType.ALL,
-    logger: ClickLogger = ClickLogger(False),
+    print_function_callback: Callable[[str], None] = lambda msg: None,
 ) -> ManifestDownloadResponse:
     """
     BETA API - This API is still evolving but will be made public in the near future.
@@ -354,7 +357,7 @@ def _manifest_download(
     boto_session: Boto3 session.
     step_id: Optional[str]: Optional, download manifest for a step
     asset_type: Which asset manifests should be downloaded for given job (& optionally step), options are Input, Output, All. Default behaviour is All.
-    logger: Click Logger instance to print to CLI as text or JSON.
+    print_function_callback: Click Logger instance to print to CLI as text or JSON.
     return ManifestDownloadResponse Downloaded Manifest data. Contains source S3 key and local download path.
     """
 
@@ -407,7 +410,7 @@ def _manifest_download(
 
     # If input manifests need to be downloaded
     if download_input:
-        logger.echo(f"Downloading input manifests for job: {job_id}")
+        print_function_callback(f"Downloading input manifests for job: {job_id}")
 
         # Get input_manifest_paths from Deadline GetJob API
         attachments: dict = job.get("attachments", {})
@@ -424,14 +427,14 @@ def _manifest_download(
                 session=queue_role_session,
             )
             if asset_manifest is not None:
-                logger.echo(f"Found input manifest for root: {root_path}")
+                print_function_callback(f"Found input manifest for root: {root_path}")
                 add_manifest_by_root(
                     manifests_by_root=manifests_by_root, root=root_path, manifest=asset_manifest
                 )
 
         # Now handle step-step dependencies
         if step_id is not None:
-            logger.echo(f"Finding step-step dependency manifests for step: {step_id}")
+            print_function_callback(f"Finding step-step dependency manifests for step: {step_id}")
 
             # Get Step-Step dependencies with pagination
             next_token = ""
@@ -445,7 +448,9 @@ def _manifest_download(
                 )
 
                 for dependent_step in step_dep_response["dependencies"]:
-                    logger.echo(f"Found Step-Step dependency. {dependent_step['stepId']}")
+                    print_function_callback(
+                        f"Found Step-Step dependency. {dependent_step['stepId']}"
+                    )
 
                     # Get manifests for the step-step dependency
                     step_manifests_by_root: Dict[str, List[BaseAssetManifest]] = (
@@ -461,7 +466,9 @@ def _manifest_download(
                     # Merge all manifests by root.
                     for root in step_manifests_by_root.keys():
                         for manifest in step_manifests_by_root[root]:
-                            logger.echo(f"Found step-step output manifest for root: {root}")
+                            print_function_callback(
+                                f"Found step-step output manifest for root: {root}"
+                            )
                             add_manifest_by_root(
                                 manifests_by_root=manifests_by_root, root=root, manifest=manifest
                             )
@@ -472,7 +479,9 @@ def _manifest_download(
     if download_output:
         output_manifests_by_root: Dict[str, List[BaseAssetManifest]]
         if step_id is not None:
-            logger.echo(f"Downloading output manifests step: {step_id} of job: {job_id}")
+            print_function_callback(
+                f"Downloading output manifests step: {step_id} of job: {job_id}"
+            )
             # Only get the output manifests for selected step
             output_manifests_by_root = get_output_manifests_by_asset_root(
                 s3_settings=queue_s3_settings,
@@ -484,7 +493,7 @@ def _manifest_download(
             )
 
         else:
-            logger.echo(f"Downloading output manifests for job: {job_id}")
+            print_function_callback(f"Downloading output manifests for job: {job_id}")
             # Get output manifests for all steps of the job
             output_manifests_by_root = get_output_manifests_by_asset_root(
                 s3_settings=queue_s3_settings,
@@ -497,7 +506,7 @@ def _manifest_download(
         # Merge all output manifests by root.
         for root in output_manifests_by_root.keys():
             for manifest in output_manifests_by_root[root]:
-                logger.echo(f"Found output manifest for root: {root}")
+                print_function_callback(f"Found output manifest for root: {root}")
                 add_manifest_by_root(
                     manifests_by_root=manifests_by_root, root=root, manifest=manifest
                 )
@@ -528,7 +537,9 @@ def _manifest_download(
         successful_downloads.append(
             ManifestDownload(manifest_root=root, local_manifest_path=str(local_manifest_file_path))
         )
-        logger.echo(f"Downloaded merged manifest for root: {root} to: {local_manifest_file_path}")
+        print_function_callback(
+            f"Downloaded merged manifest for root: {root} to: {local_manifest_file_path}"
+        )
 
     # JSON output at the end.
     output = ManifestDownloadResponse(downloaded=successful_downloads)
@@ -540,7 +551,7 @@ def _manifest_merge(
     manifest_files: List[str],
     destination: str,
     name: Optional[str],
-    logger: ClickLogger = ClickLogger(False),
+    print_function_callback: Callable[[str], None] = lambda msg: None,
 ) -> Optional[ManifestMerge]:
     """
     BETA API - API to merge multiple manifests into one.
@@ -548,7 +559,7 @@ def _manifest_merge(
     manifest_files: List of manifest files to merge.
     destination: Destination directory for the merged manifest.
     name: Name of the merged manifest.
-    logger: Click Logger instance to print to CLI as text or JSON.
+    print_function_callback: Click Logger instance to print to CLI as text or JSON.
     return ManifestMerge object containing the merged manifest.
     """
 
@@ -564,6 +575,6 @@ def _manifest_merge(
     local_manifest_file = _write_manifest(
         root=root, manifest=merged_manifest, destination=destination, name=name
     )
-    logger.echo(f"Manifest generated at {local_manifest_file}")
+    print_function_callback(f"Manifest generated at {local_manifest_file}")
 
     return ManifestMerge(manifest_root=root, local_manifest_path=local_manifest_file)

--- a/src/deadline/job_attachments/api/manifest.py
+++ b/src/deadline/job_attachments/api/manifest.py
@@ -91,7 +91,7 @@ def _manifest_snapshot(
     include_exclude_config: Optional[str] = None,
     diff: Optional[str] = None,
     force_rehash: bool = False,
-    print_function_callback: Callable[[str], None] = lambda msg: None,
+    print_function_callback: Callable[[Any], None] = lambda msg: None,
 ) -> Optional[ManifestSnapshot]:
     # Get all files in the root.
     glob_config: GlobConfig
@@ -221,7 +221,7 @@ def _manifest_diff(
     exclude: Optional[List[str]] = None,
     include_exclude_config: Optional[str] = None,
     force_rehash=False,
-    print_function_callback: Callable[[str], None] = lambda msg: None,
+    print_function_callback: Callable[[Any], None] = lambda msg: None,
 ) -> ManifestDiff:
     """
     BETA API - This API is still evolving but will be made public in the near future.
@@ -231,7 +231,7 @@ def _manifest_diff(
     :param include: Include glob to look for files to add to the manifest.
     :param exclude: Exclude glob to exclude files from the manifest.
     :param include_exclude_config: Config JSON or file containeing input and exclude config.
-    :param print_function_callback: Click Logger instance to print to CLI as text or JSON.
+    :param print_function_callback: Callback function to handle print messages.
     :returns: ManifestDiff object containing all new changed, deleted files.
     """
 
@@ -297,7 +297,7 @@ def _manifest_upload(
     s3_cas_prefix: str,
     boto_session: boto3.Session,
     s3_key_prefix: Optional[str] = None,
-    print_function_callback: Callable[[str], None] = lambda msg: None,
+    print_function_callback: Callable[[Any], None] = lambda msg: None,
 ):
     """
     BETA API - This API is still evolving but will be made public in the near future.
@@ -308,7 +308,7 @@ def _manifest_upload(
     boto_session: S3 Content Addressable Storage prefix.
     s3_key_prefix: [Optional] S3 prefix path to the Content Addressable Storge.
     boto_session: Boto3 session.
-    print_function_callback: Click Logger instance to print to CLI as text or JSON.
+    print_function_callback: Callback function to handle print messages.
     """
     # S3 metadata
 
@@ -333,6 +333,7 @@ def _manifest_upload(
             bytes=BytesIO(manifest.read().encode("utf-8")),
             bucket=s3_bucket_name,
             key=manifest_path,
+            progress_handler=print_function_callback,
             extra_args=s3_metadata,
         )
 
@@ -345,7 +346,7 @@ def _manifest_download(
     boto3_session: boto3.Session,
     step_id: Optional[str] = None,
     asset_type: AssetType = AssetType.ALL,
-    print_function_callback: Callable[[str], None] = lambda msg: None,
+    print_function_callback: Callable[[Any], None] = lambda msg: None,
 ) -> ManifestDownloadResponse:
     """
     BETA API - This API is still evolving but will be made public in the near future.
@@ -357,7 +358,7 @@ def _manifest_download(
     boto_session: Boto3 session.
     step_id: Optional[str]: Optional, download manifest for a step
     asset_type: Which asset manifests should be downloaded for given job (& optionally step), options are Input, Output, All. Default behaviour is All.
-    print_function_callback: Click Logger instance to print to CLI as text or JSON.
+    print_function_callback: Callback function to handle print messages.
     return ManifestDownloadResponse Downloaded Manifest data. Contains source S3 key and local download path.
     """
 
@@ -551,7 +552,7 @@ def _manifest_merge(
     manifest_files: List[str],
     destination: str,
     name: Optional[str],
-    print_function_callback: Callable[[str], None] = lambda msg: None,
+    print_function_callback: Callable[[Any], None] = lambda msg: None,
 ) -> Optional[ManifestMerge]:
     """
     BETA API - API to merge multiple manifests into one.
@@ -559,7 +560,7 @@ def _manifest_merge(
     manifest_files: List of manifest files to merge.
     destination: Destination directory for the merged manifest.
     name: Name of the merged manifest.
-    print_function_callback: Click Logger instance to print to CLI as text or JSON.
+    print_function_callback: Callback function to handle print messages.
     return ManifestMerge object containing the merged manifest.
     """
 

--- a/src/deadline/job_attachments/asset_manifests/_create_manifest.py
+++ b/src/deadline/job_attachments/asset_manifests/_create_manifest.py
@@ -1,6 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
-from typing import Callable, List, Optional
+from typing import Any, Callable, List, Optional
 
 from deadline.client.api._job_attachment import _hash_attachments
 from deadline.job_attachments.asset_manifests.base_manifest import BaseAssetManifest
@@ -10,7 +10,7 @@ from deadline.job_attachments.upload import S3AssetManager
 def _create_manifest_for_single_root(
     files: List[str],
     root: str,
-    print_function_callback: Callable[[str], None] = lambda msg: None,
+    print_function_callback: Callable[[Any], None] = lambda msg: None,
 ) -> Optional[BaseAssetManifest]:
     """
     Shared logic to create a manifest file from a single root.

--- a/src/deadline/job_attachments/asset_manifests/_create_manifest.py
+++ b/src/deadline/job_attachments/asset_manifests/_create_manifest.py
@@ -6,7 +6,6 @@ from deadline.client.api._job_attachment import _hash_attachments
 from deadline.client.cli._common import _ProgressBarCallbackManager
 from deadline.client.cli._groups.click_logger import ClickLogger
 from deadline.job_attachments.asset_manifests.base_manifest import BaseAssetManifest
-from deadline.job_attachments.exceptions import ManifestCreationException
 from deadline.job_attachments.upload import S3AssetManager
 
 
@@ -52,9 +51,5 @@ def _create_manifest_for_single_root(
         # This is a hard failure, we are snapshotting 1 directory.
         assert len(manifests) == 1
 
-        output_manifest = manifests[0].asset_manifest
-        if output_manifest is None:
-            raise ManifestCreationException()
-
         # Return the generated manifest.
-        return output_manifest
+        return manifests[0].asset_manifest

--- a/src/deadline/job_attachments/asset_manifests/_create_manifest.py
+++ b/src/deadline/job_attachments/asset_manifests/_create_manifest.py
@@ -1,10 +1,8 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
-from typing import List, Optional
+from typing import Callable, List, Optional
 
 from deadline.client.api._job_attachment import _hash_attachments
-from deadline.client.cli._common import _ProgressBarCallbackManager
-from deadline.client.cli._groups.click_logger import ClickLogger
 from deadline.job_attachments.asset_manifests.base_manifest import BaseAssetManifest
 from deadline.job_attachments.upload import S3AssetManager
 
@@ -12,7 +10,7 @@ from deadline.job_attachments.upload import S3AssetManager
 def _create_manifest_for_single_root(
     files: List[str],
     root: str,
-    logger: ClickLogger,
+    print_function_callback: Callable[[str], None] = lambda msg: None,
 ) -> Optional[BaseAssetManifest]:
     """
     Shared logic to create a manifest file from a single root.
@@ -23,6 +21,8 @@ def _create_manifest_for_single_root(
     """
     # Placeholder Asset Manager
     asset_manager = S3AssetManager()
+
+    from deadline.client.cli._common import _ProgressBarCallbackManager
 
     hash_callback_manager = _ProgressBarCallbackManager(length=100, label="Hashing Attachments")
 
@@ -38,14 +38,12 @@ def _create_manifest_for_single_root(
             asset_groups=upload_group.asset_groups,
             total_input_files=upload_group.total_input_files,
             total_input_bytes=upload_group.total_input_bytes,
-            print_function_callback=logger.echo,
-            hashing_progress_callback=(
-                hash_callback_manager.callback if not logger.is_json() else None
-            ),
+            print_function_callback=print_function_callback,
+            hashing_progress_callback=hash_callback_manager.callback,
         )
 
     if not manifests or len(manifests) == 0:
-        logger.echo("No manifest generated")
+        print_function_callback("No manifest generated")
         return None
     else:
         # This is a hard failure, we are snapshotting 1 directory.

--- a/test/unit/deadline_job_attachments/api/test_manifest_upload.py
+++ b/test/unit/deadline_job_attachments/api/test_manifest_upload.py
@@ -60,7 +60,6 @@ class TestManifestUpload:
             bytes=ANY,
             bucket=TEST_BUCKET_NAME,
             key=TEST_CAS_PREFIX + "/Manifests/test.manifest",
-            progress_handler=ANY,
             extra_args=ANY,
         )
 
@@ -93,6 +92,5 @@ class TestManifestUpload:
             bytes=ANY,
             bucket=TEST_BUCKET_NAME,
             key=TEST_CAS_PREFIX + "/Manifests/" + TEST_KEY_PREFIX + "/test.manifest",
-            progress_handler=ANY,
             extra_args=ANY,
         )

--- a/test/unit/deadline_job_attachments/api/test_manifest_upload.py
+++ b/test/unit/deadline_job_attachments/api/test_manifest_upload.py
@@ -60,6 +60,7 @@ class TestManifestUpload:
             bytes=ANY,
             bucket=TEST_BUCKET_NAME,
             key=TEST_CAS_PREFIX + "/Manifests/test.manifest",
+            progress_handler=ANY,
             extra_args=ANY,
         )
 
@@ -92,5 +93,6 @@ class TestManifestUpload:
             bytes=ANY,
             bucket=TEST_BUCKET_NAME,
             key=TEST_CAS_PREFIX + "/Manifests/" + TEST_KEY_PREFIX + "/test.manifest",
+            progress_handler=ANY,
             extra_args=ANY,
         )

--- a/test/unit/deadline_job_attachments/api/test_snapshot.py
+++ b/test/unit/deadline_job_attachments/api/test_snapshot.py
@@ -6,7 +6,6 @@ from pathlib import Path
 import tempfile
 from typing import List, Optional, Set
 from deadline.job_attachments.api.manifest import _manifest_snapshot
-from deadline.job_attachments.exceptions import ManifestCreationException
 from deadline.job_attachments.models import ManifestSnapshot
 from deadline.job_attachments._utils import _retry
 import pytest
@@ -33,9 +32,13 @@ class TestSnapshotAPI:
         root_dir = os.path.join(temp_dir, "foobar")
         os.makedirs(root_dir)
 
-        # When, Then.
-        with pytest.raises(ManifestCreationException):
-            _manifest_snapshot(root=root_dir, destination=temp_dir, name="test")
+        # When
+        manifest: Optional[ManifestSnapshot] = _manifest_snapshot(
+            root=root_dir, destination=temp_dir, name="test"
+        )
+
+        # Then
+        assert manifest is None
 
     def test_snapshot_folder(self, temp_dir):
         """


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
1. Currently snapshot an empty directory returns error.
```
> deadline --version
deadline, version 0.53.0

> deadline manifest snapshot --root /tmp/emp
Manifest creation path defaulted to /tmp/emp

Hashing Attachments  [####################################]  100%
The AWS Deadline Cloud CLI encountered the following exception:
Traceback (most recent call last):
  File "/Users/yuanbian/.local/share/mise/installs/python/3.11/lib/python3.11/site-packages/deadline/client/cli/_common.py", line 59, in wraps
    func(*args, **kwargs)
  File "/Users/yuanbian/.local/share/mise/installs/python/3.11/lib/python3.11/site-packages/deadline/client/cli/_groups/manifest_group.py", line 128, in manifest_snapshot
    manifest_out = _manifest_snapshot(
                   ^^^^^^^^^^^^^^^^^^^
  File "/Users/yuanbian/.local/share/mise/installs/python/3.11/lib/python3.11/site-packages/deadline/job_attachments/api/manifest.py", line 115, in _manifest_snapshot
    output_manifest = _create_manifest_for_single_root(
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/yuanbian/.local/share/mise/installs/python/3.11/lib/python3.11/site-packages/deadline/job_attachments/asset_manifests/_create_manifest.py", line 57, in _create_manifest_for_single_root
    raise ManifestCreationException()
deadline.job_attachments.exceptions.ManifestCreationException
```

2. Recent code introduced circular dependency

```
File "/opt/deadline/worker/lib64/python3.9/site-packages/deadline_worker_agent/sessions/actions/scripts/attachment_upload.py", line 27, in <module>2025/10/08 18:37:02-07:00     from deadline.job_attachments.api.manifest import _manifest_snapshot, _manifest_merge2025/10/08 18:37:02-07:00   File "/opt/deadline/worker/lib64/python3.9/site-packages/deadline/job_attachments/api/manifest.py", line 12, in <module>2025/10/08 18:37:02-07:00     from deadline.client.cli._groups.click_logger import ClickLogger2025/10/08 18:37:02-07:00   File "/opt/deadline/worker/lib64/python3.9/site-packages/deadline/client/cli/__init__.py", line 7, in <module>2025/10/08 18:37:02-07:00     from ._deadline_cli import main2025/10/08 18:37:02-07:00   File "/opt/deadline/worker/lib64/python3.9/site-packages/deadline/client/cli/_deadline_cli.py", line 10, in <module>2025/10/08 18:37:02-07:00     from ._groups import (  # noqa: F4012025/10/08 18:37:02-07:00   File "/opt/deadline/worker/lib64/python3.9/site-packages/deadline/client/cli/_groups/manifest_group.py", line 28, in <module>2025/10/08 18:37:02-07:00     from deadline.job_attachments.api.manifest import (2025/10/08 18:37:02-07:00 ImportError: cannot import name '_glob_files' from partially initialized module 'deadline.job_attachments.api.manifest' (most likely due to a circular import) (/opt/deadline/worker/lib64/python3.9/site-packages/deadline/job_attachments/api/manifest.py)2025/10/08 18:37:02-07:00 
```

### What was the solution? (How)
1. Creating empty result when snapshot an empty directory.
2. Pass in print function callback to get rid to ClickLogger from manifest.py and attachment.py to avoid circular dependency.

### What is the impact of this change?
1. Handle a legitimate case more gracefully. 
2. Fixed broken import for manifest and attachment

### How was this change tested?
- [x] Have you run the unit tests?
- [x] Have you run the integration tests?
- [N/A] Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass.

#### E2E test
Before
```
2025/10/08 11:02:26-07:00 local_manifest_paths for merge are: []2025/10/08 11:02:26-07:00 Hashing Attachments2025/10/08 11:02:26-07:00 Traceback (most recent call last):2025/10/08 11:02:26-07:00   File "/opt/deadline/worker/lib64/python3.9/site-packages/deadline_worker_agent/sessions/actions/scripts/attachment_upload.py", line 362, in <module>2025/10/08 11:02:26-07:00     main()2025/10/08 11:02:26-07:00   File "/opt/deadline/worker/lib64/python3.9/site-packages/deadline_worker_agent/sessions/actions/scripts/attachment_upload.py", line 235, in main2025/10/08 11:02:26-07:00     root_path_to_output_manifest = snapshot(2025/10/08 11:02:26-07:00   File "/opt/deadline/worker/lib64/python3.9/site-packages/deadline_worker_agent/sessions/actions/scripts/attachment_upload.py", line 115, in snapshot2025/10/08 11:02:26-07:00     output_manifest: Optional[ManifestSnapshot] = _manifest_snapshot(2025/10/08 11:02:26-07:00   File "/opt/deadline/worker/lib64/python3.9/site-packages/deadline/job_attachments/api/manifest.py", line 115, in _manifest_snapshot2025/10/08 11:02:26-07:00     output_manifest = _create_manifest_for_single_root(2025/10/08 11:02:26-07:00   File "/opt/deadline/worker/lib64/python3.9/site-packages/deadline/job_attachments/asset_manifests/_create_manifest.py", line 57, in _create_manifest_for_single_root2025/10/08 11:02:26-07:00     raise ManifestCreationException()2025/10/08 11:02:26-07:00 deadline.job_attachments.exceptions.ManifestCreationException2025/10/08 11:02:27-07:00 Process pid 30148 exited with code: 1 (unsigned) / 0x1 (hex)
```

After
```
2025/10/08 21:10:19-07:00 ==============================================
2025/10/08 21:10:19-07:00 --------- Job Attachments Upload for Task
2025/10/08 21:10:19-07:00 ==============================================
2025/10/08 21:10:19-07:00 ----------------------------------------------
2025/10/08 21:10:19-07:00 Phase: Setup
2025/10/08 21:10:19-07:00 ----------------------------------------------
2025/10/08 21:10:19-07:00 Writing embedded files for Task to disk.
2025/10/08 21:10:19-07:00 Mapping: Task.File.WorkerManifestProperties -> /sessions/session-dcca4ab746d74b85b9dc10746f6a1542e95zja43/embedded_filesg__lqhs9/tmptaarlrpa
2025/10/08 21:10:19-07:00 Wrote: WorkerManifestProperties -> /sessions/session-dcca4ab746d74b85b9dc10746f6a1542e95zja43/embedded_filesg__lqhs9/tmptaarlrpa
2025/10/08 21:10:19-07:00 ----------------------------------------------
2025/10/08 21:10:19-07:00 Phase: Running action
2025/10/08 21:10:19-07:00 ----------------------------------------------
2025/10/08 21:10:19-07:00 Running command sudo -u job-user -i setsid -w /sessions/session-dcca4ab746d74b85b9dc10746f6a1542e95zja43/tmpsss4lwck.sh
2025/10/08 21:10:19-07:00 Command started as pid: 30185
2025/10/08 21:10:19-07:00 Output:
2025/10/08 21:10:20-07:00 Hashing Attachments
2025/10/08 21:10:20-07:00 No change detected for root /var/folders/qz/djsmwst123b1b0gv040qvv900000gq/T/tmp6i66mn6b
2025/10/08 21:10:20-07:00  
2025/10/08 21:10:20-07:00 No output to upload
2025/10/08 21:10:20-07:00 Process pid 30185 exited with code: 0 (unsigned) / 0x0 (hex)
```


### Was this change documented?

- [N/A] Are relevant docstrings in the code base updated?
- [N/A] Has the README.md been updated? If you modified CLI arguments, for instance.

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?
Not breaking - the feature is still in beta.

A breaking change is one that modifies a public contract in a way that is not backwards compatible. See the 
[Public Contracts](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#public-contracts) section
of the DEVELOPMENT.md for more information on the public contracts.

If so, then please describe the changes that users of this package must make to update their scripts, or Python applications.

### Does this change impact security?

No

- Does the change need to be threat modeled? For example, does it create or modify files/directories that must only be readable by the process owner?
    - If so, then please label this pull request with the "security" label. We'll work with you to analyze the threats.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
