### PR TITLE
feat!: Update hash cache to support byte ranges for file chunking support

### DIFF
--- a/src/deadline/job_attachments/caches/__init__.py
+++ b/src/deadline/job_attachments/caches/__init__.py
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 from .cache_db import CacheDB, CONFIG_ROOT, COMPONENT_NAME
-from .hash_cache import HashCache, HashCacheEntry
+from .hash_cache import HashCache, HashCacheEntry, WHOLE_FILE_RANGE_END
 from .s3_check_cache import S3CheckCache, S3CheckCacheEntry
 
 __all__ = [
@@ -10,6 +10,7 @@ __all__ = [
     "COMPONENT_NAME",
     "HashCache",
     "HashCacheEntry",
+    "WHOLE_FILE_RANGE_END",
     "S3CheckCache",
     "S3CheckCacheEntry",
 ]

--- a/src/deadline/job_attachments/caches/hash_cache.py
+++ b/src/deadline/job_attachments/caches/hash_cache.py
@@ -2,6 +2,13 @@
 
 """
 Module for accessing the local file hash cache.
+
+Supports two types of hash entries:
+1. Whole-file hashes: range_start=0, range_end=-1 (WHOLE_FILE_RANGE_END)
+2. Byte-range hashes: range_start >= 0, range_end > 0, defining the range [start, end)
+
+The range parameters allow caching hashes for arbitrary byte ranges of files,
+which is useful for caching hashes for any chunking scheme without modifying the cache.
 """
 
 import logging
@@ -14,10 +21,17 @@ from ..asset_manifests.hash_algorithms import HashAlgorithm
 
 logger = logging.getLogger("Deadline")
 
+# Sentinel value indicating a whole-file hash (no specific byte range)
+WHOLE_FILE_RANGE_END = -1
+
 
 @dataclass
 class HashCacheEntry:
-    """Represents an entry in the local hash-cache database"""
+    """Represents an entry in the local hash-cache database.
+
+    For whole-file hashes: range_start=0, range_end=-1 (WHOLE_FILE_RANGE_END)
+    For chunk hashes: range_start and range_end define the byte range [start, end)
+    """
 
     # The file_path is stored as a BLOB in sqlite, encoded with utf-8 and the "surrogatepass"
     # error handler, as file names encountered in practice require this.
@@ -25,6 +39,20 @@ class HashCacheEntry:
     hash_algorithm: HashAlgorithm
     file_hash: str
     last_modified_time: str
+    range_start: int = 0
+    range_end: int = WHOLE_FILE_RANGE_END
+
+    def __post_init__(self) -> None:
+        # Validate byte-range entries have range_end > range_start.
+        if self.range_end != WHOLE_FILE_RANGE_END and self.range_end <= self.range_start:
+            raise ValueError(
+                f"For byte-range entries, range_end ({self.range_end}) must be greater than "
+                f"range_start ({self.range_start})"
+            )
+
+    def is_whole_file(self) -> bool:
+        """Returns True if this entry represents a whole-file hash."""
+        return self.range_start == 0 and self.range_end == WHOLE_FILE_RANGE_END
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -32,6 +60,8 @@ class HashCacheEntry:
             "hash_algorithm": self.hash_algorithm.value,
             "file_hash": self.file_hash,
             "last_modified_time": self.last_modified_time,
+            "range_start": self.range_start,
+            "range_end": self.range_end,
         }
 
 
@@ -44,14 +74,34 @@ class HashCache(CacheDB):
 
     This class also automatically locks when doing writes, so it can be called
     by multiple threads.
