### PR TITLE
feat: Add --timestamp-format relative option to 'job logs' command

### DIFF
--- a/src/deadline/client/cli/_groups/job_group.py
+++ b/src/deadline/client/cli/_groups/job_group.py
@@ -47,6 +47,7 @@ from .._common import _apply_cli_options_to_config, _cli_object_repr, _handle_er
 from .._main import deadline as main
 from ._sigint_handler import SigIntHandler
 from ...api._session import get_default_client_config
+from .._timestamp_formatter import TimestampFormat, TimestampFormatter
 
 logger = logging.getLogger("deadline.client.cli")
 
@@ -58,31 +59,6 @@ JSON_MSG_TYPE_PROGRESS = "progress"
 JSON_MSG_TYPE_SUMMARY = "summary"
 JSON_MSG_TYPE_ERROR = "error"
 JSON_MSG_TYPE_WARNING = "warning"
-
-
-def _format_timestamp(timestamp: datetime.datetime, use_local_time: bool = False) -> str:
-    """
-    Format a timestamp in ISO 8601 format with timezone information.
-
-    Args:
-        timestamp: The datetime object to format
-        use_local_time: If True, convert to local time; if False, keep as UTC
-
-    Returns:
-        Formatted timestamp string in ISO 8601 format with timezone
-    """
-    if use_local_time and timestamp.tzinfo is not None:
-        # Convert to local time
-        local_timestamp = timestamp.astimezone()
-        return local_timestamp.isoformat()
-    else:
-        # Keep as UTC - ensure it has timezone info
-        if timestamp.tzinfo is None:
-            # Assume naive datetime is UTC
-            utc_timestamp = timestamp.replace(tzinfo=datetime.timezone.utc)
-        else:
-            utc_timestamp = timestamp
-        return utc_timestamp.isoformat()
 
 
 def _parse_session_action_id(session_action_id: str) -> str:
@@ -1170,14 +1146,30 @@ def job_wait_for_completion(max_poll_interval, timeout, output, **args):
     help="Output format (verbose or json).",
 )
 @click.option(
+    "--timestamp-format",
+    type=click.Choice(["utc", "local", "relative"], case_sensitive=False),
+    default="utc",
+    help="Timestamp format for log entries (utc, local, or relative). Default is utc.",
+)
+@click.option(
     "--timezone",
     type=click.Choice(["utc", "local"], case_sensitive=False),
-    default="utc",
-    help="Timezone for timestamps (utc or local). Default is utc.",
+    help="[DEPRECATED] Use --timestamp-format instead. Timezone for timestamps (utc or local).",
 )
