### PR TITLE
feat: add search term support to `deadline job get` command

### DIFF
--- a/docs/design/cli-job-get-with-search-term.md
+++ b/docs/design/cli-job-get-with-search-term.md
@@ -1,0 +1,118 @@
+# Design: `deadline job get` with Search Term
+
+## Overview
+
+Enable users to find jobs using a search term instead of requiring job IDs. `deadline job get "search term"` searches for jobs matching that term across multiple fields, displaying full details if one matches or a summary list if multiple match.
+
+## Problem Statement
+
+Users must know the exact job ID to use commands like `deadline job get --job-id job-xxx`. This is cumbersome because:
+- Job IDs are opaque 32-character hex strings
+- Users typically remember job names, not IDs
+- Finding a job ID requires running `deadline job list` first
+
+## CLI Interface
+
+```bash
+# Search by name (single result shows full details, multiple shows summary)
+deadline job get "Blender Render"
+
+# Job ID as positional argument
+deadline job get job-eee5a7898b6c493d84aaa12ea384156b
+
+# Prefix of Job ID as positional argument
+deadline job get job-eee5a
+
+# Job ID with --job-id flag
+deadline job get --job-id job-eee5a7898b6c493d84aaa12ea384156b
+
+# No arguments uses default job ID from config
+deadline job get
+```
+
+## Command Behavior
+
+1. If `SEARCH_TERM` matches job ID pattern (`job-[0-9a-f]{32}`): get full job details
+2. If `SEARCH_TERM` is any other string: search jobs with that term
+   - Exactly one match: get full job details via `GetJob` API
+   - Multiple matches: display summary table
+   - No matches: display "No jobs found" message
+3. If no `SEARCH_TERM` provided: use `--job-id` or default job ID from config
+
+## Output Format
+
+**Single result or job ID:** Full job details from `GetJob` API
+
+**Multiple results:**
+```
+Found 10 job(s) matching "job", showing most recent 5:
+
+  Turntable with Maya/Arnold
+    job-ca34b643089742609bdf36391b4f0fe0  SUCCEEDED     2026-01-23 17:09:04 -0800
+    Tasks: 52 succeeded
+
+  Turntable with Maya/Arnold
+    job-d4c36c381d3d4854b0dfec8e35486e5d  FAILED        2026-01-23 17:06:58 -0800
+    Tasks: 1 failed, 51 canceled
+
+  This is a very long job name to test truncation - P...ender Pass - Version 3.2.1
+    job-725b3675bdaa45868501f421caeca9be  SUCCEEDED     2026-01-23 17:03:55 -0800
+    Tasks: 20 succeeded
+
+  ...
+
+  ... and 5 more
+
+To get details, run: deadline job get --job-id <job-id>
+```
+
+- Job names up to 80 characters, truncated in the middle with `...` if longer
+- Each job displays on multiple lines: name, job ID/status/timestamp, task summary
+- Task summary shows counts for running, ready, pending, succeeded, failed, canceled
+- Timestamps converted to local timezone with UTC offset
+- Limited to 5 most recent matches
+
+**No results:**
+```
+No jobs found matching "nonexistent term"
+```
+
+## Implementation Details
+
+**Files modified:**
+- `src/deadline/client/cli/_groups/job_group.py` - Modified `job_get` command
+- `src/deadline/client/cli/_groups/_job_helpers.py` - New helper module
+
+**Key functions:**
+- `_resolve_job_search(config, search_term)` - Searches jobs via `SearchJobs` API, returns job ID if single match, prints summary if multiple matches
+- `_print_job_details(config, job_id)` - Fetches and prints full job details via `GetJob` API
+- `_format_timestamp(dt)` - Converts datetime to local timezone with offset
+- `_truncate_middle(text, max_length)` - Truncates text in the middle with `...`
+- `_format_task_summary(task_counts)` - Formats task status counts into brief summary
+
+**API usage:**
+- `SearchJobs` with `searchTermFilter` using `matchType: CONTAINS` for case-insensitive substring matching
+- Results sorted by `CREATED_AT` descending, limited to 5 results
+- `GetJob` for full job details when single result or job ID provided
+
+**Config integration:**
+- Uses `_apply_cli_options_to_config` with `required_options={"job_id"}` when not searching, enabling fallback to `defaults.job_id` from config
+
+## Testing
+
+Unit tests are in `test/unit/deadline_client/cli/test_cli_job_get_with_search_term.py`.
+
+**Test cases:**
+- `test_search_single_result_shows_full_details` - Single match calls `GetJob` and shows full details
+- `test_search_multiple_results_shows_summary` - Multiple matches show summary table, no `GetJob` call
+- `test_search_no_results` - No matches show "No jobs found" message
+- `test_job_id_as_positional_arg` - Job ID pattern bypasses search, calls `GetJob` directly
+- `test_job_id_with_flag` - `--job-id` flag calls `GetJob` directly
+- `test_no_args_uses_default_job_id` - No args uses `defaults.job_id` from config
+- `test_no_args_no_default_job_id_shows_error` - No args and no default shows error
+
+## Future Iterations
+
+1. **Interactive selection**: Prompt user to select from multiple results
+2. **Extend to other commands**: `deadline job cancel`, `deadline job logs`, etc.
+3. **Fuzzy match option**: Add `--fuzzy` flag for broader matching

