### PR TITLE
feat(cli): Add --session-action-id option to 'deadline job logs'

### DIFF
--- a/src/deadline/client/cli/_groups/job_group.py
+++ b/src/deadline/client/cli/_groups/job_group.py
@@ -10,6 +10,7 @@ import logging
 from configparser import ConfigParser
 from pathlib import Path
 import os
+import re
 import sys
 from typing import Callable, Optional, Union
 import datetime
@@ -82,6 +83,37 @@ def _format_timestamp(timestamp: datetime.datetime, use_local_time: bool = False
         else:
             utc_timestamp = timestamp
         return utc_timestamp.isoformat()
+
+
+def _parse_session_action_id(session_action_id: str) -> str:
+    """
+    Parse a session action ID and extract the session ID.
+
+    Session action ID format: sessionaction-{uuid}-{number}
+    Session ID format: session-{uuid}
+
+    Args:
+        session_action_id: The session action ID to parse
+
+    Returns:
+        The derived session ID
+
+    Raises:
+        DeadlineOperationError: If the session action ID format is invalid
+    """
+    pattern = r"^sessionaction-([0-9a-f]{32})-\d+$"
+    match = re.match(pattern, session_action_id)
+
+    if not match:
+        raise DeadlineOperationError(
+            f"Invalid session action ID format: '{session_action_id}'. "
+            f"Expected format: sessionaction-{{uuid}}-{{number}}"
+        )
+
+    uuid = match.group(1)
+    session_id = f"session-{uuid}"
+
+    return session_id
 
 
 # Set up the signal handler for handling Ctrl + C interruptions.
@@ -1120,6 +1152,10 @@ def job_wait_for_completion(max_poll_interval, timeout, output, **args):
     "--session-id",
     help="The session ID to get logs for. If not provided and job-id is specified, will use the latest session based on endedAt time.",
 )
+@click.option(
+    "--session-action-id",
+    help="The session action ID to get logs for. The session ID will be derived from this.",
+)
 @click.option("--limit", default=100, help="Maximum number of log lines to return.")
 @click.option(
     "--start-time",
@@ -1140,7 +1176,9 @@ def job_wait_for_completion(max_poll_interval, timeout, output, **args):
     help="Timezone for timestamps (utc or local). Default is utc.",
 )
 @_handle_error
-def job_logs(session_id, limit, start_time, end_time, next_token, output, timezone, **args):
+def job_logs(
+    session_id, session_action_id, limit, start_time, end_time, next_token, output, timezone, **args
+):
     """
     Prints a [Deadline Cloud session log] stored in [CloudWatch logs] for the job.
     Defaults to a recent/ongoing session if a session id is not provided.
@@ -1168,6 +1206,22 @@ def job_logs(session_id, limit, start_time, end_time, next_token, output, timezo
     job_id = config_file.get_setting("defaults.job_id", config=config)
 
     is_json_output = output.lower() == "json"
+
+    # Handle session action ID if provided
+    if session_action_id:
+        # Parse session action ID to derive session ID
+        derived_session_id = _parse_session_action_id(session_action_id)
+
+        # If both session_id and session_action_id are provided, validate consistency
+        if session_id:
+            if session_id != derived_session_id:
+                raise DeadlineOperationError(
+                    f"Session ID mismatch: --session-id '{session_id}' does not match "
+                    f"session ID '{derived_session_id}' derived from --session-action-id '{session_action_id}'"
+                )
+        else:
+            # If only session_action_id is provided, set session_id from parsed value
+            session_id = derived_session_id
 
     # Get job name if job_id is available
     deadline = api.get_boto3_client("deadline", config=config)
@@ -1231,10 +1285,91 @@ def job_logs(session_id, limit, start_time, end_time, next_token, output, timezo
             "Session ID is required. Provide it with --session-id or specify a --job-id with at least one session."
         )
 
+    if session_action_id:
+        log_entity = f"session action {session_action_id}"
+    else:
+        log_entity = f"session {session_id}"
+
     if not is_json_output:
         click.echo(
-            f"Retrieving logs for session {session_id} from log group /aws/deadline/{farm_id}/{queue_id}..."
+            f"Retrieving logs for {log_entity} from log group /aws/deadline/{farm_id}/{queue_id}..."
         )
+        # Display job information if available
+        click.echo(f"Job ID: {job_id}")
+        click.echo(f"Job Name: {job_name}")
+
+    # If session_action_id is provided, retrieve session action details to get timestamp range
+    if session_action_id:
+        try:
+            session_action = deadline.get_session_action(
+                farmId=farm_id,
+                queueId=queue_id,
+                jobId=job_id,
+                sessionActionId=session_action_id,
+            )
+        except ClientError as exc:
+            if exc.response.get("Error", {}).get("Code") == "ResourceNotFoundException":
+                raise DeadlineOperationError(
+                    f"Session action '{session_action_id}' not found in job '{job_id}'"
+                ) from exc
+            else:
+                raise DeadlineOperationError(
+                    f"Failed to retrieve session action '{session_action_id}':\n{exc}"
+                ) from exc
+
+        # Extract timestamps from session action
+        action_start = session_action.get("startedAt")
+        action_end = session_action.get("endedAt")
+
+        # If session action hasn't started yet, raise an error
+        if not action_start:
+            raise DeadlineOperationError(
+                f"Session action '{session_action_id}' has not started yet. No logs are available."
+            )
+
+        if not is_json_output:
+            click.echo(f"Session action start: {action_start}")
+        if action_end:
+            if not is_json_output:
+                click.echo(f"Session action end: {action_end}")
+        else:
+            if not is_json_output:
+                click.echo("Session action is still running")
+            # If session action is still in progress, use current time as end time
+            action_end = datetime.datetime.now(datetime.timezone.utc)
+        if not is_json_output:
+            click.echo(f"Session action duration: {action_end - action_start}")
+
+        # Get the effective time range to process, which is the intersection of
+        # the session action time range and the user-provided time range
+        if start_time:
+            # Parse user's start_time
+            user_start = datetime.datetime.fromisoformat(start_time.replace("Z", "+00:00"))
+            # Use the later of the two start times
+            effective_start = max(user_start, action_start)
+        else:
+            effective_start = action_start
+
+        if end_time:
+            # Parse user's end_time
+            user_end = datetime.datetime.fromisoformat(end_time.replace("Z", "+00:00"))
+            # Use the earlier of the two end times
+            effective_end = min(user_end, action_end)
+        else:
+            effective_end = action_end
+
+        # Validate that effective_start <= effective_end
+        if effective_start > effective_end:
+            error_msg = (
+                f"The specified time range does not overlap with the session action's time range.\n"
+                f"Session action time range: {action_start.isoformat()} to {action_end.isoformat()}"
+            )
+            error_msg += f"\nSpecified time range: {start_time or 'N/A'} to {end_time or 'N/A'}"
+            raise DeadlineOperationError(error_msg)
+
+        # Use the combined timestamps for log retrieval
+        start_time = effective_start
+        end_time = effective_end
 
     try:
         result = api.get_session_logs(
@@ -1273,14 +1408,13 @@ def job_logs(session_id, limit, start_time, end_time, next_token, output, timezo
             }
             click.echo(json.dumps(response, indent=2))
         else:
+            # Separate the logs by a blank line to make the start of the log easy to find.
+            click.echo()
+
             # Display the logs in verbose format
             if not result.events:
                 click.echo("No logs found for the specified session.")
                 return
-
-            # Display job information if available
-            click.echo(f"Job ID: {job_id}")
-            click.echo(f"Job Name: {job_name}")
 
             for event in result.events:
                 timestamp = _format_timestamp(event.timestamp, use_local_time)

--- a/src/deadline/client/cli/_main.py
+++ b/src/deadline/client/cli/_main.py
@@ -5,6 +5,7 @@ The AWS Deadline Cloud CLI interface.
 """
 
 import logging
