### PR TITLE
[DRAFT] chore: Moved _hash_attachments into Job Attachments

### DIFF
--- a/src/deadline/client/api/_submit_job_bundle.py
+++ b/src/deadline/client/api/_submit_job_bundle.py
@@ -55,10 +55,15 @@ from ...job_attachments.models import (
 from ...job_attachments.progress_tracker import ProgressReportMetadata, ProgressStatus
 from ...job_attachments.upload import S3AssetManager
 from ._session import session_context
-from ._job_attachment import _hash_attachments  # type: ignore[import]
 from ...job_attachments._path_summarization import human_readable_file_size, summarize_path_list
+from ...job_attachments.api import hash_attachments
+from ...job_attachments.upload import SummaryStatistics
 
 logger = logging.getLogger(__name__)
+
+
+def hashing_telemetry_callback(hashing_summary: SummaryStatistics):
+    api.get_deadline_cloud_library_telemetry_client().record_hashing_summary(hashing_summary)
 
 
 def _summarize_asset_paths(
@@ -610,6 +615,8 @@ def create_job_from_job_bundle(
     # to users.
     known_asset_paths = _filter_redundant_known_paths(known_asset_paths)
 
+    telemetry_client = api.get_deadline_cloud_library_telemetry_client()
+
     # Hash and upload job attachments if there are any
     files_processed = False
     if asset_references and "jobAttachmentSettings" in queue:
@@ -712,13 +719,17 @@ def create_job_from_job_bundle(
                     print_function_callback("Job submission canceled (user input).")
                     raise UserInitiatedCancel()
 
-            _, asset_manifests = _hash_attachments(
+            hash_cache_dir = config_file.get_cache_directory()
+
+            hashing_summary, asset_manifests = hash_attachments(
                 asset_manager=asset_manager,
                 asset_groups=upload_group.asset_groups,
                 total_input_files=upload_group.total_input_files,
                 total_input_bytes=upload_group.total_input_bytes,
                 print_function_callback=print_function_callback,
                 hashing_progress_callback=hashing_progress_callback,
+                hash_cache_dir=hash_cache_dir,
+                telemetry_callback=hashing_telemetry_callback,
             )
 
             if not debug_snapshot_dir:
@@ -789,7 +800,7 @@ def create_job_from_job_bundle(
     if logging.DEBUG >= logger.getEffectiveLevel():
         logger.debug(json.dumps(create_job_args, indent=1))
 
-    api.get_deadline_cloud_library_telemetry_client().record_event(
+    telemetry_client.record_event(
         event_type="com.amazon.rum.deadline.submission",
         event_details={"submitter_name": submitter_name},
         from_gui=from_gui,
@@ -831,7 +842,7 @@ def create_job_from_job_bundle(
             create_job_result_callback,
         )
 
-        api.get_deadline_cloud_library_telemetry_client().record_event(
+        telemetry_client.record_event(
             event_type="com.amazon.rum.deadline.create_job",
             event_details={"is_success": success},
             from_gui=from_gui,

--- a/src/deadline/client/cli/_groups/manifest_group.py
+++ b/src/deadline/client/cli/_groups/manifest_group.py
@@ -18,6 +18,7 @@ from typing import List, Optional
 import boto3
 import click
 
+from deadline.client.api._submit_job_bundle import hashing_telemetry_callback
 from deadline.client import api
 from deadline.client.config import config_file
 from deadline.job_attachments._diff import pretty_print_cli
@@ -126,6 +127,8 @@ def manifest_snapshot(
         destination = root
         logger.echo(f"Manifest creation path defaulted to {root} \n")
 
+    hash_cache_dir = config_file.get_cache_directory()
+
     manifest_out = _manifest_snapshot(
         root=root,
         destination=destination,
@@ -136,6 +139,8 @@ def manifest_snapshot(
         diff=diff,
         force_rehash=force_rehash,
         print_function_callback=logger.echo,
+        hash_cache_dir=hash_cache_dir,
+        telemetry_callback=hashing_telemetry_callback,
     )
     if manifest_out:
         if (

--- a/src/deadline/job_attachments/api/__init__.py
+++ b/src/deadline/job_attachments/api/__init__.py
@@ -6,6 +6,7 @@ __all__ = [
     "human_readable_file_size",
     "summarize_path_list",
     "PathSummary",
+    "hash_attachments",
 ]
 
 from ...common.path_utils import (
@@ -15,3 +16,5 @@ from ...common.path_utils import (
     summarize_path_list,
     PathSummary,
 )
+
+from ._hashing import hash_attachments

--- a/src/deadline/job_attachments/api/_hashing.py
+++ b/src/deadline/job_attachments/api/_hashing.py
@@ -1,29 +1,34 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
-from .. import api
-from ..config import config_file
-from ...job_attachments.models import AssetRootGroup, AssetRootManifest
-from ...job_attachments.upload import S3AssetManager, SummaryStatistics
-from ...job_attachments.progress_tracker import ProgressReportMetadata, ProgressStatus
-
-
 import textwrap
-from configparser import ConfigParser
-from typing import Callable, List, Optional, Tuple
+
+from typing import Any, Optional, List, Callable, Tuple
+
+from deadline.job_attachments.models import (
+    AssetRootGroup,
+    AssetRootManifest,
+)
+from deadline.job_attachments.progress_tracker import ProgressReportMetadata, ProgressStatus
+from deadline.job_attachments.upload import S3AssetManager, SummaryStatistics
 
 
-def _hash_attachments(
+def hash_attachments(
+    *,
     asset_manager: S3AssetManager,
     asset_groups: List[AssetRootGroup],
     total_input_files: int,
     total_input_bytes: int,
-    print_function_callback: Callable = lambda msg: None,
-    hashing_progress_callback: Optional[Callable] = None,
-    config: Optional[ConfigParser] = None,
+    print_function_callback: Callable[[str], None] = lambda msg: None,
+    hashing_progress_callback: Optional[Callable[[Any], bool]] = None,
+    hash_cache_dir: Optional[str] = None,
+    telemetry_callback: Optional[Callable[[SummaryStatistics], None]] = None,
 ) -> Tuple[SummaryStatistics, List[AssetRootManifest]]:
     """
-    Starts the job attachments hashing and handles the progress reporting
-    callback. Returns a list of the asset manifests of the hashed files.
+    Starts the job attachments hashing and Returns a list of the asset manifests of the hashed files.
+    Provides callbacks for:
+      * Printing output
+      * Hashing progress reporting
+      * Sending hashing telemetry
     """
 
     def _default_update_hash_progress(hashing_metadata: ProgressReportMetadata) -> bool:
@@ -36,16 +41,15 @@ def _hash_attachments(
         asset_groups=asset_groups,
         total_input_files=total_input_files,
         total_input_bytes=total_input_bytes,
-        hash_cache_dir=config_file.get_cache_directory(),
+        hash_cache_dir=hash_cache_dir,
         on_preparing_to_submit=hashing_progress_callback,
     )
-    api.get_deadline_cloud_library_telemetry_client(config=config).record_hashing_summary(
-        hashing_summary
-    )
+    if telemetry_callback:
+        telemetry_callback(hashing_summary)
     if hashing_summary.total_files > 0:
         print_function_callback("Hashing Summary:")
         print_function_callback(textwrap.indent(str(hashing_summary), "    "))
-    else:
+    elif hashing_progress_callback is not None:
         # Ensure to call the callback once if no files were processed
         hashing_progress_callback(
             ProgressReportMetadata(

--- a/src/deadline/job_attachments/api/manifest.py
+++ b/src/deadline/job_attachments/api/manifest.py
@@ -83,6 +83,7 @@ def _glob_files(
 
 
 def _manifest_snapshot(
+    *,
     root: str,
     destination: str,
     name: str,
@@ -92,6 +93,8 @@ def _manifest_snapshot(
     diff: Optional[str] = None,
     force_rehash: bool = False,
     print_function_callback: Callable[[Any], None] = lambda msg: None,
+    hash_cache_dir: Optional[str] = None,
+    telemetry_callback: Optional[Callable] = None,
 ) -> Optional[ManifestSnapshot]:
     # Get all files in the root.
     glob_config: GlobConfig
@@ -112,7 +115,11 @@ def _manifest_snapshot(
     # Compute the output manifest immediately and hash.
     if not diff:
         output_manifest = _create_manifest_for_single_root(
-            files=current_files, root=root, print_function_callback=print_function_callback
+            files=current_files,
+            root=root,
+            print_function_callback=print_function_callback,
+            hash_cache_dir=hash_cache_dir,
+            telemetry_callback=telemetry_callback,
         )
         if not output_manifest:
             return None
@@ -143,7 +150,11 @@ def _manifest_snapshot(
         else:
             # In "slow / thorough" mode, we check by hash, which is definitive.
             output_manifest = _create_manifest_for_single_root(
-                files=current_files, root=root, print_function_callback=print_function_callback
+                files=current_files,
+                root=root,
+                print_function_callback=print_function_callback,
+                hash_cache_dir=hash_cache_dir,
+                telemetry_callback=telemetry_callback,
             )
             if not output_manifest:
                 return None
@@ -164,7 +175,11 @@ def _manifest_snapshot(
 
         # Since the files are already hashed, we can easily re-use has_attachments to remake a diff manifest.
         output_manifest = _create_manifest_for_single_root(
-            files=changed_paths, root=root, print_function_callback=print_function_callback
+            files=changed_paths,
+            root=root,
+            print_function_callback=print_function_callback,
+            hash_cache_dir=hash_cache_dir,
+            telemetry_callback=telemetry_callback,
         )
         if not output_manifest:
             return None

--- a/src/deadline/job_attachments/asset_manifests/_create_manifest.py
+++ b/src/deadline/job_attachments/asset_manifests/_create_manifest.py
@@ -2,15 +2,19 @@
 
 from typing import Any, Callable, List, Optional
 
-from deadline.client.api._job_attachment import _hash_attachments
 from deadline.job_attachments.asset_manifests.base_manifest import BaseAssetManifest
 from deadline.job_attachments.upload import S3AssetManager
 
+from ...job_attachments.api import hash_attachments
+
 
 def _create_manifest_for_single_root(
+    *,
     files: List[str],
     root: str,
     print_function_callback: Callable[[Any], None] = lambda msg: None,
+    hash_cache_dir: Optional[str] = None,
+    telemetry_callback: Optional[Callable] = None,
 ) -> Optional[BaseAssetManifest]:
     """
     Shared logic to create a manifest file from a single root.
@@ -33,13 +37,15 @@ def _create_manifest_for_single_root(
     assert len(upload_group.asset_groups) == 1
 
     if upload_group.asset_groups:
-        _, manifests = _hash_attachments(
+        _, manifests = hash_attachments(
             asset_manager=asset_manager,
             asset_groups=upload_group.asset_groups,
             total_input_files=upload_group.total_input_files,
             total_input_bytes=upload_group.total_input_bytes,
             print_function_callback=print_function_callback,
             hashing_progress_callback=hash_callback_manager.callback,
+            hash_cache_dir=hash_cache_dir,
+            telemetry_callback=telemetry_callback,
         )
 
     if not manifests or len(manifests) == 0:

--- a/test/unit/deadline_client/api/test_job_bundle_submission.py
+++ b/test/unit/deadline_client/api/test_job_bundle_submission.py
@@ -502,6 +502,8 @@ def test_create_job_from_job_bundle_job_attachments(
             total_input_bytes=35,
             print_function_callback=print,
             hashing_progress_callback=fake_hashing_callback,
+            hash_cache_dir=config.config_file.get_cache_directory(),
+            telemetry_callback=api._submit_job_bundle.hashing_telemetry_callback,
         )
         mock.get_boto3_client().create_job.assert_called_once_with(
             farmId=MOCK_FARM_ID,
@@ -886,6 +888,8 @@ def test_create_job_from_job_bundle_with_single_asset_file(
             total_input_bytes=15,
             print_function_callback=print,
             hashing_progress_callback=fake_hashing_callback,
+            hash_cache_dir=config.config_file.get_cache_directory(),
+            telemetry_callback=api._submit_job_bundle.hashing_telemetry_callback,
         )
 
         assert mock.get_boto3_client().create_job.mock_calls == [

--- a/test/unit/deadline_client/cli/test_cli_manifest.py
+++ b/test/unit/deadline_client/cli/test_cli_manifest.py
@@ -37,7 +37,7 @@ def mock_prepare_paths_for_upload():
 @pytest.fixture
 def mock_hash_attachments():
     with patch(
-        "deadline.job_attachments.api.manifest._hash_attachments", return_value=(Mock(), [])
+        "deadline.job_attachments.api.manifest.hash_attachments", return_value=(Mock(), [])
     ) as mock:
         yield mock
 

--- a/test/unit/deadline_client/testing_utilities.py
+++ b/test/unit/deadline_client/testing_utilities.py
@@ -214,7 +214,7 @@ def patch_calls_for_create_job_from_job_bundle(
         "_generate_message_for_asset_paths",
         wraps=_submit_job_bundle._generate_message_for_asset_paths,
     ) as mock_generate_message_for_asset_paths, patch.object(
-        _submit_job_bundle, "_hash_attachments", wraps=_submit_job_bundle._hash_attachments
+        _submit_job_bundle, "hash_attachments", wraps=_submit_job_bundle.hash_attachments
     ) as mock_hash_attachments, patch(
         "deadline.job_attachments.upload.S3AssetUploader"
     ), patch.object(


### PR DESCRIPTION
NOTE: The API Change Detection CI task will fail. This is intentional because it always fails when a new public API is added. This does not block merging.

### What was the problem/requirement? (What/Why)

Job Attachments and the rest of the client are circularly dependent on each other. The rest of the Client should depend on Job Attachments, but Job Attachments should not depend on the rest of the client. One instance of this circular dependency is the `_hash_attachments` function which is used by Job Attachments but lives in the client.

### What was the solution? (How)

Move `_hash_attachments` into Job Attachments and remove calls to other client code from it. Replace these calls with parameters and callbacks.

### What is the impact of this change?

We make progress to remove the circular dependency.

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests? __Yes__
- Have you run the integration tests? __Yes__
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass. __No__

### Was this change documented?

- Are relevant docstrings in the code base updated? __TODO__
- Has the README.md been updated? If you modified CLI arguments, for instance. __N/A__

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?

A breaking change is one that modifies a public contract in a way that is not backwards compatible. See the 
[Public Contracts](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#public-contracts) section
of the DEVELOPMENT.md for more information on the public contracts.

If so, then please describe the changes that users of this package must make to update their scripts, or Python applications.

No

### Does this change impact security?

- Does the change need to be threat modeled? For example, does it create or modify files/directories that must only be readable by the process owner?
    - If so, then please label this pull request with the "security" label. We'll work with you to analyze the threats.

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
