### PR TITLE
rfc: chore: inform user that GUI dependencies will be installed

### DIFF
--- a/src/deadline/client/ui/_utils.py
+++ b/src/deadline/client/ui/_utils.py
@@ -82,7 +82,22 @@ def gui_context_for_cli(automatically_install_dependencies: bool):
     has_pyside6 = importlib.util.find_spec("PySide6")
     has_pyside2 = importlib.util.find_spec("PySide2")
     if not (has_pyside6 or has_pyside2):
-        if not automatically_install_dependencies:
+        if automatically_install_dependencies:
+            # Show GUI confirmation dialog
+            import tkinter as tk
+            from tkinter import messagebox
+
+            root = tk.Tk()
+            root.withdraw()
+            will_install_gui = messagebox.askokcancel(
+                "Install GUI Dependencies",
+                "Dependencies required to run the interface will be downloaded and installed. The process takes several seconds."
+            )
+            root.destroy()
+            if not will_install_gui:
+                click.echo("Unable to continue without GUI, exiting")
+                sys.exit(1)
+        else:
             message = "Optional GUI components for deadline are unavailable. Would you like to install PySide?"
             will_install_gui = click.confirm(message, default=False)
             if not will_install_gui:


### PR DESCRIPTION
Note: Demoing an idea to collect feedback.

### What was the problem/requirement? (What/Why)
When the `--install-gui` flag is used like `deadline bundle gui-submit --install-gui`, the library automatically installs PySide6-essentials. Several submitters use the GUI submitter and this `--install-gui` flag to function. When they run for the first time, the submitter takes several seconds to load without the user understanding why. In these use cases, the terminal output is not usually visible.

### What was the solution? (How)
Idea for a solution: show an alert that the dependencies will be installed so that 1) the user knows to expect a delay and 2) the user approves the install. The alert uses tkinter which is part of the standard library.

<img width="372" height="340" alt="Screenshot 2025-11-05 at 2 54 17 PM" src="https://github.com/user-attachments/assets/e605f57b-8b3c-4688-af5c-e3e41e81e620" />

### What is the impact of this change?
Better visibility for users.

### How was this change tested?
n/a

### Was this change documented?
n/a

### Does this PR introduce new dependencies?

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?
Ish. It doesn't break anything, but it does change the user experience of submitters that use the GUI submitter.

### Does this change impact security?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
