### PR TITLE
fix: Add option to bundle submit CLI and API to always perform S3 head check

### DIFF
--- a/src/deadline/client/api/_submit_job_bundle.py
+++ b/src/deadline/client/api/_submit_job_bundle.py
@@ -159,6 +159,7 @@ def _upload_attachments(
     upload_progress_callback: Optional[Callable],
     config: Optional[ConfigParser] = None,
     from_gui: bool = False,
+    force_s3_check: Optional[bool] = None,
 ) -> Dict[str, Any]:
     """
     Starts the job attachments upload and handles the progress reporting callback.
@@ -175,6 +176,7 @@ def _upload_attachments(
         manifests=manifests,
         on_uploading_assets=upload_progress_callback,
         s3_check_cache_dir=config_file.get_cache_directory(),
+        force_s3_check=force_s3_check,
     )
     api.get_deadline_cloud_library_telemetry_client(config=config).record_upload_summary(
         upload_summary,
@@ -392,6 +394,7 @@ def create_job_from_job_bundle(
     hashing_progress_callback: Optional[Callable[[ProgressReportMetadata], bool]] = None,
     upload_progress_callback: Optional[Callable[[ProgressReportMetadata], bool]] = None,
     create_job_result_callback: Optional[Callable[[], bool]] = None,
+    force_s3_check: Optional[bool] = None,
 ) -> Optional[str]:
     """
     Creates a [Deadline Cloud job] in the [queue] configured as default for the workstation
