### PR TITLE
fix: attachment download command logging format change

### DIFF
--- a/src/deadline/client/cli/_groups/attachment_group.py
+++ b/src/deadline/client/cli/_groups/attachment_group.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import click
 import boto3
-
+from dataclasses import asdict
 from typing import Optional
 
 from .click_logger import ClickLogger
@@ -26,6 +26,7 @@ from deadline.job_attachments.api.attachment import (
 from deadline.job_attachments._aws.deadline import get_queue
 from deadline.job_attachments.exceptions import MissingJobAttachmentSettingsError
 from deadline.job_attachments.models import FileConflictResolution, JobAttachmentS3Settings
+from deadline.job_attachments.progress_tracker import DownloadSummaryStatistics
 
 
 @main.group(name="attachment")
@@ -124,7 +125,7 @@ def attachment_download(
     ):
         conflict_resolution = FileConflictResolution[conflict_resolution_setting]
 
-    _attachment_download(
+    download_summary: DownloadSummaryStatistics = _attachment_download(
         manifests=manifests,
         s3_root_uri=s3_root_uri,
         boto3_session=boto3_session,
@@ -132,6 +133,9 @@ def attachment_download(
         print_function_callback=logger.echo,
         conflict_resolution=conflict_resolution,
     )
+
+    logger.echo(download_summary)
+    logger.json(asdict(download_summary.convert_to_summary_statistics()))
 
 
 @cli_attachment.command(

--- a/src/deadline/job_attachments/api/attachment.py
+++ b/src/deadline/job_attachments/api/attachment.py
@@ -6,7 +6,6 @@ import json
 
 from typing import Any, Optional, List, Dict, Callable
 from pathlib import Path
-from dataclasses import asdict
 
 from deadline.job_attachments.api._utils import _read_manifests
 from deadline.job_attachments.asset_manifests.base_manifest import BaseAssetManifest
@@ -31,7 +30,7 @@ def _attachment_download(
     path_mapping_rules: Optional[str] = None,
     print_function_callback: Callable[[Any], None] = lambda msg: None,
     conflict_resolution: FileConflictResolution = FileConflictResolution.CREATE_COPY,
-):
+) -> DownloadSummaryStatistics:
     """
     BETA API - This API is still evolving.
 
@@ -80,14 +79,13 @@ def _attachment_download(
 
     # Given manifests and S3 bucket + root, downloads all files from a CAS in each manifest.
     s3_settings: JobAttachmentS3Settings = JobAttachmentS3Settings.from_s3_root_uri(s3_root_uri)
-    download_summary: DownloadSummaryStatistics = download_files_from_manifests(
+    return download_files_from_manifests(
         s3_bucket=s3_settings.s3BucketName,
         manifests_by_root=merged_manifests_by_root,
         cas_prefix=s3_settings.full_cas_prefix(),
         session=boto3_session,
         conflict_resolution=conflict_resolution,
     )
-    print_function_callback(json.dumps(asdict(download_summary.convert_to_summary_statistics())))
 
 
 def _attachment_upload(

--- a/test/unit/deadline_job_attachments/api/test_attachment.py
+++ b/test/unit/deadline_job_attachments/api/test_attachment.py
@@ -169,7 +169,7 @@ class TestAttachmentDownload:
             json.dump([PATH_MAPPING], f)
 
         if conflict_resolution:
-            _attachment_download(
+            result = _attachment_download(
                 manifests=[os.path.join(temp_assets_dir, PATH_MAPPING_HASH)],
                 s3_root_uri="s3://bucket/assetRoot",
                 boto3_session=session_mock,
@@ -177,12 +177,14 @@ class TestAttachmentDownload:
                 conflict_resolution=conflict_resolution,
             )
         else:
-            _attachment_download(
+            result = _attachment_download(
                 manifests=[os.path.join(temp_assets_dir, PATH_MAPPING_HASH)],
                 s3_root_uri="s3://bucket/assetRoot",
                 boto3_session=session_mock,
                 path_mapping_rules=mapping_file_path,
             )
+
+        assert isinstance(result, DownloadSummaryStatistics)
 
         mock_download_files_from_manifests.assert_called_once_with(
             s3_bucket="bucket",
@@ -209,11 +211,13 @@ class TestAttachmentDownload:
         ) as f:
             json.dump(MOCK_MANIFEST_CASE[manifest_case_key], f)
 
-        _attachment_download(
+        result = _attachment_download(
             manifests=[os.path.join(temp_assets_dir, manifest_case_key)],
             s3_root_uri="s3://bucket/assetRoot",
             boto3_session=session_mock,
         )
+
+        assert isinstance(result, DownloadSummaryStatistics)
 
         mock_download_files_from_manifests.assert_called_once_with(
             s3_bucket="bucket",
@@ -243,11 +247,13 @@ class TestAttachmentDownload:
             ) as f:
                 json.dump(MOCK_MANIFEST_CASE[manifest_case_key], f)
 
-        _attachment_download(
+        result = _attachment_download(
             manifests=[os.path.join(temp_assets_dir, key) for key in MOCK_MANIFEST_CASE.keys()],
             s3_root_uri="s3://bucket/assetRoot",
             boto3_session=session_mock,
         )
+
+        assert isinstance(result, DownloadSummaryStatistics)
 
         mock_download_files_from_manifests.assert_called_once_with(
             s3_bucket="bucket",


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Changed log behaviour for CLI after fixing logger circular dependency.

```
=========================== short test summary info ============================
FAILED test/integ/cli/test_cli_attachment.py::TestAttachment::test_attachment_basic_flow[TEST_CASE_1] - json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
FAILED test/integ/cli/test_cli_attachment.py::TestAttachment::test_attachment_basic_flow[TEST_CASE_2] - json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
FAILED test/integ/cli/test_cli_attachment.py::TestAttachment::test_attachment_path_mapping_flow[TEST_CASE_1] - json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
FAILED test/integ/cli/test_cli_attachment.py::TestAttachment::test_attachment_path_mapping_flow[TEST_CASE_2] - json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
FAILED test/integ/cli/test_cli_attachment.py::TestAttachment::test_attachment_file_override[CREATE_COPY-2-expected_files0] - json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
FAILED test/integ/cli/test_cli_attachment.py::TestAttachment::test_attachment_file_override[SKIP-1-expected_files1] - json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
FAILED test/integ/cli/test_cli_attachment.py::TestAttachment::test_attachment_file_override[OVERWRITE-1-expected_files2] - json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
======= 7 failed, 48 passed, 4 skipped, 6 xpassed in 2378.40s (0:39:38) ========
```

### What was the solution? (How)
Handle the CLI logging interface from the CLI caller.

### What is the impact of this change?
Keep consistent logging behaviour for CLI

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- [v] Have you run the unit tests?
- [v] Have you run the integration tests?
```
test/integ/cli/test_cli_attachment.py::TestAttachment::test_attachment_s3_cross_account_access_denied 
[gw0] [  1%] PASSED test/integ/cli/test_cli_attachment.py::TestAttachment::test_attachment_s3_cross_account_access_denied 
test/integ/cli/test_cli_attachment.py::TestAttachment::test_attachment_basic_flow[TEST_CASE_1] 
[gw0] [  3%] PASSED test/integ/cli/test_cli_attachment.py::TestAttachment::test_attachment_basic_flow[TEST_CASE_1] 
test/integ/cli/test_cli_attachment.py::TestAttachment::test_attachment_basic_flow[TEST_CASE_2] 
[gw0] [  5%] PASSED test/integ/cli/test_cli_attachment.py::TestAttachment::test_attachment_basic_flow[TEST_CASE_2] 
test/integ/cli/test_cli_attachment.py::TestAttachment::test_attachment_path_mapping_flow[TEST_CASE_1] 
[gw0] [  6%] PASSED test/integ/cli/test_cli_attachment.py::TestAttachment::test_attachment_path_mapping_flow[TEST_CASE_1] 
test/integ/cli/test_cli_attachment.py::TestAttachment::test_attachment_path_mapping_flow[TEST_CASE_2] 
[gw0] [  8%] PASSED test/integ/cli/test_cli_attachment.py::TestAttachment::test_attachment_path_mapping_flow[TEST_CASE_2] 
test/integ/cli/test_cli_attachment.py::TestAttachment::test_attachment_file_override[CREATE_COPY-2-expected_files0] 
[gw0] [ 10%] PASSED test/integ/cli/test_cli_attachment.py::TestAttachment::test_attachment_file_override[CREATE_COPY-2-expected_files0] 
test/integ/cli/test_cli_attachment.py::TestAttachment::test_attachment_file_override[SKIP-1-expected_files1] 
[gw0] [ 11%] PASSED test/integ/cli/test_cli_attachment.py::TestAttachment::test_attachment_file_override[SKIP-1-expected_files1] 
test/integ/cli/test_cli_attachment.py::TestAttachment::test_attachment_file_override[OVERWRITE-1-expected_files2] 
```

### Was this change documented?

- [N/A] Are relevant docstrings in the code base updated?
- [N/A] Has the README.md been updated? If you modified CLI arguments, for instance.

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?
No

### Does this change impact security?
No

- Does the change need to be threat modeled? For example, does it create or modify files/directories that must only be readable by the process owner?
    - If so, then please label this pull request with the "security" label. We'll work with you to analyze the threats.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
