### PR TITLE
perf: Adding thread local s3 cache db connections to fix performance …

### DIFF
--- a/src/deadline/job_attachments/caches/cache_db.py
+++ b/src/deadline/job_attachments/caches/cache_db.py
@@ -6,6 +6,7 @@ Module for defining a local cache file.
 
 import logging
 import os
+import threading as _threading
 from abc import ABC
 from threading import Lock
 from typing import Optional
@@ -34,6 +35,8 @@ class CacheDB(ABC):
         self.cache_name: str = cache_name
         self.table_name: str = table_name
         self.create_query: str = create_query
+        self._local = _threading.local()
+        self._local_connections: set = set()
 
         try:
             # SQLite is included in Python installers, but might not exist if building python from source.
@@ -64,6 +67,7 @@ class CacheDB(ABC):
                 self.db_connection: sqlite3.Connection = sqlite3.connect(
                     self.cache_dir, check_same_thread=False
                 )
+                self.db_connection.execute("PRAGMA journal_mode=WAL")
             except sqlite3.OperationalError as oe:
                 raise JobAttachmentsError(
                     f"Could not access cache file in {self.cache_dir}"
@@ -81,8 +85,35 @@ class CacheDB(ABC):
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
         """Called when exiting the context manager."""
+
         if self.enabled:
+            import sqlite3
+
             self.db_connection.close()
+            for conn in self._local_connections:
+                try:
+                    conn.close()
+                except sqlite3.Error as e:
+                    logger.warning(f"SQLite connection failed to close with error {e}")
+
+            self._local_connections.clear()
+
+    def get_local_connection(self):
+        """Create and/or returns a thread local connection to the SQLite database."""
+        if not self.enabled:
+            return None
+        import sqlite3
+
+        if not hasattr(self._local, "connection"):
+            try:
+                self._local.connection = sqlite3.connect(self.cache_dir, check_same_thread=False)
+                self._local_connections.add(self._local.connection)
+            except sqlite3.OperationalError as oe:
+                raise JobAttachmentsError(
+                    f"Could not create connection to cache in {self.cache_dir}"
+                ) from oe
+
+        return self._local.connection
 
     @classmethod
     def get_default_cache_db_file_dir(cls) -> Optional[str]:
@@ -99,12 +130,23 @@ class CacheDB(ABC):
         """
         Removes the underlying cache contents from the file system.
         """
+
         if self.enabled:
+            import sqlite3
+
             self.db_connection.close()
+            conn_list = list(self._local_connections)
+            for conn in conn_list:
+                try:
+                    conn.close()
+                    self._local_connections.remove(conn)
+                except sqlite3.Error as e:
+                    logger.warning(f"SQLite connection failed to close with error {e}")
 
         logger.debug(f"The cache {self.cache_dir} will be removed")
         try:
             os.remove(self.cache_dir)
         except Exception as e:
             logger.error(f"Error occurred while removing the cache file {self.cache_dir}: {e}")
+
             raise e

--- a/src/deadline/job_attachments/caches/hash_cache.py
+++ b/src/deadline/job_attachments/caches/hash_cache.py
@@ -59,6 +59,35 @@ class HashCache(CacheDB):
             cache_dir=cache_dir,
         )
 
+    def get_connection_entry(
+        self, file_path_key: str, hash_algorithm: HashAlgorithm, connection
+    ) -> Optional[HashCacheEntry]:
+        """
+        Returns an entry from the hash cache, if it exists.  This is the "lockless" (Doesn't take
+        the main db_lock protecting db_connection) version of get_entry which expects a connection
+        parameter for the connection which will be used to read from the DB - this can generally
+        be the thread local connection returned by get_local_connection()
+        """
+        if not self.enabled:
+            return None
+
+        entry_vals = connection.execute(
+            f"SELECT * FROM {self.table_name} WHERE file_path=? AND hash_algorithm=?",
+            [
+                file_path_key.encode(encoding="utf-8", errors="surrogatepass"),
+                hash_algorithm.value,
+            ],
+        ).fetchone()
+        if entry_vals:
+            return HashCacheEntry(
+                file_path=str(entry_vals[0], encoding="utf-8", errors="surrogatepass"),
+                hash_algorithm=HashAlgorithm(entry_vals[1]),
+                file_hash=entry_vals[2],
+                last_modified_time=str(entry_vals[3]),
+            )
+        else:
+            return None
+
     def get_entry(
         self, file_path_key: str, hash_algorithm: HashAlgorithm
     ) -> Optional[HashCacheEntry]:
