### PR TITLE
fix: Add backoff retry when opening HashDB. Also ensure each test is …

### DIFF
--- a/src/deadline/job_attachments/caches/cache_db.py
+++ b/src/deadline/job_attachments/caches/cache_db.py
@@ -12,6 +12,7 @@ from threading import Lock
 from typing import Optional
 
 from ..exceptions import JobAttachmentsError
+from .._utils import _retry
 
 CONFIG_ROOT = ".deadline"
 COMPONENT_NAME = "job_attachments"
@@ -26,6 +27,9 @@ class CacheDB(ABC):
     This class is intended to always be used with a context manager to properly
     close the connection to the cache database.
     """
+
+    # Number of retry attempts for SQLite operational errors (e.g., database locks)
+    _RETRY_ATTEMPTS = 3
 
     def __init__(
         self, cache_name: str, table_name: str, create_query: str, cache_dir: Optional[str] = None
@@ -63,24 +67,39 @@ class CacheDB(ABC):
         if self.enabled:
             import sqlite3
 
-            try:
-                self.db_connection: sqlite3.Connection = sqlite3.connect(
-                    self.cache_dir, check_same_thread=False
-                )
-                self.db_connection.execute("PRAGMA journal_mode=WAL")
-            except sqlite3.OperationalError as oe:
-                raise JobAttachmentsError(
-                    f"Could not access cache file in {self.cache_dir}"
-                ) from oe
+            @_retry(
+                ExceptionToCheck=sqlite3.OperationalError,
+                tries=self._RETRY_ATTEMPTS,
+                delay=(0.5, 1.5),  # Jitter between 0.5 and 1.5 seconds
+                backoff=1.0,
+                logger=logger.warning,
+            )
+            def _connect_to_db():
+                """
+                Connect to the SQLite database and ensure the table exists.
+
+                Raises:
+                    sqlite3.OperationalError: If there is an error connecting to the database.
+                """
+                connection = sqlite3.connect(self.cache_dir, check_same_thread=False)
+                connection.execute("PRAGMA journal_mode=WAL")
+                try:
+                    # Test the connection by trying to query the table
+                    connection.execute(f"SELECT * FROM {self.table_name}")
+                except Exception:
+                    # DB file doesn't have our table, so we need to create it
+                    logger.info(
+                        f"No cache entries for the current library version were found. Creating a new cache for {self.cache_name}"
+                    )
+                    connection.execute(self.create_query)
+                return connection
 
             try:
-                self.db_connection.execute(f"SELECT * FROM {self.table_name}")
-            except Exception:
-                # DB file doesn't have our table, so we need to create it
-                logger.info(
-                    f"No cache entries for the current library version were found. Creating a new cache for {self.cache_name}"
-                )
-                self.db_connection.execute(self.create_query)
+                self.db_connection = _connect_to_db()
+            except sqlite3.OperationalError as oe:
+                raise JobAttachmentsError(
+                    f"Could not access cache file after {self._RETRY_ATTEMPTS} retry attempts: {self.cache_dir}"
+                ) from oe
         return self
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
@@ -105,12 +124,30 @@ class CacheDB(ABC):
         import sqlite3
 
         if not hasattr(self._local, "connection"):
+
+            @_retry(
+                ExceptionToCheck=sqlite3.OperationalError,
+                tries=self._RETRY_ATTEMPTS,
+                delay=(0.5, 1.5),  # Jitter between 0.5 and 1.5 seconds
+                backoff=1.0,
+                logger=logger.warning,
+            )
+            def _create_local_connection():
+                """
+                Create a local SQLite connection.
+
+                Raises:
+                    sqlite3.OperationalError: If there is an error connecting to the database.
+                """
+                connection = sqlite3.connect(self.cache_dir, check_same_thread=False)
+                return connection
+
             try:
-                self._local.connection = sqlite3.connect(self.cache_dir, check_same_thread=False)
+                self._local.connection = _create_local_connection()
                 self._local_connections.add(self._local.connection)
             except sqlite3.OperationalError as oe:
                 raise JobAttachmentsError(
-                    f"Could not create connection to cache in {self.cache_dir}"
+                    f"Could not create connection to cache after {self._RETRY_ATTEMPTS} retry attempts: {self.cache_dir}"
                 ) from oe
 
         return self._local.connection

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -13,10 +13,13 @@ from deadline.client.config import config_file
 
 
 @pytest.fixture(scope="function")
-def fresh_deadline_config():
+def fresh_deadline_config(monkeypatch):
     """
