### PR TITLE
fix: accept host requirement amounts with value of 0

### DIFF
--- a/src/deadline/client/ui/widgets/host_requirements_tab.py
+++ b/src/deadline/client/ui/widgets/host_requirements_tab.py
@@ -663,7 +663,7 @@ class CustomAmountWidget(CustomCapabilityWidget):
             minimum = self.minimum
             maximum = self.maximum
 
-            if minimum and maximum:
+            if minimum is not None and maximum is not None:
                 requirement["min"] = minimum
                 requirement["max"] = maximum
 
@@ -671,9 +671,9 @@ class CustomAmountWidget(CustomCapabilityWidget):
                     raise NonValidInputError(
                         "Please make sure that the custom amounts in the custom host requirement options have valid min/max ranges!"
                     )
-            elif minimum:
+            elif minimum is not None:
                 requirement["min"] = minimum
-            elif maximum:
+            elif maximum is not None:
                 requirement["max"] = maximum
 
             parsed_name_match = re.match(AMOUNT_CAPABILITY_NAME_REGEX, self.name)

--- a/test/unit/deadline_client/ui/widgets/test_host_requirements_tab.py
+++ b/test/unit/deadline_client/ui/widgets/test_host_requirements_tab.py
@@ -232,3 +232,61 @@ def test_name_in_custom_attribute_widget_should_not_allow_reserved_first_identif
             == "Please make sure that the first identifier in your name is not a reserved identifier. "
             + str(RESERVED_FIRST_IDENTIFIERS)
         )
+
+
+def test_custom_amount_widget_includes_zero_minimum(qtbot):
+    widget = CustomAmountWidget(MagicMock(), 1)
+    qtbot.addWidget(widget)
+
+    widget.name_line_edit.setText("test.amount")
+    widget.min_spin_box.setValue(0)
+    widget.max_spin_box.setValue(10)
+
+    requirement = widget.get_requirement()
+
+    assert requirement["name"] == AMOUNT_CAPABILITY_PREFIX + "test.amount"
+    assert requirement["min"] == 0
+    assert requirement["max"] == 10
+
+
+def test_custom_amount_widget_includes_zero_maximum(qtbot):
+    widget = CustomAmountWidget(MagicMock(), 1)
+    qtbot.addWidget(widget)
+
+    widget.name_line_edit.setText("test.amount")
+    widget.min_spin_box.setValue(0)
+    widget.max_spin_box.setValue(0)
+
+    requirement = widget.get_requirement()
+
+    assert requirement["name"] == AMOUNT_CAPABILITY_PREFIX + "test.amount"
+    assert requirement["min"] == 0
+    assert requirement["max"] == 0
+
+
+def test_custom_amount_widget_includes_zero_only_minimum(qtbot):
+    widget = CustomAmountWidget(MagicMock(), 1)
+    qtbot.addWidget(widget)
+
+    widget.name_line_edit.setText("test.amount")
+    widget.min_spin_box.setValue(0)
+
+    requirement = widget.get_requirement()
+
+    assert requirement["name"] == AMOUNT_CAPABILITY_PREFIX + "test.amount"
+    assert requirement["min"] == 0
+    assert "max" not in requirement
+
+
+def test_custom_amount_widget_includes_zero_only_maximum(qtbot):
+    widget = CustomAmountWidget(MagicMock(), 1)
+    qtbot.addWidget(widget)
+
+    widget.name_line_edit.setText("test.amount")
+    widget.max_spin_box.setValue(0)
+
+    requirement = widget.get_requirement()
+
+    assert requirement["name"] == AMOUNT_CAPABILITY_PREFIX + "test.amount"
+    assert requirement["max"] == 0
+    assert "min" not in requirement


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Host requirements with an amount of `0` are ignored.

### What was the solution? (How)
Check if the amount is not `None`, not just falsy.

### What is the impact of this change?
Fixes a bug with host requirements with values of `0`.

### How was this change tested?
Unit tests

### Was this change documented?
n/a

### Does this PR introduce new dependencies?
No

### Is this a breaking change?
No

### Does this change impact security?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