@@ -69,22 +98,7 @@ class HashCache(CacheDB):
             return None
 
         with self.db_lock, self.db_connection:
-            entry_vals = self.db_connection.execute(
-                f"SELECT * FROM {self.table_name} WHERE file_path=? AND hash_algorithm=?",
-                [
-                    file_path_key.encode(encoding="utf-8", errors="surrogatepass"),
-                    hash_algorithm.value,
-                ],
-            ).fetchone()
-            if entry_vals:
-                return HashCacheEntry(
-                    file_path=str(entry_vals[0], encoding="utf-8", errors="surrogatepass"),
-                    hash_algorithm=HashAlgorithm(entry_vals[1]),
-                    file_hash=entry_vals[2],
-                    last_modified_time=str(entry_vals[3]),
-                )
-            else:
-                return None
+            return self.get_connection_entry(file_path_key, hash_algorithm, self.db_connection)
 
     def put_entry(self, entry: HashCacheEntry) -> None:
         """Inserts or replaces an entry into the hash cache database after acquiring the lock."""

--- a/src/deadline/job_attachments/caches/s3_check_cache.py
+++ b/src/deadline/job_attachments/caches/s3_check_cache.py
@@ -56,6 +56,32 @@ class S3CheckCache(CacheDB):
             cache_dir=cache_dir,
         )
 