-    Fixture to start with a blank AWS Deadline Cloud config file.
+    Fixture to start with a blank AWS Deadline Cloud config file and isolated cache directories.
 
+    This fixture also overrides the HOME environment variable to ensure cache isolation
+    between tests. Both HashCache and S3CheckCache will use temporary directories under
+    the isolated HOME directory.
     """
 
     # Clear the session cache. Importing the cache invalidator at runtime is necessary
@@ -33,6 +36,23 @@ def fresh_deadline_config():
         with open(temp_file_path, "w+t", encoding="utf8") as temp_file:
             temp_file.write("")
 
+        # Create a temporary HOME directory for cache isolation
+        temp_home_dir = tempfile.TemporaryDirectory()
+        temp_home_path = Path(temp_home_dir.name)
+
+        # Override HOME environment variable to isolate cache directories
+        # This affects both:
+        # - HashCache default: $HOME/.deadline/job_attachments/
+        # - S3CheckCache via config_file.get_cache_directory(): $HOME/.deadline/cache/
+        monkeypatch.setenv("HOME", str(temp_home_path))
+
+        # On Windows, os.path.expanduser("~") uses USERPROFILE instead of HOME
+        # So we need to override USERPROFILE as well for Windows compatibility
+        import sys
+
+        if sys.platform == "win32":
+            monkeypatch.setenv("USERPROFILE", str(temp_home_path))
+
         # Yield the temp file name with it patched in as the
         # AWS Deadline Cloud config file
         with patch.object(config_file, "CONFIG_FILE_PATH", str(temp_file_path)):
@@ -44,6 +64,7 @@ def fresh_deadline_config():
             yield str(temp_file_path)
     finally:
         temp_dir.cleanup()
+        temp_home_dir.cleanup()
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/test/unit/deadline_client/test_cache_isolation.py
+++ b/test/unit/deadline_client/test_cache_isolation.py
@@ -1,0 +1,79 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+from deadline.job_attachments.caches.hash_cache import HashCache
+from deadline.job_attachments.caches.s3_check_cache import S3CheckCache
+from deadline.client.config import config_file
+
+
+def _is_temp_directory(path: str) -> bool:
+    """Check if a path is in a temporary directory (cross-platform)"""
+    path_obj = Path(path).resolve()
+
+    # Get the system temp directory
+    system_temp = Path(tempfile.gettempdir()).resolve()
+
+    try:
+        # Check if the path is relative to the system temp directory
+        path_obj.relative_to(system_temp)
+        return True
+    except ValueError:
+        # Path is not under system temp directory
+        return False
+
+
+def test_cache_isolation_unit(fresh_deadline_config):
+    """Test that demonstrates cache isolation in unit tests"""
+
+    print(f"Config path: {fresh_deadline_config}")
+    print(f"HOME environment: {os.environ.get('HOME')}")
+    print(f"USERPROFILE environment (windows): {os.environ.get('USERPROFILE')}")
+    print(f"Platform: {sys.platform}")
+
+    # Test HashCache default location
+    with HashCache() as hash_cache:
+        print(f"HashCache location: {hash_cache.cache_dir}")
+        # Verify it's in a temporary directory (cross-platform)
+        assert _is_temp_directory(hash_cache.cache_dir), (
+            f"HashCache not in temp dir: {hash_cache.cache_dir}"
+        )
+        # Verify it has the expected subdirectory structure
+        assert ".deadline" in hash_cache.cache_dir
+        assert "job_attachments" in hash_cache.cache_dir
+
+    # Test S3CheckCache default location
+    with S3CheckCache() as s3_cache:
+        print(f"S3CheckCache location: {s3_cache.cache_dir}")
+        # Verify it's in a temporary directory (cross-platform)
+        assert _is_temp_directory(s3_cache.cache_dir), (
+            f"S3CheckCache not in temp dir: {s3_cache.cache_dir}"
+        )
+        # Verify it has the expected subdirectory structure
+        assert ".deadline" in s3_cache.cache_dir
+        assert "job_attachments" in s3_cache.cache_dir
+
+    # Test config_file.get_cache_directory()
+    cache_dir = config_file.get_cache_directory()
+    print(f"config_file.get_cache_directory(): {cache_dir}")
+
+    # Get the expected home directory
+    expected_home = os.environ.get("HOME")
+    if sys.platform == "win32":
+        # On Windows, also check USERPROFILE
+        expected_home = os.environ.get("USERPROFILE", expected_home)
+
+    print(f"Expected home directory: {expected_home}")
+
+    # Verify that expected_home is set and is used in the cache directory
+    assert str(expected_home) in cache_dir
+    assert _is_temp_directory(cache_dir), (
+        f"config_file.get_cache_directory() not in temp dir: {cache_dir}"
+    )
+
+    # Verify it has the expected subdirectory structure
+    assert ".deadline" in cache_dir
+    assert "cache" in cache_dir

--- a/test/unit/deadline_job_attachments/caches/test_caches.py
+++ b/test/unit/deadline_job_attachments/caches/test_caches.py
@@ -118,6 +118,86 @@ class TestCacheDB:
                     cdb.get_local_connection()
                 assert "Could not create connection to cache" in str(exc_info.value)
 
+    def test_enter_retries_on_operational_error(self, tmpdir):
+        """Tests that __enter__ retries on OperationalError and succeeds on final attempt"""
+        from unittest.mock import MagicMock
+
+        # Create a mock connection that will be returned on successful connect
+        mock_connection = MagicMock()
+        mock_connection.execute.return_value = None
+
+        # Create side effect that fails twice then succeeds
+        connect_calls = 0
+
+        def connect_side_effect(*args, **kwargs):
+            nonlocal connect_calls
+            connect_calls += 1
+            if connect_calls <= 2:
+                raise OperationalError("database is locked")
+            return mock_connection
+
+        with patch("sqlite3.connect", side_effect=connect_side_effect):
+            # This should succeed after 2 retries
+            with CacheDB(
+                "test", "test_table", "CREATE TABLE test_table (id INTEGER)", tmpdir
+            ) as cdb:
+                # Verify the connection was established
+                assert cdb.db_connection == mock_connection
+                # Verify we made the expected number of connection attempts
+                assert connect_calls == CacheDB._RETRY_ATTEMPTS
+
+    def test_enter_fails_after_max_retries(self, tmpdir):
+        """Tests that __enter__ fails with JobAttachmentsError after max retries"""
+
+        # Track connection attempts
+        connect_calls = 0
+
+        def connect_side_effect(*args, **kwargs):
+            nonlocal connect_calls
+            connect_calls += 1
+            raise OperationalError("database is locked")
+
+        # Mock sqlite3.connect to always raise OperationalError
+        with patch("sqlite3.connect", side_effect=connect_side_effect):
+            with pytest.raises(JobAttachmentsError) as exc_info:
+                with CacheDB("test", "test_table", "CREATE TABLE test_table (id INTEGER)", tmpdir):
+                    pass
+
+            # Verify the error message indicates retry exhaustion
+            assert (
+                f"Could not access cache file after {CacheDB._RETRY_ATTEMPTS} retry attempts"
+                in str(exc_info.value)
+            )
+            # Verify we made the expected number of connection attempts
+            assert connect_calls == CacheDB._RETRY_ATTEMPTS
+
+    def test_get_local_connection_retries_on_operational_error(self, tmpdir):
+        """Tests that get_local_connection retries on OperationalError and succeeds"""
+        from unittest.mock import MagicMock
+
+        # Create a mock connection that will be returned on successful connect
+        mock_connection = MagicMock()
+
+        # Create side effect that fails twice then succeeds
+        connect_calls = 0
+
+        def connect_side_effect(*args, **kwargs):
+            nonlocal connect_calls
+            connect_calls += 1
+            if connect_calls <= 2:
+                raise OperationalError("database is locked")
+            return mock_connection
+
+        with CacheDB("test", "test_table", "CREATE TABLE test_table (id INTEGER)", tmpdir) as cdb:
+            with patch("sqlite3.connect", side_effect=connect_side_effect):
+                # This should succeed after 2 retries
+                connection = cdb.get_local_connection()
+
+                # Verify the connection was established
+                assert connection == mock_connection
+                # Verify we made the expected number of connection attempts
+                assert connect_calls == CacheDB._RETRY_ATTEMPTS
+
 
 class TestHashCache:
     """


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud/issues/821
Note: This is a re-merge of a prior reverted PR due to other regressions related to the HASHDB 
 - Original PR: https://github.com/aws-deadline/deadline-cloud/pull/884
 - Revert PR: https://github.com/aws-deadline/deadline-cloud/pull/892. [Reverts thread based caching and retries]

