### PR TITLE
test(integ): mcp tests were patching old code location and comparing out of date description

### DIFF
--- a/test/integ/deadline_mcp/test_mcp_server_integration.py
+++ b/test/integ/deadline_mcp/test_mcp_server_integration.py
@@ -146,7 +146,7 @@ async def test_tool_description_extraction(get_boto_session):
         f"Got: {list_farms_tool.description}"
     )
 
-    assert "Calls the deadline:ListFarms API call" in list_farms_tool.description, (
+    assert "Calls the [deadline:ListFarms] API call" in list_farms_tool.description, (
         "Tool description should come from the function's doc string"
     )
 
@@ -358,7 +358,7 @@ def test_mcp_server_startup_telemetry():
     mock_telemetry_client = MagicMock()
 
     with patch(
-        "deadline.client.cli._mcp_server.get_deadline_cloud_library_telemetry_client"
+        "deadline.client.cli._groups.mcp_server_command.get_deadline_cloud_library_telemetry_client"
     ) as mock_get_client, patch("deadline._mcp.server.main") as mock_mcp_main:
         mock_get_client.return_value = mock_telemetry_client
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Integration tests were failing:
```
======= 2 failed, 53 passed, 4 skipped, 6 xpassed in 2444.64s (0:40:44) ========
```

1. Comparing against an out of date description
```
FAILED test/integ/deadline_mcp/test_mcp_server_integration.py::test_tool_description_extraction - AssertionError: Tool description should come from the function's doc string
assert 'Calls the deadline:ListFarms API call' in '\n    Calls the [deadline:ListFarms] API call, applying the filter for user membership\n    depending on the configuration. If the response is paginated, it repeated\n    calls the API to get all the farms.\n\n    [deadline:ListFarms]: https://docs.aws.amazon.com/deadline-cloud/latest/APIReference/API_ListFarms.html\n    '
 +  where '\n    Calls the [deadline:ListFarms] API call, applying the filter for user membership\n    depending on the configuration. If the response is paginated, it repeated\n    calls the API to get all the farms.\n\n    [deadline:ListFarms]: https://docs.aws.amazon.com/deadline-cloud/latest/APIReference/API_ListFarms.html\n    ' = Tool(name='deadline_list_farms', title=None, description='\n    Calls the [deadline:ListFarms] API call, applying the filter for user membership\n    depending on the configuration. If the response is paginated, it repeated\n    calls the API to get all the farms.\n\n    [deadline:ListFarms]: https://docs.aws.amazon.com/deadline-cloud/latest/APIReference/API_ListFarms.html\n    ', inputSchema={'properties': {'nextToken': {'default': None, 'title': 'Nexttoken', 'type': 'string'}, 'principalId': {'default': None, 'title': 'Principalid', 'type': 'string'}, 'maxResults': {'default': None, 'title': 'Maxresults', 'type': 'string'}}, 'title': 'list_farmsArguments', 'type': 'object'}, outputSchema=None, icons=None, annotations=None, meta=None).description
```

2. mcp code location moved
```
FAILED test/integ/deadline_mcp/test_mcp_server_integration.py::test_mcp_server_startup_telemetry - AttributeError: module 'deadline.client.cli' has no attribute '_mcp_server'
```

### What was the solution? (How)

I'm not sure these specific integration tests are required, as they feel more like the unit tests that already cover most of this already. But the change is incredibly easy to make.

### What is the impact of this change?

Working tests

### How was this change tested?

```
$ hatch run integ:test test/integ -k "test_mcp_tool_telemetry or test_tool_description_extraction"
test/integ/deadline_mcp/test_mcp_server_integration.py::test_tool_description_extraction 
[gw0] [ 50%] PASSED test/integ/deadline_mcp/test_mcp_server_integration.py::test_tool_description_extraction 
test/integ/deadline_mcp/test_mcp_server_integration.py::test_mcp_tool_telemetry 
[gw0] [100%] PASSED test/integ/deadline_mcp/test_mcp_server_integration.py::test_mcp_tool_telemetry 

===== 2 passed in 3.84s =====
```

### Was this change documented?

N/A

### Does this PR introduce new dependencies?

N/A

### Is this a breaking change?

N/A

### Does this change impact security?

N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
