### PR TITLE
fix!: small files in syncInputJobAttachment causes false positive sync…

### DIFF
--- a/src/deadline/client/api/_job_attachment.py
+++ b/src/deadline/client/api/_job_attachment.py
@@ -53,6 +53,7 @@ def _hash_attachments(
                 progress=100,
                 transferRate=0,
                 progressMessage="No files to hash",
+                processedFiles=0,
             )
         )
 

--- a/src/deadline/client/api/_submit_job_bundle.py
+++ b/src/deadline/client/api/_submit_job_bundle.py
@@ -192,6 +192,7 @@ def _upload_attachments(
                 progress=100,
                 transferRate=0,
                 progressMessage="No files to upload",
+                processedFiles=0,
             )
         )
 
@@ -236,6 +237,7 @@ def _snapshot_attachments(
                 progress=100,
                 transferRate=0,
                 progressMessage="No files to upload",
+                processedFiles=0,
             )
         )
 
@@ -743,6 +745,7 @@ def create_job_from_job_bundle(
                     progress=0,
                     transferRate=0,
                     progressMessage="No files to hash",
+                    processedFiles=0,
                 )
             )
         if upload_progress_callback is not None:
@@ -752,6 +755,7 @@ def create_job_from_job_bundle(
                     progress=0,
                     transferRate=0,
                     progressMessage="No files to upload",
+                    processedFiles=0,
                 )
             )
 

--- a/src/deadline/job_attachments/progress_tracker.py
+++ b/src/deadline/job_attachments/progress_tracker.py
@@ -142,6 +142,7 @@ class ProgressReportMetadata:
     progress: float  # percentage with one decimal place
     transferRate: float  # bytes/second
     progressMessage: str  # pylint: disable=invalid-name
+    processedFiles: int  # number of files completed
 
 
 @dataclass
@@ -321,6 +322,7 @@ class ProgressTracker:
             progress=percentage,
             transferRate=transfer_rate,
             progressMessage=progress_message,
+            processedFiles=self.processed_files,
         )
 
     def get_summary_statistics(self) -> SummaryStatistics:


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud/issues/478

### What was the problem/requirement? (What/Why)

When submitting any job to a CMF with worker agent installed, with thousands (10000 as tested) of small 1 byte input files, after the job starts, the syncInputJobAttachments step will fail most of the time, with an error message "Input Syncing failed due to successive low transfer rates"

```
2025/11/03 16:37:43-08:00 ==============================================2025/11/03 16:37:43-08:00 --------- Job Attachments Download for Job2025/11/03 16:37:43-08:00 ==============================================
2025/11/03 16:37:43-08:00 Syncing inputs using Job Attachments
2025/11/03 16:37:44-08:00 Downloaded 555 B / 3.56 KB of 3001 files (Transfer rate: 0 B/s)2025/11/03 
16:37:47-08:00 Downloaded 911 B / 3.56 KB of 3001 files (Transfer rate: 150 B/s)
2025/11/03 16:37:49-08:00 Downloaded 1.27 KB / 3.56 KB of 3001 files (Transfer rate: 144 B/s)
2025/11/03 16:37:52-08:00 Downloaded 1.62 KB / 3.56 KB of 3001 files (Transfer rate: 128 B/s)
2025/11/03 16:37:55-08:00 Downloaded 1.98 KB / 3.56 KB of 3001 files (Transfer rate: 141 B/s)
2025/11/03 16:37:57-08:00 Downloaded 2.33 KB / 3.56 KB of 3001 files (Transfer rate: 125 B/s)

FAILS
```

Some math:
Given tiny files of 1 byte, transfer speed is negligible for file contents. However, overhead of api calls to S3 overshadow actual latency of file transfer.

-> Given average transfer rates of 150 - 200B/s = 150 - 200 files / second
-> threshold of 10KB/s = 10,000B/s
-> needs all files to be above 50 - 60 bytes/file to not be cancelled in a false positive fashion

Low transfer rates increment `low_transfer_count` counter, with 60 consecutive counts leading to failure.
Therefore possible for many consecutive tiny files to cause errors.

### What was the solution? (How)

(Change required in both deadline-cloud and deadline-cloud-worker-agent)
Added extra checks to reset `low_transfer_count` counter when files complete, acting as a heartbeat; many tiny files that are downloaded by the worker agent will now indicate progress, ignoring the false positive case.

Note, change would not mask over the original intent of cancelling due to low transfer rates. Given `LOW_TRANSFER_RATE_THRESHOLD` of 10kb/s and `LOW_TRANSFER_COUNT_THRESHOLD`, files above ~600kb will still lead to low transfer rate failure if has low transfer rates. 

### What is the impact of this change?

Job submissions with attachments that have many tiny files will no longer cause a false positive failure of low transfer rates

### How was this change tested?

Ran unit tests:
```
================================================================================================= slowest 5 durations =================================================================================================
3.39s call     test/unit/deadline_job_attachments/test_upload.py::TestUpload::test_asset_management_no_outputs_large_number_of_inputs_already_uploaded[2023-03-03-200]
2.60s call     test/unit/deadline_job_attachments/test_upload.py::TestUpload::test_asset_management_many_inputs[2023-03-03-200]
2.40s call     test/unit/deadline_job_attachments/test_upload.py::TestUpload::test_asset_management_many_inputs[2023-03-03-100]
2.08s call     test/unit/deadline_job_attachments/caches/test_caches.py::TestS3CheckCache::test_large_db_concurrent_operations_expose_timeout_issues
1.87s call     test/unit/deadline_job_attachments/test_upload.py::TestUpload::test_asset_management_no_outputs_large_number_of_inputs_already_uploaded[2023-03-03-100]
==================================================================================== 1987 passed, 78 skipped, 1 xfailed in 30.02s =====================================================================================
```
Ran Integ Tests:
```
================================================================================================= slowest 5 durations =================================================================================================
832.98s call     test/integ/cli/test_cli_incremental_download.py::test_incremental_download_dependency_chain
414.80s call     test/integ/cli/test_cli_incremental_download.py::test_incremental_download_dep_data_flow
412.42s call     test/integ/cli/test_cli_incremental_download.py::test_conflict_resolution_with_requeue[task]
371.12s call     test/integ/cli/test_cli_incremental_download.py::test_conflict_resolution_with_requeue[job]
323.94s call     test/integ/cli/test_cli_incremental_download.py::test_conflict_resolution_with_requeue[step]
========================================================================== 55 passed, 4 skipped, 2 xfailed, 4 xpassed in 2746.38s (0:45:46) ===========================================================================
```

### Was this change documented?

- Are relevant docstrings in the code base updated?
- Has the README.md been updated? If you modified CLI arguments, for instance.

### Does this PR introduce new dependencies?

No

### Is this a breaking change?

BREAKING CHANGE: the parameter `processedFiles` is added to `ProgressReportMetadata`.

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