### What was the problem/requirement? (What/Why)

The HashCache and S3CheckCache classes lacked proper test isolation:

1. **Test Isolation Issues**: Tests shared cache directories, causing potential interference between test runs:
   - All tests using HashCache/S3CheckCache wrote to the same user cache directories
   - SQLite database lock errors could occur when multiple tests accessed the same cache files
   - Tests could leave behind cache data affecting subsequent test runs

2. **SQLite Operational Errors**: Database lock errors occurred when multiple processes/tests tried to access the same cache database simultaneously

### What was the solution? (How)

1. **Added Retry Logic with Jitter**: 
   - In `CacheDB.__enter__()` and `get_local_connection()` methods with `@_retry` decorator
   - Configured 3 retry attempts with 0.5-1.5 second jitter for `sqlite3.OperationalError`
   - Added specific logging: "Error connecting to database, retrying."

2. **Implemented Cache Isolation for Tests**:
   - Modified `fresh_deadline_config` fixture in both unit test configurations
   - Added `HOME` environment variable override to create isolated temporary cache directories per test
   - Each test now gets its own isolated cache directories under a temporary HOME directory

3. **Cross-Platform Compatibility**:
   - Created cross-platform test verification using `_is_temp_directory()` helper function
   - Ensured cache isolation works on Windows, Linux, and macOS
   - Used `Path().resolve()` for proper cross-platform path handling

