### PR TITLE
feat: add release date display to about dialog

### DIFF
--- a/src/deadline/client/ui/dataclasses/_environment_info.py
+++ b/src/deadline/client/ui/dataclasses/_environment_info.py
@@ -30,6 +30,7 @@ class _EnvironmentInfo:
 
     Attributes:
         deadline_dep_versions: Dictionary of deadline dependency package names to versions
+        release_date: Human-readable release date of the deadline package (e.g., "December 11, 2025")
         os_name: Name of the operating system
         os_version: Operating system version
         os_architecture: OS architecture (e.g., "x86_64", "arm64")
@@ -39,6 +40,9 @@ class _EnvironmentInfo:
 
     deadline_dep_versions: dict[str, str]
     """Dictionary of deadline dependency package names to versions"""
+
+    release_date: str
+    """Human-readable release date of the deadline package (e.g., "December 11, 2025")"""
 
     os_name: str
     """Name of the operating system"""
@@ -54,6 +58,37 @@ class _EnvironmentInfo:
 
     qt_version: str
     """Qt framework version"""
+
+    @staticmethod
+    def _extract_release_date(version_string: str) -> str:
+        """
+        Extract and format the release date from a version string.
+
+        The version string may contain a date component in the format dYYYYMMDD
+        (e.g., '0.53.3.post24+g9eb659973.d20251211').
+
+        Args:
+            version_string: Version string potentially containing a date component
+
+        Returns:
+            Human-readable date string (e.g., 'December 11, 2025') or 'Unknown'
+        """
+        from datetime import datetime
+
+        # Look for date component in format dYYYYMMDD
+        match = re.search(r"\.d(\d{8})(?:\.|$)", version_string)
+        if not match:
+            return "Unknown"
+
+        date_str = match.group(1)
+        try:
+            # Parse YYYYMMDD format
+            date_obj = datetime.strptime(date_str, "%Y%m%d")
+            # Format as human-readable date (e.g., "December 11, 2025")
+            return date_obj.strftime("%B %d, %Y")
+        except ValueError:
+            logger.debug(f"Failed to parse date from version string: {version_string}")
+            return "Unknown"
 
     @staticmethod
     def collect() -> "_EnvironmentInfo":
@@ -140,8 +175,14 @@ class _EnvironmentInfo:
             logger.warning(f"Failed to retrieve Qt version: {e}")
             qt_version = "Unknown"
 
+        # Extract release date from deadline version string
+        release_date = _EnvironmentInfo._extract_release_date(
+            deadline_dep_versions.get("deadline", "")
+        )
+
         return _EnvironmentInfo(
             deadline_dep_versions=deadline_dep_versions,
+            release_date=release_date,
             python_version=python_version,
             os_name=os_name,
             os_version=os_version,

--- a/src/deadline/client/ui/dialogs/_about_dialog.py
+++ b/src/deadline/client/ui/dialogs/_about_dialog.py
@@ -102,7 +102,10 @@ class _AboutDialog(QDialog):
 
         combined_info = {**submitter_dict, **env_data}
 
-        yaml_str = yaml.dump(combined_info, indent=4, sort_keys=False)
+        # Replace underscores with spaces in keys for user-friendly display
+        friendly_info = {k.replace("_", " "): v for k, v in combined_info.items()}
+
+        yaml_str = yaml.dump(friendly_info, indent=4, sort_keys=False)
         return yaml_str
 
     def _format_for_copy(self) -> str:

--- a/test/unit/deadline_client/ui/dataclasses/test_environment_info.py
+++ b/test/unit/deadline_client/ui/dataclasses/test_environment_info.py
@@ -1,0 +1,40 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import pytest
+from deadline.client.ui.dataclasses._environment_info import _EnvironmentInfo
+
+
+@pytest.mark.parametrize(
+    "version_string,expected",
+    [
+        pytest.param(
+            "0.53.3.post24+g9eb659973.d20251211",
+            "December 11, 2025",
+            id="full_version_with_date",
+        ),
+        pytest.param(
+            "1.0.0.d20240115",
+            "January 15, 2024",
+            id="version_with_date_no_post",
+        ),
+        pytest.param(
+            "0.53.3",
+            "Unknown",
+            id="release_version_no_date",
+        ),
+        pytest.param(
+            "invalid",
+            "Unknown",
+            id="invalid_version_string",
+        ),
+        pytest.param(
+            "",
+            "Unknown",
+            id="empty_string",
+        ),
+    ],
+)
+def test_extract_release_date(version_string, expected):
+    """Test that release dates are correctly extracted from version strings."""
+    result = _EnvironmentInfo._extract_release_date(version_string)
+    assert result == expected


### PR DESCRIPTION
Fixes: *<insert link to GitHub issue here>*

### What was the problem/requirement? (What/Why)
It isn't easy for customer to find out if they are on the vastest version. Sometimes it is easier to look for the release date. In addition the info on the about page was snake case. It should be human readable 
### What was the solution? (How)
Add the release date to the About dialog
### What is the impact of this change?
Easier to find the release date of the submitter and also eaiser to read (human readable
### How was this change tested?
unit and manually
See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests? yes
- Have you run the integration tests? yes
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass. No

### Was this change documented?
no

- Are relevant docstrings in the code base updated? no
- Has the README.md been updated? If you modified CLI arguments, for instance. no

### Does this PR introduce new dependencies? no

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [ ] This PR does not add any new dependencies.

### Is this a breaking change?
no
A breaking change is one that modifies a public contract in a way that is not backwards compatible. See the 
[Public Contracts](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#public-contracts) section
of the DEVELOPMENT.md for more information on the public contracts.

If so, then please describe the changes that users of this package must make to update their scripts, or Python applications.

### Does this change impact security?

- Does the change need to be threat modeled? For example, does it create or modify files/directories that must only be readable by the process owner?
    - If so, then please label this pull request with the "security" label. We'll work with you to analyze the threats.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