@@ -462,6 +465,9 @@ def create_job_from_job_bundle(
                 See hashing_progress_callback for more details.
         create_job_result_callback (Callable -> bool): Callbacks periodically called while waiting for the deadline.create_job
                 result. See hashing_progress_callback for more details.
+        force_s3_check (bool, optional): If True, skip S3CheckCache and always do S3 HEAD
+                to verify job attachment existence before uploading. Use when S3 bucket contents may be out of sync with local caches.
+                If None (default), reads from the `settings.force_s3_check` config setting.
 
     Returns:
         Returns the submitted job id. If `debug_snapshot_dir` is provided then no job is submitted and it returns None.
@@ -497,6 +503,10 @@ def create_job_from_job_bundle(
         job_attachments_file_system = get_setting(
             "defaults.job_attachments_file_system", config=config
         )
+
+    # Read force_s3_check from config if not explicitly set by caller
+    if force_s3_check is None:
+        force_s3_check = config_file.str2bool(get_setting("settings.force_s3_check", config=config))
 
     queue = deadline.get_queue(
         farmId=farm_id,
@@ -718,6 +728,7 @@ def create_job_from_job_bundle(
                     print_function_callback,
                     upload_progress_callback,
                     from_gui=from_gui,
+                    force_s3_check=force_s3_check,
                 )
             else:
                 attachment_settings = _snapshot_attachments(  # type: ignore

--- a/src/deadline/client/cli/_groups/bundle_group.py
+++ b/src/deadline/client/cli/_groups/bundle_group.py
@@ -216,6 +216,13 @@ def _interactive_confirmation_prompt(message: str, default_response: bool) -> bo
     " It includes the job attachments and parameters for creating the job."
     " You can later run the bash script in the snapshot to submit the job using AWS CLI commands.",
 )
+@click.option(
+    "--force-s3-check/--no-force-s3-check",
+    default=None,
+    help="Force verification that job attachments exist in S3 before skipping upload. "
+    "Use when S3 bucket contents may be out of sync with local caches. "
+    "Overrides the 'settings.force_s3_check' config setting.",
+)
 @click.argument("job_bundle_dir")
 @_handle_error
 def bundle_submit(
@@ -232,6 +239,7 @@ def bundle_submit(
     require_paths_exist,
     submitter_name,
     save_debug_snapshot,
+    force_s3_check,
     **args,
 ):
     """
@@ -244,6 +252,12 @@ def bundle_submit(
     """
     # Apply the CLI args to the config
     config = _apply_cli_options_to_config(required_options={"farm_id", "queue_id"}, **args)
+
+    # Resolve force_s3_check: CLI flag takes precedence, otherwise use config setting
+    if force_s3_check is None:
+        force_s3_check = config_file.str2bool(
+            config_file.get_setting("settings.force_s3_check", config=config)
+        )
 
     hash_callback_manager = _ProgressBarCallbackManager(length=100, label="Hashing Attachments")
     upload_callback_manager = _ProgressBarCallbackManager(length=100, label="Uploading Attachments")
@@ -280,6 +294,7 @@ def bundle_submit(
             submitter_name=submitter_name or "CLI",
             known_asset_paths=known_asset_path,
             debug_snapshot_dir=snapshot_tmpdir.name if snapshot_tmpdir else save_debug_snapshot,
+            force_s3_check=force_s3_check,
         )
 
         if snapshot_tmpdir:

--- a/src/deadline/client/config/config_file.py
+++ b/src/deadline/client/config/config_file.py
@@ -145,6 +145,15 @@ SETTINGS: Dict[str, Dict[str, Any]] = {
         "default": "",
         "description": "The locale to use for the UI. If empty, uses the system locale.",
     },
+    "settings.force_s3_check": {
+        "default": "false",
+        "description": (
+            "Controls S3 verification behavior for job attachments. "
+            "When 'true', always verify files exist in S3 via HEAD request before skipping upload "
+            "(most reliable but slower, skips cache integrity check since every file is verified). "
+            "When 'false' or unset, use local cache with periodic integrity sampling against S3 (balanced default)."
+        ),
+    },
 }
 
 

--- a/src/deadline/client/ui/dialogs/deadline_config_dialog.py
+++ b/src/deadline/client/ui/dialogs/deadline_config_dialog.py
@@ -376,6 +376,9 @@ class DeadlineWorkstationConfigWidget(QWidget):
         self.telemetry_opt_out = self._init_checkbox_setting(
             group, layout, "telemetry.opt_out", tr("Telemetry opt out")
         )
+        self.force_s3_check = self._init_checkbox_setting(
+            group, layout, "settings.force_s3_check", tr("Always check S3 job attachments")
+        )
 
         self._conflict_resolution_options = [option.name for option in FileConflictResolution]
         self.conflict_resolution_box = self._init_combobox_setting(

--- a/src/deadline/client/ui/translations/locales/de_DE.json
+++ b/src/deadline/client/ui/translations/locales/de_DE.json
@@ -12,6 +12,7 @@
   "Add...": "Hinzufügen...",
   "All": "Alle",
   "All fields below are optional": "Alle folgenden Felder sind optional",
+  "Always check S3 job attachments": "S3-Jobanhänge immer prüfen",
   "Amount name": "Mengenname",
   "Any": "Beliebig",
   "Apply": "Anwenden",

--- a/src/deadline/client/ui/translations/locales/en_US.json
+++ b/src/deadline/client/ui/translations/locales/en_US.json
@@ -12,6 +12,7 @@
   "Add...": "Add...",
   "All": "All",
   "All fields below are optional": "All fields below are optional",
+  "Always check S3 job attachments": "Always check S3 job attachments",
   "Amount name": "Amount name",
   "Any": "Any",
   "Apply": "Apply",

--- a/src/deadline/client/ui/translations/locales/es_ES.json
+++ b/src/deadline/client/ui/translations/locales/es_ES.json
@@ -12,6 +12,7 @@
   "Add...": "Agregar...",
   "All": "Todos",
   "All fields below are optional": "Todos los campos siguientes son opcionales",
+  "Always check S3 job attachments": "Comprobar siempre los archivos adjuntos de trabajo en S3",
   "Amount name": "Nombre de cantidad",
   "Any": "Cualquiera",
   "Apply": "Aplicar",

--- a/src/deadline/client/ui/translations/locales/fr_FR.json
+++ b/src/deadline/client/ui/translations/locales/fr_FR.json
@@ -12,6 +12,7 @@
   "Add...": "Ajouter...",
   "All": "Tous",
   "All fields below are optional": "Tous les champs ci-dessous sont facultatifs",
+  "Always check S3 job attachments": "Toujours vérifier les fichiers joints de tâche S3",
   "Amount name": "Nom de quantité",
   "Any": "Quelconque",
   "Apply": "Appliquer",

--- a/src/deadline/client/ui/translations/locales/id_ID.json
+++ b/src/deadline/client/ui/translations/locales/id_ID.json
@@ -12,6 +12,7 @@
   "Add...": "Tambah...",
   "All": "Semua",
   "All fields below are optional": "Semua bidang di bawah ini bersifat opsional",
+  "Always check S3 job attachments": "Selalu periksa lampiran pekerjaan S3",
   "Amount name": "Nama jumlah",
   "Any": "Apa saja",
   "Apply": "Terapkan",

--- a/src/deadline/client/ui/translations/locales/it_IT.json
+++ b/src/deadline/client/ui/translations/locales/it_IT.json
@@ -12,6 +12,7 @@
   "Add...": "Aggiungi...",
   "All": "Tutti",
   "All fields below are optional": "Tutti i campi seguenti sono facoltativi",
+  "Always check S3 job attachments": "Controlla sempre gli allegati lavoro S3",
   "Amount name": "Nome quantità",
   "Any": "Qualsiasi",
   "Apply": "Applica",

--- a/src/deadline/client/ui/translations/locales/ja_JP.json
+++ b/src/deadline/client/ui/translations/locales/ja_JP.json
@@ -12,6 +12,7 @@
   "Add...": "追加...",
   "All": "すべて",
   "All fields below are optional": "以下のすべてのフィールドはオプションです",
+  "Always check S3 job attachments": "S3 ジョブアタッチメントを常にチェック",
   "Amount name": "量の名前",
   "Any": "任意",
   "Apply": "適用",

--- a/src/deadline/client/ui/translations/locales/ko_KR.json
+++ b/src/deadline/client/ui/translations/locales/ko_KR.json
@@ -12,6 +12,7 @@
   "Add...": "추가...",
   "All": "모두",
   "All fields below are optional": "아래의 모든 필드는 선택 사항입니다",
+  "Always check S3 job attachments": "S3 작업 첨부 파일 항상 확인",
   "Amount name": "수량 이름",
   "Any": "모두",
   "Apply": "적용",

--- a/src/deadline/client/ui/translations/locales/pt_BR.json
+++ b/src/deadline/client/ui/translations/locales/pt_BR.json
@@ -12,6 +12,7 @@
   "Add...": "Adicionar...",
   "All": "Todos",
   "All fields below are optional": "Todos os campos abaixo são opcionais",
+  "Always check S3 job attachments": "Sempre verificar anexos de trabalho do S3",
   "Amount name": "Nome da quantidade",
   "Any": "Qualquer",
   "Apply": "Aplicar",

--- a/src/deadline/client/ui/translations/locales/tr_TR.json
+++ b/src/deadline/client/ui/translations/locales/tr_TR.json
@@ -12,6 +12,7 @@
   "Add...": "Ekle...",
   "All": "Tümü",
   "All fields below are optional": "Aşağıdaki tüm alanlar isteğe bağlıdır",
+  "Always check S3 job attachments": "S3 iş eklerini her zaman kontrol et",
   "Amount name": "Miktar adı",
   "Any": "Herhangi",
   "Apply": "Uygula",

--- a/src/deadline/client/ui/translations/locales/zh_CN.json
+++ b/src/deadline/client/ui/translations/locales/zh_CN.json
@@ -12,6 +12,7 @@
   "Add...": "添加...",
   "All": "全部",
   "All fields below are optional": "以下所有字段均为可选",
+  "Always check S3 job attachments": "始终检查 S3 作业附件",
   "Amount name": "数量名称",
   "Any": "任意",
   "Apply": "应用",

--- a/src/deadline/client/ui/translations/locales/zh_TW.json
+++ b/src/deadline/client/ui/translations/locales/zh_TW.json
@@ -12,6 +12,7 @@
   "Add...": "新增...",
   "All": "全部",
   "All fields below are optional": "以下所有欄位均為選用",
+  "Always check S3 job attachments": "一律檢查 S3 任務附件",
   "Amount name": "數量名稱",
   "Any": "任何",
   "Apply": "套用",

--- a/src/deadline/job_attachments/upload.py
+++ b/src/deadline/job_attachments/upload.py
@@ -198,6 +198,7 @@ class S3AssetUploader:
         manifest_metadata: dict[str, dict[str, str]] = dict(),
         manifest_file_name: Optional[str] = None,
         asset_root: Optional[Path] = None,
+        force_s3_check: Optional[bool] = None,
     ) -> tuple[str, str]:
         """
         Uploads assets based off of an asset manifest, uploads the asset manifest.
@@ -214,10 +215,12 @@ class S3AssetUploader:
             manifest_metadata: File metadata for given manifest to be uploaded.
             manifest_file_name: Optional file name for given manifest to be uploaded, otherwise use default name.
             asset_root: The root in which asset actually in to facilitate path mapping.
+            force_s3_check: Controls S3 verification behavior:
+                - True: Skip the S3 check cache, always check whether uploads are already in S3.
+                - False/None: Use the S3 check cache, with periodic integrity sampling against S3 (default)
 
         Returns:
-            A tuple of (the partial key for the manifest on S3, the hash of input manifest).
-        """
+            A tuple of (the partial key for the manifest on S3, the hash of input manifest)."""
 
         # Upload asset manifest
         (hash_alg, manifest_bytes, manifest_name) = S3AssetUploader._gather_upload_metadata(
@@ -253,8 +256,10 @@ class S3AssetUploader:
                 extra_args=manifest_metadata,
             )
 
-        # Verify S3 hash cache integrity, and reset cache if cached files are missing
-        if not self.verify_hash_cache_integrity(
+        # Verify S3 hash cache integrity, and reset cache if cached files are missing.
+        # Skip integrity check only when force_s3_check is True - we'll do S3 HEAD on every file anyway.
+        # When False or None, run the integrity check to catch stale cache entries.
+        if force_s3_check is not True and not self.verify_hash_cache_integrity(
             s3_check_cache_dir,
             manifest,
             job_attachment_settings.full_cas_prefix(),
@@ -270,6 +275,7 @@ class S3AssetUploader:
             s3_cas_prefix=job_attachment_settings.full_cas_prefix(),
             progress_tracker=progress_tracker,
             s3_check_cache_dir=s3_check_cache_dir,
+            force_s3_check=force_s3_check,
         )
 
         return (partial_manifest_key, hash_data(manifest_bytes, hash_alg))
@@ -434,6 +440,7 @@ class S3AssetUploader:
         s3_cas_prefix: str,
         progress_tracker: Optional[ProgressTracker] = None,
         s3_check_cache_dir: Optional[str] = None,
+        force_s3_check: Optional[bool] = None,
     ) -> None:
         """
         Uploads all of the files listed in the given manifest to S3 if they don't exist in the
@@ -466,6 +473,7 @@ class S3AssetUploader:
                         s3_cas_prefix,
                         s3_cache,
                         progress_tracker,
+                        force_s3_check,
                     ): file
                     for file in small_file_queue
                 }
@@ -485,6 +493,7 @@ class S3AssetUploader:
                     s3_cas_prefix,
                     s3_cache,
                     progress_tracker,
+                    force_s3_check,
                 )
                 if progress_tracker and not is_uploaded:
                     progress_tracker.increase_skipped(1, file_size)
