### PR TITLE
fix: Job history error after more than 100 submissions

### DIFF
--- a/src/deadline/client/job_bundle/__init__.py
+++ b/src/deadline/client/job_bundle/__init__.py
@@ -48,10 +48,15 @@ def create_job_history_bundle_dir(submitter_name: str, job_name: str) -> str:
 
     # Index the files so they sort in order of submission
     number = 1
-    existing_dirs = sorted(glob.glob(os.path.join(month_dir, f"{date_tag}-*")))
+    existing_dirs = glob.glob(os.path.join(month_dir, f"{date_tag}-*"))
     if existing_dirs:
-        latest_dir = existing_dirs[-1]
-        number = int(os.path.basename(latest_dir)[len(date_tag) + 1 :].split("-", 1)[0]) + 1
+        for dir_path in existing_dirs:
+            try:
+                dir_number = int(os.path.basename(dir_path)[len(date_tag) + 1 :].split("-", 1)[0])
+                number = max(number, dir_number + 1)
+            except ValueError:
+                # Skip if this dir has no number
+                pass
 
     result = os.path.join(
         month_dir, f"{date_tag}-{number:02}-{submitter_name_cleaned}-{job_name_cleaned}"

--- a/test/unit/deadline_client/job_bundle/test_job_history_folders.py
+++ b/test/unit/deadline_client/job_bundle/test_job_history_folders.py
@@ -95,3 +95,19 @@ def test_create_job_bundle_dir_sanitization(
             tmpdir, expected_output_path
         )
         assert os.path.isdir(os.path.join(tmpdir, expected_output_path))
+
+
+def test_create_job_bundle_dir_many_jobs(fresh_deadline_config, tmp_path):
+    """Tests that it can create 150 jobs within the same dir"""
+    config.set_setting("settings.job_history_dir", str(tmp_path))
+
+    # When we call the function 150 times
+    created_dirs: set = set()
+    with freeze_time("2025-10-13T03:05"):
+        for _ in range(150):
+            dir_path = job_bundle.create_job_history_bundle_dir("cli_job", "Test CLI Job Name")
+            created_dirs.add(os.path.basename(dir_path))
+
+    # Then there should be 150 directories, and they should match what was returned
+    assert len(created_dirs) == 150
+    assert set(os.listdir(tmp_path / "2025-10")) == created_dirs


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

When submitting more than 100 jobs with largely the same name, the job numbering for the history directory stopped at 100 so repeated values and threw an error.

### What was the solution? (How)

Change the logic to take the max of all numbers, not assume they have 2 digits.

### What is the impact of this change?

Correct numbering of job directories within the monthly directories after job 100.

### How was this change tested?

Confirmed that the fix addressed the failing case. Added a unit test.

### Was this change documented?

N/A

### Does this PR introduce new dependencies?

No

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