+import os
 import sys
 from logging import getLogger
 from typing import Optional
@@ -116,6 +117,10 @@ def deadline(
         else:
             open_mode = "w"
         sys.stdout = sys.stderr = open(redirect_output, open_mode, encoding="utf-8", buffering=1)
+    elif sys.stdout and os.name == "nt":
+        # Force the output encoding to be UTF-8 on Windows. Commands like `deadline job logs` print out logs that
+        # can include unicode, and this enables output without errors.
+        sys.stdout.reconfigure(encoding="utf-8")  # type: ignore
     if log_level is None:
         log_level = _get_default_log_level()
 

--- a/test/unit/deadline_client/cli/test_cli_job_logs.py
+++ b/test/unit/deadline_client/cli/test_cli_job_logs.py
@@ -8,12 +8,17 @@ import json
 import datetime
 from unittest.mock import ANY, MagicMock, patch
 
+import pytest
+from botocore.exceptions import ClientError
 from click.testing import CliRunner
+from freezegun import freeze_time
 
 from deadline.client import api
 from deadline.client.cli import main
+from deadline.client.cli._groups.job_group import _parse_session_action_id
 from deadline.client.config import config_file as config
 from deadline.client.api._job_monitoring import SessionLogResult, LogEvent
+from deadline.client.exceptions import DeadlineOperationError
 
 from ..shared_constants import (
     MOCK_FARM_ID,
@@ -1142,3 +1147,1257 @@ def test_cli_job_logs_timezone_local_json(fresh_deadline_config):
         assert "T" in ingestion2 and ("+" in ingestion2 or "-" in ingestion2)
 
         assert result.exit_code == 0
+
+
+def test_cli_job_logs_with_session_action_id_only(fresh_deadline_config, deadline_mock):
+    """
+    Test job logs command with only session action ID provided.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
+
+    session_id = "session-0123456789abcdefabcdefabcdefabcd"
+    session_action_id = "sessionaction-0123456789abcdefabcdefabcdefabcd-1"
+
+    # Mock get_job to return job name
+    deadline_mock.get_job.return_value = {"name": "Test Job Name"}
+
+    # Mock get_session_action to return session action details
+    deadline_mock.get_session_action.return_value = {
+        "sessionActionId": session_action_id,
+        "status": "SUCCEEDED",
+        "startedAt": datetime.datetime(2023, 1, 27, 7, 24, 0, tzinfo=datetime.timezone.utc),
+        "endedAt": datetime.datetime(2023, 1, 27, 7, 25, 0, tzinfo=datetime.timezone.utc),
+    }
+
+    with patch.object(api, "get_session_logs") as mock_get_logs:
+        # Mock the API response
+        mock_get_logs.return_value = SessionLogResult(
+            events=[
+                LogEvent(
+                    timestamp=datetime.datetime(
+                        2023, 1, 27, 7, 24, 45, tzinfo=datetime.timezone.utc
+                    ),
+                    message="Test log message from session action",
+                    ingestion_time=datetime.datetime(
+                        2023, 1, 27, 7, 24, 46, tzinfo=datetime.timezone.utc
+                    ),
+                    event_id="event-1",
+                ),
+            ],
+            count=1,
+            next_token=None,
+            log_group=f"/aws/deadline/{MOCK_FARM_ID}/{MOCK_QUEUE_ID}",
+            log_stream=session_id,
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "job",
+                "logs",
+                "--session-action-id",
+                session_action_id,
+            ],
+        )
+
+        # Verify the API was called with the derived session ID and session action timestamps
+        mock_get_logs.assert_called_once_with(
+            farm_id=MOCK_FARM_ID,
+            queue_id=MOCK_QUEUE_ID,
+            session_id=session_id,
+            limit=100,
+            start_time=datetime.datetime(2023, 1, 27, 7, 24, 0, tzinfo=datetime.timezone.utc),
+            end_time=datetime.datetime(2023, 1, 27, 7, 25, 0, tzinfo=datetime.timezone.utc),
+            next_token=None,
+            config=ANY,
+        )
+
+        # Check output
+        assert f"Retrieving logs for session action {session_action_id}" in result.output
+        assert "Test log message from session action" in result.output
+        assert result.exit_code == 0
+
+
+def test_cli_job_logs_with_session_action_id_and_matching_session_id(
+    fresh_deadline_config, deadline_mock
+):
+    """
+    Test job logs command with both session action ID and matching session ID.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
+
+    session_action_id = "sessionaction-0123456789abcdefabcdefabcdefabcd-1"
+    session_id = "session-0123456789abcdefabcdefabcdefabcd"
+
+    # Mock get_job to return job name
+    deadline_mock.get_job.return_value = {"name": "Test Job Name"}
+
+    # Mock get_session_action to return session action details
+    deadline_mock.get_session_action.return_value = {
+        "sessionActionId": session_action_id,
+        "status": "SUCCEEDED",
+        "startedAt": datetime.datetime(2023, 1, 27, 7, 24, 0, tzinfo=datetime.timezone.utc),
+        "endedAt": datetime.datetime(2023, 1, 27, 7, 25, 0, tzinfo=datetime.timezone.utc),
+    }
+
+    with patch.object(api, "get_session_logs") as mock_get_logs:
+        # Mock the API response
+        mock_get_logs.return_value = SessionLogResult(
+            events=[
+                LogEvent(
+                    timestamp=datetime.datetime(
+                        2023, 1, 27, 7, 24, 45, tzinfo=datetime.timezone.utc
+                    ),
+                    message="Test log message",
+                    ingestion_time=datetime.datetime(
+                        2023, 1, 27, 7, 24, 46, tzinfo=datetime.timezone.utc
+                    ),
+                    event_id="event-1",
+                ),
+            ],
+            count=1,
+            next_token=None,
+            log_group=f"/aws/deadline/{MOCK_FARM_ID}/{MOCK_QUEUE_ID}",
+            log_stream=session_id,
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "job",
+                "logs",
+                "--session-id",
+                session_id,
+                "--session-action-id",
+                session_action_id,
+            ],
+        )
+
+        # Verify the API was called with the session ID and session action timestamps
+        mock_get_logs.assert_called_once_with(
+            farm_id=MOCK_FARM_ID,
+            queue_id=MOCK_QUEUE_ID,
+            session_id=session_id,
+            limit=100,
+            start_time=datetime.datetime(2023, 1, 27, 7, 24, 0, tzinfo=datetime.timezone.utc),
+            end_time=datetime.datetime(2023, 1, 27, 7, 25, 0, tzinfo=datetime.timezone.utc),
+            next_token=None,
+            config=ANY,
+        )
+
+        # Check output
+        assert "Test log message" in result.output
+        assert result.exit_code == 0
+
+
+def test_cli_job_logs_with_session_action_id_and_mismatching_session_id(
+    fresh_deadline_config, deadline_mock
+):
+    """
+    Test job logs command with session action ID and mismatching session ID raises error.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
+
+    session_action_id = "sessionaction-0123456789abcdefabcdefabcdefabcd-1"
+    wrong_session_id = "session-ffffffffffffffffffffffffffffffff"
+
+    # Mock get_job to return job name
+    deadline_mock.get_job.return_value = {"name": "Test Job Name"}
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "job",
+            "logs",
+            "--session-id",
+            wrong_session_id,
+            "--session-action-id",
+            session_action_id,
+        ],
+    )
+
+    # Check error message
+    assert "Session ID mismatch" in result.output
+    assert wrong_session_id in result.output
+    assert "session-0123456789abcdefabcdefabcdefabcd" in result.output
+    assert session_action_id in result.output
+    assert result.exit_code != 0
+
+
+def test_cli_job_logs_with_invalid_session_action_id_format(fresh_deadline_config, deadline_mock):
+    """
+    Test job logs command with invalid session action ID format raises error.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
+
+    invalid_session_action_id = "invalid-format"
+
+    # Mock get_job to return job name
+    deadline_mock.get_job.return_value = {"name": "Test Job Name"}
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "job",
+            "logs",
+            "--session-action-id",
+            invalid_session_action_id,
+        ],
+    )
+
+    # Check error message
+    assert "Invalid session action ID format" in result.output
+    assert invalid_session_action_id in result.output
+    assert "sessionaction-{uuid}-{number}" in result.output
+    assert result.exit_code != 0
+
+
+# Tests for _parse_session_action_id function
+
+
+@pytest.mark.parametrize(
+    "session_action_id,expected_session_id",
+    [
+        (
+            "sessionaction-0123456789abcdef0123456789abcdef-0",
+            "session-0123456789abcdef0123456789abcdef",
+        ),
+        (
+            "sessionaction-abcdef0123456789abcdef0123456789-999999",
+            "session-abcdef0123456789abcdef0123456789",
+        ),
+        (
+            "sessionaction-ffffffffffffffffffffffffffffffff-123",
+            "session-ffffffffffffffffffffffffffffffff",
+        ),
+        (
+            "sessionaction-0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d-42",
+            "session-0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d",
+        ),
+        (
+            "sessionaction-0123456789abcdef0123456789abcdef-5",
+            "session-0123456789abcdef0123456789abcdef",
+        ),
+        (
+            "sessionaction-0123456789abcdef0123456789abcdef-12345",
+            "session-0123456789abcdef0123456789abcdef",
+        ),
+    ],
+    ids=[
+        "standard_format",
+        "large_number",
+        "all_lowercase_hex",
+        "mixed_hex",
+        "single_digit_number",
+        "multi_digit_number",
+    ],
+)
+def test_parse_session_action_id_valid_formats(session_action_id, expected_session_id):
+    """Test that _parse_session_action_id correctly parses valid session action IDs."""
+    result = _parse_session_action_id(session_action_id)
+    assert result == expected_session_id
+
+
+@pytest.mark.parametrize(
+    "session_action_id",
+    [
+        "session-0123456789abcdef0123456789abcdef-0",
+        "wrongprefix-0123456789abcdef0123456789abcdef-0",
+        "sessionaction-0123456789abcdef-0",
+        "sessionaction-0123456789abcdef0123456789abcdef00-0",
+        "sessionaction-0123456789ABCDEF0123456789ABCDEF-0",
+        "sessionaction-0123456789abcdefghij0123456789ab-0",
+        "sessionaction-0123456789abcdef0123456789abcdef",
+        "sessionaction--0",
+        "",
+        "sessionaction-",
+        "sessionaction-0123456789abcdef0123456789abcdef-0-extra",
+        "sessionaction-0123456789abcdef0123456789abcdef-abc",
+        "sessionaction-0123456789abcdef0123456789abcdef--1",
+        "sessionaction-0123456789abcdef0123456789abcdef-0 ",
+        " sessionaction-0123456789abcdef0123456789abcdef-0",
+        "sessionaction-01234567-89ab-cdef-0123-456789abcdef-0",
+        "not-a-valid-session-action-id",
+    ],
+    ids=[
+        "invalid_prefix",
+        "wrong_prefix",
+        "uuid_too_short",
+        "uuid_too_long",
+        "uuid_uppercase",
+        "uuid_non_hex",
+        "missing_number",
+        "missing_uuid",
+        "empty_string",
+        "only_prefix",
+        "extra_dashes",
+        "number_with_letters",
+        "negative_number",
+        "trailing_spaces",
+        "leading_spaces",
+        "uuid_with_dashes",
+        "malformed_structure",
+    ],
+)
+def test_parse_session_action_id_invalid_formats(session_action_id):
+    """Test that _parse_session_action_id raises error for invalid session action IDs."""
+    with pytest.raises(DeadlineOperationError) as exc_info:
+        _parse_session_action_id(session_action_id)
+
+    assert "Invalid session action ID format" in str(exc_info.value)
+
+
+# ===== Tests for Session Action Retrieval =====
+
+
+def test_session_action_retrieval_success_complete(fresh_deadline_config, deadline_mock):
+    """
+    Test successful retrieval of a completed session action with all timestamps.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
+
+    session_action_id = "sessionaction-0123456789abcdefabcdefabcdefabcd-1"
+    session_id = "session-0123456789abcdefabcdefabcdefabcd"
+
+    action_start = datetime.datetime(2023, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
+    action_end = datetime.datetime(2023, 1, 1, 13, 0, 0, tzinfo=datetime.timezone.utc)
+
+    # Mock get_job to return job name
+    deadline_mock.get_job.return_value = {"name": "Test Job Name"}
+
+    # Mock get_session_action to return complete session action data
+    deadline_mock.get_session_action.return_value = {
+        "sessionActionId": session_action_id,
+        "status": "SUCCEEDED",
+        "startedAt": action_start,
+        "endedAt": action_end,
+        "sessionId": session_id,
+        "definition": {"taskRun": {"taskId": "task-1"}},
+    }
+
+    with patch("deadline.client.api.get_session_logs") as mock_get_logs:
+        # Mock get_session_logs response
+        mock_get_logs.return_value = SAMPLE_LOG_RESULT
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "job",
+                "logs",
+                "--session-action-id",
+                session_action_id,
+            ],
+        )
+
+        assert result.exit_code == 0
+
+        # Verify get_session_action was called with correct parameters
+        deadline_mock.get_session_action.assert_called_once_with(
+            farmId=MOCK_FARM_ID,
+            queueId=MOCK_QUEUE_ID,
+            jobId=MOCK_JOB_ID,
+            sessionActionId=session_action_id,
+        )
+
+        # Verify get_session_logs was called with the session action's time range
+        mock_get_logs.assert_called_once()
+        _, kwargs = mock_get_logs.call_args
+        assert kwargs["farm_id"] == MOCK_FARM_ID
+        assert kwargs["queue_id"] == MOCK_QUEUE_ID
+        assert kwargs["session_id"] == session_id
+        assert kwargs["start_time"] == action_start
+        assert kwargs["end_time"] == action_end
+
+
+def test_session_action_retrieval_success_in_progress(fresh_deadline_config, deadline_mock):
+    """
+    Test successful retrieval of an in-progress session action (no endedAt).
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
+
+    session_action_id = "sessionaction-0123456789abcdefabcdefabcdefabcd-1"
+    session_id = "session-0123456789abcdefabcdefabcdefabcd"
+
+    action_start = datetime.datetime(2023, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
+
+    # Mock get_job to return job name
+    deadline_mock.get_job.return_value = {"name": "Test Job Name"}
+
+    # Mock get_session_action to return in-progress session action (no endedAt)
+    deadline_mock.get_session_action.return_value = {
+        "sessionActionId": session_action_id,
+        "status": "RUNNING",
+        "startedAt": action_start,
+        # No endedAt - session action is in progress
+        "sessionId": session_id,
+        "definition": {"taskRun": {"taskId": "task-1"}},
+    }
+
+    with patch("deadline.client.api.get_session_logs") as mock_get_logs, patch(
+        "deadline.client.cli._groups.job_group.datetime"
+    ) as mock_datetime:
+        # Mock datetime.now to return a fixed time
+        mock_now = datetime.datetime(2023, 1, 1, 14, 0, 0, tzinfo=datetime.timezone.utc)
+        mock_datetime.datetime.now.return_value = mock_now
+        mock_datetime.timezone = datetime.timezone
+
+        # Mock get_session_logs response
+        mock_get_logs.return_value = SAMPLE_LOG_RESULT
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "job",
+                "logs",
+                "--session-action-id",
+                session_action_id,
+            ],
+        )
+
+        assert result.exit_code == 0
+
+        # Verify get_session_action was called with correct parameters
+        deadline_mock.get_session_action.assert_called_once_with(
+            farmId=MOCK_FARM_ID,
+            queueId=MOCK_QUEUE_ID,
+            jobId=MOCK_JOB_ID,
+            sessionActionId=session_action_id,
+        )
+
+        # Verify get_session_logs was called with current time as end time
+        mock_get_logs.assert_called_once()
+        _, kwargs = mock_get_logs.call_args
+        assert kwargs["farm_id"] == MOCK_FARM_ID
+        assert kwargs["queue_id"] == MOCK_QUEUE_ID
+        assert kwargs["session_id"] == session_id
+        assert kwargs["start_time"] == action_start
+        assert kwargs["end_time"] == mock_now
+
+
+def test_session_action_retrieval_resource_not_found(fresh_deadline_config, deadline_mock):
+    """
+    Test handling of ResourceNotFoundException when session action doesn't exist.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
+
+    session_action_id = "sessionaction-0123456789abcdefabcdefabcdefabcd-1"
+
+    # Mock get_job to return job name
+    deadline_mock.get_job.return_value = {"name": "Test Job Name"}
+
+    # Mock get_session_action to raise ResourceNotFoundException
+    error_response = {"Error": {"Code": "ResourceNotFoundException", "Message": "Not found"}}
+    deadline_mock.get_session_action.side_effect = ClientError(error_response, "GetSessionAction")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "job",
+            "logs",
+            "--session-action-id",
+            session_action_id,
+        ],
+    )
+
+    # Verify error message is clear
+    assert result.exit_code != 0
+    assert f"Session action '{session_action_id}' not found" in result.output
+    assert f"job '{MOCK_JOB_ID}'" in result.output
+
+
+def test_session_action_retrieval_other_client_error(fresh_deadline_config, deadline_mock):
+    """
+    Test handling of other ClientError scenarios when retrieving session action.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
+
+    session_action_id = "sessionaction-0123456789abcdefabcdefabcdefabcd-1"
+
+    # Mock get_job to return job name
+    deadline_mock.get_job.return_value = {"name": "Test Job Name"}
+
+    # Mock get_session_action to raise a different ClientError
+    error_response = {"Error": {"Code": "AccessDeniedException", "Message": "Access denied"}}
+    deadline_mock.get_session_action.side_effect = ClientError(error_response, "GetSessionAction")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "job",
+            "logs",
+            "--session-action-id",
+            session_action_id,
+        ],
+    )
+
+    # Verify error message includes the session action ID
+    assert result.exit_code != 0
+    assert f"Failed to retrieve session action '{session_action_id}'" in result.output
+
+
+def test_session_action_retrieval_not_started(fresh_deadline_config, deadline_mock):
+    """
+    Test handling of session action that hasn't started yet (no startedAt).
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
+
+    session_action_id = "sessionaction-0123456789abcdefabcdefabcdefabcd-1"
+    session_id = "session-0123456789abcdefabcdefabcdefabcd"
+
+    # Mock get_job to return job name
+    deadline_mock.get_job.return_value = {"name": "Test Job Name"}
+
+    # Mock get_session_action to return session action without startedAt
+    deadline_mock.get_session_action.return_value = {
+        "sessionActionId": session_action_id,
+        "status": "SCHEDULED",
+        # No startedAt - session action hasn't started yet
+        "sessionId": session_id,
+        "definition": {"taskRun": {"taskId": "task-1"}},
+    }
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "job",
+            "logs",
+            "--session-action-id",
+            session_action_id,
+        ],
+    )
+
+    # Verify error message indicates no logs are available
+    assert result.exit_code != 0
+    assert f"Session action '{session_action_id}' has not started yet" in result.output
+    assert "No logs are available" in result.output
+
+
+def test_session_action_retrieval_verifies_api_parameters(fresh_deadline_config, deadline_mock):
+    """
+    Test that correct parameters are passed to get_session_action API.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
+
+    session_action_id = "sessionaction-abcdef0123456789abcdef0123456789-42"
+    session_id = "session-abcdef0123456789abcdef0123456789"
+
+    action_start = datetime.datetime(2023, 5, 15, 10, 30, 0, tzinfo=datetime.timezone.utc)
+    action_end = datetime.datetime(2023, 5, 15, 11, 45, 0, tzinfo=datetime.timezone.utc)
+
+    # Mock get_job to return job name
+    deadline_mock.get_job.return_value = {"name": "Test Job Name"}
+
+    # Mock get_session_action
+    deadline_mock.get_session_action.return_value = {
+        "sessionActionId": session_action_id,
+        "status": "SUCCEEDED",
+        "startedAt": action_start,
+        "endedAt": action_end,
+        "sessionId": session_id,
+        "definition": {"envEnter": {"environmentId": "env-1"}},
+    }
+
+    with patch("deadline.client.api.get_session_logs") as mock_get_logs:
+        # Mock get_session_logs response
+        mock_get_logs.return_value = SAMPLE_LOG_RESULT
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "job",
+                "logs",
+                "--session-action-id",
+                session_action_id,
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--job-id",
+                MOCK_JOB_ID,
+            ],
+        )
+
+        assert result.exit_code == 0
+
+        # Verify get_session_action was called with exact parameters
+        deadline_mock.get_session_action.assert_called_once_with(
+            farmId=MOCK_FARM_ID,
+            queueId=MOCK_QUEUE_ID,
+            jobId=MOCK_JOB_ID,
+            sessionActionId=session_action_id,
+        )
+
+        # Verify the derived session ID was used correctly
+        mock_get_logs.assert_called_once()
+        _, kwargs = mock_get_logs.call_args
+        assert kwargs["session_id"] == session_id
+
+
+def test_time_range_intersection_only_session_action_timestamps(
+    fresh_deadline_config, deadline_mock
+):
+    """
+    Test time range intersection with only session action timestamps (no user times).
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
+
+    session_action_id = "sessionaction-abcdef0123456789abcdef0123456789-42"
+    session_id = "session-abcdef0123456789abcdef0123456789"
+
+    action_start = datetime.datetime(2023, 5, 15, 10, 30, 0, tzinfo=datetime.timezone.utc)
+    action_end = datetime.datetime(2023, 5, 15, 11, 45, 0, tzinfo=datetime.timezone.utc)
+
+    # Mock get_job to return job name
+    deadline_mock.get_job.return_value = {"name": "Test Job Name"}
+
+    # Mock get_session_action
+    deadline_mock.get_session_action.return_value = {
+        "sessionActionId": session_action_id,
+        "status": "SUCCEEDED",
+        "startedAt": action_start,
+        "endedAt": action_end,
+        "sessionId": session_id,
+        "definition": {"taskRun": {"taskId": "task-1"}},
+    }
+
+    with patch("deadline.client.api.get_session_logs") as mock_get_logs:
+        # Mock get_session_logs response
+        mock_get_logs.return_value = SAMPLE_LOG_RESULT
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "job",
+                "logs",
+                "--session-action-id",
+                session_action_id,
+            ],
+        )
+
+        assert result.exit_code == 0
+
+        # Verify get_session_logs was called with session action timestamps
+        mock_get_logs.assert_called_once()
+        _, kwargs = mock_get_logs.call_args
+        assert kwargs["start_time"] == action_start
+        assert kwargs["end_time"] == action_end
+
+
+def test_time_range_intersection_user_start_time_within_range(fresh_deadline_config, deadline_mock):
+    """
+    Test time range intersection with user start time within session action range.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
+
+    session_action_id = "sessionaction-abcdef0123456789abcdef0123456789-42"
+    session_id = "session-abcdef0123456789abcdef0123456789"
+
+    action_start = datetime.datetime(2023, 5, 15, 10, 0, 0, tzinfo=datetime.timezone.utc)
+    action_end = datetime.datetime(2023, 5, 15, 12, 0, 0, tzinfo=datetime.timezone.utc)
+    user_start = "2023-05-15T10:30:00Z"  # Within action range
+
+    # Mock get_job to return job name
+    deadline_mock.get_job.return_value = {"name": "Test Job Name"}
+
+    # Mock get_session_action
+    deadline_mock.get_session_action.return_value = {
+        "sessionActionId": session_action_id,
+        "status": "SUCCEEDED",
+        "startedAt": action_start,
+        "endedAt": action_end,
+        "sessionId": session_id,
+        "definition": {"taskRun": {"taskId": "task-1"}},
+    }
+
+    with patch("deadline.client.api.get_session_logs") as mock_get_logs:
+        # Mock get_session_logs response
+        mock_get_logs.return_value = SAMPLE_LOG_RESULT
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "job",
+                "logs",
+                "--session-action-id",
+                session_action_id,
+                "--start-time",
+                user_start,
+            ],
+        )
+
+        assert result.exit_code == 0
+
+        # Verify get_session_logs was called with max(user_start, action_start)
+        mock_get_logs.assert_called_once()
+        _, kwargs = mock_get_logs.call_args
+        # User start is later, so it should be used
+        expected_start = datetime.datetime(2023, 5, 15, 10, 30, 0, tzinfo=datetime.timezone.utc)
+        assert kwargs["start_time"] == expected_start
+        assert kwargs["end_time"] == action_end
+
+
+def test_time_range_intersection_user_end_time_within_range(fresh_deadline_config, deadline_mock):
+    """
+    Test time range intersection with user end time within session action range.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
+
+    session_action_id = "sessionaction-abcdef0123456789abcdef0123456789-42"
+    session_id = "session-abcdef0123456789abcdef0123456789"
+
+    action_start = datetime.datetime(2023, 5, 15, 10, 0, 0, tzinfo=datetime.timezone.utc)
+    action_end = datetime.datetime(2023, 5, 15, 12, 0, 0, tzinfo=datetime.timezone.utc)
+    user_end = "2023-05-15T11:30:00Z"  # Within action range
+
+    # Mock get_job to return job name
+    deadline_mock.get_job.return_value = {"name": "Test Job Name"}
+
+    # Mock get_session_action
+    deadline_mock.get_session_action.return_value = {
+        "sessionActionId": session_action_id,
+        "status": "SUCCEEDED",
+        "startedAt": action_start,
+        "endedAt": action_end,
+        "sessionId": session_id,
+        "definition": {"taskRun": {"taskId": "task-1"}},
+    }
+
+    with patch("deadline.client.api.get_session_logs") as mock_get_logs:
+        # Mock get_session_logs response
+        mock_get_logs.return_value = SAMPLE_LOG_RESULT
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "job",
+                "logs",
+                "--session-action-id",
+                session_action_id,
+                "--end-time",
+                user_end,
+            ],
+        )
+
+        assert result.exit_code == 0
+
+        # Verify get_session_logs was called with min(user_end, action_end)
+        mock_get_logs.assert_called_once()
+        _, kwargs = mock_get_logs.call_args
+        # User end is earlier, so it should be used
+        expected_end = datetime.datetime(2023, 5, 15, 11, 30, 0, tzinfo=datetime.timezone.utc)
+        assert kwargs["start_time"] == action_start
+        assert kwargs["end_time"] == expected_end
+
+
+def test_time_range_intersection_both_user_times_within_range(fresh_deadline_config, deadline_mock):
+    """
+    Test time range intersection with both user start and end times within session action range.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
+
+    session_action_id = "sessionaction-abcdef0123456789abcdef0123456789-42"
+    session_id = "session-abcdef0123456789abcdef0123456789"
+
+    action_start = datetime.datetime(2023, 5, 15, 10, 0, 0, tzinfo=datetime.timezone.utc)
+    action_end = datetime.datetime(2023, 5, 15, 12, 0, 0, tzinfo=datetime.timezone.utc)
+    user_start = "2023-05-15T10:30:00Z"  # Within action range
+    user_end = "2023-05-15T11:30:00Z"  # Within action range
+
+    # Mock get_job to return job name
+    deadline_mock.get_job.return_value = {"name": "Test Job Name"}
+
+    # Mock get_session_action
+    deadline_mock.get_session_action.return_value = {
+        "sessionActionId": session_action_id,
+        "status": "SUCCEEDED",
+        "startedAt": action_start,
+        "endedAt": action_end,
+        "sessionId": session_id,
+        "definition": {"taskRun": {"taskId": "task-1"}},
+    }
+
+    with patch("deadline.client.api.get_session_logs") as mock_get_logs:
+        # Mock get_session_logs response
+        mock_get_logs.return_value = SAMPLE_LOG_RESULT
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "job",
+                "logs",
+                "--session-action-id",
+                session_action_id,
+                "--start-time",
+                user_start,
+                "--end-time",
+                user_end,
+            ],
+        )
+
+        assert result.exit_code == 0
+
+        # Verify get_session_logs was called with user times (both within range)
+        mock_get_logs.assert_called_once()
+        _, kwargs = mock_get_logs.call_args
+        expected_start = datetime.datetime(2023, 5, 15, 10, 30, 0, tzinfo=datetime.timezone.utc)
+        expected_end = datetime.datetime(2023, 5, 15, 11, 30, 0, tzinfo=datetime.timezone.utc)
+        assert kwargs["start_time"] == expected_start
+        assert kwargs["end_time"] == expected_end
+
+
+def test_time_range_intersection_user_times_partially_overlap_start_before(
+    fresh_deadline_config, deadline_mock
+):
+    """
+    Test time range intersection when user start time is before action start (should use intersection).
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
+
+    session_action_id = "sessionaction-abcdef0123456789abcdef0123456789-42"
+    session_id = "session-abcdef0123456789abcdef0123456789"
+
+    action_start = datetime.datetime(2023, 5, 15, 10, 0, 0, tzinfo=datetime.timezone.utc)
+    action_end = datetime.datetime(2023, 5, 15, 12, 0, 0, tzinfo=datetime.timezone.utc)
+    user_start = "2023-05-15T09:00:00Z"  # Before action start
+    user_end = "2023-05-15T11:00:00Z"  # Within action range
+
+    # Mock get_job to return job name
+    deadline_mock.get_job.return_value = {"name": "Test Job Name"}
+
+    # Mock get_session_action
+    deadline_mock.get_session_action.return_value = {
+        "sessionActionId": session_action_id,
+        "status": "SUCCEEDED",
+        "startedAt": action_start,
+        "endedAt": action_end,
+        "sessionId": session_id,
+        "definition": {"taskRun": {"taskId": "task-1"}},
+    }
+
+    with patch("deadline.client.api.get_session_logs") as mock_get_logs:
+        # Mock get_session_logs response
+        mock_get_logs.return_value = SAMPLE_LOG_RESULT
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "job",
+                "logs",
+                "--session-action-id",
+                session_action_id,
+                "--start-time",
+                user_start,
+                "--end-time",
+                user_end,
+            ],
+        )
+
+        assert result.exit_code == 0
+
+        # Verify get_session_logs was called with intersection
+        mock_get_logs.assert_called_once()
+        _, kwargs = mock_get_logs.call_args
+        # Should use max(user_start, action_start) = action_start
+        # Should use min(user_end, action_end) = user_end
+        assert kwargs["start_time"] == action_start
+        expected_end = datetime.datetime(2023, 5, 15, 11, 0, 0, tzinfo=datetime.timezone.utc)
+        assert kwargs["end_time"] == expected_end
+
+
+def test_time_range_intersection_user_times_partially_overlap_end_after(
+    fresh_deadline_config, deadline_mock
+):
+    """
+    Test time range intersection when user end time is after action end (should use intersection).
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
+
+    session_action_id = "sessionaction-abcdef0123456789abcdef0123456789-42"
+    session_id = "session-abcdef0123456789abcdef0123456789"
+
+    action_start = datetime.datetime(2023, 5, 15, 10, 0, 0, tzinfo=datetime.timezone.utc)
+    action_end = datetime.datetime(2023, 5, 15, 12, 0, 0, tzinfo=datetime.timezone.utc)
+    user_start = "2023-05-15T11:00:00Z"  # Within action range
+    user_end = "2023-05-15T13:00:00Z"  # After action end
+
+    # Mock get_job to return job name
+    deadline_mock.get_job.return_value = {"name": "Test Job Name"}
+
+    # Mock get_session_action
+    deadline_mock.get_session_action.return_value = {
+        "sessionActionId": session_action_id,
+        "status": "SUCCEEDED",
+        "startedAt": action_start,
+        "endedAt": action_end,
+        "sessionId": session_id,
+        "definition": {"taskRun": {"taskId": "task-1"}},
+    }
+
+    with patch("deadline.client.api.get_session_logs") as mock_get_logs:
+        # Mock get_session_logs response
+        mock_get_logs.return_value = SAMPLE_LOG_RESULT
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "job",
+                "logs",
+                "--session-action-id",
+                session_action_id,
+                "--start-time",
+                user_start,
+                "--end-time",
+                user_end,
+            ],
+        )
+
+        assert result.exit_code == 0
+
+        # Verify get_session_logs was called with intersection
+        mock_get_logs.assert_called_once()
+        _, kwargs = mock_get_logs.call_args
+        # Should use max(user_start, action_start) = user_start
+        # Should use min(user_end, action_end) = action_end
+        expected_start = datetime.datetime(2023, 5, 15, 11, 0, 0, tzinfo=datetime.timezone.utc)
+        assert kwargs["start_time"] == expected_start
+        assert kwargs["end_time"] == action_end
+
+
+def test_time_range_intersection_user_times_no_overlap_before(fresh_deadline_config, deadline_mock):
+    """
+    Test time range intersection when user times don't overlap (before action range) - should raise error.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
+
+    session_action_id = "sessionaction-abcdef0123456789abcdef0123456789-42"
+    session_id = "session-abcdef0123456789abcdef0123456789"
+
+    action_start = datetime.datetime(2023, 5, 15, 10, 0, 0, tzinfo=datetime.timezone.utc)
+    action_end = datetime.datetime(2023, 5, 15, 12, 0, 0, tzinfo=datetime.timezone.utc)
+    user_start = "2023-05-15T08:00:00Z"  # Before action start
+    user_end = "2023-05-15T09:00:00Z"  # Before action start
+
+    # Mock get_job to return job name
+    deadline_mock.get_job.return_value = {"name": "Test Job Name"}
+
+    # Mock get_session_action
+    deadline_mock.get_session_action.return_value = {
+        "sessionActionId": session_action_id,
+        "status": "SUCCEEDED",
+        "startedAt": action_start,
+        "endedAt": action_end,
+        "sessionId": session_id,
+        "definition": {"taskRun": {"taskId": "task-1"}},
+    }
+
+    with patch("deadline.client.api.get_session_logs") as mock_get_logs:
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "job",
+                "logs",
+                "--session-action-id",
+                session_action_id,
+                "--start-time",
+                user_start,
+                "--end-time",
+                user_end,
+            ],
+        )
+
+        # Should fail with error about non-overlapping ranges
+        assert result.exit_code != 0
+        assert "does not overlap with the session action's time range" in result.output
+        # Verify error message includes both time ranges
+        assert "2023-05-15T10:00:00+00:00" in result.output  # action_start
+        assert "2023-05-15T12:00:00+00:00" in result.output  # action_end
+        assert user_start in result.output  # user_start
+        assert user_end in result.output  # user_end
+
+        # Verify get_session_logs was NOT called
+        mock_get_logs.assert_not_called()
+
+
+def test_time_range_intersection_user_times_no_overlap_after(fresh_deadline_config, deadline_mock):
+    """
+    Test time range intersection when user times don't overlap (after action range) - should raise error.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
+
+    session_action_id = "sessionaction-abcdef0123456789abcdef0123456789-42"
+    session_id = "session-abcdef0123456789abcdef0123456789"
+
+    action_start = datetime.datetime(2023, 5, 15, 10, 0, 0, tzinfo=datetime.timezone.utc)
+    action_end = datetime.datetime(2023, 5, 15, 12, 0, 0, tzinfo=datetime.timezone.utc)
+    user_start = "2023-05-15T13:00:00Z"  # After action end
+    user_end = "2023-05-15T14:00:00Z"  # After action end
+
+    # Mock get_job to return job name
+    deadline_mock.get_job.return_value = {"name": "Test Job Name"}
+
+    # Mock get_session_action
+    deadline_mock.get_session_action.return_value = {
+        "sessionActionId": session_action_id,
+        "status": "SUCCEEDED",
+        "startedAt": action_start,
+        "endedAt": action_end,
+        "sessionId": session_id,
+        "definition": {"taskRun": {"taskId": "task-1"}},
+    }
+
+    with patch("deadline.client.api.get_session_logs") as mock_get_logs:
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "job",
+                "logs",
+                "--session-action-id",
+                session_action_id,
+                "--start-time",
+                user_start,
+                "--end-time",
+                user_end,
+            ],
+        )
+
+        # Should fail with error about non-overlapping ranges
+        assert result.exit_code != 0
+        assert "does not overlap with the session action's time range" in result.output
+        # Verify error message includes both time ranges
+        assert "2023-05-15T10:00:00+00:00" in result.output  # action_start
+        assert "2023-05-15T12:00:00+00:00" in result.output  # action_end
+        assert user_start in result.output  # user_start
+        assert user_end in result.output  # user_end
+
+        # Verify get_session_logs was NOT called
+        mock_get_logs.assert_not_called()
+
+
+def test_time_range_intersection_in_progress_session_action(fresh_deadline_config, deadline_mock):
+    """
+    Test time range intersection with in-progress session action (no endedAt).
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
+
+    session_action_id = "sessionaction-abcdef0123456789abcdef0123456789-42"
+    session_id = "session-abcdef0123456789abcdef0123456789"
+
+    action_start = datetime.datetime(2023, 5, 15, 10, 0, 0, tzinfo=datetime.timezone.utc)
+    # No endedAt - session action is in progress
+
+    # Mock get_job to return job name
+    deadline_mock.get_job.return_value = {"name": "Test Job Name"}
+
+    # Mock get_session_action - no endedAt
+    deadline_mock.get_session_action.return_value = {
+        "sessionActionId": session_action_id,
+        "status": "RUNNING",
+        "startedAt": action_start,
+        # No endedAt - in progress
+        "sessionId": session_id,
+        "definition": {"taskRun": {"taskId": "task-1"}},
+    }
+
+    # Mock current time
+    mock_now = datetime.datetime(2023, 5, 15, 11, 30, 0, tzinfo=datetime.timezone.utc)
+
+    with patch("deadline.client.api.get_session_logs") as mock_get_logs:
+        # Mock get_session_logs response
+        mock_get_logs.return_value = SAMPLE_LOG_RESULT
+
+        with freeze_time(mock_now):
+            runner = CliRunner()
+            result = runner.invoke(
+                main,
+                [
+                    "job",
+                    "logs",
+                    "--session-action-id",
+                    session_action_id,
+                ],
+            )
+
+            assert result.exit_code == 0
+
+            # Verify get_session_logs was called with action_start and current time
+            mock_get_logs.assert_called_once()
+        _, kwargs = mock_get_logs.call_args
+        assert kwargs["start_time"] == action_start
+        assert kwargs["end_time"] == mock_now
+
+
+def test_time_range_intersection_in_progress_with_user_end_time(
+    fresh_deadline_config, deadline_mock
+):
+    """
+    Test time range intersection with in-progress session action and user end time.
+    Should use min(user_end, current_time).
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
+
+    session_action_id = "sessionaction-abcdef0123456789abcdef0123456789-42"
+    session_id = "session-abcdef0123456789abcdef0123456789"
+
+    action_start = datetime.datetime(2023, 5, 15, 10, 0, 0, tzinfo=datetime.timezone.utc)
+    user_end = "2023-05-15T11:00:00Z"  # User wants logs up to this time
+
+    # Mock get_job to return job name
+    deadline_mock.get_job.return_value = {"name": "Test Job Name"}
+
+    # Mock get_session_action - no endedAt
+    deadline_mock.get_session_action.return_value = {
+        "sessionActionId": session_action_id,
+        "status": "RUNNING",
+        "startedAt": action_start,
+        # No endedAt - in progress
+        "sessionId": session_id,
+        "definition": {"taskRun": {"taskId": "task-1"}},
+    }
+
+    # Mock current time (later than user_end)
+    mock_now = datetime.datetime(2023, 5, 15, 11, 30, 0, tzinfo=datetime.timezone.utc)
+
+    with patch("deadline.client.api.get_session_logs") as mock_get_logs:
+        # Mock get_session_logs response
+        mock_get_logs.return_value = SAMPLE_LOG_RESULT
+
+        with freeze_time(mock_now):
+            runner = CliRunner()
+            result = runner.invoke(
+                main,
+                [
+                    "job",
+                    "logs",
+                    "--session-action-id",
+                    session_action_id,
+                    "--end-time",
+                    user_end,
+                ],
+            )
+
+            assert result.exit_code == 0
+
+            # Verify get_session_logs was called with action_start and min(user_end, current_time)
+            mock_get_logs.assert_called_once()
+            _, kwargs = mock_get_logs.call_args
+            assert kwargs["start_time"] == action_start
+            # User end is earlier than current time, so it should be used
+            expected_end = datetime.datetime(2023, 5, 15, 11, 0, 0, tzinfo=datetime.timezone.utc)
+            assert kwargs["end_time"] == expected_end
+
+
+def test_time_range_intersection_error_message_includes_both_ranges(
+    fresh_deadline_config, deadline_mock
+):
+    """
+    Test that error message includes both time ranges when they don't overlap.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
+
+    session_action_id = "sessionaction-abcdef0123456789abcdef0123456789-42"
+    session_id = "session-abcdef0123456789abcdef0123456789"
+
+    action_start = datetime.datetime(2023, 5, 15, 10, 0, 0, tzinfo=datetime.timezone.utc)
+    action_end = datetime.datetime(2023, 5, 15, 12, 0, 0, tzinfo=datetime.timezone.utc)
+    user_start = "2023-05-15T14:00:00Z"
+    user_end = "2023-05-15T15:00:00Z"
+
+    # Mock get_job to return job name
+    deadline_mock.get_job.return_value = {"name": "Test Job Name"}
+
+    # Mock get_session_action
+    deadline_mock.get_session_action.return_value = {
+        "sessionActionId": session_action_id,
+        "status": "SUCCEEDED",
+        "startedAt": action_start,
+        "endedAt": action_end,
+        "sessionId": session_id,
+        "definition": {"taskRun": {"taskId": "task-1"}},
+    }
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "job",
+            "logs",
+            "--session-action-id",
+            session_action_id,
+            "--start-time",
+            user_start,
+            "--end-time",
+            user_end,
+        ],
+    )
+
+    # Should fail with detailed error message
+    assert result.exit_code != 0
+    assert "does not overlap with the session action's time range" in result.output
+    # Verify error message includes session action time range
+    assert "Session action time range:" in result.output
+    assert "2023-05-15T10:00:00+00:00" in result.output
+    assert "2023-05-15T12:00:00+00:00" in result.output
+    # Verify error message includes specified time range
+    assert "Specified time range:" in result.output
+    assert user_start in result.output
+    assert user_end in result.output


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The `deadline job logs` command doesn't have a way to retrieve the logs for a specific session action. For example, to get the enter or exit action for an environment when debugging it or checking its performance characteristics.

While testing, also ran into some logs that failed to print due to unicode.

### What was the solution? (How)

Add the `--session-action-id` option to the `deadline job logs` command. Because the session action id includes info to reconstruct the session id, `--session-id` is optional when it's provided.

Added a fix to reconfigure sys.stdout on Windows to enable that output to work.

A majority of the code was produced using a Kiro spec and the Claude Sonnet 4.5 model.

### What is the impact of this change?

Using the Deadline CLI to view logs is useful for more cases.

Example output:

```
$ deadline job logs --job-id job-abc--session-action-id sessionaction-123-1 --limit 1000
Retrieving logs for session action sessionaction-123-1 from log group /aws/deadline/farm-387104b942d645d091ca2180ceb80b79/queue-def...
Job ID: job-abc
Job Name: Turntable with Maya/Arnold
Session action start: 2025-10-17 22:04:44.443000+00:00
Session action end: 2025-10-17 22:05:58.927000+00:00
Session action duration: 0:01:14.484000

[2025-10-17T22:04:44.443000+00:00]
[2025-10-17T22:04:44.443000+00:00] ==============================================
[2025-10-17T22:04:44.443000+00:00] --------- Entering Environment: Conda
[2025-10-17T22:04:44.443000+00:00] ==============================================
[2025-10-17T22:04:44.444000+00:00] ----------------------------------------------
[2025-10-17T22:04:44.444000+00:00] Phase: Setup
[2025-10-17T22:04:44.444000+00:00] ----------------------------------------------
[2025-10-17T22:04:44.444000+00:00] Writing embedded files for Environment to disk.
[2025-10-17T22:04:44.444000+00:00] Mapping: Env.File.Enter -> /sessions/session-123/embedded_files_lsli27q/conda-queue-env-enter.sh
[2025-10-17T22:04:44.444000+00:00] Mapping: Env.File.OpenJDVarsCapture -> /sessions/session-123/embedded_files_lsli27q/openjd-vars-capture.py
[2025-10-17T22:04:44.444000+00:00] Wrote: Enter -> /sessions/session-123/embedded_files_lsli27q/conda-queue-env-enter.sh
[2025-10-17T22:04:44.444000+00:00] Wrote: OpenJDVarsCapture -> /sessions/session-123/embedded_files_lsli27q/openjd-vars-capture.py
[2025-10-17T22:04:44.445000+00:00] ----------------------------------------------
[2025-10-17T22:04:44.445000+00:00] Phase: Running action
[2025-10-17T22:04:44.445000+00:00] ----------------------------------------------
[2025-10-17T22:04:44.445000+00:00] Running command sudo -u job-user -i setsid -w /sessions/session-e1c5b119c03645b18036736ac0baa9ed7fx6t0hh/tmpmf15_41_.sh
...
```

### How was this change tested?

Added unit tests, and ran a variety of manual test cases.

### Was this change documented?

The option is documented via docstring.

### Does this PR introduce new dependencies?

No

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