--- a/src/deadline/client/cli/_groups/_job_helpers.py
+++ b/src/deadline/client/cli/_groups/_job_helpers.py
@@ -1,0 +1,149 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Private helper functions for job CLI commands.
+"""
+
+from configparser import ConfigParser
+from datetime import datetime
+from typing import Optional
+
+import click
+from botocore.exceptions import ClientError
+
+from ... import api
+from ...config import config_file
+from ...exceptions import DeadlineOperationError
+from .._common import _cli_object_repr
+
+
+def _format_timestamp(dt: datetime) -> str:
+    """Format a datetime to local time with timezone offset."""
+    if dt is None:
+        return ""
+    local_dt = dt.astimezone()
+    return local_dt.strftime("%Y-%m-%d %H:%M:%S %z")
+
+
+def _truncate_middle(text: str, max_length: int) -> str:
+    """Truncate text in the middle with '...' if too long."""
+    if len(text) <= max_length:
+        return text
+    # Keep more at start than end for readability
+    keep = max_length - 3  # account for "..."
+    start = (keep * 2) // 3
+    end = keep - start
+    return text[:start] + "..." + text[-end:]
+
+
+def _format_task_summary(task_counts: dict) -> str:
+    """Format task status counts into a brief summary."""
+    ready = task_counts.get("READY", 0)
+    running = (
+        task_counts.get("RUNNING", 0)
+        + task_counts.get("STARTING", 0)
+        + task_counts.get("ASSIGNED", 0)
+        + task_counts.get("SCHEDULED", 0)
+    )
+    interrupting = task_counts.get("INTERRUPTING", 0)
+    pending = task_counts.get("PENDING", 0)
+    suspended = task_counts.get("SUSPENDED", 0)
+    succeeded = task_counts.get("SUCCEEDED", 0)
+    failed = task_counts.get("FAILED", 0)
+    canceled = task_counts.get("CANCELED", 0)
+    not_compatible = task_counts.get("NOT_COMPATIBLE", 0)
+
+    parts = []
+    if ready:
+        parts.append(f"{ready} ready")
+    if running:
+        parts.append(f"{running} running")
+    if interrupting:
+        parts.append(f"{interrupting} interrupting")
+    if pending:
+        parts.append(f"{pending} pending")
+    if suspended:
+        parts.append(f"{suspended} suspended")
+    if succeeded:
+        parts.append(f"{succeeded} succeeded")
+    if failed:
+        parts.append(f"{failed} failed")
+    if canceled:
+        parts.append(f"{canceled} canceled")
+    if not_compatible:
+        parts.append(f"{not_compatible} not compatible")
+
+    return ", ".join(parts) if parts else "no tasks"
+
+
+def _resolve_job_search(config: Optional[ConfigParser], search_term: str) -> Optional[str]:
+    """
+    Search for jobs with a search term and resolve to a single job ID.
+
+    Returns the job ID if exactly one job matches.
+    If multiple jobs match, prints a summary table and returns None.
+    If no jobs match, prints a message and returns None.
+    """
+    farm_id = config_file.get_setting("defaults.farm_id", config=config)
+    queue_id = config_file.get_setting("defaults.queue_id", config=config)
+
+    deadline = api.get_boto3_client("deadline", config=config)
+
+    try:
+        response = deadline.search_jobs(
+            farmId=farm_id,
+            queueIds=[queue_id],
+            itemOffset=0,
+            pageSize=5,
+            filterExpressions={
+                "filters": [
+                    {"searchTermFilter": {"searchTerm": search_term, "matchType": "CONTAINS"}}
+                ],
+                "operator": "AND",
+            },
+            sortExpressions=[{"fieldSort": {"name": "CREATED_AT", "sortOrder": "DESCENDING"}}],
+        )
+    except ClientError as exc:
+        raise DeadlineOperationError(f"Failed to search jobs:\n{exc}") from exc
+
+    jobs = response.get("jobs", [])
+    total = response.get("totalResults", 0)
+
+    if not jobs:
+        click.echo(f'No jobs found matching "{search_term}"')
+        return None
+
+    # Single result - return job ID for detailed lookup
+    if total == 1:
+        return jobs[0]["jobId"]
+
+    # Multiple results - display summary
+    click.echo(f'Found {total} job(s) matching "{search_term}", showing most recent {len(jobs)}:\n')
+
+    for job in jobs:
+        name = _truncate_middle(job.get("name", job.get("displayName", "")), 80)
+        created = _format_timestamp(job.get("createdAt"))
+        task_counts = job.get("taskRunStatusCounts", {})
+        task_summary = _format_task_summary(task_counts)
+
+        click.echo(f"  {name}")
+        click.echo(f"    {job['jobId']}  {job['taskRunStatus']:<12}  {created}")
+        click.echo(f"    Tasks: {task_summary}")
+        click.echo()
+
+    if total > len(jobs):
+        click.echo(f"\n  ... and {total - len(jobs)} more")
+
+    click.echo("\nTo get details, run: deadline job get --job-id <job-id>")
+    return None
+
+
+def _print_job_details(config: Optional[ConfigParser], job_id: str) -> None:
+    """Fetch and print full job details."""
+    farm_id = config_file.get_setting("defaults.farm_id", config=config)
+    queue_id = config_file.get_setting("defaults.queue_id", config=config)
+
+    deadline = api.get_boto3_client("deadline", config=config)
+    response = deadline.get_job(farmId=farm_id, queueId=queue_id, jobId=job_id)
+    response.pop("ResponseMetadata", None)
+    click.echo(_cli_object_repr(response))

--- a/src/deadline/client/cli/_groups/job_group.py
+++ b/src/deadline/client/cli/_groups/job_group.py
@@ -48,6 +48,7 @@ from .._main import deadline as main
 from ._sigint_handler import SigIntHandler
 from ...api._session import get_default_client_config
 from .._timestamp_formatter import TimestampFormat, TimestampFormatter
+from ._job_helpers import _resolve_job_search, _print_job_details
 
 logger = logging.getLogger("deadline.client.cli")
 
@@ -171,31 +172,42 @@ def job_list(page_size, item_offset, **args):
 
 
 @cli_job.command(name="get")
+@click.argument("search_term", required=False)
 @click.option("--profile", help="The AWS profile to use.")
 @click.option("--farm-id", help="The farm to use.")
 @click.option("--queue-id", help="The queue to use.")
 @click.option("--job-id", help="The job to get.")
 @_handle_error
-def job_get(**args):
+def job_get(search_term: Optional[str], **args):
     """
