### PR TITLE
fix: move bundle loading button when using gui-submit --browse

### DIFF
--- a/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
@@ -239,6 +239,10 @@ class SubmitJobToDeadlineDialog(QDialog):
         self.submit_button = QPushButton(tr("Submit"))
         self.submit_button.clicked.connect(self.on_submit)
         self.button_box.addButton(self.submit_button, QDialogButtonBox.AcceptRole)
+        if hasattr(initial_job_settings, "browse_enabled") and initial_job_settings.browse_enabled:
+            self.load_bundle_button = QPushButton(tr("Load a different job bundle"))
+            self.load_bundle_button.clicked.connect(self._on_load_bundle)
+            self.button_box.addButton(self.load_bundle_button, QDialogButtonBox.AcceptRole)
         self.export_bundle_button = QPushButton(tr("Export bundle"))
         self.export_bundle_button.clicked.connect(self.on_export_bundle)
         self.button_box.addButton(self.export_bundle_button, QDialogButtonBox.AcceptRole)
@@ -415,6 +419,11 @@ class SubmitJobToDeadlineDialog(QDialog):
                 "Error",
                 f"Failed to display About dialog: {str(e)}",
             )
+
+    def _on_load_bundle(self):
+        """Delegates to the job_settings widget's on_load_bundle method."""
+        if hasattr(self.job_settings, "on_load_bundle"):
+            self.job_settings.on_load_bundle()
 
     def on_export_bundle(self):
         """

--- a/src/deadline/client/ui/widgets/job_bundle_settings_tab.py
+++ b/src/deadline/client/ui/widgets/job_bundle_settings_tab.py
@@ -11,15 +11,10 @@ from logging import getLogger
 from typing import Any, Optional
 
 from qtpy.QtCore import Signal  # type: ignore
-from .._utils import tr
 from qtpy.QtWidgets import (  # type: ignore
     QVBoxLayout,
-    QHBoxLayout,
     QWidget,
     QFileDialog,
-    QPushButton,
-    QSpacerItem,
-    QSizePolicy,
     QMessageBox,
 )
 
@@ -61,14 +56,6 @@ class JobBundleSettingsWidget(QWidget):
         self.input_job_bundle_dir = initial_settings.input_job_bundle_dir
 
         layout = QVBoxLayout(self)
-
-        if initial_settings.browse_enabled:
-            btnBox = QHBoxLayout()
-            self.load_bundle_button = QPushButton(tr("Load a different job bundle"))
-            self.load_bundle_button.clicked.connect(self.on_load_bundle)
-            btnBox.addWidget(self.load_bundle_button)
-            btnBox.addItem(QSpacerItem(0, 0, QSizePolicy.Expanding, QSizePolicy.Minimum))
-            layout.addLayout(btnBox)
 
         layout.addLayout(self.param_layout)
         self.refresh_ui(initial_settings)

--- a/test/unit/deadline_client/ui/dialogs/test_submit_job_to_deadline_dialog.py
+++ b/test/unit/deadline_client/ui/dialogs/test_submit_job_to_deadline_dialog.py
@@ -1,0 +1,67 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+try:
+    from deadline.client.ui.dialogs.submit_job_to_deadline_dialog import SubmitJobToDeadlineDialog
+    from deadline.client.ui.dataclasses import JobBundleSettings
+    from deadline.client.job_bundle.submission import AssetReferences
+except ImportError:
+    pytest.importorskip("deadline.client.ui.dialogs.submit_job_to_deadline_dialog")
+
+
+@pytest.fixture
+def mock_job_settings_widget():
+    """Create a mock job settings widget type."""
+    widget = MagicMock()
+    widget.return_value = MagicMock()
+    widget.return_value.parameter_changed = MagicMock()
+    widget.return_value.parameter_changed.connect = MagicMock()
+    return widget
+
+
+@patch("deadline.client.ui.dialogs.submit_job_to_deadline_dialog.DeadlineAuthenticationStatus")
+def test_load_bundle_button_shown_when_browse_enabled(
+    mock_auth_status, qtbot, mock_job_settings_widget
+):
+    """Test that the Load a different job bundle button is shown when browse_enabled is True."""
+    mock_auth_status.getInstance.return_value = MagicMock()
+
+    settings = JobBundleSettings(browse_enabled=True)
+
+    dialog = SubmitJobToDeadlineDialog(
+        job_setup_widget_type=mock_job_settings_widget,
+        initial_job_settings=settings,
+        initial_shared_parameter_values={},
+        auto_detected_attachments=AssetReferences(),
+        attachments=AssetReferences(),
+        on_create_job_bundle_callback=MagicMock(),
+    )
+    qtbot.addWidget(dialog)
+
+    assert hasattr(dialog, "load_bundle_button")
+    assert dialog.load_bundle_button.text() == "Load a different job bundle"
+
+
+@patch("deadline.client.ui.dialogs.submit_job_to_deadline_dialog.DeadlineAuthenticationStatus")
+def test_load_bundle_button_hidden_when_browse_disabled(
+    mock_auth_status, qtbot, mock_job_settings_widget
+):
+    """Test that the Load a different job bundle button is not shown when browse_enabled is False."""
+    mock_auth_status.getInstance.return_value = MagicMock()
+
+    settings = JobBundleSettings(browse_enabled=False)
+
+    dialog = SubmitJobToDeadlineDialog(
+        job_setup_widget_type=mock_job_settings_widget,
+        initial_job_settings=settings,
+        initial_shared_parameter_values={},
+        auto_detected_attachments=AssetReferences(),
+        attachments=AssetReferences(),
+        on_create_job_bundle_callback=MagicMock(),
+    )
+    qtbot.addWidget(dialog)
+
+    assert not hasattr(dialog, "load_bundle_button")


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
When using `deadline bundle gui-submit --browse`, there's an awkward button under job specific settings to swap job bundles. It looks weird.

The option was added a couple years ago in this PR: https://github.com/aws-deadline/deadline-cloud/pull/35

<img width="652" height="840" alt="Screenshot 2025-12-11 at 10 41 57 AM" src="https://github.com/user-attachments/assets/980d8595-c377-4d3c-a352-f6271105ea33" />

### What was the solution? (How)
Move the button to the bottom of the window next to the "Export bundle" button.

<img width="652" height="840" alt="Screenshot 2025-12-11 at 12 51 39 PM" src="https://github.com/user-attachments/assets/88f49b72-0372-4da1-8a50-3e3fae4589bf" />

### What is the impact of this change?
Cleaner bundle submitter.

### How was this change tested?
Ran the command, saw the button was moved. Added unit tets

### Was this change documented?
n/a

### Does this PR introduce new dependencies?
No

### Is this a breaking change?
No

### Does this change impact security?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
