### PR TITLE
docs: Update docs about --timezone option

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,13 +254,16 @@ $ deadline job logs --session-id session-12345 --start-time 2023-01-01T12:00:00Z
 $ deadline job logs --session-id session-12345 --output json
 
 # Get logs with timestamps in local timezone (default is UTC)
-$ deadline job logs --session-id session-12345 --timezone local
+$ deadline job logs --session-id session-12345 --timestamp-format local
 
 # Get logs with explicit UTC timestamps (default behavior)
-$ deadline job logs --session-id session-12345 --timezone utc
+$ deadline job logs --session-id session-12345 --timestamp-format utc
 
-# Combine timezone option with JSON output
-$ deadline job logs --session-id session-12345 --timezone local --output json
+# Get logs with relative timestamps
+$ deadline job logs --session-id session-12345 --timestamp-format relative
+
+# Combine timestamp format option with JSON output
+$ deadline job logs --session-id session-12345 --timestamp-format local --output json
 
 # Paginate through logs
 $ deadline job logs --session-id session-12345 --next-token next-token-value
@@ -270,9 +273,10 @@ $ deadline job logs --session-id session-12345 --next-token next-token-value
 - UTC format: `2025-07-03T10:49:33.821306+00:00`
 - Local format: `2025-07-03T03:49:33.821306-07:00` (example for PST)
 
-**Timezone Options**:
-- `--timezone utc` (default): Display timestamps in UTC with `+00:00` offset
-- `--timezone local`: Display timestamps converted to your local system timezone
+**Timestamp Format Options**:
+- `--timestamp-format utc` (default): Display timestamps in UTC with `+00:00` offset
+- `--timestamp-format local`: Display timestamps converted to your local system timezone
+- `--timestamp-format relative`: Display timestamps relative to the session or session action start time
 
 When using a Deadline Cloud monitor profile, the `job logs` command will use the Queue role credentials to read logs. Otherwise, the chosen profile credentials are used for all API invocations. This allows you to access logs with the appropriate permissions based on your authentication method.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -233,13 +233,16 @@ $ deadline job logs --session-id session-12345 --start-time 2023-01-01T12:00:00Z
 $ deadline job logs --session-id session-12345 --output json
 
 # Get logs with timestamps in local timezone (default is UTC)
-$ deadline job logs --session-id session-12345 --timezone local
+$ deadline job logs --session-id session-12345 --timestamp-format local
 
 # Get logs with explicit UTC timestamps (default behavior)
-$ deadline job logs --session-id session-12345 --timezone utc
+$ deadline job logs --session-id session-12345 --timestamp-format utc
 
-# Combine timezone option with JSON output
-$ deadline job logs --session-id session-12345 --timezone local --output json
+# Get logs with relative timestamps
+$ deadline job logs --session-id session-12345 --timestamp-format relative
+
+# Combine timestamp format option with JSON output
+$ deadline job logs --session-id session-12345 --timestamp-format local --output json
 
 # Paginate through logs
 $ deadline job logs --session-id session-12345 --next-token next-token-value
@@ -249,9 +252,10 @@ $ deadline job logs --session-id session-12345 --next-token next-token-value
 - UTC format: `2025-07-03T10:49:33.821306+00:00`
 - Local format: `2025-07-03T03:49:33.821306-07:00` (example for PST)
 
-**Timezone Options**:
-- `--timezone utc` (default): Display timestamps in UTC with `+00:00` offset
-- `--timezone local`: Display timestamps converted to your local system timezone
+**Timestamp Format Options**:
+- `--timestamp-format utc` (default): Display timestamps in UTC with `+00:00` offset
+- `--timestamp-format local`: Display timestamps converted to your local system timezone
+- `--timestamp-format relative`: Display timestamps relative to the session or session action start time
 
 When using a Deadline Cloud monitor profile, the `job logs` command will use the Queue role credentials to read logs. Otherwise, the chosen profile credentials are used for all API invocations. This allows you to access logs with the appropriate permissions based on your authentication method.
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The 'deadline job logs' command has a --timezone option that was deprecated to be replaced by --timezone-format.

### What was the solution? (How)

This change updates the docs to describe the new option.

### What is the impact of this change?

Documentation is consistent with implementation.

### How was this change tested?

N/A

### Was this change documented?

Docs change

### Does this PR introduce new dependencies?

No

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