-    Get the details of a [Deadline Cloud job] in the queue.
+    Get the details of a [Deadline Cloud job], or search for jobs with a search term.
+
+    SEARCH_TERM can be a job ID (job-xxx) or a search string to find matching jobs.
+    If exactly one job matches, shows full details. If multiple match, shows a summary list.
+    If no arguments provided, shows the default job from config.
 
     [Deadline Cloud job]: https://docs.aws.amazon.com/deadline-cloud/latest/userguide/deadline-cloud-jobs.html
     """
-    # Get a temporary config object with the standard options handled
-    config = _apply_cli_options_to_config(
-        required_options={"farm_id", "queue_id", "job_id"}, **args
-    )
+    # Check if search_term is actually a job ID
+    if search_term and re.match(r"^job-[0-9a-f]{32}$", search_term):
+        args["job_id"] = search_term
+        search_term = None
 
-    farm_id = config_file.get_setting("defaults.farm_id", config=config)
-    queue_id = config_file.get_setting("defaults.queue_id", config=config)
-    job_id = config_file.get_setting("defaults.job_id", config=config)
-
-    deadline = api.get_boto3_client("deadline", config=config)
-    response = deadline.get_job(farmId=farm_id, queueId=queue_id, jobId=job_id)
-    response.pop("ResponseMetadata", None)
-
-    click.echo(_cli_object_repr(response))
+    if search_term:
+        # Search with term - don't require job_id
+        config = _apply_cli_options_to_config(required_options={"farm_id", "queue_id"}, **args)
+        found_job_id = _resolve_job_search(config, search_term)
+        if found_job_id:
+            _print_job_details(config, found_job_id)
+    else:
+        # Get job by ID (from arg or config default)
+        config = _apply_cli_options_to_config(
+            required_options={"farm_id", "queue_id", "job_id"}, **args
+        )
+        job_id = config_file.get_setting("defaults.job_id", config=config)
+        if job_id is None:
+            raise DeadlineOperationError("Missing job ID. Provide a job ID or search term.")
+        _print_job_details(config, job_id)
 
 
 @cli_job.command(name="cancel")

--- a/test/unit/deadline_client/cli/test_cli_job_get_with_search_term.py
+++ b/test/unit/deadline_client/cli/test_cli_job_get_with_search_term.py
@@ -1,0 +1,175 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Tests for the search term functionality in `deadline job get`.
+"""
+
+import datetime
+from datetime import timezone
+
+from click.testing import CliRunner
+
+from deadline.client import config
+from deadline.client.cli import main
+
+from ..shared_constants import MOCK_FARM_ID, MOCK_QUEUE_ID
+
+
+MOCK_JOB_1 = {
+    "jobId": "job-aaf4cdf8aae242f58fb84c5bb19f199b",
+    "name": "Blender Render",
+    "taskRunStatus": "SUCCEEDED",
+    "taskRunStatusCounts": {"SUCCEEDED": 1},
+    "lifecycleStatus": "CREATE_COMPLETE",
+    "createdBy": "user-123",
+    "createdAt": datetime.datetime(2023, 1, 27, 7, 34, 41, tzinfo=timezone.utc),
+    "startedAt": datetime.datetime(2023, 1, 27, 7, 37, 53, tzinfo=timezone.utc),
+    "endedAt": datetime.datetime(2023, 1, 27, 7, 39, 17, tzinfo=timezone.utc),
+    "priority": 50,
+}
+
+MOCK_JOB_2 = {
+    "jobId": "job-0d239749fa05435f90263b3a8be54144",
+    "name": "Blender Render Scene 2",
+    "taskRunStatus": "RUNNING",
+    "taskRunStatusCounts": {"RUNNING": 1},
+    "lifecycleStatus": "CREATE_COMPLETE",
+    "createdBy": "user-123",
+    "createdAt": datetime.datetime(2023, 1, 27, 7, 24, 22, tzinfo=timezone.utc),
+    "startedAt": datetime.datetime(2023, 1, 27, 7, 27, 6, tzinfo=timezone.utc),
+    "priority": 50,
+}
+
+MOCK_JOB_FULL_DETAILS = {
+    **MOCK_JOB_1,
+    "lifecycleStatusMessage": "Job completed successfully",
+    "taskRunStatusCounts": {
+        "PENDING": 0,
+        "READY": 0,
+        "SUCCEEDED": 1,
+    },
+    "maxFailedTasksCount": 20,
+    "maxRetriesPerTask": 5,
+}
+
+
+class TestJobGetSearch:
+    """Tests for job search functionality."""
+
+    def test_search_single_result_shows_full_details(self, fresh_deadline_config, deadline_mock):
+        """When search returns exactly one job, show full job details."""
+        config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+        config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+
+        deadline_mock.search_jobs.return_value = {
+            "jobs": [MOCK_JOB_1],
+            "totalResults": 1,
+        }
+        deadline_mock.get_job.return_value = MOCK_JOB_FULL_DETAILS
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["job", "get", "Blender Render"])
+
+        assert result.exit_code == 0
+        deadline_mock.get_job.assert_called_once_with(
+            farmId=MOCK_FARM_ID, queueId=MOCK_QUEUE_ID, jobId=MOCK_JOB_1["jobId"]
+        )
+        assert "jobId: job-aaf4cdf8aae242f58fb84c5bb19f199b" in result.output
+        assert "lifecycleStatusMessage:" in result.output
+
+    def test_search_multiple_results_shows_summary(self, fresh_deadline_config, deadline_mock):
+        """When search returns multiple jobs, show summary table."""
+        config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+        config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+
+        deadline_mock.search_jobs.return_value = {
+            "jobs": [MOCK_JOB_1, MOCK_JOB_2],
+            "totalResults": 2,
+        }
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["job", "get", "Blender"])
+
+        assert result.exit_code == 0
+        deadline_mock.get_job.assert_not_called()
+        assert 'Found 2 job(s) matching "Blender"' in result.output
+        assert "job-aaf4cdf8aae242f58fb84c5bb19f199b" in result.output
+        assert "job-0d239749fa05435f90263b3a8be54144" in result.output
+        assert "To get details, run:" in result.output
+
+    def test_search_no_results(self, fresh_deadline_config, deadline_mock):
+        """When search returns no jobs, show appropriate message."""
+        config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+        config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+
+        deadline_mock.search_jobs.return_value = {
+            "jobs": [],
+            "totalResults": 0,
+        }
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["job", "get", "nonexistent"])
+
+        assert result.exit_code == 0
+        assert 'No jobs found matching "nonexistent"' in result.output
+
+    def test_job_id_as_positional_arg(self, fresh_deadline_config, deadline_mock):
+        """When positional arg is a job ID, fetch that job directly."""
+        config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+        config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+
+        job_id = "job-aaf4cdf8aae242f58fb84c5bb19f199b"
+        deadline_mock.get_job.return_value = MOCK_JOB_FULL_DETAILS
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["job", "get", job_id])
+
+        assert result.exit_code == 0
+        deadline_mock.search_jobs.assert_not_called()
+        deadline_mock.get_job.assert_called_once_with(
+            farmId=MOCK_FARM_ID, queueId=MOCK_QUEUE_ID, jobId=job_id
+        )
+
+    def test_job_id_with_flag(self, fresh_deadline_config, deadline_mock):
+        """When --job-id is provided, fetch that job directly."""
+        config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+        config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+
+        job_id = "job-aaf4cdf8aae242f58fb84c5bb19f199b"
+        deadline_mock.get_job.return_value = MOCK_JOB_FULL_DETAILS
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["job", "get", "--job-id", job_id])
+
+        assert result.exit_code == 0
+        deadline_mock.get_job.assert_called_once_with(
+            farmId=MOCK_FARM_ID, queueId=MOCK_QUEUE_ID, jobId=job_id
+        )
+
+    def test_no_args_uses_default_job_id(self, fresh_deadline_config, deadline_mock):
+        """When no args provided, use default job ID from config."""
+        config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+        config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+        config.set_setting("defaults.job_id", str(MOCK_JOB_1["jobId"]))
+
+        deadline_mock.get_job.return_value = MOCK_JOB_FULL_DETAILS
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["job", "get"])
+
+        assert result.exit_code == 0
+        deadline_mock.get_job.assert_called_once_with(
+            farmId=MOCK_FARM_ID, queueId=MOCK_QUEUE_ID, jobId=MOCK_JOB_1["jobId"]
+        )
+
+    def test_no_args_no_default_job_id_shows_error(self, fresh_deadline_config):
+        """When no args and no default job ID, show error."""
+        config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+        config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+        # No default job_id set
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["job", "get"])
+
+        assert result.exit_code != 0
+        assert "Missing '--job-id' or default Job ID configuration" in result.output


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Users must know the exact job ID to use commands like `deadline job get --job-id job-xxx`. This is cumbersome because:
- Job IDs are opaque 32-character hex strings
- Users typically remember job names, not IDs
- Finding a job ID requires running `deadline job list` first

### What was the solution? (How)

Enable users to find jobs using a search term instead of requiring exact job IDs. `deadline job get "search term"` searches for jobs matching that term across multiple fields, displaying full details if one matches or a summary list if multiple match.

- Add positional SEARCH_TERM argument to job get command
- Single result shows full job details via GetJob API
- Multiple results show summary with job name, ID, status, timestamp, and task counts
- Job ID pattern (job-xxx) as positional arg bypasses search
- No args uses default job_id from config (preserves original behavior)
- Add helper module _job_helpers.py with search and display functions
- Timestamps displayed in local timezone with UTC offset
- Task summary shows running, ready, pending, succeeded, failed, canceled counts
- Limit results to 5 most recent matches

### What is the impact of this change?

Better UX when querying the status of jobs from the CLI.

### How was this change tested?

Added unit tests for the new cases. Tested the command on a farm with a variety of test jobs, e.g. with longer names to see how the results look.

### Was this change documented?

Docstrings for the CLI command are updated, so it shows up in CLI help.

### Does this PR introduce new dependencies?

No

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
