### PR TITLE
chore: update pytest xfail and timeout markers for incremental download tests

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -145,9 +145,10 @@ interfaces with the local filesystem or an AWS service API.
 
 #### Running Integration Tests
 
-Our integration tests run using using infrastructure that is in your AWS Account. The identifiers for
-these resources are communicated to the tests through environment variables that you must define before running
-the tests. Define the following environment variables:
+Our integration tests run using infrastructure that is in your AWS Account. A Farm, Queue and Fleet (that associated with 
+the Queue) will be required to run the integration tests. The identifiers for these resources are communicated to the 
+tests through environment variables that you must define before running the tests. Define the following environment 
+variables:
 
 ```bash
 # Replace with your AWS Account ID

--- a/test/integ/cli/test_cli_incremental_download.py
+++ b/test/integ/cli/test_cli_incremental_download.py
@@ -165,10 +165,7 @@ def incremental_download_test(deadline_cli_test: DeadlineCliTest):
 
 
 @pytest.mark.integ
-@pytest.mark.timeout(900)  # 15 minutes timeout
-@pytest.mark.xfail(
-    reason="Soft-fail until edge case is root caused and fixed in sync-output CLI", strict=False
-)
+@pytest.mark.timeout(1200)  # 20 minute timeout
 def test_incremental_download_many_small_files(incremental_download_test, tmp_path):
     """Test incremental download with many small files (10,000 files total)."""
 
@@ -247,10 +244,7 @@ def test_incremental_download_many_small_files(incremental_download_test, tmp_pa
 
 
 @pytest.mark.integ
-@pytest.mark.timeout(900)  # 15 minutes timeout
-@pytest.mark.xfail(
-    reason="Soft-fail until edge case is root caused and fixed in sync-output CLI", strict=False
-)
+@pytest.mark.timeout(1200)  # 20 minute timeout
 def test_incremental_download_dep_data_flow(incremental_download_test, tmp_path):
     """Test incremental download with dep_data_flow template."""
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
* We had 2 tests tagged with `xfail` that have been consistently passing.
* We should remove the `xfail` marker to detect regressions

### What was the solution? (How)
* Remove these markers

### What is the impact of this change?
* Future failures of these tests will detect real regressions.

### How was this change tested?

- Have you run the unit tests?
  - N/A - No change to unit tests
- Have you run the integration tests?
  -  Yes
```
======================= 51 passed, 5 skipped, 4 xpassed in 2264.57s (0:37:44) ========================

```

- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass.
  - No
  
### Was this change documented?

- Are relevant docstrings in the code base updated? 
  - N/A
- Has the README.md been updated? If you modified CLI arguments, for instance.
  - I've updated the DEVELOPMENT.md to document the need for a connected fleet and queue to run the integration tests

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [X] This PR does not add any new dependencies.

### Is this a breaking change?

A breaking change is one that modifies a public contract in a way that is not backwards compatible. See the 
[Public Contracts](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#public-contracts) section
of the DEVELOPMENT.md for more information on the public contracts.

- No

If so, then please describe the changes that users of this package must make to update their scripts, or Python applications.

### Does this change impact security?

- Does the change need to be threat modeled? For example, does it create or modify files/directories that must only be readable by the process owner?
    - If so, then please label this pull request with the "security" label. We'll work with you to analyze the threats.


- No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
