### PR TITLE
fix: linux failed to install optional pyside6 dependencies

### DIFF
--- a/src/deadline/client/ui/_utils.py
+++ b/src/deadline/client/ui/_utils.py
@@ -16,6 +16,9 @@ if TYPE_CHECKING:
 else:
     TranslationKey = str
 
+_LD_LIBRARY_PATH = "LD_LIBRARY_PATH"
+_LD_LIBRARY_PATH_ORIG = "LD_LIBRARY_PATH_ORIG"
+
 
 @lru_cache(maxsize=1)
 def _get_translations() -> Dict[str, str]:
@@ -157,7 +160,16 @@ def gui_context_for_cli(automatically_install_dependencies: bool):
             ]
             python_executable = shutil.which("python3") or shutil.which("python")
             if python_executable:
-                subprocess.run([python_executable] + pip_command)
+                # https://pyinstaller.org/en/stable/common-issues-and-pitfalls.html#linux-and-unix-like-oses
+                env = os.environ.copy()
+                if os.name != "nt":
+                    if env.get(_LD_LIBRARY_PATH_ORIG) is not None:
+                        env[_LD_LIBRARY_PATH] = env[_LD_LIBRARY_PATH_ORIG]
+                    else:
+                        # This happens when LD_LIBRARY_PATH was not set.
+                        env.pop(_LD_LIBRARY_PATH, None)
+
+                subprocess.run([python_executable] + pip_command, env=env)
             else:
                 click.echo(
                     "Unable to install GUI dependencies, if you have python available you can install it by running:"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

On RHEL9, the pyinstaller version of the 0.54 release candidate `deadline` executable fails to install pyside6 
```
$ deadline config gui
Optional GUI components for deadline are unavailable. Would you like to install PySide? [y/N]: y
Traceback (most recent call last):
  File "/usr/lib64/python3.9/random.py", line 61, in <module>
    from _sha512 import sha512 as _sha512
ModuleNotFoundError: No module named '_sha512'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib64/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib64/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/usr/lib/python3.9/site-packages/pip/__main__.py", line 29, in <module>
    from pip._internal.cli.main import main as _main
  File "/usr/lib/python3.9/site-packages/pip/_internal/cli/main.py", line 9, in <module>
    from pip._internal.cli.autocompletion import autocomplete
  File "/usr/lib/python3.9/site-packages/pip/_internal/cli/autocompletion.py", line 10, in <module>
    from pip._internal.cli.main_parser import create_main_parser
  File "/usr/lib/python3.9/site-packages/pip/_internal/cli/main_parser.py", line 8, in <module>
    from pip._internal.cli import cmdoptions
  File "/usr/lib/python3.9/site-packages/pip/_internal/cli/cmdoptions.py", line 23, in <module>
    from pip._internal.cli.parser import ConfigOptionParser
  File "/usr/lib/python3.9/site-packages/pip/_internal/cli/parser.py", line 12, in <module>
    from pip._internal.configuration import Configuration, ConfigurationError
  File "/usr/lib/python3.9/site-packages/pip/_internal/configuration.py", line 20, in <module>
    from pip._internal.exceptions import (
  File "/usr/lib/python3.9/site-packages/pip/_internal/exceptions.py", line 7, in <module>
    from pip._vendor.pkg_resources import Distribution
  File "/usr/lib/python3.9/site-packages/pip/_vendor/pkg_resources/__init__.py", line 36, in <module>
    import email.parser
  File "/usr/lib64/python3.9/email/parser.py", line 12, in <module>
    from email.feedparser import FeedParser, BytesFeedParser
  File "/usr/lib64/python3.9/email/feedparser.py", line 27, in <module>
    from email._policybase import compat32
  File "/usr/lib64/python3.9/email/_policybase.py", line 9, in <module>
    from email.utils import _has_surrogates
  File "/usr/lib64/python3.9/email/utils.py", line 28, in <module>
    import random
  File "/usr/lib64/python3.9/random.py", line 64, in <module>
    from hashlib import sha512 as _sha512
  File "/usr/lib64/python3.9/hashlib.py", line 77, in <module>
    import _hashlib
ImportError: /home/ec2-user/DeadlineCloudClient_revert_ind/DeadlineClient/_internal/cli/_internal/libcrypto.so.3: version `OPENSSL_3.4.0' not found (required by /usr/lib64/python3.9/lib-dynload/_hashlib.cpython-39-x86_64-linux-gnu.so)
Failed to import qtpy/PySide/Qt, which is required to show the GUI:
No Qt bindings could be found
```

The python command that we use to download the optional dependencies grabs the first python on the path. This python was finding our `libcrypto` instead of its own compatible version due to how the pyinstaller generated executable modifies its environment.

* https://pyinstaller.org/en/stable/common-issues-and-pitfalls.html#linux-and-unix-like-oses


> During the frozen application’s startup, the PyInstaller’s bootloader checks whether the LD_LIBRARY_PATH environment variable is already set, and, if necessary, creates a copy of its contents into LD_LIBRARY_PATH_ORIG environment variable. Then, it modifies LD_LIBRARY_PATH by prepending the application’s top level directory (i.e., the path that is also available in sys._MEIPASS).

> Therefore, prior to launching an external program, the LD_LIBRARY_PATH should be either cleared (to use the system default) or reset to the value stored in LD_LIBRARY_PATH_ORIG (if available).

This wasn't previously a problem due to some luck where the libcrypto/libssl we ship was compatible with the operating systems that we test on. With this next release we've upgraded from python 3.12 to python 3.13 which brings in a newer version of openssl thus causing the mismatch error to appear.

### What was the solution? (How)

Follow pyinstaller's recommended method of launching applications from the frozen build which involves resetting `LD_LIBRARY_PATH` for the subprocess so that `python3` / `python` leverage their respective libs.

* https://pyinstaller.org/en/stable/runtime-information.html#ld-library-path-libpath-considerations

### What is the impact of this change?

Working linux installs

### How was this change tested?

Built an installer for linux and macos. Confirmed that both platforms are able to download and install pyside dependencies through the executable.

### Was this change documented?

N/A

### Does this PR introduce new dependencies?

N/A

### Is this a breaking change?

N/A

### Does this change impact security?

N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
