### PR TITLE
fix: load job bundle button text too long for default UI width

### DIFF
--- a/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
@@ -240,7 +240,7 @@ class SubmitJobToDeadlineDialog(QDialog):
         self.submit_button.clicked.connect(self.on_submit)
         self.button_box.addButton(self.submit_button, QDialogButtonBox.AcceptRole)
         if hasattr(initial_job_settings, "browse_enabled") and initial_job_settings.browse_enabled:
-            self.load_bundle_button = QPushButton(tr("Load a different job bundle"))
+            self.load_bundle_button = QPushButton(tr("Load Bundle"))
             self.load_bundle_button.clicked.connect(self._on_load_bundle)
             self.button_box.addButton(self.load_bundle_button, QDialogButtonBox.AcceptRole)
         self.export_bundle_button = QPushButton(tr("Export bundle"))

--- a/src/deadline/client/ui/translations/locales/de_DE.json
+++ b/src/deadline/client/ui/translations/locales/de_DE.json
@@ -66,7 +66,7 @@
   "Known asset paths": "Bekannte Asset-Pfade",
   "Language": "Sprache",
   "Language will change next time the submitter is opened": "Die Sprache wird beim nächsten Öffnen des Submitters geändert",
-  "Load a different job bundle": "Ein anderes Jobpaket laden",
+  "Load Bundle": "Paket laden",
   "Log in": "Anmelden",
   "Log in to AWS Deadline Cloud": "Bei AWS Deadline Cloud anmelden",
   "Logging you in...": "Sie werden angemeldet...",

--- a/src/deadline/client/ui/translations/locales/en_US.json
+++ b/src/deadline/client/ui/translations/locales/en_US.json
@@ -66,7 +66,7 @@
   "Known asset paths": "Known asset paths",
   "Language": "Language",
   "Language will change next time the submitter is opened": "Language will change next time the submitter is opened",
-  "Load a different job bundle": "Load a different job bundle",
+  "Load Bundle": "Load Bundle",
   "Log in": "Log in",
   "Log in to AWS Deadline Cloud": "Log in to AWS Deadline Cloud",
   "Logging you in...": "Logging you in...",

--- a/src/deadline/client/ui/translations/locales/es_ES.json
+++ b/src/deadline/client/ui/translations/locales/es_ES.json
@@ -66,7 +66,7 @@
   "Known asset paths": "Rutas de recursos conocidas",
   "Language": "Idioma",
   "Language will change next time the submitter is opened": "El idioma cambiará la próxima vez que se abra el submitter",
-  "Load a different job bundle": "Cargar un paquete de trabajos diferente",
+  "Load Bundle": "Cargar paquete",
   "Log in": "Iniciar sesión",
   "Log in to AWS Deadline Cloud": "Iniciar sesión en AWS Deadline Cloud",
   "Logging you in...": "Iniciando sesión...",

--- a/src/deadline/client/ui/translations/locales/fr_FR.json
+++ b/src/deadline/client/ui/translations/locales/fr_FR.json
@@ -66,7 +66,7 @@
   "Known asset paths": "Chemins d'actifs connus",
   "Language": "Langue",
   "Language will change next time the submitter is opened": "La langue changera lors de la prochaine ouverture du submitter",
-  "Load a different job bundle": "Charger un lot de tâches différent",
+  "Load Bundle": "Charger le lot",
   "Log in": "Se connecter",
   "Log in to AWS Deadline Cloud": "Se connecter à AWS Deadline Cloud",
   "Logging you in...": "Connexion en cours...",

--- a/src/deadline/client/ui/translations/locales/id_ID.json
+++ b/src/deadline/client/ui/translations/locales/id_ID.json
@@ -66,7 +66,7 @@
   "Known asset paths": "Jalur aset yang diketahui",
   "Language": "Bahasa",
   "Language will change next time the submitter is opened": "Bahasa akan berubah saat submitter dibuka kembali",
-  "Load a different job bundle": "Muat bundel pekerjaan yang berbeda",
+  "Load Bundle": "Muat bundel",
   "Log in": "Masuk",
   "Log in to AWS Deadline Cloud": "Masuk ke AWS Deadline Cloud",
   "Logging you in...": "Memasukkan Anda...",

--- a/src/deadline/client/ui/translations/locales/it_IT.json
+++ b/src/deadline/client/ui/translations/locales/it_IT.json
@@ -66,7 +66,7 @@
   "Known asset paths": "Percorsi asset noti",
   "Language": "Lingua",
   "Language will change next time the submitter is opened": "La lingua cambierà alla prossima apertura del submitter",
-  "Load a different job bundle": "Carica un pacchetto lavoro diverso",
+  "Load Bundle": "Carica pacchetto",
   "Log in": "Accedi",
   "Log in to AWS Deadline Cloud": "Accedi ad AWS Deadline Cloud",
   "Logging you in...": "Accesso in corso...",

--- a/src/deadline/client/ui/translations/locales/ja_JP.json
+++ b/src/deadline/client/ui/translations/locales/ja_JP.json
@@ -66,7 +66,7 @@
   "Known asset paths": "既知のアセットパス",
   "Language": "言語",
   "Language will change next time the submitter is opened": "言語は次回サブミッターを開いたときに変更されます",
