### PR TITLE
chore: fix 3.12 installer builds

### DIFF
--- a/scripts/attributions/cli.py
+++ b/scripts/attributions/cli.py
@@ -225,11 +225,11 @@ _EXPECTED_MISSING_LICENSE = {"pywin32"}
 
 def _get_desired_python_version() -> str:
     if platform.system() == "Darwin":
-        return "3.13"
+        return "3.12"
     elif platform.system() == "Windows":
-        return "3.13"
+        return "3.12"
     elif platform.system() == "Linux":
-        return "3.13"
+        return "3.12"
     raise RuntimeError("Platform not supported")
 
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Installer builds which use 3.13 were failing for 3.12 

### What was the solution? (How)

Change the expected version