+
+    Schema (hashesV4):
+        - file_path: blob (part of composite primary key)
+        - hash_algorithm: text (part of composite primary key)
+        - range_start: integer (part of composite primary key)
+        - range_end: integer (part of composite primary key)
+        - file_hash: text
+        - last_modified_time: timestamp
+
+    For whole-file hashes, range_start=0 and range_end=-1.
+    For byte-range hashes, range_start and range_end define [start, end).
     """
 
     CACHE_NAME = "hash_cache"
-    CACHE_DB_VERSION = 3
+    CACHE_DB_VERSION = 4
 
     def __init__(self, cache_dir: Optional[str] = None) -> None:
         table_name: str = f"hashesV{self.CACHE_DB_VERSION}"
-        create_query: str = f"CREATE TABLE hashesV{self.CACHE_DB_VERSION}(file_path blob primary key, hash_algorithm text secondary key, file_hash text, last_modified_time timestamp)"
+        create_query: str = (
+            f"CREATE TABLE {table_name}("
+            "file_path blob, "
+            "hash_algorithm text, "
+            "range_start integer, "
+            "range_end integer, "
+            "file_hash text, "
+            "last_modified_time timestamp, "
+            "PRIMARY KEY (file_path, hash_algorithm, range_start, range_end))"
+        )
         super().__init__(
             cache_name=self.CACHE_NAME,
             table_name=table_name,
@@ -60,55 +110,101 @@ class HashCache(CacheDB):
         )
 
     def get_connection_entry(
-        self, file_path_key: str, hash_algorithm: HashAlgorithm, connection
+        self,
+        file_path_key: str,
+        hash_algorithm: HashAlgorithm,
+        connection: Any,
+        range_start: int = 0,
+        range_end: int = WHOLE_FILE_RANGE_END,
     ) -> Optional[HashCacheEntry]:
         """
-        Returns an entry from the hash cache, if it exists.  This is the "lockless" (Doesn't take
-        the main db_lock protecting db_connection) version of get_entry which expects a connection
+        Returns an entry from the hash cache, if it exists.
+
+        This is the "lockless" version of get_entry which expects a connection
         parameter for the connection which will be used to read from the DB - this can generally
         be the thread local connection returned by get_local_connection()
+
+        Args:
+            file_path_key: The file path to look up
+            hash_algorithm: The hash algorithm used
+            connection: SQLite connection to use
+            range_start: Start byte offset (0 for whole-file)
+            range_end: End byte offset (-1/WHOLE_FILE_RANGE_END for whole-file)
+
+        Returns:
+            HashCacheEntry if found, None otherwise
         """
         if not self.enabled:
             return None
 
+        encoded_path = file_path_key.encode(encoding="utf-8", errors="surrogatepass")
+
         entry_vals = connection.execute(
-            f"SELECT * FROM {self.table_name} WHERE file_path=? AND hash_algorithm=?",
-            [
-                file_path_key.encode(encoding="utf-8", errors="surrogatepass"),
-                hash_algorithm.value,
-            ],
+            f"SELECT * FROM {self.table_name} "
+            "WHERE file_path=? AND hash_algorithm=? AND range_start=? AND range_end=?",
+            [encoded_path, hash_algorithm.value, range_start, range_end],
         ).fetchone()
+
         if entry_vals:
             return HashCacheEntry(
                 file_path=str(entry_vals[0], encoding="utf-8", errors="surrogatepass"),
                 hash_algorithm=HashAlgorithm(entry_vals[1]),
-                file_hash=entry_vals[2],
-                last_modified_time=str(entry_vals[3]),
+                file_hash=entry_vals[4],
+                last_modified_time=str(entry_vals[5]),
+                range_start=entry_vals[2],
+                range_end=entry_vals[3],
             )
-        else:
-            return None
+
+        return None
 
     def get_entry(
-        self, file_path_key: str, hash_algorithm: HashAlgorithm
+        self,
+        file_path_key: str,
+        hash_algorithm: HashAlgorithm,
+        range_start: int = 0,
+        range_end: int = WHOLE_FILE_RANGE_END,
     ) -> Optional[HashCacheEntry]:
         """
         Returns an entry from the hash cache, if it exists.