-  "Load a different job bundle": "別のジョブバンドルを読み込む",
+  "Load Bundle": "バンドルを読み込む",
   "Log in": "ログイン",
   "Log in to AWS Deadline Cloud": "AWS Deadline Cloud にログイン",
   "Logging you in...": "ログイン中...",

--- a/src/deadline/client/ui/translations/locales/ko_KR.json
+++ b/src/deadline/client/ui/translations/locales/ko_KR.json
@@ -66,7 +66,7 @@
   "Known asset paths": "알려진 자산 경로",
   "Language": "언어",
   "Language will change next time the submitter is opened": "언어는 다음에 제출자를 열 때 변경됩니다",
-  "Load a different job bundle": "다른 작업 번들 로드",
+  "Load Bundle": "번들 로드",
   "Log in": "로그인",
   "Log in to AWS Deadline Cloud": "AWS Deadline Cloud에 로그인",
   "Logging you in...": "로그인 중...",

--- a/src/deadline/client/ui/translations/locales/pt_BR.json
+++ b/src/deadline/client/ui/translations/locales/pt_BR.json
@@ -66,7 +66,7 @@
   "Known asset paths": "Caminhos de ativos conhecidos",
   "Language": "Idioma",
   "Language will change next time the submitter is opened": "O idioma será alterado na próxima vez que o submitter for aberto",
-  "Load a different job bundle": "Carregar um pacote de tarefas diferente",
+  "Load Bundle": "Carregar pacote",
   "Log in": "Fazer login",
   "Log in to AWS Deadline Cloud": "Fazer login no AWS Deadline Cloud",
   "Logging you in...": "Fazendo login...",

--- a/src/deadline/client/ui/translations/locales/tr_TR.json
+++ b/src/deadline/client/ui/translations/locales/tr_TR.json
@@ -66,7 +66,7 @@
   "Known asset paths": "Bilinen varlık yolları",
   "Language": "Dil",
   "Language will change next time the submitter is opened": "Dil, submitter bir sonraki açılışında değişecektir",
-  "Load a different job bundle": "Farklı bir iş paketi yükle",
+  "Load Bundle": "Paket yükle",
   "Log in": "Oturum aç",
   "Log in to AWS Deadline Cloud": "AWS Deadline Cloud'da oturum aç",
   "Logging you in...": "Oturum açılıyor...",

--- a/src/deadline/client/ui/translations/locales/zh_CN.json
+++ b/src/deadline/client/ui/translations/locales/zh_CN.json
@@ -66,7 +66,7 @@
   "Known asset paths": "已知资产路径",
   "Language": "语言",
   "Language will change next time the submitter is opened": "语言将在下次打开提交器时更改",
-  "Load a different job bundle": "加载不同的作业捆绑包",
+  "Load Bundle": "加载捆绑包",
   "Log in": "登录",
   "Log in to AWS Deadline Cloud": "登录 AWS Deadline Cloud",
   "Logging you in...": "正在登录...",

--- a/src/deadline/client/ui/translations/locales/zh_TW.json
+++ b/src/deadline/client/ui/translations/locales/zh_TW.json
@@ -66,7 +66,7 @@
   "Known asset paths": "已知資產路徑",
   "Language": "語言",
   "Language will change next time the submitter is opened": "語言將在下次開啟提交器時變更",
-  "Load a different job bundle": "載入不同的任務套件",
+  "Load Bundle": "載入套件",
   "Log in": "登入",
   "Log in to AWS Deadline Cloud": "登入 AWS Deadline Cloud",
   "Logging you in...": "正在登入...",

--- a/test/unit/deadline_client/ui/dialogs/test_submit_job_to_deadline_dialog.py
+++ b/test/unit/deadline_client/ui/dialogs/test_submit_job_to_deadline_dialog.py
@@ -42,7 +42,7 @@ def test_load_bundle_button_shown_when_browse_enabled(
     qtbot.addWidget(dialog)
 
     assert hasattr(dialog, "load_bundle_button")
-    assert dialog.load_bundle_button.text() == "Load a different job bundle"
+    assert dialog.load_bundle_button.text() == "Load Bundle"
 
 
 @patch("deadline.client.ui.dialogs.submit_job_to_deadline_dialog.DeadlineAuthenticationStatus")


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
A recent change moved where the `Load a different job bundle` button goes when calling `deadline bundle gui-submit --browse`. In this new area the text is too long for the default UI width.

### What was the solution? (How)
Shorten the text to just `Load Bundle` which matches the `Export Bundle` button it sits beside
<img width="1092" height="116" alt="image" src="https://github.com/user-attachments/assets/aa93f170-cc6e-43c1-9166-3677a3d99ad0" />

Updated all the translations as well

### What is the impact of this change?
UI displays nicely at the default width when calling `deadline bundle gui-submit --browse`

### How was this change tested?

See the screenshot above

### Was this change documented?

No

### Does this PR introduce new dependencies?

No

### Is this a breaking change?
No

### Does this change impact security?

No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