+@click.pass_context
 @_handle_error
 def job_logs(
-    session_id, session_action_id, limit, start_time, end_time, next_token, output, timezone, **args
+    ctx,
+    session_id,
+    session_action_id,
+    limit,
+    start_time,
+    end_time,
+    next_token,
+    output,
+    timestamp_format,
+    timezone,
+    **args,
 ):
     """
     Prints a [Deadline Cloud session log] stored in [CloudWatch logs] for the job.
@@ -1207,6 +1199,32 @@ def job_logs(
 
     is_json_output = output.lower() == "json"
 
+    # Check if --timestamp-format was explicitly provided by the user
+    timestamp_format_provided = (
+        ctx.get_parameter_source("timestamp_format") != click.core.ParameterSource.DEFAULT
+    )
+
+    # Handle timestamp format options and deprecation
+    if timezone and timestamp_format_provided:
+        raise DeadlineOperationError(
+            "Cannot use both --timezone and --timestamp-format options. Use --timestamp-format instead."
+        )
+
+    # Handle deprecation of --timezone option
+    if timezone:
+        # Only show deprecation warning for non-JSON output to avoid interfering with JSON parsing
+        if not is_json_output:
+            warning_message = (
+                f"Warning: --timezone is deprecated and will be removed in a future version. "
+                f"Use --timestamp-format {timezone} instead."
+            )
+            click.echo(warning_message, err=True)
+        # Map deprecated timezone values to new format
+        timestamp_format = timezone
+
+    # Convert timestamp_format to enum
+    timestamp_format_enum = TimestampFormat(timestamp_format.lower())
+
     # Handle session action ID if provided
     if session_action_id:
         # Parse session action ID to derive session ID
@@ -1227,8 +1245,6 @@ def job_logs(
     deadline = api.get_boto3_client("deadline", config=config)
     job = deadline.get_job(farmId=farm_id, queueId=queue_id, jobId=job_id)
     job_name = job["name"]
-
-    use_local_time = timezone.lower() == "local"
 
     # If session_id is not provided but job_id is, try to find the session
     if not session_id and job_id:
@@ -1327,6 +1343,9 @@ def job_logs(
                 f"Session action '{session_action_id}' has not started yet. No logs are available."
             )
 
+        # Set reference time for relative format (session action start time)
+        reference_start_time = action_start
+
         if not is_json_output:
             click.echo(f"Session action start: {action_start}")
         if action_end:
@@ -1370,6 +1389,25 @@ def job_logs(
         # Use the combined timestamps for log retrieval
         start_time = effective_start
         end_time = effective_end
+    else:
+        # Get session start time for the timestamp formatter
+        try:
+            session_details = deadline.get_session(
+                farmId=farm_id, queueId=queue_id, jobId=job_id, sessionId=session_id
+            )
+            try:
+                reference_start_time = session_details["startedAt"]
+            except KeyError:
+                raise DeadlineOperationError(
+                    f"Session '{session_id}' has not started yet."
+                ) from None
+        except ClientError as exc:
+            raise DeadlineOperationError(
+                f"Failed to retrieve session details for session ID '{session_id}':\n{exc}"
+            ) from exc
+
+    # Create timestamp formatter now that we have all necessary information
+    timestamp_formatter = TimestampFormatter(timestamp_format_enum, reference_start_time)
 
     try:
         result = api.get_session_logs(
@@ -1390,10 +1428,10 @@ def job_logs(
                 "jobName": job_name,
                 "events": [
                     {
-                        "timestamp": _format_timestamp(event.timestamp, use_local_time),
+                        "timestamp": timestamp_formatter.format_timestamp(event.timestamp),
                         "message": event.message,
                         "ingestionTime": (
-                            _format_timestamp(event.ingestion_time, use_local_time)
+                            timestamp_formatter.format_timestamp(event.ingestion_time)
                             if event.ingestion_time
                             else None
                         ),
@@ -1408,6 +1446,14 @@ def job_logs(
             }
             click.echo(json.dumps(response, indent=2))
         else:
+            # Display reference time for relative format
+            if (
+                timestamp_format_enum == TimestampFormat.RELATIVE
+                and timestamp_formatter.reference_start_time
+            ):
+                reference_display = timestamp_formatter.reference_start_time.isoformat()
+                click.echo(f"Logs relative to start time: {reference_display}")
+
             # Separate the logs by a blank line to make the start of the log easy to find.
             click.echo()
 
@@ -1417,7 +1463,7 @@ def job_logs(
                 return
 
             for event in result.events:
-                timestamp = _format_timestamp(event.timestamp, use_local_time)
+                timestamp = timestamp_formatter.format_timestamp(event.timestamp)
                 click.echo(f"[{timestamp}] {event.message}")
 
             click.echo(f"\nRetrieved {result.count} log events.")

--- a/src/deadline/client/cli/_timestamp_formatter.py
+++ b/src/deadline/client/cli/_timestamp_formatter.py
@@ -1,0 +1,71 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Timestamp formatting utilities for the Deadline CLI.
+"""
+
+from __future__ import annotations
+import datetime
+from enum import Enum
+
+
+class TimestampFormat(str, Enum):
+    """Enumeration of supported timestamp formats."""
+
+    UTC = "utc"
+    LOCAL = "local"
+    RELATIVE = "relative"
+
+
+class TimestampFormatter:
+    """
+    A utility class for formatting timestamps in different formats.
+
+    Supports UTC ISO format, local timezone ISO format, and relative time
+    from a reference timestamp.
+    """
+
+    def __init__(self, format_type: TimestampFormat, reference_start_time: datetime.datetime):
+        """
+        Initialize the TimestampFormatter.
+
+        Args:
+            format_type: The format type to use for timestamp formatting
+            reference_start_time: Reference timestamp for relative formatting
+        """
+        self.format_type = format_type
+
+        if reference_start_time.tzinfo is None:
+            raise ValueError("Reference time must have a timezone")
+
+        self.reference_start_time = reference_start_time
+
+    def format_timestamp(self, timestamp: datetime.datetime) -> str:
+        """
+        Format a timestamp according to the specified format type.
+
+        Args:
+            timestamp: The datetime object to format. It must have a timezone.
+
+        Returns:
+            Formatted timestamp string
+
+        Raises:
+            ValueError: If format type is unsupported
+        """
+        if timestamp.tzinfo is None:
+            raise ValueError("Timestamp must have a timezone")
+
+        if self.format_type == TimestampFormat.UTC:
+            utc_timestamp = timestamp.astimezone(datetime.timezone.utc)
+            return utc_timestamp.isoformat()
+        elif self.format_type == TimestampFormat.LOCAL:
+            local_timestamp = timestamp.astimezone()
+            return local_timestamp.isoformat()
+        elif self.format_type == TimestampFormat.RELATIVE:
+            time_delta = timestamp - self.reference_start_time
+            # Return the string representation of timedelta which matches Python's format
+            # This gives us "H:MM:SS.ffffff" format automatically
+            return str(time_delta)
+        else:
+            raise ValueError(f"Unsupported timestamp format: {self.format_type}")

--- a/test/unit/deadline_client/cli/test_cli_job_logs.py
+++ b/test/unit/deadline_client/cli/test_cli_job_logs.py
@@ -449,9 +449,13 @@ def test_cli_job_logs_with_job_id_single_session(fresh_deadline_config):
         mock_get_logs.return_value = api.SessionLogResult(
             events=[
                 api.LogEvent(
-                    timestamp=datetime.datetime(2023, 1, 27, 7, 24, 45),
+                    timestamp=datetime.datetime(
+                        2023, 1, 27, 7, 24, 45, tzinfo=datetime.timezone.utc
+                    ),
                     message="Test log message",
-                    ingestion_time=datetime.datetime(2023, 1, 27, 7, 24, 46),
+                    ingestion_time=datetime.datetime(
+                        2023, 1, 27, 7, 24, 46, tzinfo=datetime.timezone.utc
+                    ),
                     event_id="event-1",
                 ),
             ],
@@ -560,7 +564,9 @@ def test_cli_job_logs_with_pagination(fresh_deadline_config):
                 "sessions": [
                     {
                         "sessionId": "session-1",
-                        "endedAt": datetime.datetime(2023, 1, 27, 7, 0, 0),
+                        "endedAt": datetime.datetime(
+                            2023, 1, 27, 7, 0, 0, tzinfo=datetime.timezone.utc
+                        ),
                     }
                 ]
             },
