### PR TITLE
fix: process hangs on exit with high volume of telemetry

### DIFF
--- a/src/deadline/client/api/_telemetry.py
+++ b/src/deadline/client/api/_telemetry.py
@@ -213,7 +213,13 @@ class TelemetryClient:
         return metadata
 
     def _exit_cleanly(self):
-        self.event_queue.put(None)
+        try:
+            self.event_queue.put_nowait(None)
+        except Full:
+            # If the queue is full, it may mean the telemetry processing thread has already joined
+            # since it is daemon and the Python runtime will shut it down on exit.
+            # Ignore the error, since this is a best-effort cleanup.
+            pass
         self.processing_thread.join()
 
     def _send_request(self, req: request.Request) -> None:


### PR DESCRIPTION
Fixes: #935

### What was the problem/requirement? (What/Why)

From the issue above:

>   Python programs using `deadline` with telemetry enabled can hang when there is a high volume of telemetry events queued.
>   
>   The telemetry module uses a Python `Thread` to report telemetry events asynchronously from the calling thread that logs the telemetry event. This was done to avoid blocking the caller, since telemetry should be treated as best-effort. The module uses an instance of `queue.Queue` from the Python standard library and sets a maximum size on the queue:
>   
>   https://github.com/aws-deadline/deadline-cloud/blob/f030ff2698ca25975e5de7368c568068161c2987/src/deadline/client/api/_telemetry.py#L189-L191
>   
>   To handle cleanup when the process ends, the module:
>   
>   1.  marks the telemetry thread as daemon:
>   
>       https://github.com/aws-deadline/deadline-cloud/blob/f030ff2698ca25975e5de7368c568068161c2987/src/deadline/client/api/_telemetry.py#L194
>   
>       the Python runtime terminates this thread when the program is exiting
>   2.  registers a Python `atexit` callback so that the thread exits gracefully:
>   
>       https://github.com/aws-deadline/deadline-cloud/blob/f030ff2698ca25975e5de7368c568068161c2987/src/deadline/client/api/_telemetry.py#L192
>   
>       *   This callback appends `None` to the queue:
>   
>           https://github.com/aws-deadline/deadline-cloud/blob/f030ff2698ca25975e5de7368c568068161c2987/src/deadline/client/api/_telemetry.py#L216
>   
>   In cases with a high volume of telemetry, when the program exits the thread may terminate leaving behind a full queue. When the `atexit` callback is called, it will try to add `None` to the queue but since it uses a blocking put, it will never finish. This causes the program to hang on exit.

### What was the solution? (How)

Change the `atexit` callback to use a non-blocking put and catch the `queue.Empty` exception. The cleanup is best-effort and since the telemetry thread has `daemon=True`, the Python runtime should not block on the thread joining.

### What is the impact of this change?

Programs using `deadline` with telemetry enabled will not block when exiting attempting to gracefully cleanup.

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests?
    - yes
- Have you run the integration tests?
    - no
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass.
    - no

I also tested using the minimal reproduction Python script provided in #935 and was no longer able to reproduce the process hanging issue after 5 attempts. Without the fix, the script reproduces the issue 5/5 times.

### Was this change documented?

- Are relevant docstrings in the code base updated?
    - no
- Has the README.md been updated? If you modified CLI arguments, for instance.
    - no

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