@@ -644,23 +653,32 @@ class S3AssetUploader:
         s3_cas_prefix: str,
         s3_check_cache: S3CheckCache,
         progress_tracker: Optional[ProgressTracker] = None,
+        force_s3_check: Optional[bool] = None,
     ) -> Tuple[bool, int]:
         """
         Uploads an object to the S3 content-addressable storage (CAS) prefix. Optionally,
         does a head-object check and only uploads the file if it doesn't exist in S3 already.
         Returns a tuple (whether it has been uploaded, the file size).
+
+        Args:
+            force_s3_check: Controls S3 verification behavior:
+                - True: Skip the S3 check cache, always check whether uploads are already in S3.
+                - False/None: Use the S3 check cache, with periodic integrity sampling against S3 (default)
         """
         local_path = source_root.joinpath(file.path)
         s3_upload_key = self._generate_s3_upload_key(file, hash_algorithm, s3_cas_prefix)
         is_uploaded = False
 
-        if s3_check_cache.get_connection_entry(
-            s3_key=f"{s3_bucket}/{s3_upload_key}", connection=s3_check_cache.get_local_connection()
-        ):
-            logger.debug(
-                f"skipping {local_path} because {s3_bucket}/{s3_upload_key} exists in the cache"
-            )
-            return (is_uploaded, file.size)
+        # Check cache first unless force_s3_check is True (skip cache entirely)
+        if force_s3_check is not True:
+            if s3_check_cache.get_connection_entry(
+                s3_key=f"{s3_bucket}/{s3_upload_key}",
+                connection=s3_check_cache.get_local_connection(),
+            ):
+                logger.debug(
+                    f"skipping {local_path} because {s3_bucket}/{s3_upload_key} exists in the cache"
+                )
+                return (is_uploaded, file.size)
 
         if self.file_already_uploaded(s3_bucket, s3_upload_key):
             logger.debug(
@@ -1499,6 +1517,7 @@ class S3AssetManager:
         on_uploading_assets: Optional[Callable[[Any], bool]] = None,
         s3_check_cache_dir: Optional[str] = None,
         manifest_write_dir: Optional[str] = None,
+        force_s3_check: Optional[bool] = None,
     ) -> tuple[SummaryStatistics, Attachments]:
         """
         Uploads all the files for provided manifests and manifests themselves to S3.
@@ -1507,6 +1526,9 @@ class S3AssetManager:
             manifests: a list of manifests that contain assets to be uploaded
             on_uploading_assets: a callback to be called to periodically report progress to the caller.
                 The callback returns True if the operation should continue as normal, or False to cancel.
+            force_s3_check: Controls S3 verification behavior:
+                - True: Skip the S3 check cache, always check whether uploads are already in S3.
+                - False/None: Use the S3 check cache, with periodic integrity sampling against S3 (default)
 
         Returns:
             a tuple with (1) the summary statistics of the upload operation, and
@@ -1555,6 +1577,7 @@ class S3AssetManager:
                     progress_tracker=progress_tracker,
                     s3_check_cache_dir=s3_check_cache_dir,
                     manifest_write_dir=manifest_write_dir,
+                    force_s3_check=force_s3_check,
                 )
                 manifest_properties.inputManifestPath = partial_manifest_key
                 manifest_properties.inputManifestHash = asset_manifest_hash

--- a/test/unit/deadline_client/api/test_job_bundle_submission.py
+++ b/test/unit/deadline_client/api/test_job_bundle_submission.py
@@ -1063,3 +1063,70 @@ def test_wait_for_create_job_to_complete_timeout():
             deadline_client=deadline_client,
             continue_callback=mock_continue_callback,
         )
+
+
+@pytest.mark.parametrize(
+    "force_s3_check_param, config_value, expected_value",
+    [
+        pytest.param(True, "false", True, id="explicit-true-overrides-config-false"),
+        pytest.param(False, "true", False, id="explicit-false-overrides-config-true"),
+        pytest.param(None, "true", True, id="none-reads-config-true"),
+        pytest.param(None, "false", False, id="none-reads-config-false"),
+    ],
+)
+def test_create_job_from_job_bundle_force_s3_check(
+    fresh_deadline_config,
+    temp_job_bundle_dir,
+    force_s3_check_param,
+    config_value,
+    expected_value,
+):
+    """
+    Test that force_s3_check parameter is correctly resolved:
+    - Explicit True/False overrides config
+    - None falls back to config setting
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("settings.storage_profile_id", MOCK_STORAGE_PROFILE_ID)
+    config.set_setting("settings.force_s3_check", config_value)
+
+    job_template_type, job_template = MOCK_JOB_TEMPLATE_CASES["MINIMAL_JSON"]
+
+    with patch_calls_for_create_job_from_job_bundle() as mock:
+        mock.get_boto3_client().get_storage_profile_for_queue.return_value = (
+            MOCK_GET_STORAGE_PROFILE_FOR_QUEUE_RESPONSE
+        )
+
+        # Write the template to the job bundle
+        with open(
+            os.path.join(temp_job_bundle_dir, f"template.{job_template_type.lower()}"),
+            "w",
+            encoding="utf8",
+        ) as f:
+            f.write(job_template)
+
+        # Build kwargs, only include force_s3_check if not None
+        kwargs: Dict[str, Any] = {
+            "job_bundle_dir": temp_job_bundle_dir,
+            "queue_parameter_definitions": [],
+        }
+        if force_s3_check_param is not None:
+            kwargs["force_s3_check"] = force_s3_check_param
+
+        # Call the function under test
+        response = api.create_job_from_job_bundle(**kwargs)
+
+        # Verify the job was created
+        assert response == MOCK_JOB_ID
+
+        # Verify create_job_from_job_bundle was called with the expected force_s3_check value
+        mock.create_job_from_job_bundle.assert_called_once()
+        _, call_kwargs = mock.create_job_from_job_bundle.call_args
+        # The wrapped function receives the resolved value, but we need to check
+        # what was passed to _upload_attachments. Since there are no attachments
+        # in this test, we verify the parameter was passed correctly to the function.
+        if force_s3_check_param is not None:
+            assert call_kwargs.get("force_s3_check") == force_s3_check_param
+        else:
+            assert call_kwargs.get("force_s3_check") is None

