### PR TITLE
chore(docs): Update docs github action to depend on src/ contents

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -6,6 +6,7 @@ on:
       - mainline
     paths:
       - 'docs/**'
+      - 'src/**'
       - 'mkdocs.yml'
       - '.github/workflows/mkdocs.yml'
   workflow_dispatch:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Both the CLI and API reference look at the src to generate content, so the docs should be rebuilt when there are changes in src/ in addition to when there are changes in docs/.

### What was the solution? (How)

Update the github action to depend on `src/**` too.

### What is the impact of this change?

Docs will stay up to date.

### How was this change tested?

Can't test, will see the behavior in future PRs.

### Was this change documented?

No

### Does this PR introduce new dependencies?

No

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