### What is the impact of this change?

1. **Improved Test Reliability**: 
   - Tests are now isolated and won't interfere with each other
   - Eliminates SQLite database lock errors in test environments
   - Tests automatically clean up cache data

2. **Retry Error Handling**: 
   - SQLite operational errors (including database locks) are now handled with retry logic in case of process collisions
   - Improved logging provides visibility into retry attempts

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- [x] Have you run the unit tests?
  - Added comprehensive unit tests in `test/unit/deadline_client/test_cache_isolation.py`
  - Added retry logic tests in `test/unit/deadline_job_attachments/caches/test_caches.py`:
    - `test_enter_retries_on_operational_error`: Tests successful retry after 2 failures
    - `test_enter_fails_after_max_retries`: Tests failure after exhausting retries
    - `test_get_local_connection_retries_on_operational_error`: Tests retry logic for local connections

```
===================================================================================================== slowest 5 durations ======================================================================================================
3.48s call     test/unit/deadline_job_attachments/test_upload.py::TestUpload::test_asset_management_no_outputs_large_number_of_inputs_already_uploaded[2023-03-03-200]
2.89s call     test/unit/deadline_job_attachments/caches/test_caches.py::TestCacheDB::test_enter_fails_after_max_retries
2.80s call     test/unit/deadline_job_attachments/caches/test_caches.py::TestS3CheckCache::test_large_db_concurrent_operations_expose_timeout_issues
2.77s call     test/unit/deadline_job_attachments/caches/test_caches.py::TestCacheDB::test_get_local_connection_handles_sqlite_error
2.73s call     test/unit/deadline_client/api/test_job_bundle_submission_asset_refs.py::test_create_job_from_job_bundle_with_all_asset_ref_variants
========================================================================================= 2022 passed, 63 skipped, 1 xfailed in 39.62s =========================================================================================
```