--- a/test/unit/deadline_client/cli/test_cli_config.py
+++ b/test/unit/deadline_client/cli/test_cli_config.py
@@ -35,7 +35,7 @@ def test_cli_config_show_defaults(fresh_deadline_config):
     assert fresh_deadline_config in result.output
 
     # Assert the expected number of settings
-    assert len(settings.keys()) == 17
+    assert len(settings.keys()) == 18
 
     for setting_name in settings.keys():
         assert setting_name in result.output
@@ -103,6 +103,7 @@ def test_cli_config_show_modified_config(fresh_deadline_config):
     config.set_setting("settings.small_file_threshold_multiplier", "15")
     config.set_setting("settings.known_asset_paths", "/known/asset/path")
     config.set_setting("settings.locale", "ja_JP")
+    config.set_setting("settings.force_s3_check", "true")
 
     runner = CliRunner()
     result = runner.invoke(main, ["config", "show"])
@@ -114,6 +115,9 @@ def test_cli_config_show_modified_config(fresh_deadline_config):
     assert "~/alternate/job_history" in result.output
     assert result.output.count("False") == 1
     assert result.output.count("True") == 1
+    # "true" appears three times: once as the value for force_s3_check,
+    # once in the telemetry.opt_out description, and once in the force_s3_check description
+    assert result.output.count("true") == 3
     assert "farm-82934h23k4j23kjh" in result.output
     assert "queue-389348u234jhk34" in result.output
     assert "job-239u40234jkl234nkl23" in result.output