+    def get_connection_entry(self, s3_key: str, connection) -> Optional[S3CheckCacheEntry]:
+        """
+        Returns an entry from the hash cache, if it exists.  This is the "lockless" (Doesn't take
+        the main db_lock protecting db_connection) version of get_entry which expects a connection
+        parameter for the connection which will be used to read from the DB - this can generally
+        be the thread local connection returned by get_local_connection()
+        """
+
+        entry_vals = connection.execute(
+            f"SELECT * FROM {self.table_name} WHERE s3_key=?",
+            [s3_key],
+        ).fetchone()
+        if entry_vals:
+            entry = S3CheckCacheEntry(
+                s3_key=entry_vals[0],
+                last_seen_time=str(entry_vals[1]),
+            )
+            try:
+                last_seen = datetime.fromtimestamp(float(entry.last_seen_time))
+                if (datetime.now() - last_seen).days < self.ENTRY_EXPIRY_DAYS:
+                    return entry
+            except ValueError:
+                logger.warning(f"Timestamp for S3 key {s3_key} is not valid. Ignoring.")
+
+        return None
+
     def get_entry(self, s3_key: str) -> Optional[S3CheckCacheEntry]:
         """
         Checks if an entry exists in the cache, and returns it if it hasn't expired.
@@ -64,23 +90,7 @@ class S3CheckCache(CacheDB):
             return None
 
         with self.db_lock, self.db_connection:
-            entry_vals = self.db_connection.execute(
-                f"SELECT * FROM {self.table_name} WHERE s3_key=?",
-                [s3_key],
-            ).fetchone()
-            if entry_vals:
-                entry = S3CheckCacheEntry(
-                    s3_key=entry_vals[0],
-                    last_seen_time=str(entry_vals[1]),
-                )
-                try:
-                    last_seen = datetime.fromtimestamp(float(entry.last_seen_time))
-                    if (datetime.now() - last_seen).days < self.ENTRY_EXPIRY_DAYS:
-                        return entry
-                except ValueError:
-                    logger.warning(f"Timestamp for S3 key {s3_key} is not valid. Ignoring.")
-
-            return None
+            return self.get_connection_entry(s3_key, self.db_connection)
 
     def put_entry(self, entry: S3CheckCacheEntry) -> None:
         """Inserts or replaces an entry into the cache database."""

--- a/src/deadline/job_attachments/upload.py
+++ b/src/deadline/job_attachments/upload.py
@@ -593,8 +593,11 @@ class S3AssetUploader:
         random.shuffle(s3_upload_keys)
         sampled_cache_entries: List[S3CheckCacheEntry] = []
         with S3CheckCache(s3_check_cache_dir) as s3_cache:
+            local_connection = s3_cache.get_local_connection()
             for upload_key in s3_upload_keys:
-                this_entry = s3_cache.get_entry(s3_key=f"{s3_bucket}/{upload_key}")
+                this_entry = s3_cache.get_connection_entry(
+                    s3_key=f"{s3_bucket}/{upload_key}", connection=local_connection
+                )
                 if this_entry is not None:
                     sampled_cache_entries.append(this_entry)
                     if len(sampled_cache_entries) >= 30:
@@ -651,7 +654,9 @@ class S3AssetUploader:
         s3_upload_key = self._generate_s3_upload_key(file, hash_algorithm, s3_cas_prefix)
         is_uploaded = False
 
-        if s3_check_cache.get_entry(s3_key=f"{s3_bucket}/{s3_upload_key}"):
+        if s3_check_cache.get_connection_entry(
+            s3_key=f"{s3_bucket}/{s3_upload_key}", connection=s3_check_cache.get_local_connection()
+        ):
             logger.debug(
                 f"skipping {local_path} because {s3_bucket}/{s3_upload_key} exists in the cache"
             )
@@ -1068,7 +1073,9 @@ class S3AssetManager:
         file_status: FileStatus = FileStatus.UNCHANGED
         actual_modified_time = str(datetime.fromtimestamp(path.stat().st_mtime))
 
-        entry: Optional[HashCacheEntry] = hash_cache.get_entry(full_path, hash_alg)
+        entry: Optional[HashCacheEntry] = hash_cache.get_connection_entry(
+            full_path, hash_alg, connection=hash_cache.get_local_connection()
+        )
         if entry is not None:
             # If the file was modified, we need to rehash it
             if actual_modified_time != entry.last_modified_time:

--- a/test/unit/deadline_job_attachments/caches/test_caches.py
+++ b/test/unit/deadline_job_attachments/caches/test_caches.py
@@ -1,6 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 import os
+import threading
 from datetime import datetime
 from sqlite3 import OperationalError
 from unittest.mock import patch
@@ -68,6 +69,54 @@ class TestCacheDB:
         """Tests that a JobAttachmentsError is raised if init args are empty"""
         with pytest.raises(JobAttachmentsError):
             CacheDB(cache_name, table_name, create_query)
+
+    def test_get_local_connection_same_thread(self, tmpdir):
+        """Tests that get_local_connection returns the same connection for a single thread"""
+        cache_dir = tmpdir.mkdir("cache")
+
+        with CacheDB(
+            "test", "test_table", "CREATE TABLE test_table (id INTEGER)", cache_dir
+        ) as cdb:
+            # Get connection from main thread
+            conn1 = cdb.get_local_connection()
+            conn2 = cdb.get_local_connection()
+
+            # Should return same connection for same thread
+            assert conn1 is conn2
+
+    def test_get_local_connection_different_threads(self, tmpdir):
+        """Tests that get_local_connection creates separate connections for different threads"""
+        cache_dir = tmpdir.mkdir("cache")
+        connections = {}
+
+        # Create the cache and table first
+        with CacheDB(
+            "test", "test_table", "CREATE TABLE test_table (id INTEGER)", cache_dir
+        ) as cdb:
+
+            def get_connection(thread_id):
+                connections[thread_id] = cdb.get_local_connection()
+
+            # Create connections from different threads
+            thread1 = threading.Thread(target=get_connection, args=(1,))
+            thread2 = threading.Thread(target=get_connection, args=(2,))
+
+            thread1.start()
+            thread2.start()
+            thread1.join()
+            thread2.join()
+
+            # Connections should be different for different threads
+            assert connections[1] is not connections[2]
+
+    def test_get_local_connection_handles_sqlite_error(self, tmpdir):
+        """Tests that get_local_connection raises JobAttachmentsError on SQLite errors"""
+        with CacheDB("test", "test_table", "CREATE TABLE test_table (id INTEGER)", tmpdir) as cdb:
+            # Mock sqlite3.connect to raise OperationalError
+            with patch("sqlite3.connect", side_effect=OperationalError("test error")):
+                with pytest.raises(JobAttachmentsError) as exc_info:
+                    cdb.get_local_connection()
+                assert "Could not create connection to cache" in str(exc_info.value)
 
 
 class TestHashCache:
@@ -223,3 +272,207 @@ class TestS3CheckCache:
 
             # Test if the cache file was deleted
             assert not os.path.exists(file_name)
+
+    def test_get_connection_entry_returns_valid_entry(self, tmpdir):
+        """Tests that get_connection_entry returns a valid entry with provided connection"""
+        cache_dir = tmpdir.mkdir("cache")
+        expected_entry = S3CheckCacheEntry(
+            s3_key="bucket/Data/somehash",
+            last_seen_time=str(datetime.now().timestamp()),
+        )
+
+        with S3CheckCache(cache_dir) as s3c:
+            s3c.put_entry(expected_entry)
+            connection = s3c.get_local_connection()
+            actual_entry = s3c.get_connection_entry("bucket/Data/somehash", connection)
+
+            assert actual_entry == expected_entry
+
+    def test_get_connection_entry_returns_none_for_nonexistent_key(self, tmpdir):
+        """Tests that get_connection_entry returns None for non-existent key"""
+        cache_dir = tmpdir.mkdir("cache")
+
+        with S3CheckCache(cache_dir) as s3c:
+            connection = s3c.get_local_connection()
+            actual_entry = s3c.get_connection_entry("nonexistent/key", connection)
+
+            assert actual_entry is None
+
+    def test_get_connection_entry_returns_none_for_expired_entry(self, tmpdir):
+        """Tests that get_connection_entry returns None for expired entries"""
+        cache_dir = tmpdir.mkdir("cache")
+        expired_entry = S3CheckCacheEntry(
+            s3_key="bucket/Data/somehash",
+            last_seen_time="123.456",  # very old timestamp
+        )
+
+        with S3CheckCache(cache_dir) as s3c:
+            s3c.put_entry(expired_entry)
+            connection = s3c.get_local_connection()
+            actual_entry = s3c.get_connection_entry("bucket/Data/somehash", connection)
+
+            assert actual_entry is None
+
+    def test_concurrent_read_write_operations_should_not_lock(self, tmpdir):
+        """Test that concurrent reads and writes don't cause database locked errors"""
+        import threading
+        import time
+
+        cache_dir = tmpdir.mkdir("cache")
+        errors = {}
+        results = {}
+
+        with HashCache(cache_dir) as cache:
+
+            def aggressive_writer_thread(thread_id):
+                """Thread that aggressively writes to cache with transactions"""
+                try:
+                    for i in range(20):  # More operations
+                        entry = HashCacheEntry(
+                            file_path=f"/test/file_{thread_id}_{i}.txt",
+                            hash_algorithm=HashAlgorithm.XXH128,
+                            file_hash=f"hash_{thread_id}_{i}",
+                            last_modified_time=str(time.time()),
+                        )
+                        cache.put_entry(entry)
+                except Exception as e:
+                    errors[f"writer_{thread_id}"] = str(e)
+
+            def aggressive_reader_thread(thread_id):
+                """Thread that aggressively reads from cache using thread-local connection"""
+                try:
+                    conn = cache.get_local_connection()
+                    for i in range(50):  # Many more read operations
+                        # Try to read - this should never get "database is locked"
+                        entry = cache.get_connection_entry(
+                            f"/test/file_{i % 4}_{i % 5}.txt", HashAlgorithm.XXH128, conn
+                        )
+                        results[f"reader_{thread_id}_{i}"] = entry is not None
+                except Exception as e:
+                    errors[f"reader_{thread_id}"] = str(e)
+
+            # Start many more threads concurrently
+            threads = []
+
+            # Start 5 writer threads (more write contention)
+            for i in range(5):
+                t = threading.Thread(target=aggressive_writer_thread, args=(i,))
+                threads.append(t)
+                t.start()
+
+            # Start 10 reader threads (more read contention)
+            for i in range(10):
+                t = threading.Thread(target=aggressive_reader_thread, args=(i,))
+                threads.append(t)
+                t.start()
+
+            # Wait for all threads
+            for t in threads:
+                t.join()
+
+        # Should have no "database is locked" errors
+        locked_errors = {k: v for k, v in errors.items() if "database is locked" in v}
+        assert len(locked_errors) == 0, f"Got database locked errors: {locked_errors}"
+        assert len(errors) == 0, f"Got other errors: {errors}"
+
+    def test_large_db_concurrent_operations_expose_timeout_issues(self, tmpdir):
+        """Test that large database (~50MB) exposes timeout issues without proper SQLite configuration"""
+        import threading
+        import time
+
+        cache_dir = tmpdir.mkdir("cache")
+
+        # Prepopulate database to ~50MB (approximately 500K records for more realistic size)
+        print("Prepopulating database to ~50MB...")
+        with HashCache(cache_dir) as cache:
+            # Initialize cache with one entry to ensure table exists
+            init_entry = HashCacheEntry(
+                file_path="/init.txt",
+                hash_algorithm=HashAlgorithm.XXH128,
+                file_hash="init_hash",
+                last_modified_time=str(time.time()),
+            )
+            cache.put_entry(init_entry)
+
+            conn = cache.db_connection
+            batch_data = []
+            batch_size = 10000
+
+            for i in range(500000):  # Increased to 500K records
+                batch_data.append(
+                    (
+                        f"/large/test/file_{i:06d}.txt",
+                        HashAlgorithm.XXH128.value,
+                        f"hash_{i:032x}" * 2,  # Longer hash to increase record size
+                        str(time.time() + i),
+                    )
+                )
+
+                if len(batch_data) >= batch_size:
+                    conn.executemany(
+                        f"INSERT OR REPLACE INTO {cache.table_name} (file_path, hash_algorithm, file_hash, last_modified_time) VALUES (?, ?, ?, ?)",
+                        batch_data,
+                    )
+                    conn.commit()
+                    batch_data = []
+                    if i % 50000 == 0:
+                        print(f"  Added {i + 1} records...")
+
+            # Insert remaining records
+            if batch_data:
+                conn.executemany(
+                    f"INSERT OR REPLACE INTO {cache.table_name} (file_path, hash_algorithm, file_hash, last_modified_time) VALUES (?, ?, ?, ?)",
+                    batch_data,
+                )
+                conn.commit()
+
+        print("Database prepopulated. Starting aggressive concurrency test...")
+
+        errors = {}
+        results = {}
+
+        with HashCache(cache_dir) as cache:
+
+            def aggressive_writer_thread(thread_id):
+                try:
+                    for i in range(50):  # More write operations
+                        entry = HashCacheEntry(
+                            file_path=f"/concurrent/file_{thread_id}_{i}.txt",
+                            hash_algorithm=HashAlgorithm.XXH128,
+                            file_hash=f"concurrent_hash_{thread_id}_{i}",
+                            last_modified_time=str(time.time()),
+                        )
+                        cache.put_entry(entry)
+                except Exception as e:
+                    errors[f"writer_{thread_id}"] = str(e)
+
+            def aggressive_reader_thread(thread_id):
+                try:
+                    conn = cache.get_local_connection()
+                    for i in range(100):  # Many more read operations
+                        entry = cache.get_connection_entry(
+                            f"/large/test/file_{i:06d}.txt", HashAlgorithm.XXH128, conn
+                        )
+                        results[f"reader_{thread_id}_{i}"] = entry is not None
+                except Exception as e:
+                    errors[f"reader_{thread_id}"] = str(e)
+
+            # Start many concurrent operations on large database
+            threads = []
+            for i in range(15):  # More writer threads
+                t = threading.Thread(target=aggressive_writer_thread, args=(i,))
+                threads.append(t)
+                t.start()
+
+            for i in range(25):  # More reader threads
+                t = threading.Thread(target=aggressive_reader_thread, args=(i,))
+                threads.append(t)
+                t.start()
+
+            for t in threads:
+                t.join()
+
+        # With proper SQLite configuration (timeout + WAL), should have no lock errors
+        locked_errors = {k: v for k, v in errors.items() if "database is locked" in v}
+        assert len(locked_errors) == 0, f"Got database locked errors: {locked_errors}"
+        assert len(errors) == 0, f"Got other errors: {errors}"