@@ -568,7 +574,9 @@ def test_cli_job_logs_with_pagination(fresh_deadline_config):
                 "sessions": [
                     {
                         "sessionId": "session-2",
-                        "endedAt": datetime.datetime(2023, 1, 27, 8, 0, 0),
+                        "endedAt": datetime.datetime(
+                            2023, 1, 27, 8, 0, 0, tzinfo=datetime.timezone.utc
+                        ),
                     }
                 ]
             },
@@ -578,9 +586,11 @@ def test_cli_job_logs_with_pagination(fresh_deadline_config):
         mock_get_logs.return_value = api.SessionLogResult(
             events=[
                 api.LogEvent(
-                    timestamp=datetime.datetime(2023, 1, 27, 8, 0, 0),
+                    timestamp=datetime.datetime(2023, 1, 27, 8, 0, 0, tzinfo=datetime.timezone.utc),
                     message="Test log message",
-                    ingestion_time=datetime.datetime(2023, 1, 27, 8, 0, 1),
+                    ingestion_time=datetime.datetime(
+                        2023, 1, 27, 8, 0, 1, tzinfo=datetime.timezone.utc
+                    ),
                     event_id="event-1",
                 ),
             ],
@@ -648,30 +658,34 @@ def test_cli_job_logs_with_job_id_prioritizes_ongoing_sessions(fresh_deadline_co
                         "sessions": [
                             {
                                 "sessionId": "session-completed-recent",
-                                "startedAt": datetime.datetime(2023, 1, 27, 8, 0, 0),
+                                "startedAt": datetime.datetime(
+                                    2023, 1, 27, 8, 0, 0, tzinfo=datetime.timezone.utc
+                                ),
                                 "endedAt": datetime.datetime(
-                                    2023, 1, 27, 9, 0, 0
+                                    2023, 1, 27, 9, 0, 0, tzinfo=datetime.timezone.utc
                                 ),  # Most recent completion
                             },
                             {
                                 "sessionId": "session-ongoing-older",
                                 "startedAt": datetime.datetime(
-                                    2023, 1, 27, 6, 0, 0
+                                    2023, 1, 27, 6, 0, 0, tzinfo=datetime.timezone.utc
                                 ),  # Ongoing but older
                                 # No endedAt - this is ongoing
                             },
                             {
                                 "sessionId": "session-ongoing-newer",
                                 "startedAt": datetime.datetime(
-                                    2023, 1, 27, 7, 30, 0
+                                    2023, 1, 27, 7, 30, 0, tzinfo=datetime.timezone.utc
                                 ),  # Ongoing and newer
                                 # No endedAt - this is ongoing
                             },
                             {
                                 "sessionId": "session-completed-older",
-                                "startedAt": datetime.datetime(2023, 1, 27, 5, 0, 0),
+                                "startedAt": datetime.datetime(
+                                    2023, 1, 27, 5, 0, 0, tzinfo=datetime.timezone.utc
+                                ),
                                 "endedAt": datetime.datetime(
-                                    2023, 1, 27, 6, 0, 0
+                                    2023, 1, 27, 6, 0, 0, tzinfo=datetime.timezone.utc
                                 ),  # Older completion
                             },
                         ]
@@ -682,9 +696,13 @@ def test_cli_job_logs_with_job_id_prioritizes_ongoing_sessions(fresh_deadline_co
                 mock_get_logs.return_value = api.SessionLogResult(
                     events=[
                         api.LogEvent(
-                            timestamp=datetime.datetime(2023, 1, 27, 7, 30, 0),
+                            timestamp=datetime.datetime(
+                                2023, 1, 27, 7, 30, 0, tzinfo=datetime.timezone.utc
+                            ),
                             message="Ongoing session log message",
-                            ingestion_time=datetime.datetime(2023, 1, 27, 7, 30, 1),
+                            ingestion_time=datetime.datetime(
+                                2023, 1, 27, 7, 30, 1, tzinfo=datetime.timezone.utc
+                            ),
                             event_id="event-1",
                         ),
                     ],
@@ -718,9 +736,11 @@ def test_cli_job_logs_with_job_id_prioritizes_ongoing_sessions(fresh_deadline_co
                 )
 
                 # Check output
-                assert "Using the latest session: session-ongoing-newer" in result.output
-                assert "Ongoing session log message" in result.output
-                assert result.exit_code == 0
+                assert "Using the latest session: session-ongoing-newer" in result.output, (
+                    result.output
+                )
+                assert "Ongoing session log message" in result.output, result.output
+                assert result.exit_code == 0, result.output
 
 
 def test_cli_job_logs_with_job_id_selects_most_recent_completed_when_no_ongoing(
@@ -748,16 +768,20 @@ def test_cli_job_logs_with_job_id_selects_most_recent_completed_when_no_ongoing(
                         "sessions": [
                             {
                                 "sessionId": "session-completed-older",
-                                "startedAt": datetime.datetime(2023, 1, 27, 6, 0, 0),
+                                "startedAt": datetime.datetime(
+                                    2023, 1, 27, 6, 0, 0, tzinfo=datetime.timezone.utc
+                                ),
                                 "endedAt": datetime.datetime(
-                                    2023, 1, 27, 7, 0, 0
+                                    2023, 1, 27, 7, 0, 0, tzinfo=datetime.timezone.utc
                                 ),  # Older completion
                             },
                             {
                                 "sessionId": "session-completed-newer",
-                                "startedAt": datetime.datetime(2023, 1, 27, 8, 0, 0),
+                                "startedAt": datetime.datetime(
+                                    2023, 1, 27, 8, 0, 0, tzinfo=datetime.timezone.utc
+                                ),
                                 "endedAt": datetime.datetime(
-                                    2023, 1, 27, 9, 0, 0
+                                    2023, 1, 27, 9, 0, 0, tzinfo=datetime.timezone.utc
                                 ),  # Most recent completion
                             },
                         ]
@@ -768,9 +792,13 @@ def test_cli_job_logs_with_job_id_selects_most_recent_completed_when_no_ongoing(
                 mock_get_logs.return_value = api.SessionLogResult(
                     events=[
                         api.LogEvent(
-                            timestamp=datetime.datetime(2023, 1, 27, 9, 0, 0),
+                            timestamp=datetime.datetime(
+                                2023, 1, 27, 9, 0, 0, tzinfo=datetime.timezone.utc
+                            ),
                             message="Most recent completed session log",
-                            ingestion_time=datetime.datetime(2023, 1, 27, 9, 0, 1),
+                            ingestion_time=datetime.datetime(
+                                2023, 1, 27, 9, 0, 1, tzinfo=datetime.timezone.utc
+                            ),
                             event_id="event-1",
                         ),
                     ],
@@ -804,9 +832,11 @@ def test_cli_job_logs_with_job_id_selects_most_recent_completed_when_no_ongoing(
                 )
 
                 # Check output
-                assert "Using the latest session: session-completed-newer" in result.output
-                assert "Most recent completed session log" in result.output
-                assert result.exit_code == 0
+                assert "Using the latest session: session-completed-newer" in result.output, (
+                    result.output
+                )
+                assert "Most recent completed session log" in result.output, result.output
+                assert result.exit_code == 0, result.output
 
 
 def test_cli_job_logs_with_job_id_selects_most_recent_among_multiple_ongoing(fresh_deadline_config):
@@ -833,21 +863,21 @@ def test_cli_job_logs_with_job_id_selects_most_recent_among_multiple_ongoing(fre
                             {
                                 "sessionId": "session-ongoing-oldest",
                                 "startedAt": datetime.datetime(
-                                    2023, 1, 27, 5, 0, 0
+                                    2023, 1, 27, 5, 0, 0, tzinfo=datetime.timezone.utc
                                 ),  # Oldest ongoing
                                 # No endedAt - this is ongoing
                             },
                             {
                                 "sessionId": "session-ongoing-middle",
                                 "startedAt": datetime.datetime(
-                                    2023, 1, 27, 6, 0, 0
+                                    2023, 1, 27, 6, 0, 0, tzinfo=datetime.timezone.utc
                                 ),  # Middle ongoing
                                 # No endedAt - this is ongoing
                             },
                             {
                                 "sessionId": "session-ongoing-newest",
                                 "startedAt": datetime.datetime(
-                                    2023, 1, 27, 7, 0, 0
+                                    2023, 1, 27, 7, 0, 0, tzinfo=datetime.timezone.utc
                                 ),  # Most recent ongoing
                                 # No endedAt - this is ongoing
                             },
@@ -862,9 +892,13 @@ def test_cli_job_logs_with_job_id_selects_most_recent_among_multiple_ongoing(fre
                 mock_get_logs.return_value = api.SessionLogResult(
                     events=[
                         api.LogEvent(
-                            timestamp=datetime.datetime(2023, 1, 27, 7, 0, 0),
+                            timestamp=datetime.datetime(
+                                2023, 1, 27, 7, 0, 0, tzinfo=datetime.timezone.utc
+                            ),
                             message="Most recent ongoing session log",
-                            ingestion_time=datetime.datetime(2023, 1, 27, 7, 0, 1),
+                            ingestion_time=datetime.datetime(
+                                2023, 1, 27, 7, 0, 1, tzinfo=datetime.timezone.utc
+                            ),
                             event_id="event-1",
                         ),
                     ],
@@ -2401,3 +2435,239 @@ def test_time_range_intersection_error_message_includes_both_ranges(
     assert "Specified time range:" in result.output
     assert user_start in result.output
     assert user_end in result.output
+
+
+# ===== Tests for --timestamp-format CLI Option =====
+
+
+def test_cli_job_logs_timestamp_format_utc(fresh_deadline_config):
+    """
+    Test that logs CLI works correctly with --timestamp-format utc.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
+
+    with patch("deadline.client.api.get_session_logs") as mock_get_logs, patch(
+        "deadline.client.api._job_monitoring.get_user_and_identity_store_id"
+    ) as mock_get_user, patch("deadline.client.api.get_boto3_client") as boto3_client_mock:
+        mock_get_user.return_value = (None, None)
+        mock_get_logs.return_value = SAMPLE_LOG_RESULT
+
+        # Mock get_job to return job name
+        boto3_client_mock().get_job.return_value = {"name": "Test Job Name"}
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main, ["job", "logs", "--session-id", "test-session", "--timestamp-format", "utc"]
+        )
+
+        # Verify UTC timestamps are displayed
+        assert "[2023-01-01T12:00:00.123456+00:00] Log message 1" in result.output
+        assert "[2023-01-01T12:01:00.789012+00:00] Log message 2" in result.output
+        assert result.exit_code == 0
+
+
+def test_cli_job_logs_timestamp_format_local(fresh_deadline_config):
+    """
+    Test that logs CLI works correctly with --timestamp-format local.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
+
+    with patch("deadline.client.api.get_session_logs") as mock_get_logs, patch(
+        "deadline.client.api._job_monitoring.get_user_and_identity_store_id"
+    ) as mock_get_user, patch("deadline.client.api.get_boto3_client") as boto3_client_mock:
+        mock_get_user.return_value = (None, None)
+        mock_get_logs.return_value = SAMPLE_LOG_RESULT
+
+        # Mock get_job to return job name
+        boto3_client_mock().get_job.return_value = {"name": "Test Job Name"}
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main, ["job", "logs", "--session-id", "test-session", "--timestamp-format", "local"]
+        )
+
+        # The exact local time will depend on the system timezone, but we can verify
+        # that the format is ISO 8601 and that the command succeeds
+        assert "Log message 1" in result.output
+        assert "Log message 2" in result.output
+        # Check that timestamps contain 'T' (ISO format) and timezone offset
+        assert "T" in result.output
+        assert "+" in result.output or "-" in result.output  # timezone offset
+        assert result.exit_code == 0
+
+
+def test_cli_job_logs_timestamp_format_relative(fresh_deadline_config):
+    """
+    Test that logs CLI works correctly with --timestamp-format relative.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
+
+    session_start_time = datetime.datetime(2023, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
+
+    with patch("deadline.client.api.get_session_logs") as mock_get_logs, patch(
+        "deadline.client.api._job_monitoring.get_user_and_identity_store_id"
+    ) as mock_get_user, patch("deadline.client.api.get_boto3_client") as boto3_client_mock:
+        mock_get_user.return_value = (None, None)
+        mock_get_logs.return_value = SAMPLE_LOG_RESULT
+
+        # Mock get_job to return job name
+        boto3_client_mock().get_job.return_value = {"name": "Test Job Name"}
+
+        # Mock get_session to return session details with start time
+        boto3_client_mock().get_session.return_value = {
+            "sessionId": "test-session",
+            "startedAt": session_start_time,
+        }
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main, ["job", "logs", "--session-id", "test-session", "--timestamp-format", "relative"]
+        )
+
+        # Verify relative timestamps are displayed
+        # First event is at 12:00:00.123456, session starts at 12:00:00, so relative is 0:00:00.123456
+        assert "[0:00:00.123456] Log message 1" in result.output
+        # Second event is at 12:01:00.789012, session starts at 12:00:00, so relative is 0:01:00.789012
+        assert "[0:01:00.789012] Log message 2" in result.output
+        # Verify reference time is displayed
+        assert "Logs relative to start time: 2023-01-01T12:00:00+00:00" in result.output
+        assert result.exit_code == 0
+
+
+def test_cli_job_logs_timestamp_format_default(fresh_deadline_config):
+    """
+    Test that logs CLI defaults to UTC format when no --timestamp-format is provided.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
+
+    with patch("deadline.client.api.get_session_logs") as mock_get_logs, patch(
+        "deadline.client.api._job_monitoring.get_user_and_identity_store_id"
+    ) as mock_get_user, patch("deadline.client.api.get_boto3_client") as boto3_client_mock:
+        mock_get_user.return_value = (None, None)
+        mock_get_logs.return_value = SAMPLE_LOG_RESULT
+
+        # Mock get_job to return job name
+        boto3_client_mock().get_job.return_value = {"name": "Test Job Name"}
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["job", "logs", "--session-id", "test-session"])
+
+        # Verify UTC timestamps are displayed (default behavior)
+        assert "[2023-01-01T12:00:00.123456+00:00] Log message 1" in result.output
+        assert "[2023-01-01T12:01:00.789012+00:00] Log message 2" in result.output
+        assert result.exit_code == 0
+
+
+def test_cli_job_logs_timestamp_format_invalid(fresh_deadline_config):
+    """
+    Test that logs CLI rejects invalid --timestamp-format values.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["job", "logs", "--session-id", "test-session", "--timestamp-format", "invalid"]
+    )
+
+    # Verify error message is displayed
+    assert "Invalid value for '--timestamp-format'" in result.output
+    assert result.exit_code != 0
+
+
+def test_cli_job_logs_timezone_and_timestamp_format_mutual_exclusivity(fresh_deadline_config):
+    """
+    Test that using both --timezone and --timestamp-format options raises an error.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "job",
+            "logs",
+            "--session-id",
+            "test-session",
+            "--timezone",
+            "utc",
+            "--timestamp-format",
+            "local",
+        ],
+    )
+
+    # Verify error message about mutual exclusivity
+    assert "Cannot use both --timezone and --timestamp-format options" in result.output
+    assert result.exit_code != 0
+
+
+def test_cli_job_logs_timezone_deprecation_warning_utc(fresh_deadline_config):
+    """
+    Test that using --timezone utc displays a deprecation warning.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
+
+    with patch("deadline.client.api.get_session_logs") as mock_get_logs, patch(
+        "deadline.client.api._job_monitoring.get_user_and_identity_store_id"
+    ) as mock_get_user, patch("deadline.client.api.get_boto3_client") as boto3_client_mock:
+        mock_get_user.return_value = (None, None)
+        mock_get_logs.return_value = SAMPLE_LOG_RESULT
+
+        # Mock get_job to return job name
+        boto3_client_mock().get_job.return_value = {"name": "Test Job Name"}
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main, ["job", "logs", "--session-id", "test-session", "--timezone", "utc"]
+        )
+
+        # Verify deprecation warning is displayed
+        assert "Warning: --timezone is deprecated" in result.output
+        assert "Use --timestamp-format utc instead" in result.output
+        # Verify the command still works with UTC format
+        assert "[2023-01-01T12:00:00.123456+00:00] Log message 1" in result.output
+        assert result.exit_code == 0
+
+
+def test_cli_job_logs_timezone_deprecation_warning_local(fresh_deadline_config):
+    """
+    Test that using --timezone local displays a deprecation warning.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
+
+    with patch("deadline.client.api.get_session_logs") as mock_get_logs, patch(
+        "deadline.client.api._job_monitoring.get_user_and_identity_store_id"
+    ) as mock_get_user, patch("deadline.client.api.get_boto3_client") as boto3_client_mock:
+        mock_get_user.return_value = (None, None)
+        mock_get_logs.return_value = SAMPLE_LOG_RESULT
+
+        # Mock get_job to return job name
+        boto3_client_mock().get_job.return_value = {"name": "Test Job Name"}
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main, ["job", "logs", "--session-id", "test-session", "--timezone", "local"]
+        )
+
+        # Verify deprecation warning is displayed
+        assert "Warning: --timezone is deprecated" in result.output
+        assert "Use --timestamp-format local instead" in result.output
+        # Verify the command still works with local format
+        assert "Log message 1" in result.output
+        assert "Log message 2" in result.output
+        assert result.exit_code == 0

--- a/test/unit/deadline_client/cli/test_timestamp_formatter.py
+++ b/test/unit/deadline_client/cli/test_timestamp_formatter.py
@@ -1,0 +1,228 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Tests for the TimestampFormatter utility class.
+"""
+
+import datetime
+import pytest
+
+from deadline.client.cli._timestamp_formatter import TimestampFormatter, TimestampFormat
+
+# Valid timezone offset patterns for testing
+VALID_TIMEZONE_OFFSETS = [
+    "+00",
+    "+01",
+    "+02",
+    "+03",
+    "+04",
+    "+05",
+    "+06",
+    "+07",
+    "+08",
+    "+09",
+    "+10",
+    "+11",
+    "+12",
+    "-01",
+    "-02",
+    "-03",
+    "-04",
+    "-05",
+    "-06",
+    "-07",
+    "-08",
+    "-09",
+    "-10",
+    "-11",
+    "-12",
+]
+
+
+class TestTimestampFormatter:
+    """Test cases for the TimestampFormatter class."""
+
+    def test_utc_format_with_utc_timestamp(self):
+        """Test UTC format with a UTC timestamp."""
+        formatter = TimestampFormatter(
+            TimestampFormat.UTC, datetime.datetime.now(tz=datetime.timezone.utc)
+        )
+        timestamp = datetime.datetime(2023, 1, 1, 12, 0, 0, 123456, tzinfo=datetime.timezone.utc)
+
+        result = formatter.format_timestamp(timestamp)
+
+        assert result == "2023-01-01T12:00:00.123456+00:00"
+
+    def test_utc_format_with_non_utc_timestamp(self):
+        """Test UTC format with a non-UTC timestamp."""
+        formatter = TimestampFormatter(
+            TimestampFormat.UTC, datetime.datetime.now(tz=datetime.timezone.utc)
+        )
+        # Create a timestamp in EST (UTC-5)
+        est_tz = datetime.timezone(datetime.timedelta(hours=-5))
+        timestamp = datetime.datetime(2023, 1, 1, 7, 0, 0, 123456, tzinfo=est_tz)
+
+        result = formatter.format_timestamp(timestamp)
+
+        # Should be converted to UTC (7 AM EST = 12 PM UTC)
+        assert result == "2023-01-01T12:00:00.123456+00:00"
+
+    def test_local_format_with_utc_timestamp(self):
+        """Test LOCAL format with a UTC timestamp."""
+        formatter = TimestampFormatter(
+            TimestampFormat.LOCAL, datetime.datetime.now(tz=datetime.timezone.utc)
+        )
+        timestamp = datetime.datetime(2023, 1, 1, 12, 0, 0, 123456, tzinfo=datetime.timezone.utc)
+
+        result = formatter.format_timestamp(timestamp)
+
+        # Result will depend on system timezone, but should be in ISO format
+        assert "2023-01-01T" in result
+        assert ".123456" in result
+        # Should have timezone offset (either +HH:MM or -HH:MM format)
+        assert result[-6:-3] in VALID_TIMEZONE_OFFSETS
+        assert result.endswith(":00")
+
+    def test_local_format_with_non_utc_timestamp(self):
+        """Test LOCAL format with a non-UTC timestamp."""
+        formatter = TimestampFormatter(
+            TimestampFormat.LOCAL, datetime.datetime.now(tz=datetime.timezone.utc)
+        )
+        # Create a timestamp in EST (UTC-5)
+        est_tz = datetime.timezone(datetime.timedelta(hours=-5))
+        timestamp = datetime.datetime(2023, 1, 1, 7, 0, 0, 123456, tzinfo=est_tz)
+
+        result = formatter.format_timestamp(timestamp)
+
+        # Result will depend on system timezone, but should be in ISO format
+        assert "2023-01-01T" in result
+        assert ".123456" in result
+        # Should have timezone offset
+        assert result[-6:-3] in VALID_TIMEZONE_OFFSETS
+        assert result.endswith(":00")
+
+    def test_local_format_timezone_conversion_consistency(self):
+        """Test LOCAL format converts different input timezones to same local time."""
+        formatter = TimestampFormatter(
+            TimestampFormat.LOCAL, datetime.datetime.now(tz=datetime.timezone.utc)
+        )
+
+        # Create the same moment in time using different timezone representations
+        utc_timestamp = datetime.datetime(
+            2023, 1, 1, 12, 0, 0, 123456, tzinfo=datetime.timezone.utc
+        )
+        est_tz = datetime.timezone(datetime.timedelta(hours=-5))
+        est_timestamp = datetime.datetime(
+            2023, 1, 1, 7, 0, 0, 123456, tzinfo=est_tz
+        )  # Same moment as UTC 12:00
+        pst_tz = datetime.timezone(datetime.timedelta(hours=-8))
+        pst_timestamp = datetime.datetime(
+            2023, 1, 1, 4, 0, 0, 123456, tzinfo=pst_tz
+        )  # Same moment as UTC 12:00
+
+        utc_result = formatter.format_timestamp(utc_timestamp)
+        est_result = formatter.format_timestamp(est_timestamp)
+        pst_result = formatter.format_timestamp(pst_timestamp)
+
+        # All should convert to the same local time since they represent the same moment
+        assert utc_result == est_result == pst_result
+
+    def test_relative_format_with_positive_delta(self):
+        """Test RELATIVE format with a positive time delta."""
+        reference_start_time = datetime.datetime(2023, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
+        formatter = TimestampFormatter(TimestampFormat.RELATIVE, reference_start_time)
+
+        # Timestamp 1 hour, 23 minutes, 45 seconds, and 123456 microseconds after reference
+        timestamp = datetime.datetime(2023, 1, 1, 13, 23, 45, 123456, tzinfo=datetime.timezone.utc)
+
+        result = formatter.format_timestamp(timestamp)
+
+        assert result == "1:23:45.123456"
+
+    def test_relative_format_with_zero_delta(self):
+        """Test RELATIVE format when timestamp equals reference time."""
+        reference_start_time = datetime.datetime(2023, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
+        formatter = TimestampFormatter(TimestampFormat.RELATIVE, reference_start_time)
+
+        result = formatter.format_timestamp(reference_start_time)
+
+        assert result == "0:00:00"
+
+    def test_relative_format_with_negative_delta(self):
+        """Test RELATIVE format with a negative time delta."""
+        reference_start_time = datetime.datetime(2023, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
+        formatter = TimestampFormatter(TimestampFormat.RELATIVE, reference_start_time)
+
+        # Timestamp 30 minutes before reference
+        timestamp = datetime.datetime(2023, 1, 1, 11, 30, 0, tzinfo=datetime.timezone.utc)
+
+        result = formatter.format_timestamp(timestamp)
+
+        assert result == "-1 day, 23:30:00"
+
+    def test_relative_format_with_different_timezones(self):
+        """Test RELATIVE format with timestamps in different timezones."""
+        reference_start_time = datetime.datetime(2023, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
+        formatter = TimestampFormatter(TimestampFormat.RELATIVE, reference_start_time)
+
+        # Create timestamp in EST (UTC-5) that represents the same moment as 13:00 UTC
+        est_tz = datetime.timezone(datetime.timedelta(hours=-5))
+        timestamp = datetime.datetime(2023, 1, 1, 8, 0, 0, tzinfo=est_tz)  # 8 AM EST = 1 PM UTC
+
+        result = formatter.format_timestamp(timestamp)
+
+        assert result == "1:00:00"
+
+    def test_relative_format_with_microseconds(self):
+        """Test RELATIVE format preserves microseconds."""
+        reference_start_time = datetime.datetime(
+            2023, 1, 1, 12, 0, 0, 100000, tzinfo=datetime.timezone.utc
+        )
+        formatter = TimestampFormatter(TimestampFormat.RELATIVE, reference_start_time)
+
+        # Timestamp 1.5 seconds after reference
+        timestamp = datetime.datetime(2023, 1, 1, 12, 0, 1, 600000, tzinfo=datetime.timezone.utc)
+
+        result = formatter.format_timestamp(timestamp)
+
+        assert result == "0:00:01.500000"
+
+    def test_init_relative_format_with_timezone_naive_reference(self):
+        """Test that RELATIVE format requires reference time with timezone."""
+        reference_start_time = datetime.datetime(2023, 1, 1, 12, 0, 0)  # No timezone
+
+        with pytest.raises(ValueError, match="Reference time must have a timezone"):
+            TimestampFormatter(TimestampFormat.RELATIVE, reference_start_time)
+
+    def test_init_utc_format_with_reference_start_time(self):
+        """Test that UTC format can be initialized with reference time (ignored)."""
+        reference_start_time = datetime.datetime(2023, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
+        formatter = TimestampFormatter(TimestampFormat.UTC, reference_start_time)
+
+        assert formatter.reference_start_time == reference_start_time
+
+    def test_init_local_format_with_reference_start_time(self):
+        """Test that LOCAL format can be initialized with reference time (ignored)."""
+        reference_start_time = datetime.datetime(2023, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
+        formatter = TimestampFormatter(TimestampFormat.LOCAL, reference_start_time)
+
+        assert formatter.reference_start_time == reference_start_time
+
+    def test_format_timestamp_with_timezone_naive_timestamp(self):
+        """Test that format_timestamp raises error for timezone-naive timestamps."""
+        formatter = TimestampFormatter(
+            TimestampFormat.UTC, datetime.datetime.now(tz=datetime.timezone.utc)
+        )
+        timestamp = datetime.datetime(2023, 1, 1, 12, 0, 0)  # No timezone
+
+        with pytest.raises(ValueError, match="Timestamp must have a timezone"):
+            formatter.format_timestamp(timestamp)
+
+    def test_format_timestamp_with_timezone_naive_timestamp_relative(self):
+        """Test that format_timestamp raises error for timezone-naive timestamps in relative mode."""
+        reference_start_time = datetime.datetime(2023, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
+        formatter = TimestampFormatter(TimestampFormat.RELATIVE, reference_start_time)
+        timestamp = datetime.datetime(2023, 1, 1, 13, 0, 0)  # No timezone
+
+        with pytest.raises(ValueError, match="Timestamp must have a timezone"):
+            formatter.format_timestamp(timestamp)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The 'deadline job logs' command prints out logs from running parts of a job. It has an option `--timezone` that lets you select utc or local. All the entities that it is printing logs for have starting times, and it is natural to think of event times relative to those starting times, so an option to enable that would be helpful.

### What was the solution? (How)

`--timezone relative` doesn't really make sense, so instead this takes precedent from the OpenJD CLI that offers a `--timestamp-format` option with utc, local, or relative inputs.

This also marks the --timezone option as deprecated. When we remove that in the future, it will be a breaking change for the CLI interface.

This change was authored with assistance from [Kiro](https://kiro.dev/).

### What is the impact of this change?

Here's example output of a session action with the relative option:

```
$ deadline job logs --session-id session-123 --job-id job-123 --timestamp-format relative --limit 10000 --session-action-id sessionaction-123-9
Retrieving logs for session action sessionaction-123-9 from log group /aws/deadline/farm-123/queue-123...
Job ID: job-123
Job Name: Maya/Arnold Tiled Render
Session action start: 2025-10-25 00:40:35.001000+00:00
Session action end: 2025-10-25 00:40:41.040000+00:00
Session action duration: 0:00:06.039000
Logs relative to start time: 2025-10-25T00:40:35.001000+00:00

[0:00:00]
[0:00:00] ==============================================
[0:00:00] --------- Running Task
[0:00:00] ==============================================
[0:00:00] Parameter values:
[0:00:00] Frame(INT) = 7
[0:00:00.001000] ----------------------------------------------
[0:00:00.001000] Phase: Setup
[0:00:00.001000] ----------------------------------------------
[0:00:00.001000] Writing embedded files for Task to disk.
...
```

Similarly for the session itself:

```
$ deadline job logs --session-id session-123 --job-id job-123 --timestamp-format relative --limit 10000
Retrieving logs for session session-123 from log group /aws/deadline/farm-123 /queue-123...
Job ID: job-123
Job Name: Maya/Arnold Tiled Render
Logs relative to start time: 2025-10-25T00:39:24.150000+00:00

[0:00:14.219000] Running Session Actions as user: job-user
[0:00:14.744000] ==============================================
[0:00:14.744000] --------- Job Attachments Download for Job
[0:00:14.744000] ==============================================
[0:00:14.814000] Using saved path /opt/deadline_vfs/bin/deadline_vfs
...
```

Compare the readability to local timestamp format. In relative format, it's easier to compare the time taken from line to line, and from the start of the session or session action.

```
$ deadline job logs --session-id session-123 --job-id job-123 --timestamp-format local --limit 10000
Retrieving logs for session session-123 from log group /aws/deadline/farm-123 /queue-123...
Job ID: job-123
Job Name: Maya/Arnold Tiled Render

[2025-10-24T17:39:38.369000-07:00] Running Session Actions as user: job-user
[2025-10-24T17:39:38.894000-07:00] ==============================================
[2025-10-24T17:39:38.894000-07:00] --------- Job Attachments Download for Job
[2025-10-24T17:39:38.894000-07:00] ==============================================
[2025-10-24T17:39:38.964000-07:00] Using saved path /opt/deadline_vfs/bin/deadline_vfs
...
```

### How was this change tested?

Implemented unit tests and ran some manual tests of output.

### Was this change documented?

Here's how the new/changed parts look in the help output:

```
  --timestamp-format [utc|local|relative]
                                  Timestamp format for log entries (utc,
                                  local, or relative). Default is utc.
  --timezone [utc|local]          [DEPRECATED] Use --timestamp-format instead.
                                  Timezone for timestamps (utc or local).
```

### Does this PR introduce new dependencies?

No

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