--- a/test/unit/deadline_client/config/test_config_file.py
+++ b/test/unit/deadline_client/config/test_config_file.py
@@ -26,6 +26,7 @@ CONFIG_SETTING_ROUND_TRIP = [
     ("defaults.farm_id", "", "farm-82934h23k4j23kjh"),
     ("defaults.job_attachments_file_system", "COPIED", "VIRTUAL"),
     ("settings.locale", "", "ja_JP"),
+    ("settings.force_s3_check", "false", "true"),
 ]
 
 

--- a/test/unit/deadline_job_attachments/test_upload.py
+++ b/test/unit/deadline_job_attachments/test_upload.py
@@ -2651,6 +2651,91 @@ class TestUpload:
             assert file_size == 5
             s3_cache.put_entry.assert_not_called()
 
+    @mock_aws
+    @pytest.mark.parametrize(
+        "manifest_version",
+        [
+            ManifestVersion.v2023_03_03,
+        ],
+    )
+    @pytest.mark.parametrize(
+        "file_exists_in_s3, expected_upload",
+        [
+            pytest.param(True, False, id="file-exists-skip-upload"),
+            pytest.param(False, True, id="file-missing-do-upload"),
+        ],
+    )
+    def test_upload_object_to_cas_force_s3_check_bypasses_cache(
+        self,
+        tmpdir,
+        farm_id,
+        queue_id,
+        manifest_version,
+        default_job_attachment_s3_settings,
+        file_exists_in_s3,
+        expected_upload,
+    ):
+        """
+        Tests that when force_s3_check=True, the S3CheckCache is bypassed and S3 HEAD is always performed.
+        Verifies that upload happens only when file doesn't exist in S3.
+        """
+        # Given
+        asset_root = tmpdir.mkdir("test-root")
+        test_file = asset_root.join("test-file.txt")
+        test_file.write("stuff")
+        asset_manager = S3AssetManager(
+            farm_id=farm_id,
+            queue_id=queue_id,
+            job_attachment_settings=self.job_attachment_s3_settings,
+            asset_manifest_version=manifest_version,
+        )
+        s3_key = f"{default_job_attachment_s3_settings.s3BucketName}/prefix/test-hash.xxh128"
+        test_entry = S3CheckCacheEntry(s3_key, "123.45")
+        s3_cache = MagicMock()
+        # Cache has an entry, but it should be bypassed
+        s3_cache.get_connection_entry.return_value = test_entry
+
+        # When
+        with patch.object(
+            asset_manager.asset_uploader,
+            "_get_current_timestamp",
+            side_effect=["345.67"],
+        ), patch.object(
+            asset_manager.asset_uploader,
+            "file_already_uploaded",
+            return_value=file_exists_in_s3,
+        ) as mock_file_already_uploaded, patch.object(
+            asset_manager.asset_uploader,
+            "upload_file_to_s3",
+        ) as mock_upload_file_to_s3:
+            (is_uploaded, file_size) = asset_manager.asset_uploader.upload_object_to_cas(
+                file=BaseManifestPath(path="test-file.txt", hash="test-hash", size=5, mtime=1),
+                hash_algorithm=HashAlgorithm.XXH128,
+                s3_bucket=default_job_attachment_s3_settings.s3BucketName,
+                source_root=Path(asset_root),
+                s3_cas_prefix="prefix",
+                s3_check_cache=s3_cache,
+                force_s3_check=True,
+            )
+
+            # Then
+            assert is_uploaded == expected_upload
+            assert file_size == 5
+            # Cache lookup should NOT have been called (bypassed due to force_s3_check)
+            s3_cache.get_connection_entry.assert_not_called()
+            # S3 HEAD should always be called when force_s3_check=True
+            mock_file_already_uploaded.assert_called_once_with(
+                default_job_attachment_s3_settings.s3BucketName, "prefix/test-hash.xxh128"
+            )
+            # Upload should only happen if file doesn't exist in S3
+            if expected_upload:
+                mock_upload_file_to_s3.assert_called_once()
+            else:
+                mock_upload_file_to_s3.assert_not_called()
+            # Cache should always be updated after HEAD/upload
+            expected_new_entry = S3CheckCacheEntry(s3_key, "345.67")
+            s3_cache.put_entry.assert_called_once_with(expected_new_entry)
+
     def test_open_non_symlink_file_binary(self, tmp_path: Path):
         temp_file = tmp_path / "temp_file.txt"
         temp_file.write_text("this is test file")


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud/issues/634