- [x] Have you run the integration tests?
  - Updated integration test fixture to include cache isolation
  - Verified existing integration tests continue to work with isolated cache directories

```
[gw0] [100%] PASSED test/integ/deadline_mcp/test_mcp_server_integration.py::test_mcp_tool_error_handling 

============================================================================================= slowest 5 durations =============================================================================================
10.21s call     test/integ/cli/test_cli_manifest_download.py::TestManifestDownload::test_manifest_download_job_input_with_given_step_and_step_dependency[True]
9.80s call     test/integ/cli/test_cli_manifest_download.py::TestManifestDownload::test_manifest_download_job_asset_type_with_no_step_dependency[input-True]
9.66s call     test/integ/cli/test_cli_manifest_download.py::TestManifestDownload::test_manifest_download_asset_type_with_job_step_dependency[output-True]
9.32s call     test/integ/cli/test_cli_manifest_download.py::TestManifestDownload::test_manifest_download_asset_type_with_job_step_dependency[output-False]
9.24s call     test/integ/cli/test_cli_manifest_download.py::TestManifestDownload::test_manifest_download_asset_type_with_job_step_dependency[all-True]
================================================================================= 55 passed, 10 skipped in 253.78s (0:04:13) ==================================================================================

```

- [ ] Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended that you ensure that the docker-based unit tests pass.
  - No changes made to `download` or `asset_sync` modules

### Was this change documented?

- [x] Are relevant docstrings in the code base updated?
  - Updated `fresh_deadline_config` fixture docstrings to document cache isolation behavior
  - Added comprehensive test documentation

- [x] Has the README.md been updated? If you modified CLI arguments, for instance.
  - No CLI arguments were modified
  - Created `hash.md` documenting cache directory analysis and inconsistencies for future reference

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatibilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?

