### PR TITLE
feat: report paths of downloaded files in json summary

### DIFF
--- a/src/deadline/client/cli/_groups/job_group.py
+++ b/src/deadline/client/cli/_groups/job_group.py
@@ -789,7 +789,10 @@ def _get_download_summary_message(
         return _get_json_line(
             JSON_MSG_TYPE_SUMMARY,
             f"Downloaded {download_summary.processed_files} files",
-            extra_properties={"fileCount": download_summary.processed_files},
+            extra_properties={
+                "fileCount": download_summary.processed_files,
+                "files": download_summary.downloaded_files,
+            },
         )
     else:
         paths_joined = "\n        ".join(

--- a/src/deadline/job_attachments/progress_tracker.py
+++ b/src/deadline/job_attachments/progress_tracker.py
@@ -8,7 +8,7 @@ import time
 from dataclasses import asdict, dataclass, field
 from enum import Enum
 from threading import Lock
-from typing import Callable, Dict, Optional, Union
+from typing import Callable, Dict, List, Optional, Union
 
 from ._path_summarization import human_readable_file_size
 
@@ -76,6 +76,7 @@ class DownloadSummaryStatistics(SummaryStatistics):
     """
 
     file_counts_by_root_directory: Dict[str, int] = field(default_factory=dict)
+    downloaded_files: List[str] = field(default_factory=list)
 
     def aggregate(self, other: SummaryStatistics) -> SummaryStatistics:
         """
@@ -100,6 +101,7 @@ class DownloadSummaryStatistics(SummaryStatistics):
         """
         download_summary_statistics_dict = asdict(self)
         del download_summary_statistics_dict["file_counts_by_root_directory"]
+        del download_summary_statistics_dict["downloaded_files"]
         return SummaryStatistics(**download_summary_statistics_dict)
 
 
@@ -349,6 +351,10 @@ class ProgressTracker:
         summary_statistics_dict["file_counts_by_root_directory"] = {
             root: len(paths) for root, paths in downloaded_files_paths_by_root.items()
         }
+        all_files = []
+        for _, paths in downloaded_files_paths_by_root.items():
+            all_files.extend(paths)
+        summary_statistics_dict["downloaded_files"] = sorted(all_files)
         return DownloadSummaryStatistics(**summary_statistics_dict)
 
     def _log_progress_message(self) -> None:

--- a/test/unit/deadline_client/cli/test_cli_job.py
+++ b/test/unit/deadline_client/cli/test_cli_job.py
@@ -743,14 +743,19 @@ def test_cli_job_download_output_stdout_with_json_format(
     ), patch.object(job_group, "_assert_valid_path", return_value=None), patch.object(
         api, "get_queue_user_boto3_session"
     ):
+        mock_root_path = "/root/path" if sys.platform != "win32" else "C:\\Users\\username"
         mock_download = MagicMock()
         mock_download.return_value = DownloadSummaryStatistics(
             total_time=12,
             processed_files=3,
             processed_bytes=1024,
+            downloaded_files=[
+                f"{mock_root_path}/outputs/file1.txt",
+                f"{mock_root_path}/outputs/file2.txt",
+                f"{mock_root_path}/outputs/file3.txt",
+            ],
         )
         MockOutputDownloader.return_value.download_job_output = mock_download
-        mock_root_path = "/root/path" if sys.platform != "win32" else "C:\\Users\\username"
         mock_files_list = ["outputs/file1.txt", "outputs/file2.txt", "outputs/file3.txt"]
         MockOutputDownloader.return_value.get_output_paths_by_root.side_effect = [
             {

--- a/test/unit/deadline_client/cli/test_cli_job.py
+++ b/test/unit/deadline_client/cli/test_cli_job.py
@@ -838,10 +838,23 @@ def test_cli_job_download_output_stdout_with_json_format(
             {"messageType": "pathconfirm", "value": [mock_root_path, str(tmp_path)]}
         )
 
-        assert (
-            f"{expected_json_title}\n{expected_json_presummary}\n{expected_json_path}\n {expected_json_pathconfirm}\n"
-            in result.output
-        )
+        assert expected_json_title in result.output
+        assert expected_json_presummary in result.output
+        assert expected_json_path in result.output
+        assert expected_json_pathconfirm in result.output
+
+        # Verify the summary includes the files list
+        output_lines = result.output.strip().split("\n")
+        summary_line = [line for line in output_lines if '"messageType": "summary"' in line]
+        assert len(summary_line) == 1
+        summary_data = json.loads(summary_line[0])
+        assert summary_data["fileCount"] == 3
+        assert summary_data["files"] == [
+            f"{mock_root_path}/outputs/file1.txt",
+            f"{mock_root_path}/outputs/file2.txt",
+            f"{mock_root_path}/outputs/file3.txt",
+        ]
+
         assert result.exit_code == 0
 
 

--- a/test/unit/deadline_client/cli/test_cli_job.py
+++ b/test/unit/deadline_client/cli/test_cli_job.py
@@ -1616,6 +1616,11 @@ class TestJsonLineHelpers:
         summary.total_time = 2.5
         summary.transfer_rate = 409.6
         summary.file_counts_by_root_directory = {"/downloads": 3}
+        summary.downloaded_files = [
+            "/downloads/file1.txt",
+            "/downloads/file2.txt",
+            "/downloads/file3.txt",
+        ]
 
         result = _get_download_summary_message(summary, is_json_format=True)
         parsed = json.loads(result)
@@ -1623,6 +1628,11 @@ class TestJsonLineHelpers:
         assert parsed["messageType"] == "summary"
         assert parsed["value"] == "Downloaded 3 files"
         assert parsed["fileCount"] == 3
+        assert parsed["files"] == [
+            "/downloads/file1.txt",
+            "/downloads/file2.txt",
+            "/downloads/file3.txt",
+        ]
 
     def test_get_download_summary_message_json_zero_files(self):
         """Test _get_download_summary_message with zero files."""
@@ -1630,6 +1640,7 @@ class TestJsonLineHelpers:
 
         summary = DownloadSummaryStatistics()
         summary.processed_files = 0
+        summary.downloaded_files = []
 
         result = _get_download_summary_message(summary, is_json_format=True)
         parsed = json.loads(result)
@@ -1637,6 +1648,39 @@ class TestJsonLineHelpers:
         assert parsed["messageType"] == "summary"
         assert parsed["value"] == "Downloaded 0 files"
         assert parsed["fileCount"] == 0
+        assert parsed["files"] == []
+
+    def test_get_download_summary_message_json_with_files_list(self):
+        """Test _get_download_summary_message includes files list in JSON format."""
+        from deadline.job_attachments.progress_tracker import DownloadSummaryStatistics
+
+        summary = DownloadSummaryStatistics()
+        summary.processed_files = 5
+        summary.processed_bytes = 2048
+        summary.total_time = 3.0
+        summary.transfer_rate = 682.67
+        summary.file_counts_by_root_directory = {"/downloads": 3, "/output": 2}
+        summary.downloaded_files = [
+            "/downloads/file1.txt",
+            "/downloads/file2.txt",
+            "/downloads/subdir/file3.txt",
+            "/output/result1.png",
+            "/output/result2.png",
+        ]
+
+        result = _get_download_summary_message(summary, is_json_format=True)
+        parsed = json.loads(result)
+
+        assert parsed["messageType"] == "summary"
+        assert parsed["value"] == "Downloaded 5 files"
+        assert parsed["fileCount"] == 5
+        assert parsed["files"] == [
+            "/downloads/file1.txt",
+            "/downloads/file2.txt",
+            "/downloads/subdir/file3.txt",
+            "/output/result1.png",
+            "/output/result2.png",
+        ]
 
     def test_get_download_summary_message_non_json_unchanged(self):
         """Test _get_download_summary_message non-JSON format is unchanged."""

--- a/test/unit/deadline_job_attachments/test_download.py
+++ b/test/unit/deadline_job_attachments/test_download.py
@@ -403,6 +403,7 @@ def assert_progress_tracker_values(
             skipped_bytes=0,
             transfer_rate=expected_total_bytes / summary_statistics.total_time,
             file_counts_by_root_directory=file_counts_by_root_directory,
+            downloaded_files=sorted([str(path) for path in expected_files_set]),
         )
     else:
         # If the manifest version does not support `size` and `total_size` properties,
@@ -420,6 +421,7 @@ def assert_progress_tracker_values(
             skipped_bytes=0,
             transfer_rate=0.0,
             file_counts_by_root_directory=file_counts_by_root_directory,
+            downloaded_files=sorted([str(path) for path in expected_files_set]),
         )
 
     actual_args, _ = mock_on_downloading_files.call_args


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
DCM uses the `deadline job download-output --output json` command to download job outputs. Currently the notification just says, "Downloaded 3 files" but I'd like to know which files were downloaded and where.

### What was the solution? (How)
As the first step, report the downloaded file paths in the JSON report.

### What is the impact of this change?
Enables programmatic parsing of download file paths from the `download-output` command.

### How was this change tested?
Unit tests and manual testing.

### Was this change documented?
No, not needed.

### Does this PR introduce new dependencies?
No

### Is this a breaking change?
No

### Does this change impact security?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
