### PR TITLE
perf: avoid S3 HEAD requests when downloading job outputs

### DIFF
--- a/src/deadline/job_attachments/download.py
+++ b/src/deadline/job_attachments/download.py
@@ -21,7 +21,7 @@ import boto3
 from boto3.s3.transfer import ProgressCallbackInvoker
 from botocore.client import BaseClient
 from botocore.exceptions import BotoCoreError, ClientError
-from s3transfer.subscribers import BaseSubscriber
+from s3transfer.subscribers import BaseSubscriber as _BaseSubscriber
 
 from .asset_manifests.base_manifest import BaseAssetManifest, BaseManifestPath as RelativeFilePath
 from .asset_manifests.hash_algorithms import HashAlgorithm
@@ -79,7 +79,7 @@ from threading import Lock
 download_logger = getLogger("deadline.job_attachments.download")
 
 
-class _FileSizeSubscriber(BaseSubscriber):
+class _FileSizeSubscriber(_BaseSubscriber):
     """Subscriber that provides file size to skip HEAD requests."""
 
     def __init__(self, size):

--- a/src/deadline/job_attachments/download.py
+++ b/src/deadline/job_attachments/download.py
@@ -21,6 +21,7 @@ import boto3
 from boto3.s3.transfer import ProgressCallbackInvoker
 from botocore.client import BaseClient
 from botocore.exceptions import BotoCoreError, ClientError
+from s3transfer.subscribers import BaseSubscriber
 
 from .asset_manifests.base_manifest import BaseAssetManifest, BaseManifestPath as RelativeFilePath
 from .asset_manifests.hash_algorithms import HashAlgorithm
@@ -76,6 +77,22 @@ from ._utils import (
 from threading import Lock
 
 download_logger = getLogger("deadline.job_attachments.download")
+
+
+class _FileSizeSubscriber(BaseSubscriber):
+    """Subscriber that provides file size to skip HEAD requests."""
+
+    def __init__(self, size):
+        self._size = size
+
+    def on_queued(self, future, **kwargs):
+        future.meta.provide_transfer_size(self._size)
+        # Provide a dummy etag to skip HEAD request if the method exists (added in s3transfer 0.6.0).
+        # For downloads from CAS, we don't need etag validation since files are content-addressed.
+        # Older s3transfer versions don't have this method, so we check before calling.
+        if hasattr(future.meta, "provide_object_etag"):
+            future.meta.provide_object_etag("dummy-etag")
+
 
 S3_DOWNLOAD_MAX_CONCURRENCY = 10
 WINDOWS_MAX_PATH_LENGTH = 260
@@ -549,7 +566,7 @@ def download_file(
             if not should_continue:
                 future.cancel()
 
-    subscribers = [ProgressCallbackInvoker(handler)]
+    subscribers = [_FileSizeSubscriber(file_bytes), ProgressCallbackInvoker(handler)]
 
     future = transfer_manager.download(
         bucket=s3_bucket,

--- a/test/unit/deadline_job_attachments/test_download.py
+++ b/test/unit/deadline_job_attachments/test_download.py
@@ -1782,7 +1782,7 @@ class TestFullDownload:
         s3_client = boto3.client("s3")
         stubber = Stubber(s3_client)
         stubber.add_client_error(
-            "head_object",
+            "get_object",
             service_error_code="AccessDenied",
             service_message="Access Denied",
             http_status_code=403,
@@ -1868,6 +1868,58 @@ class TestFullDownload:
             ) in str(exc.value)
             mock_lock.assert_not_called()
             mock_collision_dict.assert_not_called()
+
+    def test_download_file_does_not_make_head_request_when_size_known(self):
+        """
+        Test that download_file does not make a HEAD request when file size is known from manifest.
+        """
+        mock_s3_client = MagicMock()
+        mock_transfer_manager = MagicMock()
+        mock_lock = MagicMock()
+        mock_collision_dict = MagicMock()
+
+        file_size = 12345
+        file_path = ManifestPathv2023_03_03(
+            path="inputs/input1.txt", hash="input1", size=file_size, mtime=1234000000
+        )
+
+        with patch(
+            f"{deadline.__package__}.job_attachments.download.get_s3_client",
+            return_value=mock_s3_client,
+        ), patch(
+            f"{deadline.__package__}.job_attachments.download.get_s3_transfer_manager",
+            return_value=mock_transfer_manager,
+        ), patch(f"{deadline.__package__}.job_attachments.download.Path.mkdir"), patch(
+            f"{deadline.__package__}.job_attachments.download.os.utime"
+        ):
+            download_file(
+                file_path,
+                HashAlgorithm.XXH128,
+                "/home/username/assets",
+                mock_lock,
+                mock_collision_dict,
+                "test-bucket",
+                "rootPrefix/Data",
+                mock_s3_client,
+            )
+            mock_s3_client.head_object.assert_not_called()
+
+    def test_file_size_subscriber_without_provide_object_etag(self):
+        """
+        Test that _FileSizeSubscriber works with older s3transfer versions
+        that don't have provide_object_etag method.
+        """
+        from deadline.job_attachments.download import _FileSizeSubscriber
+
+        mock_future = MagicMock()
+        mock_future.meta.provide_transfer_size = MagicMock()
+        # Simulate older s3transfer where provide_object_etag doesn't exist
+        del mock_future.meta.provide_object_etag
+
+        subscriber = _FileSizeSubscriber(12345)
+        subscriber.on_queued(mock_future)
+
+        mock_future.meta.provide_transfer_size.assert_called_once_with(12345)
 
     @pytest.mark.skipif(
         sys.platform == "win32",


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Job attachments uses the s3transfer library to download files from S3. When it estimates whether to use multipart downloads or a single download, it makes a HEAD request to get the file size. Job attachments already knows the file size though from the manifest. For small files, the HEAD requests take about half the total download time.

### What was the solution? (How)
Provide the file size to s3transfer.

### What is the impact of this change?
Roughly halves the transfer time for small files.

### How was this change tested?
I created a job that generates 10k small files. It took 3m52s to download before this change and 2m04s after.

### Was this change documented?
n/a

### Does this PR introduce new dependencies?
No

### Is this a breaking change?
No

### Does this change impact security?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