A breaking change is one that modifies a public contract in a way that is not backwards compatible. See the [Public Contracts](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#public-contracts) section of the DEVELOPMENT.md for more information on the public contracts.

**No, this is not a breaking change.**

- The retry logic is internal to the cache classes and doesn't change public APIs
- Test fixture changes only affect test environments, not production code
- Cache directory behavior remains the same for production usage
- All existing public interfaces remain unchanged

### Does this change impact security?

- Does the change need to be threat modeled? **No**
  - The changes only affect test isolation and error handling
  - No new files/directories are created in production environments
  - Temporary test directories are properly cleaned up and isolated per test
  
- If so, then please label this pull request with the "security" label. We'll work with you to analyze the threats.
  - **Not applicable** - no security implications

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*


---
# How I arrived at patching the specific environment variables to fix test code:

# Cache Directory Analysis Summary

## HashCache Call Stack Analysis

### **Instances where HashCache uses DEFAULT cache directory (`$HOME/.deadline/job_attachments/`):**

1. **`scripted_tests/upload_cancel_test.py`**
   - Calls `hash_assets_and_create_manifest()` **WITHOUT** `hash_cache_dir` parameter
   - **Uses default**: `$HOME/.deadline/job_attachments/`

2. **`scripted_tests/upload_scale_test.py`**
   - Calls `hash_assets_and_create_manifest()` **WITHOUT** `hash_cache_dir` parameter  
   - **Uses default**: `$HOME/.deadline/job_attachments/`

### **Instances where HashCache uses EXPLICIT cache directory (`$HOME/.deadline/cache/`):**

1. **`src/deadline/client/api/_job_attachment.py`**
   - Calls `hash_assets_and_create_manifest(hash_cache_dir=config_file.get_cache_directory())`
   - **Uses**: `$HOME/.deadline/cache/`

2. **`examples/submit_job.py`**
   - Calls `hash_assets_and_create_manifest()` with `cache_directory` from `get_cache_directory()`
   - **Uses**: `$HOME/.deadline/cache/`

3. **`src/deadline/job_attachments/api/manifest.py`**
   - Creates `HashCache(cache_config)` where `cache_config = config_file.get_cache_directory()`
   - **Uses**: `$HOME/.deadline/cache/`

4. **`src/deadline/job_attachments/_diff.py`**
   - Creates `HashCache(cache_config)` where `cache_config = config_file.get_cache_directory()`
   - **Uses**: `$HOME/.deadline/cache/`

### **HashCache Key Findings:**

#### **Two Different Default Behaviors:**
1. **When `hash_cache_dir=None`** (scripted tests): HashCache falls back to `$HOME/.deadline/job_attachments/`
2. **When `hash_cache_dir=config_file.get_cache_directory()`** (production code): HashCache uses `$HOME/.deadline/cache/`

#### **Inconsistency Issue:**
- **Production code** consistently uses `$HOME/.deadline/cache/` via `config_file.get_cache_directory()`
- **Scripted tests** use `$HOME/.deadline/job_attachments/` by not passing the parameter
- This means **different cache locations** are used in different contexts!

---

## S3CheckCache Call Stack Analysis

### **S3CheckCache Instantiation Points:**

1. **`src/deadline/job_attachments/upload.py:414`** - `upload_input_files()` method
2. **`src/deadline/job_attachments/upload.py:503`** - `reset_s3_check_cache()` method  
3. **`src/deadline/job_attachments/upload.py:555`** - `verify_hash_cache_integrity()` method

### **Call Stack Trace:**

```
S3CheckCache(s3_check_cache_dir)
    ↑
upload_input_files(s3_check_cache_dir=s3_check_cache_dir)
    ↑
upload_assets(s3_check_cache_dir=s3_check_cache_dir) [single manifest method]
    ↑
Called by 3 sources:

1. src/deadline/client/api/_submit_job_bundle.py
   → upload_assets(s3_check_cache_dir=config_file.get_cache_directory())
   
2. src/deadline/job_attachments/api/attachment.py  
   → upload_assets(s3_check_cache_dir=config_file.get_cache_directory())
   
3. src/deadline/job_attachments/upload.py [multi-manifest method]
   → upload_assets(s3_check_cache_dir=s3_check_cache_dir)
   → This is called by external code with s3_check_cache_dir parameter
```

### **S3CheckCache Cache Directory Locations:**

#### **When `s3_check_cache_dir` is explicitly set:**
- **`src/deadline/client/api/_submit_job_bundle.py`**: Uses `config_file.get_cache_directory()` → **`~/.deadline/cache/`**
- **`src/deadline/job_attachments/api/attachment.py`**: Uses `config_file.get_cache_directory()` → **`~/.deadline/cache/`**

#### **When `s3_check_cache_dir=None` (fallback to default):**
- **`src/deadline/job_attachments/upload.py`** (multi-manifest method): When external callers don't pass `s3_check_cache_dir`
- **Fallback location**: `CacheDB.get_default_cache_db_file_dir()` → **`$HOME/.deadline/job_attachments/`**

### **S3CheckCache Final Summary:**

**S3CheckCache uses TWO different cache locations in src code:**

1. **Primary production usage**: **`~/.deadline/cache/`** (via `config_file.get_cache_directory()`)
   - Used by job submission and attachment APIs
   
2. **Fallback usage**: **`~/.deadline/job_attachments/`** (via `CacheDB` default)
   - Used when external callers don't specify `s3_check_cache_dir`

---

## Overall Cache Inconsistency Issue

Both HashCache and S3CheckCache have the same fundamental problem: **different parts of the codebase use different cache directories** for the same functionality, leading to:

1. **Cache fragmentation** - same data stored in multiple locations
2. **Test isolation issues** - tests may interfere with each other
3. **Inconsistent behavior** - depending on code path, different cache locations are used

The root cause is that some code paths explicitly set cache directories via `config_file.get_cache_directory()` while others rely on the `CacheDB` default fallback mechanism.