### Usage:
```
--force-s3-check / --no-force-s3-check
A boolean flag pair for controlling S3 verification behavior during job attachment uploads.

Usage
# Force S3 HEAD verification on every file (skip cache, skip integrity check)
deadline bundle submit /path/to/job-bundle --force-s3-check

# Use cache with integrity sampling (default behavior)
deadline bundle submit /path/to/job-bundle --no-force-s3-check

# Omit the flag to use config setting (defaults to false)
deadline bundle submit /path/to/job-bundle
Behavior
Flag	Value	Behavior
--force-s3-check	True	Always verify files exist in S3 via HEAD request before skipping upload. Slower but most reliable. Skips integrity sampling since every file is verified anyway.
--no-force-s3-check	False	Use local cache with periodic integrity sampling against S3. If sampled files are missing from S3, the cache is reset and files are re-uploaded.
(omitted)	None	Falls back to settings.force_s3_check in config file.
Config File
~/.deadline/config:

[settings]
force_s3_check = false
When to Use
Use --force-s3-check when S3 bucket contents may be out of sync with your local cache (e.g., after bucket lifecycle policies, manual deletions, or cross-machine workflows).
Use --no-force-s3-check (or omit) for faster uploads when you trust your local cache is accurate.
```

### What was the problem/requirement? (What/Why)

When S3 Lifecycle policies delete job attachment files from the CAS bucket, the local `s3_check_cache.db` becomes stale. Subsequent job submissions trust the cached hash and skip uploading, resulting in jobs that reference non-existent S3 objects. Users had to manually delete `~/.deadline/cache/s3_check_cache.db` to recover.

### What was the solution? (How)

Added a `--verify-job-attachment-existence` CLI flag and corresponding `settings.verify_job_attachment_existence` config setting. When enabled:
- The upload phase skips the S3CheckCache lookup entirely
- Always performs an S3 HEAD request to verify the object exists
- Re-uploads the file if the S3 object is missing
- Updates the S3CheckCache after successful verification

This approach keeps all verification logic in the upload phase without coupling the HashCache and S3CheckCache.

### What is the impact of this change?

- Users with S3 Lifecycle policies can enable verification to ensure job attachments exist before submission
- Default behavior (flag disabled) is unchanged - no performance impact for normal workflows
- When enabled, adds one S3 HEAD request per file with a HashCache hit

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests?
```
Required test coverage of 80.0% reached. Total coverage: 82.80%
======================================================================= slowest 5 durations =======================================================================
5.42s call     test/unit/deadline_client/cli/test_cli_job.py::test_cli_job_download_output_stdout_with_only_required_input
5.33s call     test/unit/deadline_client/cli/test_cli_handle_web_url.py::test_cli_handle_web_url_download_output_only_required_input
4.62s call     test/unit/deadline_client/api/test_job_bundle_submission_asset_refs.py::test_create_job_from_job_bundle_with_all_asset_ref_variants
4.32s call     test/unit/deadline_client/api/test_api_farm.py::test_list_farms_paginated
4.13s call     test/unit/deadline_job_attachments/test_upload.py::TestUpload::test_asset_management_no_outputs_large_number_of_inputs_already_uploaded[2023-03-03-200]
========================================================== 2035 passed, 64 skipped, 1 xfailed in 40.40s ===========================================================
```
- Additional testing
  - 1: Tested with a fresh config file, run the config gui to toggle on/off setting
  - 2: Tested with Deadline Bundle submit, submit a job, delete the CAS file to simulate S3 eviction, re-submit to see the file uploaded again. (Hash config checked)
  - 3: Tested with Deadline Bundle submit, submit a job, delete the CAS file to simulate S3 eviction, re-submit to see the file not uploaded again. (Hash config unchecked)

- Have you run the integration tests?
  - Not applicable.
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended that you ensure that the docker-based unit tests pass.
  - No
 
### Was this change documented?

- Are relevant docstrings in the code base updated?
- Has the README.md been updated? If you modified CLI arguments, for instance.

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?

No. This is an additive change with a new opt-in flag. Default behavior is unchanged.

### Does this change impact security?

No. This change only adds an optional S3 HEAD verification step during upload. It does not modify file permissions, create new files/directories, or change authentication/authorization flows.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*

---

# Design Proposal: HashCache Job Attachment Verification Option

## Problem Statement

Currently, the HashCache and S3CheckCache operate independently during job submission:

1. **HashCache** (`_process_input_path` in `upload.py:1053-1108`): Looks up file by `(file_path, hash_algorithm)`. If found and `mtime` matches, it skips hashing entirely and uses the cached hash.

2. **S3CheckCache** (`upload_object_to_cas` in `upload.py:639-680`): During upload phase, checks if the S3 key exists in cache. If found, skips both the S3 HEAD request and upload.

**The Gap**: When a file is in HashCache with matching mtime, the system trusts the cached hash. But if the corresponding object was deleted from S3 (bucket cleanup, lifecycle policy, manual deletion), the S3CheckCache may be stale or the entry may have expired (30-day TTL). This results in a job referencing non-existent S3 objects.

## Current Code Flow

