### PR TITLE
chore(dev): as of hatch 1.16.0, 'hatch build' can't be run in non-builder envs

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -15,15 +15,6 @@ lint = ["style", "typing"]
 [[envs.all.matrix]]
 python = ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
-[envs.default.env-vars]
-SKIP_BOOTSTRAP_TEST_RESOURCES = "True"
-
-[envs.codebuild.scripts]
-build = "hatch build"
-
-[envs.codebuild.env-vars]
-SKIP_BOOTSTRAP_TEST_RESOURCES = "True"
-
 [envs.integ]
 pre-install-commands = [
   "pip install -r requirements-integ-testing.txt",
@@ -33,18 +24,14 @@ pre-install-commands = [
 [envs.integ.scripts]
 test = "pytest --xfail-tb --no-cov -vvv --numprocesses=1 {args:test/integ}"
 
-[envs.installer.env-vars]
-SKIP_BOOTSTRAP_TEST_RESOURCES = "True"
-
 [envs.installer]
 pre-install-commands = ["pip install -r requirements-installer.txt"]
 
 [envs.installer.scripts]
-build = "hatch build"
 make_exe = "python scripts/pyinstaller/make_exe.py --output {root}/installer/components/DeadlineClient.zip --version-file {root}/pyinstaller-version.json"
 prepare_artifacts = "python scripts/prepare_artifacts.py --archive-path {root}/installer/components/DeadlineClient.zip --output-path {root}/installer/components/DeadlineClient"
 build_installer = "python {root}/scripts/build_installer_cli.py --installer-source-path {root}/installer/DeadlineCloudClient.xml {args:}"
-build_installer_local = "hatch build && hatch run make_exe && hatch run prepare_artifacts && hatch run build_installer --local-dev"
+build_installer_local = "hatch run make_exe && hatch run prepare_artifacts && hatch run build_installer --local-dev"
 validate_exe = "python {root}/scripts/pyinstaller/validate.py --zip-path {root}/installer/components/DeadlineClient.zip {args:}"
 validate_exe_local = "python {root}/scripts/pyinstaller/validate.py {args:}"
 

--- a/pipeline/build.ps1
+++ b/pipeline/build.ps1
@@ -12,9 +12,9 @@ python -m pip install --upgrade twine
 if ($LASTEXITCODE -ne 0) { throw "Failed to update twine" }
 
 # Run hatch commands
-hatch -v run codebuild:lint
+hatch -v run lint
 if ($LASTEXITCODE -ne 0) { throw "Failed to run lint" }
-hatch run codebuild:test
+hatch run test
 if ($LASTEXITCODE -ne 0) { throw "Failed to run test" }
-hatch -v run codebuild:build
+hatch -v build
 if ($LASTEXITCODE -ne 0) { throw "Failed to run build" }

--- a/pipeline/build.sh
+++ b/pipeline/build.sh
@@ -6,6 +6,6 @@ set -e
 pip install --upgrade pip
 pip install --upgrade hatch
 pip install --upgrade twine
-hatch -v run codebuild:lint
-hatch run codebuild:test
-hatch -v run codebuild:build
+hatch -v run lint
+hatch run test
+hatch -v build

--- a/pipeline/build_pyinstaller_artifact.ps1
+++ b/pipeline/build_pyinstaller_artifact.ps1
@@ -10,7 +10,7 @@ if ($LASTEXITCODE -ne 0) { throw "Failed to update pip" }
 pip install --upgrade hatch
 if ($LASTEXITCODE -ne 0) { throw "Failed to update hatch" }
 
-hatch run installer:build
+hatch build
 if ($LASTEXITCODE -ne 0) { throw "Failed to build project" }
 hatch run installer:make_exe
 if ($LASTEXITCODE -ne 0) { throw "Failed to build pyinstaller artifact" }

--- a/pipeline/build_pyinstaller_artifact.sh
+++ b/pipeline/build_pyinstaller_artifact.sh
@@ -7,6 +7,6 @@ pip3 install --upgrade pip
 pip3 install --upgrade hatch
 
 hatch run attributions:generate
-hatch run installer:build
+hatch build
 hatch run installer:make_exe
 hatch run installer:validate_exe


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Errors when running `hatch run installer:build`, `hatch run codebuild:build`,  and `hatch run installer:build_installer_local`

```
Environment `codebuild` is not a builder environment
```
and
```
Environment `installer` is not a builder environment
```

Due to yesterday's hatch 1.16.0 release, you can no longer run `hatch build` within other envs. It has its own `hatch-build` env that is used.

### What was the solution? (How)

Remove `hatch build` from other environment scripts. This is easily done due to `SKIP_BOOTSTRAP_TEST_RESOURCES` no longer being used. 

### What is the impact of this change?

Working CI

### How was this change tested?

Ran codebuild actions

### Was this change documented?

N/A

### Does this PR introduce new dependencies?

N/A

### Is this a breaking change?

N/A

### Does this change impact security?

N/A
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
