### PR TITLE
revert: chore: fix 3.12 installer builds

### DIFF
--- a/scripts/attributions/cli.py
+++ b/scripts/attributions/cli.py
@@ -225,11 +225,11 @@ _EXPECTED_MISSING_LICENSE = {"pywin32"}
 
 def _get_desired_python_version() -> str:
     if platform.system() == "Darwin":
-        return "3.12"
+        return "3.13"
     elif platform.system() == "Windows":
-        return "3.12"
+        return "3.13"
     elif platform.system() == "Linux":
-        return "3.12"
+        return "3.13"
     raise RuntimeError("Platform not supported")
 
 


### PR DESCRIPTION
Revert 50c7101a0a1172db1534c467ca5f7ea967db7183 which was made temporarily for a patch release.
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