+
+        Args:
+            file_path_key: The file path to look up
+            hash_algorithm: The hash algorithm used
+            range_start: Start byte offset (0 for whole-file)
+            range_end: End byte offset (-1/WHOLE_FILE_RANGE_END for whole-file)
+
+        Returns:
+            HashCacheEntry if found, None otherwise
         """
         if not self.enabled:
             return None
 
         with self.db_lock, self.db_connection:
-            return self.get_connection_entry(file_path_key, hash_algorithm, self.db_connection)
+            return self.get_connection_entry(
+                file_path_key, hash_algorithm, self.db_connection, range_start, range_end
+            )
 
     def put_entry(self, entry: HashCacheEntry) -> None:
-        """Inserts or replaces an entry into the hash cache database after acquiring the lock."""
+        """
+        Inserts or replaces an entry into the hash cache database after acquiring the lock.
+
+        The entry's range_start and range_end determine whether this is a whole-file
+        hash (range_start=0, range_end=-1) or a byte-range hash.
+        """
         if self.enabled:
             with self.db_lock, self.db_connection:
-                entry_dict = entry.to_dict()
-                entry_dict["file_path"] = entry_dict["file_path"].encode(
-                    encoding="utf-8", errors="surrogatepass"
-                )
+                encoded_path = entry.file_path.encode(encoding="utf-8", errors="surrogatepass")
+
                 self.db_connection.execute(
-                    f"INSERT OR REPLACE INTO {self.table_name} VALUES(:file_path, :hash_algorithm, :file_hash, :last_modified_time)",
-                    entry_dict,
+                    f"INSERT OR REPLACE INTO {self.table_name} "
+                    "VALUES(:file_path, :hash_algorithm, :range_start, :range_end, "
+                    ":file_hash, :last_modified_time)",
+                    {
+                        "file_path": encoded_path,
+                        "hash_algorithm": entry.hash_algorithm.value,
+                        "range_start": entry.range_start,
+                        "range_end": entry.range_end,
+                        "file_hash": entry.file_hash,
+                        "last_modified_time": entry.last_modified_time,
+                    },
                 )

--- a/test/unit/deadline_job_attachments/caches/test_caches.py
+++ b/test/unit/deadline_job_attachments/caches/test_caches.py
@@ -17,6 +17,7 @@ from deadline.job_attachments.caches import (
     HashCacheEntry,
     S3CheckCache,
     S3CheckCacheEntry,
+    WHOLE_FILE_RANGE_END,
 )
 
 
@@ -266,6 +267,297 @@ class TestHashCache:
                     )
                 )
                 assert hc.get_entry("/no/file", HashAlgorithm.XXH128) is None
+
+    def test_get_entry_with_byte_range(self, tmpdir):
+        """
+        Tests that a byte range entry is returned when it exists in the cache
+        """
+        # GIVEN
+        cache_dir = tmpdir.mkdir("cache")
+        expected_entry = HashCacheEntry(
+            file_path="large_file.bin",
+            hash_algorithm=HashAlgorithm.XXH128,
+            file_hash="chunk_hash_1",
+            last_modified_time="1234.5678",
+            range_start=0,
+            range_end=268435456,  # 256MB
+        )
+
+        # WHEN
+        with HashCache(cache_dir) as hc:
+            hc.put_entry(expected_entry)
+            actual_entry = hc.get_entry(
+                "large_file.bin", HashAlgorithm.XXH128, range_start=0, range_end=268435456
+            )
+
+            # THEN
+            assert actual_entry == expected_entry
+            assert actual_entry.range_start == 0
+            assert actual_entry.range_end == 268435456
+
+    def test_get_entry_multiple_byte_ranges_same_file(self, tmpdir):
+        """
+        Tests that multiple byte range entries for the same file are stored and retrieved correctly
+        """
+        # GIVEN
+        cache_dir = tmpdir.mkdir("cache")
+        chunk_size = 268435456  # 256MB
+        entries = [
+            HashCacheEntry(
+                file_path="large_file.bin",
+                hash_algorithm=HashAlgorithm.XXH128,
+                file_hash=f"chunk_hash_{i}",
+                last_modified_time="1234.5678",
+                range_start=i * chunk_size,
+                range_end=(i + 1) * chunk_size,
+            )
+            for i in range(4)  # 4 chunks
+        ]
+
+        # WHEN
+        with HashCache(cache_dir) as hc:
+            for entry in entries:
+                hc.put_entry(entry)
+
+            # THEN - each chunk should be retrievable independently
+            for i, expected_entry in enumerate(entries):
+                actual_entry = hc.get_entry(
+                    "large_file.bin",
+                    HashAlgorithm.XXH128,
+                    range_start=i * chunk_size,
+                    range_end=(i + 1) * chunk_size,
+                )
+                assert actual_entry == expected_entry
+                assert actual_entry.file_hash == f"chunk_hash_{i}"
+
+    def test_get_entry_byte_range_not_found(self, tmpdir):
+        """
+        Tests that None is returned when a specific byte range doesn't exist
+        """
+        # GIVEN
+        cache_dir = tmpdir.mkdir("cache")
+        entry = HashCacheEntry(
+            file_path="file.bin",
+            hash_algorithm=HashAlgorithm.XXH128,
+            file_hash="chunk_hash",
+            last_modified_time="1234.5678",
+            range_start=0,
+            range_end=1000,
+        )
+
+        # WHEN
+        with HashCache(cache_dir) as hc:
+            hc.put_entry(entry)
+
+            # THEN - different range should return None
+            assert (
+                hc.get_entry("file.bin", HashAlgorithm.XXH128, range_start=0, range_end=2000)
+                is None
+            )
+            assert (
+                hc.get_entry("file.bin", HashAlgorithm.XXH128, range_start=1000, range_end=2000)
+                is None
+            )
+
+    def test_get_entry_whole_file_vs_byte_range_independent(self, tmpdir):
+        """
+        Tests that whole-file hashes and byte-range hashes are stored independently
+        """
+        # GIVEN
+        cache_dir = tmpdir.mkdir("cache")
+        whole_file_entry = HashCacheEntry(
+            file_path="file.bin",
+            hash_algorithm=HashAlgorithm.XXH128,
+            file_hash="whole_file_hash",
+            last_modified_time="1234.5678",
+            range_start=0,
+            range_end=WHOLE_FILE_RANGE_END,
+        )
+        chunk_entry = HashCacheEntry(
+            file_path="file.bin",
+            hash_algorithm=HashAlgorithm.XXH128,
+            file_hash="chunk_hash",
+            last_modified_time="1234.5678",
+            range_start=0,
+            range_end=1000,
+        )
+
+        # WHEN
+        with HashCache(cache_dir) as hc:
+            hc.put_entry(whole_file_entry)
+            hc.put_entry(chunk_entry)
+
+            # THEN - both should be retrievable independently
+            actual_whole = hc.get_entry("file.bin", HashAlgorithm.XXH128)
+            actual_chunk = hc.get_entry(
+                "file.bin", HashAlgorithm.XXH128, range_start=0, range_end=1000
+            )
+
+            assert actual_whole == whole_file_entry
+            assert actual_whole.file_hash == "whole_file_hash"
+            assert actual_chunk == chunk_entry
+            assert actual_chunk.file_hash == "chunk_hash"
+
+    def test_get_connection_entry_with_byte_range(self, tmpdir):
+        """
+        Tests that get_connection_entry works with byte range parameters
+        """
+        # GIVEN
+        cache_dir = tmpdir.mkdir("cache")
+        expected_entry = HashCacheEntry(
+            file_path="file.bin",
+            hash_algorithm=HashAlgorithm.XXH128,
+            file_hash="chunk_hash",
+            last_modified_time="1234.5678",
+            range_start=1000,
+            range_end=2000,
+        )
+
+        # WHEN
+        with HashCache(cache_dir) as hc:
+            hc.put_entry(expected_entry)
+            connection = hc.get_local_connection()
+            actual_entry = hc.get_connection_entry(
+                "file.bin", HashAlgorithm.XXH128, connection, range_start=1000, range_end=2000
+            )
+
+            # THEN
+            assert actual_entry == expected_entry
+
+    def test_hash_cache_entry_is_whole_file(self):
+        """
+        Tests the is_whole_file() helper method on HashCacheEntry
+        """
+        whole_file = HashCacheEntry(
+            file_path="file.txt",
+            hash_algorithm=HashAlgorithm.XXH128,
+            file_hash="hash",
+            last_modified_time="1234.5678",
+        )
+        assert whole_file.is_whole_file() is True
+
+        chunk = HashCacheEntry(
+            file_path="file.txt",
+            hash_algorithm=HashAlgorithm.XXH128,
+            file_hash="hash",
+            last_modified_time="1234.5678",
+            range_start=0,
+            range_end=1000,
+        )
+        assert chunk.is_whole_file() is False
+
+        # Edge case: range_start != 0 but range_end == -1 should not be whole file
+        weird_entry = HashCacheEntry(
+            file_path="file.txt",
+            hash_algorithm=HashAlgorithm.XXH128,
+            file_hash="hash",
+            last_modified_time="1234.5678",
+            range_start=100,
+            range_end=WHOLE_FILE_RANGE_END,
+        )
+        assert weird_entry.is_whole_file() is False
+
+    def test_put_entry_replaces_existing_byte_range(self, tmpdir):
+        """
+        Tests that put_entry replaces an existing entry with the same byte range
+        """
+        # GIVEN
+        cache_dir = tmpdir.mkdir("cache")
+        original_entry = HashCacheEntry(
+            file_path="file.bin",
+            hash_algorithm=HashAlgorithm.XXH128,
+            file_hash="original_hash",
+            last_modified_time="1234.5678",
+            range_start=0,
+            range_end=1000,
+        )
+        updated_entry = HashCacheEntry(
+            file_path="file.bin",
+            hash_algorithm=HashAlgorithm.XXH128,
+            file_hash="updated_hash",
+            last_modified_time="9999.9999",
+            range_start=0,
+            range_end=1000,
+        )
+
+        # WHEN
+        with HashCache(cache_dir) as hc:
+            hc.put_entry(original_entry)
+            hc.put_entry(updated_entry)
+            actual_entry = hc.get_entry(
+                "file.bin", HashAlgorithm.XXH128, range_start=0, range_end=1000
+            )
+
+            # THEN
+            assert actual_entry.file_hash == "updated_hash"
+            assert actual_entry.last_modified_time == "9999.9999"
+
+    def test_hash_cache_entry_to_dict_includes_range(self):
+        """
+        Tests that to_dict() includes range_start and range_end
+        """
+        entry = HashCacheEntry(
+            file_path="file.bin",
+            hash_algorithm=HashAlgorithm.XXH128,
+            file_hash="hash",
+            last_modified_time="1234.5678",
+            range_start=100,
+            range_end=200,
+        )
+        result = entry.to_dict()
+
+        assert result["file_path"] == "file.bin"
+        assert result["hash_algorithm"] == "xxh128"
+        assert result["file_hash"] == "hash"
+        assert result["last_modified_time"] == "1234.5678"
+        assert result["range_start"] == 100
+        assert result["range_end"] == 200
+
+    def test_hash_cache_entry_validates_byte_range(self):
+        """
+        Tests that HashCacheEntry raises ValueError when range_end <= range_start for byte-range entries
+        """
+        # Valid byte-range entry should work
+        HashCacheEntry(
+            file_path="file.bin",
+            hash_algorithm=HashAlgorithm.XXH128,
+            file_hash="hash",
+            last_modified_time="1234.5678",
+            range_start=0,
+            range_end=100,
+        )
+
+        # Whole-file entry (range_end=-1) should work regardless of range_start
+        HashCacheEntry(
+            file_path="file.bin",
+            hash_algorithm=HashAlgorithm.XXH128,
+            file_hash="hash",
+            last_modified_time="1234.5678",
+            range_start=0,
+            range_end=WHOLE_FILE_RANGE_END,
+        )
+
+        # Invalid: range_end == range_start
+        with pytest.raises(ValueError, match="range_end.*must be greater than.*range_start"):
+            HashCacheEntry(
+                file_path="file.bin",
+                hash_algorithm=HashAlgorithm.XXH128,
+                file_hash="hash",
+                last_modified_time="1234.5678",
+                range_start=100,
+                range_end=100,
+            )
+
+        # Invalid: range_end < range_start
+        with pytest.raises(ValueError, match="range_end.*must be greater than.*range_start"):
+            HashCacheEntry(
+                file_path="file.bin",
+                hash_algorithm=HashAlgorithm.XXH128,
+                file_hash="hash",
+                last_modified_time="1234.5678",
+                range_start=200,
+                range_end=100,
+            )
 
 
 class TestS3CheckCache:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The hash cache only supports caching the hashes of whole files. We'd like to make a manifest format update that chunks large files, and it will need a hash cache for the chunks.

### What was the solution? (How)

By extending the hash cache to support arbitrary byte ranges, it is ready for any chunking scheme. The update follows the table versioning precedent, creating a new V4 table for the hash cache.

### What is the impact of this change?

The existing interface for whole file hash caching is unchanged, and new range start/end parameters are available for byte-range hash caching.

### How was this change tested?

Implemented unit tests for the change, confirmed all the existing unit tests pass unchanged.

### Was this change documented?

Updated the docstrings.

### Does this PR introduce new dependencies?

No

### Is this a breaking change?

Yes, it updates the hash cache DB schema from V3 to V4.

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
