### PR TITLE
chore: fix flaky unit test

### DIFF
--- a/test/unit/deadline_client/cli/test_cli_job.py
+++ b/test/unit/deadline_client/cli/test_cli_job.py
@@ -808,35 +808,43 @@ def test_cli_job_download_output_stdout_with_json_format(
             session=ANY,
         )
 
-        expected_json_title = json.dumps({"messageType": "title", "value": "Mock Job"})
-        expected_json_presummary = json.dumps(
-            {
-                "messageType": "presummary",
-                "value": {
-                    mock_root_path: [
-                        "outputs/file1.txt",
-                        "outputs/file2.txt",
-                        "outputs/file3.txt",
-                    ],
-                    f"{mock_root_path}2": [
-                        "outputs/file1.txt",
-                        "outputs/file2.txt",
-                        "outputs/file3.txt",
-                    ],
-                },
-            }
-        )
-        expected_json_path = json.dumps(
-            {"messageType": "path", "value": [mock_root_path, f"{mock_root_path}2"]}
-        )
-        expected_json_pathconfirm = json.dumps(
-            {"messageType": "pathconfirm", "value": [mock_root_path, str(tmp_path)]}
-        )
+        expected_json_title = {"messageType": "title", "value": "Mock Job"}
+        expected_json_presummary = {
+            "messageType": "presummary",
+            "value": {
+                mock_root_path: [
+                    "outputs/file1.txt",
+                    "outputs/file2.txt",
+                    "outputs/file3.txt",
+                ],
+                f"{mock_root_path}2": [
+                    "outputs/file1.txt",
+                    "outputs/file2.txt",
+                    "outputs/file3.txt",
+                ],
+            },
+        }
+        expected_json_path = {
+            "messageType": "path",
+            "value": [mock_root_path, f"{mock_root_path}2"],
+        }
+        expected_json_pathconfirm = {
+            "messageType": "pathconfirm",
+            "value": [mock_root_path, str(tmp_path)],
+        }
 
-        assert (
-            f"{expected_json_title}\n{expected_json_presummary}\n{expected_json_path}\n {expected_json_pathconfirm}\n"
-            in result.output
-        )
+        parsed_lines = []
+        for line in result.output.strip().split("\n"):
+            if line.strip():
+                try:
+                    parsed_lines.append(json.loads(line))
+                except json.JSONDecodeError:
+                    # Command can output non-JSON lines e.g. telemetry errors. Ignore lines that aren't valid JSON
+                    pass
+        assert expected_json_title in parsed_lines
+        assert expected_json_presummary in parsed_lines
+        assert expected_json_path in parsed_lines
+        assert expected_json_pathconfirm in parsed_lines
         assert result.exit_code == 0
 
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
One of the unit tests is failing because the command output has a different space character than expected. The test fails on the current mainline code. I could not find a root cause in a reasonable amount of time. Could be a dependency update.

The test assertion was unnecessarily pedantic to begin with though.

### What was the solution? (How)
Compare the JSON data of the command result instead of the particular string. The command under test is outputting JSON for programmatic parsing so whitespace doesn't matter.

### What is the impact of this change?
Fixes the test.

### How was this change tested?
Running the test

### Was this change documented?
n/a

### Does this PR introduce new dependencies?
No

### Is this a breaking change?
No

### Does this change impact security?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
