### PR TITLE
chore: downgrade deadline-cloud-test-fixture to 0.18.8

### DIFF
--- a/requirements-integ-testing.txt
+++ b/requirements-integ-testing.txt
@@ -1,4 +1,4 @@
-deadline-cloud-test-fixtures ~= 0.18.9
+deadline-cloud-test-fixtures == 0.18.8 # Pinning due to a regression in 0.18.9
 # MCP (Model Context Protocol) library for MCP server integration tests
 mcp >= 1.13.0
 pytest-asyncio == 1.*

--- a/test/integ/conftest.py
+++ b/test/integ/conftest.py
@@ -4,8 +4,6 @@ import json
 import os
 import pytest
 
-pytest_plugins = ["deadline_test_fixtures.pytest_hooks"]
-
 
 @pytest.fixture()
 def external_bucket() -> str:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Failing integration tests where it looks like test runs are deleting eachothers queues from a recent change to some cleanup code that is in deadline-cloud-test-fixtures 0.18.9

### What was the solution? (How)
Downgrade to 0.18.8 for now

### What is the impact of this change?
Tests should start passing again

### How was this change tested?

It wasn't
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
