### PR TITLE
feat(mcp): add get_session_logs to mcp server

### DIFF
--- a/docs/mcp_guide.md
+++ b/docs/mcp_guide.md
@@ -61,6 +61,8 @@ With the AWS Deadline Cloud MCP Server, you can use natural language for various
 - "Submit the render job in /path/to/my-job-bundle"
 - "Submit a job with priority 80 to my render queue"
 - "Show me the status of job job-3a907bac684841f69fc344867ee166de"
+- "Get the logs for session session-abc123 to see why my task failed"
+- "Show me the CloudWatch logs for session session-xyz789"
 - "Download output from job job-3a907bac684841f69fc344867ee166de"
 - "Download output from step step-render in job job-3a907bac684841f69fc344867ee166de"
 ```
@@ -76,7 +78,7 @@ The MCP server provides access to all allowlisted/configured Deadline Cloud API 
 - `deadline_list_storage_profiles_for_queue()`: List storage profiles for a queue
 
 - `deadline_check_authentication_status()`: Check current authentication status
-
+- `deadline_get_session_logs()`: Get CloudWatch logs for a specific session
 - `deadline_submit_job()`: Submit an Open Job Description job bundle to AWS Deadline Cloud
 - `deadline_download_job_output()`: Download job output files from AWS Deadline Cloud
 

--- a/src/deadline/_mcp/registry.py
+++ b/src/deadline/_mcp/registry.py
@@ -59,6 +59,18 @@ TOOL_REGISTRY: Dict[str, ToolDefinition] = {
         "func": api.check_authentication_status,
         "param_names": None,
     },
+    "get_session_logs": {
+        "func": api.get_session_logs,
+        "param_names": [
+            "farm_id",
+            "queue_id",
+            "session_id",
+            "limit",
+            "start_time",
+            "end_time",
+            "next_token",
+        ],
+    },
     "submit_job": {
         "func": job.submit_job,
         "param_names": None,

--- a/src/deadline/client/api/_job_monitoring.py
+++ b/src/deadline/client/api/_job_monitoring.py
@@ -4,7 +4,6 @@
 Functions for monitoring job status and retrieving job information.
 """
 
-from __future__ import annotations
 import datetime
 import time
 from typing import List, Dict, Any, Optional, Callable

--- a/test/unit/deadline_mcp/test_mcp.py
+++ b/test/unit/deadline_mcp/test_mcp.py
@@ -39,7 +39,7 @@ class TestToolRegistry:
 
     def test_expected_functions(self):
         """Test that expected functions are in the registry."""
-        expected = ["list_farms", "submit_job", "download_job_output"]
+        expected = ["list_farms", "submit_job", "download_job_output", "get_session_logs"]
         for func_name in expected:
             assert func_name in TOOL_REGISTRY
 


### PR DESCRIPTION
One of the endpoints needed to fulfill the user
story "tell me why my job is failing"

### What was the problem/requirement? (What/Why)

In order to eventually fulfill the user story of a user asking an AI agent "why is my job failing", the agent will need access to the get_session_logs() function. This PR exposes that functionality.

### What was the solution? (How)

get_session_logs was added to the tool registry. This required the removal of `from __future__ import annotations` from `_job_monitoring` due to how FastMCP handles annotations,  but that future behavior did not appear to be required in this module.

### What is the impact of this change?

Agentic AIs can now get session logs.

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests?

Yes, on Python 3.8 and 3.11

- Have you run the integration tests?

No.

- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass.

No.

### Was this change documented?

The mcp_guide.md file was updated

### Does this PR introduce new dependencies?

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [X] This PR does not add any new dependencies.

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