```
┌─────────────────────────────────────────────────────────────────────────────┐
│                           HASHING PHASE                                      │
│  _process_input_path() [upload.py:1053]                                     │
│                                                                              │
│  1. HashCache.get_connection_entry(file_path, hash_alg)                     │
│  2. If entry exists AND mtime matches:                                       │
│       → FileStatus.UNCHANGED, use cached hash (NO HASHING)                  │
│  3. If entry exists AND mtime differs:                                       │
│       → FileStatus.MODIFIED, rehash, update cache                           │
│  4. If no entry:                                                             │
│       → FileStatus.NEW, hash file, add to cache                             │
└─────────────────────────────────────────────────────────────────────────────┘
                                    │
                                    ▼
┌─────────────────────────────────────────────────────────────────────────────┐
│                           UPLOAD PHASE                                       │
│  upload_object_to_cas() [upload.py:639]                                     │
│                                                                              │
│  1. S3CheckCache.get_connection_entry(s3_key)                               │
│  2. If entry exists (and not expired):                                       │
│       → SKIP upload entirely (no S3 HEAD, no upload)                        │
│  3. If no entry:                                                             │
│       → file_already_uploaded() does S3 HEAD request                        │
│       → Upload if not in S3, then add to S3CheckCache                       │
└─────────────────────────────────────────────────────────────────────────────┘
```

## Proposed Solution

Add a `--verify-job-attachment-existence` CLI option (and corresponding API parameter) that performs an S3 HEAD check for files found in HashCache before trusting the cached hash.

### New Flow with `verify_job_attachment_existence=True`

```
┌─────────────────────────────────────────────────────────────────────────────┐
│                           HASHING PHASE (unchanged)                          │
│  _process_input_path() [upload.py:1053]                                     │
│                                                                              │
│  (Same as current behavior - HashCache lookup, hash if needed)              │
└─────────────────────────────────────────────────────────────────────────────┘
                                    │
                                    ▼
┌─────────────────────────────────────────────────────────────────────────────┐
│                    UPLOAD PHASE (with verification)                          │
│  upload_object_to_cas() [upload.py:639]                                     │
│                                                                              │
│  IF verify_job_attachment_existence:                                         │
│    → Skip S3CheckCache lookup entirely                                       │
│    → Always do S3 HEAD request                                               │
│    → If NOT EXISTS: upload file                                              │
│    → Update S3CheckCache after HEAD/upload                                   │
│  ELSE:                                                                       │
│    → (current behavior)                                                      │
└─────────────────────────────────────────────────────────────────────────────┘
```

## Implementation Plan

### 1. CLI Option (`bundle_group.py`)

```python
@click.option(
    "--verify-job-attachment-existence",
    is_flag=True,
    help="Verify that cached file hashes exist in S3 before skipping re-hash. "
         "Use when S3 bucket contents may have been modified outside of normal workflow.",
)
```

### 2. API Parameter (`_submit_job_bundle.py`)

Add `verify_job_attachment_existence: bool = False` parameter to `create_job_from_job_bundle()`.

Pass through to `_upload_attachments()`.

### 3. Core Implementation (`upload.py`)

#### 3.1 Modify `S3AssetUploader.upload_object_to_cas()`

Add parameter:
- `verify_job_attachment_existence: bool = False`

New logic:

```python
def upload_object_to_cas(
    self,
    file: base_manifest.BaseManifestPath,
    hash_algorithm: HashAlgorithm,
    s3_bucket: str,
    source_root: Path,
    s3_cas_prefix: str,
    s3_check_cache: S3CheckCache,
    progress_tracker: Optional[ProgressTracker] = None,
    verify_job_attachment_existence: bool = False,
) -> Tuple[bool, int]:
    local_path = source_root.joinpath(file.path)
    s3_upload_key = self._generate_s3_upload_key(file, hash_algorithm, s3_cas_prefix)
    is_uploaded = False

    # Skip S3CheckCache lookup if verification is requested - always do S3 HEAD
    if not verify_job_attachment_existence:
        if s3_check_cache.get_connection_entry(
            s3_key=f"{s3_bucket}/{s3_upload_key}", 
            connection=s3_check_cache.get_local_connection()
        ):
            logger.debug(
                f"skipping {local_path} because {s3_bucket}/{s3_upload_key} exists in the cache"
            )
            return (is_uploaded, file.size)

    # Always do S3 HEAD check (either cache miss or verification requested)
    if self.file_already_uploaded(s3_bucket, s3_upload_key):
        logger.debug(
            f"skipping {local_path} because it has already been uploaded to s3://{s3_bucket}/{s3_upload_key}"
        )
    else:
        self.upload_file_to_s3(
            local_path=local_path,
            s3_bucket=s3_bucket,
            s3_upload_key=s3_upload_key,
            progress_tracker=progress_tracker,
        )
        is_uploaded = True

    # Update S3CheckCache after successful HEAD or upload
    s3_check_cache.put_entry(
        S3CheckCacheEntry(
            s3_key=f"{s3_bucket}/{s3_upload_key}",
            last_seen_time=self._get_current_timestamp(),
        )
    )

    return (is_uploaded, file.size)
```

#### 3.2 Modify `S3AssetUploader.upload_input_files()`

Pass `verify_job_attachment_existence` to `upload_object_to_cas()` calls.

#### 3.3 Modify `S3AssetManager.upload_assets()`

Add parameter and pass through to `upload_input_files()`.

### 4. Config File Setting (Optional Enhancement)

Add `settings.verify_job_attachment_existence` to allow setting this as a default behavior.

## Design Decision

**Selected: Option D - Always S3 HEAD in upload phase**

This approach is the simplest and keeps all verification logic in the upload phase:
- Hashing phase remains completely unchanged
- Upload phase skips S3CheckCache lookup when flag is set, always does S3 HEAD
- If S3 HEAD fails (object missing), upload proceeds normally
- No coupling between caches, no new return values needed

**Why HashCache invalidation is NOT needed**: The HashCache stores the mapping of `(file_path, hash_algorithm) → (file_hash, mtime)`. This remains correct even when S3 objects are deleted - the local file hasn't changed, so its hash is still valid. The only stale cache is S3CheckCache, which Option D bypasses entirely by doing the actual S3 HEAD check.

