### PR TITLE
chore: Explicitly call main in deadline_cli_main.py to fix pyinstaller executables

### DIFF
--- a/src/deadline/client/cli/deadline_cli_main.py
+++ b/src/deadline/client/cli/deadline_cli_main.py
@@ -8,3 +8,6 @@ Required by pyinstaller, do not delete.
 from deadline.client.cli._main import deadline as main
 
 __all__ = ["main"]
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Pyinstaller executables for deadline-cloud were completely broken and not doing anything.

### What was the solution? (How)

Running a build built with pyinstallers debug option showed that deadline_cli_main.py was being run, but nothing was happening. I added an explicit call to main() from here, which caused it to work again.

### What is the impact of this change?

Executables will work again

### How was this change tested?

I build a pyinstaller executable and ran `deadline --version` and verified that it now printed the version rather than doing nothing. I also ran the same command through a normal Python interpreter to make sure it didn't break anything when not running through pyinstaller.

### Was this change documented?

N/A

### Does this PR introduce new dependencies?

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?

No, this is a fixing change

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
