### PR TITLE
docs: Update DEVELOPMENT.md to add contract example

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -227,6 +227,87 @@ For the Python library interface:
 
 Note that we enforce our public contract through GitHub actions. See the [API Change Detection section](scripts/README.md#api-change-detection) in the scripts README for more information about generating and validating API changes.
 
+#### Private Modules
+
+New code should reside in private modules (example: `_my_module.py`), which removes the need to mark imports, classes, and functions as private with an underscore.
+
+```python
+# _my_module.py
+import os
+
+class PublicClass:
+    def publicmethod(self):
+        pass
+    # We still need to mark this as private, since the class will be public
+    def _privatemethod(self):
+        pass
+
+class PrivateClass:
+    def privatemethod(self):
+        pass
+```
+
+Public contracts in private modules are defined by imports in the corresponding `__init__.py` in the same directory as the private module.
+
+```python
+# __init__.py
+
+from _my_module import PublicClass
+```
+
+#### Public Modules
+
+A public module (for example `my_module.py`) in this package will be defined with the following style:
+
+```python
+# my_module.py
+
+# The os module is not part of this file's external interface
+import os as _os
+
+# PublicClass is part of this file's external interface.
+class PublicClass:
+    def publicmethod(self):
+        pass
+
+    def _privatemethod(self):
+        pass
+
+# _PrivateClass is not part of this file's external interface.
+class _PrivateClass:
+    def publicmethod(self):
+        pass
+
+    def _privatemethod(self):
+        pass
+```
+
+#### On `import os as _os`
+
+Every module/symbol that is imported into a Python module becomes a part of that module's interface.
+Thus, if we have a module called `foo.py` such as:
+
+```python
+# foo.py
+
+import os
+```
+
+Then, the `os` module becomes part of the public interface for `foo.py` and a consumer of that module
+is free to do:
+
+```python
+from foo import os
+```
+
+We don't want all (generally, we don't want any) of our imports to become part of the public API for
+the module, so we import modules/symbols into a public module with the following style:
+
+```python
+import os as _os
+from typing import Dict as _Dict
+```
+
 ### Library Dependencies
 
 Library dependencies are Python packages required to build and run the Deadline Cloud Python project. Dependencies are specified in the `dependencies` section of `pyproject.toml`.


### PR DESCRIPTION
Fixes: No associated issue

### What was the problem/requirement? (What/Why)
Now that we track API changes/breakages in our CI, we need to have clear examples of what we expect out of our public API.

### What was the solution? (How)
Our OJD documentation already has a great example to pull from https://github.com/OpenJobDescription/openjd-sessions-for-python/blob/mainline/DEVELOPMENT.md#things-to-know

I just copied that over to the DEVELOPMENT.md here.

### What is the impact of this change?
Code authors now have a clear example to look at when making changes to our public API.

### How was this change tested?
N/A

### Was this change documented?
Yes

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [X] This PR does not add any new dependencies.

### Is this a breaking change?
No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