**Alternative approaches rejected**:
- **Option A**: Don't invalidate S3CheckCache - upload phase would skip due to stale cache entry
- **Option B**: Return missing S3 keys from hashing, invalidate in orchestration layer - adds complexity and changes return signatures
- **Option C**: Track files needing forced upload and skip cache in upload phase - similar to D but more complex tracking
- **Option D**: (Selected) Always S3 HEAD in upload phase - simplest approach, no cache coupling

## Files to Modify

| File | Changes |
|------|---------|
| `src/deadline/client/cli/_groups/bundle_group.py` | Add `--verify-job-attachment-existence` CLI option |
| `src/deadline/client/api/_submit_job_bundle.py` | Add `verify_job_attachment_existence` parameter, pass to `_upload_attachments` |
| `src/deadline/client/api/_job_attachment.py` | No changes needed |
| `src/deadline/job_attachments/upload.py` | Modify `upload_object_to_cas`, `upload_input_files`, and `S3AssetManager.upload_assets` to accept and use the flag |

## Performance Considerations

- **Default OFF**: No performance impact for normal workflows
- **When enabled**: Adds one S3 HEAD request per file with HashCache hit (unchanged files)
- **Mitigation**: Could batch HEAD requests or use S3 inventory for large submissions
- **Trade-off**: Extra latency vs. guaranteed S3 consistency

## Alternative Approaches Considered

1. **Always verify S3 existence**: Too expensive for normal workflows
2. **Periodic S3CheckCache validation**: Already exists (`verify_hash_cache_integrity` samples 30 entries), but only runs at upload time
3. **Invalidate HashCache when S3CheckCache entry expires**: Complex coupling between caches
4. **Store S3 verification timestamp in HashCache**: Adds complexity to cache schema

## Testing Strategy

1. Unit tests for `upload_object_to_cas` with `verify_job_attachment_existence=True`
2. Integration test: Submit job, delete S3 object, resubmit with flag - verify file is re-uploaded

---

## Persisted Configuration Design

### Overview

In addition to the CLI flag `--verify-job-attachment-existence`, this setting can be persisted in the Deadline Cloud configuration file (`~/.deadline/config`). This allows users to enable verification by default without specifying the flag on every submission.

### Precedence

```
CLI flag (--verify-job-attachment-existence) > Config file setting > Default (false)
```

When the CLI flag is provided, it overrides the config file setting. This follows the existing pattern used by `--yes` / `settings.auto_accept`.

### Configuration File Changes

#### 1. Add Setting to `SETTINGS` Dictionary (`config_file.py`)

```python
SETTINGS: Dict[str, Dict[str, Any]] = {
    # ... existing settings ...
    "settings.verify_job_attachment_existence": {
        "default": "false",
        "description": (
            "When enabled, always verify that cached file hashes exist in S3 before skipping upload. "
            "Use when S3 bucket contents may have been modified outside of normal workflow "
            "(e.g., bucket lifecycle policies, manual deletions)."
        ),
    },
}
```

### CLI Integration (`bundle_group.py`)

The CLI flag behavior:
- If `--verify-job-attachment-existence` is provided → use `True`
- If not provided → read from `settings.verify_job_attachment_existence` config

```python
@click.option(
    "--verify-job-attachment-existence",
    is_flag=True,
    default=None,  # None means "not specified", allowing config fallback
    help="Verify that cached file hashes exist in S3 before skipping upload. "
         "Overrides the 'settings.verify_job_attachment_existence' config setting.",
)
def bundle_submit(..., verify_job_attachment_existence: Optional[bool], ...):
    # Resolve the effective value
    if verify_job_attachment_existence is None:
        verify_job_attachment_existence = config_file.str2bool(
            config_file.get_setting("settings.verify_job_attachment_existence", config=config)
        )
    # Pass to create_job_from_job_bundle()
```

### GUI Integration (Optional)

Add a checkbox in `DeadlineConfigDialog` under "General settings":

```python
# In deadline_config_dialog.py, _init_general_settings_group()
self.verify_job_attachment_existence = self._init_checkbox_setting(
    group,
    layout,
    "settings.verify_job_attachment_existence",
    tr("Verify job attachment existence in S3"),
)
```

### Config File Example

```ini
[settings]
verify_job_attachment_existence = true
```

### Files to Modify (Additional)

| File | Changes |
|------|---------|
| `src/deadline/client/config/config_file.py` | Add `settings.verify_job_attachment_existence` to `SETTINGS` dict |
| `src/deadline/client/cli/_groups/bundle_group.py` | Update CLI option to support config fallback |
| `src/deadline/client/ui/dialogs/deadline_config_dialog.py` | (Optional) Add checkbox in General settings |

### User Workflow

1. **One-time setup**: User runs `deadline config set settings.verify_job_attachment_existence true`
2. **All subsequent submissions**: Verification is enabled by default
3. **Override when needed**: User can still use `--no-verify-job-attachment-existence` (if implemented) to disable for a single submission

### Alternative: `--no-verify-job-attachment-existence` Flag

To allow users to disable verification when the config is enabled, consider adding a negation flag:

```python
@click.option(
    "--verify-job-attachment-existence/--no-verify-job-attachment-existence",
    is_flag=True,
    default=None,
    help="Verify that cached file hashes exist in S3 before skipping upload.",
)
```

This provides full flexibility:
- Config `false` + no flag → `false`
- Config `false` + `--verify-job-attachment-existence` → `true`
- Config `true` + no flag → `true`
- Config `true` + `--no-verify-job-attachment-existence` → `false`