--- a/test/unit/deadline_job_attachments/test_upload.py
+++ b/test/unit/deadline_job_attachments/test_upload.py
@@ -1582,7 +1582,7 @@ class TestUpload:
         # WHEN
         test_entry = HashCacheEntry(test_file, HashAlgorithm.XXH128, "a", "123.45")
         hash_cache = MagicMock()
-        hash_cache.get_entry.return_value = test_entry
+        hash_cache.get_connection_entry.return_value = test_entry
 
         with patch(f"{deadline.__package__}.job_attachments.upload.hash_file", side_effect=["b"]):
             asset_manager = S3AssetManager(
@@ -1616,7 +1616,7 @@ class TestUpload:
         # WHEN
         test_entry = HashCacheEntry(test_file, HashAlgorithm.XXH128, "a", file_time)
         hash_cache = MagicMock()
-        hash_cache.get_entry.return_value = test_entry
+        hash_cache.get_connection_entry.return_value = test_entry
 
         with patch(f"{deadline.__package__}.job_attachments.upload.hash_file", side_effect=["a"]):
             asset_manager = S3AssetManager(
@@ -2491,7 +2491,7 @@ class TestUpload:
     def test_verify_hash_cache_integrity_returns_true_when_cache_and_s3_match(self, cache_entry):
         # Given
         mock_s3_check_cache_impl = MagicMock()
-        mock_s3_check_cache_impl.get_entry.return_value = cache_entry
+        mock_s3_check_cache_impl.get_connection_entry.return_value = cache_entry
         mock_s3_check_cache = MagicMock()
         mock_s3_check_cache.__enter__.return_value = mock_s3_check_cache_impl
 
@@ -2537,7 +2537,7 @@ class TestUpload:
     def test_verify_hash_cache_integrity_returns_false_when_cache_and_s3_mismatch(self):
         # Given
         mock_s3_check_cache_impl = MagicMock()
-        mock_s3_check_cache_impl.get_entry.return_value = S3CheckCacheEntry(
+        mock_s3_check_cache_impl.get_connection_entry.return_value = S3CheckCacheEntry(
             s3_key="bucket/Data/test-hash",
             last_seen_time=str(datetime.now().timestamp()),
         )
@@ -2629,7 +2629,7 @@ class TestUpload:
         s3_key = f"{default_job_attachment_s3_settings.s3BucketName}/prefix/test-hash.xxh128"
         test_entry = S3CheckCacheEntry(s3_key, "123.45")
         s3_cache = MagicMock()
-        s3_cache.get_entry.return_value = test_entry
+        s3_cache.get_connection_entry.return_value = test_entry
 
         # When
         with patch.object(
@@ -2716,7 +2716,7 @@ class TestUpload:
         )
         s3_key = f"{default_job_attachment_s3_settings.s3BucketName}/prefix/test-hash.xxh128"
         s3_cache = MagicMock()
-        s3_cache.get_entry.return_value = None
+        s3_cache.get_connection_entry.return_value = None
         expected_new_entry = S3CheckCacheEntry(s3_key, "345.67")
 
         # When


### PR DESCRIPTION
Note this is a re-revert of a previous commit/PR with additional testing and improvements from adding WAL mode - https://github.com/aws-deadline/deadline-cloud/pull/848

Adding back the comments and updating each with the additional bottleneck uncovered and solution.

### What was the problem/requirement? (What/Why)
Our S3 cache was using a connection shared across threads which required a lock for all access, creating a bottleneck when attempting to divide up work across threads.

With the original fix this uncovered further bottlenecks when attempting to write and read concurrently to larger DB files in particular.  The original code prevented us from seeing this bottleneck because we were sharing a single connection which was protected by a lock.  Concurrent reading was not possible due to the shared connection and shared self.db_lock - another thread attempting to read through one of our methods would simply sit on the lock until it was released.  With the original fix this bottleneck was removed, and instead in cases particularly with larger DB files we could see our DB connection timer (Set as the default 5 seconds) time out due to missing additional configuration settings preventing concurrent readers.

### What was the solution? (How)
Add back the original fix and enable [Write Ahead Logging](https://sqlite.org/wal.html)

Add additional unit tests to deadline-cloud to better stress test concurrent reading/writing with larger DB files.

### What is the impact of this change?
Improved DB performance.  Testing with the Meerkat scene in Unreal:

(Deleting my cache DB files before each test:

**5 runs with Current Code:**
19.715
19.078
19.499
19.531
19.191
**Avg: 19.4028**

**5 runs with this change:**
14.392
14.337
14.286
14.559
14.253
**Avg: 14.3654**

**~26% improvement**

### How was this change tested?
**New Unit Test** - Note you can see test_large_db_concurrent_operations_expose_timeout_issues catch the timeout error if you remove the pragma setting WAL mode in the DB.

New and existing unit tests pass.

When starting from a large DB file which previously failed in Worker Agent tests:
ev-dsk-baxelson-2b-c90f05c5 % ls -al ~/.deadline/cache
total 65404
drwxr-xr-x 3 baxelson amazon     4096 Oct 25 14:14 .
drwxr-xr-x 3 baxelson amazon     4096 Oct 17 19:47 ..
drwxr-xr-x 2 baxelson amazon     4096 Oct 17 21:16 bak
-rw-r--r-- 1 baxelson amazon 65358848 Oct 25 14:14 hash_cache.db
-rw-r--r-- 1 baxelson amazon  1592320 Oct 25 14:14 s3_check_cache.db

(25-10-25 14:37:29) <0> [~/clients/deadline-cloud-worker-agent]

Worker agent Linux tests pass:
================================================= slowest 5 durations ==================================================
648.55s call     test/e2e/test_worker_config.py::TestWorkerConfiguration::test_worker_shuts_down_host_machine_if_configured
253.08s call     test/e2e/test_worker_config.py::TestWorkerConfiguration::test_worker_requires_no_instance_profile
228.66s setup    test/e2e/test_job_submissions.py::TestJobSubmission::test_worker_enters_stopping_state_while_draining
214.67s call     test/e2e/test_worker_config.py::TestWorkerConfiguration::test_worker_local_session_logs_can_be_turned_off
213.22s setup    test/e2e/test_cap_kill.py::test_cap_kill_not_inherited_by_running_jobs
========================== 45 passed, 15 skipped, 1 xpassed, 1 warning in 4094.63s (1:08:14) ===========================

And Windows tests pass:
================================================= slowest 5 durations ==================================================
679.29s call     test/e2e/test_worker_config.py::TestWorkerConfiguration::test_worker_shuts_down_host_machine_if_configured
343.84s setup    test/e2e/test_job_submissions.py::TestJobSubmission::test_worker_enters_stopping_state_while_draining
329.59s call     test/e2e/test_worker_config.py::TestWorkerConfiguration::test_worker_requires_no_instance_profile
328.70s setup    test/e2e/test_credential_handling.py::test_access_worker_credential_file_from_job_windows
325.79s call     test/e2e/test_worker_config.py::TestWorkerConfiguration::test_session_root_dir
================================ 43 passed, 18 skipped, 1 warning in 5141.65s (1:25:41) ================================

### Was this change documented?
Yes

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [ X] This PR does not add any new dependencies.

### Is this a breaking change?
No

### Does this change impact security?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
