### PR TITLE
feat: suggest available resources on CLI access errors

### DIFF
--- a/docs/design/cli-resource-id-error-suggestions.md
+++ b/docs/design/cli-resource-id-error-suggestions.md
@@ -1,0 +1,112 @@
+# Design: CLI Resource ID Error Suggestions
+
+## Overview
+
+When users provide an incorrect resource ID (farm, queue, fleet, job, worker, storage profile) and receive an access denied or not found error, the CLI automatically suggests available resources they have access to. This helps users quickly identify and fix typos in resource IDs.
+
+## Implemented Commands
+
+The following commands show resource suggestions on access/not-found errors:
+
+| Command | Suggestions Shown |
+|---------|-------------------|
+| `deadline bundle submit` | queues → farms (fallback) |
+| `deadline farm list` | farms |
+| `deadline farm get` | farms |
+| `deadline fleet list` | fleets → farms (fallback) |
+| `deadline fleet get` | fleets → farms (fallback) |
+| `deadline queue list` | queues → farms (fallback) |
+| `deadline queue get` | queues → farms (fallback) |
+| `deadline queue paramdefs` | queues → farms (fallback) |
+| `deadline job list` | jobs → queues → farms (fallback) |
+| `deadline job get` | jobs → queues → farms (fallback) |
+| `deadline job cancel` | jobs → queues → farms (fallback) |
+| `deadline worker list` | workers → fleets (fallback) |
+| `deadline worker get` | workers → fleets (fallback) |
+
+## Key Behaviors
+
+- **CLI-only feature**: Library users (`deadline.client.api`) receive original `ClientError` exceptions
+- **Operation detection**: Uses `exc.operation_name` attribute for reliable operation identification
+- **Fuzzy matching for workers**: When a worker_id is provided, uses `searchTermFilter` with fuzzy matching
+- **Fallback hierarchy**: When List APIs fail, falls back up the resource hierarchy
+- **Permission hint**: When all List APIs fail, shows hint about missing IAM List permissions
+- **Truncation**: Lists are truncated at 10 items with "... and N more" message
+
+## Resource Hierarchy
+
+When an error occurs, the CLI attempts to list resources, falling back up the hierarchy if needed:
+
+```
+Farm
+├── Queue
+│   ├── Job
+│   └── Storage Profile
+└── Fleet
+    └── Worker
+```
+
+## Output Examples
+
+**Queue ID error with available queues:**
+```
+Failed to submit the job bundle to AWS Deadline Cloud:
+An error occurred (AccessDeniedException) when calling the GetQueue operation: ...
+
+Available queues in farm farm-0123456789abcdef0123456789abcdef:
+  queue-abcd1234567890abcdef1234567890ab  Production Render Queue
+  queue-efgh5678901234cdef5678901234cdef  Test Queue
+```
+
+**Farm ID error (cascading fallback):**
+```
+Failed to get Jobs from Deadline:
+An error occurred (ResourceNotFoundException) when calling the SearchJobs operation: ...
+
+Farm farm-wrongid12345678901234567890 may be incorrect. Available farms:
+  farm-0123456789abcdef0123456789abcdef  Studio Farm
+  farm-abcdef01234567890abcdef012345678  Development Farm
+```
+
+**Truncation for long lists:**
+```
+Available queues in farm farm-0123456789abcdef0123456789abcdef:
+  queue-abcd1234567890abcdef1234567890ab  Production Render Queue
+  queue-efgh5678901234cdef5678901234cdef  Test Queue
+  ... and 8 more
+```
+
+**Permission hint when all List APIs fail:**
+```
+Could not list available resources to suggest alternatives.
+This may indicate your IAM policy is missing List permissions.
+```
+
+## Handled Error Codes
+
+- `AccessDeniedException` - User lacks permission (likely wrong ID)
+- `ResourceNotFoundException` - Resource doesn't exist
+- `ValidationException` - Invalid ID format
+
+## Use Cases
+
+### UC1: Mistyped Queue ID
+User provides wrong queue ID. CLI suggests available queues in the specified farm.
+
+### UC2: Mistyped Farm ID
+User provides wrong farm ID. CLI suggests available farms.
+
+### UC3: Mistyped Farm ID (cascading)
+User provides wrong farm ID when specifying a queue. Both GetQueue and ListQueues fail. CLI suggests available farms.
+
+### UC4: Mistyped Fleet ID
+User provides wrong fleet ID. CLI suggests available fleets in the farm.
+
+### UC5: Mistyped Job ID
+User provides wrong job ID. CLI suggests recent jobs in the queue.
+
+### UC6: Mistyped Worker ID
+User provides wrong worker ID. CLI suggests available workers in the fleet.
+
+### UC7: Mistyped Storage Profile ID
+User provides wrong storage profile ID. CLI suggests available storage profiles for the queue.

--- a/src/deadline/client/cli/_common.py
+++ b/src/deadline/client/cli/_common.py
@@ -15,6 +15,7 @@ __all__ = [
     "_ProgressBarCallbackManager",
     "_parse_file_parameter",
     "_parse_multi_format_parameters",
+    "_suggest_resources_on_client_error",
 ]
 
 import sys
@@ -342,3 +343,7 @@ class _ProgressBarCallbackManager:
             self._exit_stack.close()
 
         return sigint_handler.continue_operation
+
+
+# Re-export from _suggest_resources for backward compatibility
+from ._suggest_resources import _suggest_resources_on_client_error  # noqa: E402,F401

--- a/src/deadline/client/cli/_groups/_job_helpers.py
+++ b/src/deadline/client/cli/_groups/_job_helpers.py
@@ -14,7 +14,7 @@ from botocore.exceptions import ClientError
 from ... import api
 from ...config import config_file
 from ...exceptions import DeadlineOperationError
-from .._common import _cli_object_repr
+from .._common import _cli_object_repr, _suggest_resources_on_client_error
 
 
 def _format_timestamp(dt: datetime) -> str:
@@ -144,6 +144,14 @@ def _print_job_details(config: Optional[ConfigParser], job_id: str) -> None:
     queue_id = config_file.get_setting("defaults.queue_id", config=config)
 
     deadline = api.get_boto3_client("deadline", config=config)
-    response = deadline.get_job(farmId=farm_id, queueId=queue_id, jobId=job_id)
+    try:
+        response = deadline.get_job(farmId=farm_id, queueId=queue_id, jobId=job_id)
+    except ClientError as exc:
+        suggestion = _suggest_resources_on_client_error(
+            exc, farm_id=farm_id, queue_id=queue_id, config=config
+        )
+        raise DeadlineOperationError(
+            f"Failed to get Job from Deadline:\n{exc}{suggestion}"
+        ) from exc
     response.pop("ResponseMetadata", None)
     click.echo(_cli_object_repr(response))

--- a/src/deadline/client/cli/_groups/bundle_group.py
+++ b/src/deadline/client/cli/_groups/bundle_group.py
@@ -35,6 +35,7 @@ from .._common import (
     _handle_error,
     _ProgressBarCallbackManager,
     _parse_multi_format_parameters,
+    _suggest_resources_on_client_error,
 )
 from .._main import deadline as main
 from ._sigint_handler import SigIntHandler
@@ -335,8 +336,14 @@ def bundle_submit(
             click.echo("Canceled waiting for final status of CreateJob.")
             sys.exit(1)
     except ClientError as exc:
+        suggestion = _suggest_resources_on_client_error(
+            exc,
+            farm_id=config_file.get_setting("defaults.farm_id", config=config),
+            queue_id=config_file.get_setting("defaults.queue_id", config=config),
+            config=config,
+        )
         raise DeadlineOperationError(
-            f"Failed to submit the job bundle to AWS Deadline Cloud:\n{exc}"
+            f"Failed to submit the job bundle to AWS Deadline Cloud:\n{exc}{suggestion}"
         ) from exc
     except MisconfiguredInputsError as exc:
         click.echo(str(exc))

--- a/src/deadline/client/cli/_groups/farm_group.py
+++ b/src/deadline/client/cli/_groups/farm_group.py
@@ -10,7 +10,12 @@ from botocore.exceptions import ClientError  # type: ignore[import]
 from ... import api
 from ...config import config_file
 from ...exceptions import DeadlineOperationError
-from .._common import _apply_cli_options_to_config, _cli_object_repr, _handle_error
+from .._common import (
+    _apply_cli_options_to_config,
+    _cli_object_repr,
+    _handle_error,
+    _suggest_resources_on_client_error,
+)
 from .._main import deadline as main
 
 
@@ -42,7 +47,10 @@ def farm_list(**args):
     try:
         response = api.list_farms(config=config)
     except ClientError as exc:
-        raise DeadlineOperationError(f"Failed to get Farms from Deadline:\n{exc}") from exc
+        suggestion = _suggest_resources_on_client_error(exc, config=config)
+        raise DeadlineOperationError(
+            f"Failed to get Farms from Deadline:\n{exc}{suggestion}"
+        ) from exc
 
     # Select which fields to print and in which order
     structured_farm_list = [
@@ -68,7 +76,13 @@ def farm_get(**args):
     farm_id = config_file.get_setting("defaults.farm_id", config=config)
 
     deadline = api.get_boto3_client("deadline", config=config)
-    response = deadline.get_farm(farmId=farm_id)
+    try:
+        response = deadline.get_farm(farmId=farm_id)
+    except ClientError as exc:
+        suggestion = _suggest_resources_on_client_error(exc, farm_id=farm_id, config=config)
+        raise DeadlineOperationError(
+            f"Failed to get Farm from Deadline:\n{exc}{suggestion}"
+        ) from exc
     response.pop("ResponseMetadata", None)
 
     click.echo(_cli_object_repr(response))

--- a/src/deadline/client/cli/_groups/fleet_group.py
+++ b/src/deadline/client/cli/_groups/fleet_group.py
@@ -10,7 +10,12 @@ from botocore.exceptions import ClientError  # type: ignore[import]
 from ... import api
 from ...config import config_file
 from ...exceptions import DeadlineOperationError
-from .._common import _apply_cli_options_to_config, _cli_object_repr, _handle_error
+from .._common import (
+    _apply_cli_options_to_config,
+    _cli_object_repr,
+    _handle_error,
+    _suggest_resources_on_client_error,
+)
 from .._main import deadline as main
 
 
@@ -45,7 +50,10 @@ def fleet_list(**args):
     try:
         response = api.list_fleets(farmId=farm_id, config=config)
     except ClientError as exc:
-        raise DeadlineOperationError(f"Failed to get Fleets from Deadline:\n{exc}") from exc
+        suggestion = _suggest_resources_on_client_error(exc, farm_id=farm_id, config=config)
+        raise DeadlineOperationError(
+            f"Failed to get Fleets from Deadline:\n{exc}{suggestion}"
+        ) from exc
 
     # Select which fields to print and in which order
     structured_fleet_list = [
@@ -90,12 +98,28 @@ def fleet_get(fleet_id, queue_id, **args):
     deadline = api.get_boto3_client("deadline", config=config)
 
     if fleet_id:
-        response = deadline.get_fleet(farmId=farm_id, fleetId=fleet_id)
+        try:
+            response = deadline.get_fleet(farmId=farm_id, fleetId=fleet_id)
+        except ClientError as exc:
+            suggestion = _suggest_resources_on_client_error(
+                exc, farm_id=farm_id, fleet_id=fleet_id, config=config
+            )
+            raise DeadlineOperationError(
+                f"Failed to get Fleet from Deadline:\n{exc}{suggestion}"
+            ) from exc
         response.pop("ResponseMetadata", None)
 
         click.echo(_cli_object_repr(response))
     else:
-        response = deadline.get_queue(farmId=farm_id, queueId=queue_id)
+        try:
+            response = deadline.get_queue(farmId=farm_id, queueId=queue_id)
+        except ClientError as exc:
+            suggestion = _suggest_resources_on_client_error(
+                exc, farm_id=farm_id, queue_id=queue_id, config=config
+            )
+            raise DeadlineOperationError(
+                f"Failed to get Queue from Deadline:\n{exc}{suggestion}"
+            ) from exc
         queue_name = response["displayName"]
 
         response = api._list_apis._call_paginated_deadline_list_api(

--- a/src/deadline/client/cli/_groups/job_group.py
+++ b/src/deadline/client/cli/_groups/job_group.py
@@ -43,7 +43,12 @@ from ....job_attachments._path_summarization import (
 from ... import api
 from ...config import config_file
 from ...exceptions import DeadlineOperationError, DeadlineOperationTimedOut
-from .._common import _apply_cli_options_to_config, _cli_object_repr, _handle_error
+from .._common import (
+    _apply_cli_options_to_config,
+    _cli_object_repr,
+    _handle_error,
+    _suggest_resources_on_client_error,
+)
 from .._main import deadline as main
 from ._sigint_handler import SigIntHandler
 from ...api._session import get_default_client_config
@@ -140,7 +145,12 @@ def job_list(page_size, item_offset, **args):
             sortExpressions=[{"fieldSort": {"name": "CREATED_AT", "sortOrder": "DESCENDING"}}],
         )
     except ClientError as exc:
-        raise DeadlineOperationError(f"Failed to get Jobs from Deadline:\n{exc}") from exc
+        suggestion = _suggest_resources_on_client_error(
+            exc, farm_id=farm_id, queue_id=queue_id, config=config
+        )
+        raise DeadlineOperationError(
+            f"Failed to get Jobs from Deadline:\n{exc}{suggestion}"
+        ) from exc
 
     total_results = response["totalResults"]
 
@@ -248,7 +258,15 @@ def job_cancel(mark_as: str, yes: bool, **args):
     deadline = api.get_boto3_client("deadline", config=config)
 
     # Print a summary of the job to cancel
-    job = deadline.get_job(farmId=farm_id, queueId=queue_id, jobId=job_id)
+    try:
+        job = deadline.get_job(farmId=farm_id, queueId=queue_id, jobId=job_id)
+    except ClientError as exc:
+        suggestion = _suggest_resources_on_client_error(
+            exc, farm_id=farm_id, queue_id=queue_id, config=config
+        )
+        raise DeadlineOperationError(
+            f"Failed to get Job from Deadline:\n{exc}{suggestion}"
+        ) from exc
     # Remove the zero-count status counts
     job["taskRunStatusCounts"] = {
         name: count for name, count in job["taskRunStatusCounts"].items() if count != 0

--- a/src/deadline/client/cli/_groups/queue_group.py
+++ b/src/deadline/client/cli/_groups/queue_group.py
@@ -19,7 +19,12 @@ from ... import api
 from ...api._session import get_session_client
 from ...config import config_file
 from ...exceptions import DeadlineOperationError
-from .._common import _apply_cli_options_to_config, _cli_object_repr, _handle_error
+from .._common import (
+    _apply_cli_options_to_config,
+    _cli_object_repr,
+    _handle_error,
+    _suggest_resources_on_client_error,
+)
 from ....job_attachments.models import (
     FileConflictResolution,
 )
@@ -65,7 +70,10 @@ def queue_list(**args):
     try:
         response = api.list_queues(farmId=farm_id, config=config)
     except ClientError as exc:
-        raise DeadlineOperationError(f"Failed to get Queues from Deadline:\n{exc}") from exc
+        suggestion = _suggest_resources_on_client_error(exc, farm_id=farm_id, config=config)
+        raise DeadlineOperationError(
+            f"Failed to get Queues from Deadline:\n{exc}{suggestion}"
+        ) from exc
 
     # Select which fields to print and in which order
     structured_queue_list = [
@@ -201,8 +209,11 @@ def queue_paramdefs(**args):
     try:
         response = api.get_queue_parameter_definitions(farmId=farm_id, queueId=queue_id)
     except ClientError as exc:
+        suggestion = _suggest_resources_on_client_error(
+            exc, farm_id=farm_id, queue_id=queue_id, config=config
+        )
         raise DeadlineOperationError(
-            f"Failed to get Queue Parameter Definitions from Deadline:\n{exc}"
+            f"Failed to get Queue Parameter Definitions from Deadline:\n{exc}{suggestion}"
         ) from exc
 
     click.echo(_cli_object_repr(response))
@@ -226,7 +237,15 @@ def queue_get(**args):
     queue_id = config_file.get_setting("defaults.queue_id", config=config)
 
     deadline = api.get_boto3_client("deadline", config=config)
-    response = deadline.get_queue(farmId=farm_id, queueId=queue_id)
+    try:
+        response = deadline.get_queue(farmId=farm_id, queueId=queue_id)
+    except ClientError as exc:
+        suggestion = _suggest_resources_on_client_error(
+            exc, farm_id=farm_id, queue_id=queue_id, config=config
+        )
+        raise DeadlineOperationError(
+            f"Failed to get Queue from Deadline:\n{exc}{suggestion}"
+        ) from exc
     response.pop("ResponseMetadata", None)
 
     click.echo(_cli_object_repr(response))

--- a/src/deadline/client/cli/_groups/worker_group.py
+++ b/src/deadline/client/cli/_groups/worker_group.py
@@ -10,7 +10,12 @@ from botocore.exceptions import ClientError  # type: ignore[import]
 from ... import api
 from ...config import config_file
 from ...exceptions import DeadlineOperationError
-from .._common import _apply_cli_options_to_config, _cli_object_repr, _handle_error
+from .._common import (
+    _apply_cli_options_to_config,
+    _cli_object_repr,
+    _handle_error,
+    _suggest_resources_on_client_error,
+)
 from .._main import deadline as main
 
 
@@ -44,7 +49,12 @@ def worker_list(page_size, item_offset, fleet_id, **args):
             farmId=farm_id, fleetIds=[fleet_id], itemOffset=item_offset, pageSize=page_size
         )
     except ClientError as exc:
-        raise DeadlineOperationError(f"Failed to get Workers from Deadline:\n{exc}") from exc
+        suggestion = _suggest_resources_on_client_error(
+            exc, farm_id=farm_id, fleet_id=fleet_id, config=config
+        )
+        raise DeadlineOperationError(
+            f"Failed to get Workers from Deadline:\n{exc}{suggestion}"
+        ) from exc
 
     total_results = response["totalResults"]
 
@@ -77,7 +87,15 @@ def worker_get(fleet_id, worker_id, **args):
     farm_id = config_file.get_setting("defaults.farm_id", config=config)
 
     deadline = api.get_boto3_client("deadline", config=config)
-    response = deadline.get_worker(farmId=farm_id, fleetId=fleet_id, workerId=worker_id)
+    try:
+        response = deadline.get_worker(farmId=farm_id, fleetId=fleet_id, workerId=worker_id)
+    except ClientError as exc:
+        suggestion = _suggest_resources_on_client_error(
+            exc, farm_id=farm_id, fleet_id=fleet_id, worker_id=worker_id, config=config
+        )
+        raise DeadlineOperationError(
+            f"Failed to get Worker from Deadline:\n{exc}{suggestion}"
+        ) from exc
     response.pop("ResponseMetadata", None)
 
     click.echo(_cli_object_repr(response))

--- a/src/deadline/client/cli/_suggest_resources.py
+++ b/src/deadline/client/cli/_suggest_resources.py
@@ -1,0 +1,264 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Helper functions for suggesting available resources when CLI commands fail
+due to incorrect resource IDs.
+"""
+
+from __future__ import annotations
+
+from configparser import ConfigParser
+from typing import Optional
+
+from botocore.exceptions import ClientError
+
+from .. import api
+
+
+def _format_resource_suggestions(
+    items: list,
+    id_field: str,
+    name_field: str,
+    header: str,
+    max_items: int = 10,
+) -> list[str]:
+    """Format a list of resources as suggestion lines."""
+    if not items:
+        return []
+    lines = [f"\n{header}"]
+    for item in items[:max_items]:
+        lines.append(f"  {item[id_field]}  {item.get(name_field, '')}")
+    if len(items) > max_items:
+        lines.append(f"  ... and {len(items) - max_items} more")
+    return lines
+
+
+def _try_suggestion_chain(
+    fetchers: list[tuple],
+    config: Optional[ConfigParser],
+) -> tuple[list[str], bool]:
+    """
+    Try a chain of fetchers until one succeeds.
+    Each fetcher is a tuple of (fetch_func, response_key, id_field, name_field, header).
+    Returns (suggestion_lines, all_failed).
+    """
+    for fetch_func, response_key, id_field, name_field, header in fetchers:
+        try:
+            response = fetch_func()
+            items = response.get(response_key, [])
+            suggestions = _format_resource_suggestions(items, id_field, name_field, header)
+            if suggestions:
+                return suggestions, False
+        except ClientError:
+            continue
+    return [], True
+
+
+# Mapping of operation names to their suggestion configuration.
+_OPERATION_GROUPS: dict[str, dict[str, tuple]] = {
+    "queue": {
+        "operations": ("GetQueue", "ListQueues", "ListQueueEnvironments"),
+        "requires": ("farm_id",),
+    },
+    "farm": {
+        "operations": ("GetFarm", "ListFarms"),
+        "requires": (),
+    },
+    "fleet": {
+        "operations": ("GetFleet", "ListFleets"),
+        "requires": ("farm_id",),
+    },
+    "worker": {
+        "operations": ("GetWorker", "SearchWorkers"),
+        "requires": ("farm_id", "fleet_id"),
+    },
+    "job": {
+        "operations": ("GetJob", "ListJobs", "SearchJobs"),
+        "requires": ("farm_id", "queue_id"),
+    },
+    "storage_profile": {
+        "operations": ("GetStorageProfileForQueue", "ListStorageProfilesForQueue"),
+        "requires": ("farm_id", "queue_id"),
+    },
+}
+
+
+def _suggest_resources_on_client_error(
+    exc: ClientError,
+    farm_id: Optional[str] = None,
+    queue_id: Optional[str] = None,
+    fleet_id: Optional[str] = None,
+    worker_id: Optional[str] = None,
+    config: Optional[ConfigParser] = None,
+) -> str:
+    """
+    When a ClientError occurs (e.g., AccessDeniedException), attempt to list
+    available resources to help users identify typos in resource IDs.
+
+    Returns a suggestion string to append to the error message, or empty string
+    if no suggestions could be generated.
+    """
+    error_code = exc.response.get("Error", {}).get("Code", "")
+
+    # Only handle access/not-found type errors that indicate a wrong resource ID
+    if error_code not in (
+        "AccessDeniedException",
+        "ResourceNotFoundException",
+        "ValidationException",
+    ):
+        return ""
+
+    operation_name = getattr(exc, "operation_name", "") or ""
+
+    # Build fetcher functions that capture the config and resource IDs
+    def list_farms():
+        return api.list_farms(config=config)
+
+    def list_queues():
+        return api.list_queues(farmId=farm_id, config=config)
+
+    def list_fleets():
+        return api.list_fleets(farmId=farm_id, config=config)
+
+    def list_jobs():
+        return api.list_jobs(farmId=farm_id, queueId=queue_id, config=config)
+
+    def list_storage_profiles():
+        return api.list_storage_profiles_for_queue(farmId=farm_id, queueId=queue_id, config=config)
+
+    def search_workers():
+        deadline = api.get_boto3_client("deadline", config=config)
+        search_kwargs: dict = {"farmId": farm_id, "fleetIds": [fleet_id], "itemOffset": 0}
+        if worker_id:
+            search_kwargs["filterExpressions"] = {
+                "filters": [{"searchTermFilter": {"searchTerm": worker_id}}],
+                "operator": "AND",
+            }
+        return deadline.search_workers(**search_kwargs)
+
+    # Define suggestion chains for each operation group
+    suggestions: list[str] = []
+    list_failed = False
+
+    if operation_name in _OPERATION_GROUPS["queue"]["operations"] and farm_id:
+        suggestions, list_failed = _try_suggestion_chain(
+            [
+                (
+                    list_queues,
+                    "queues",
+                    "queueId",
+                    "displayName",
+                    f"Available queues in farm {farm_id}:",
+                ),
+                (
+                    list_farms,
+                    "farms",
+                    "farmId",
+                    "displayName",
+                    f"Farm {farm_id} may be incorrect. Available farms:",
+                ),
+            ],
+            config,
+        )
+
+    elif operation_name in _OPERATION_GROUPS["farm"]["operations"]:
+        suggestions, list_failed = _try_suggestion_chain(
+            [(list_farms, "farms", "farmId", "displayName", "Available farms:")],
+            config,
+        )
+
+    elif operation_name in _OPERATION_GROUPS["fleet"]["operations"] and farm_id:
+        suggestions, list_failed = _try_suggestion_chain(
+            [
+                (
+                    list_fleets,
+                    "fleets",
+                    "fleetId",
+                    "displayName",
+                    f"Available fleets in farm {farm_id}:",
+                ),
+                (
+                    list_farms,
+                    "farms",
+                    "farmId",
+                    "displayName",
+                    f"Farm {farm_id} may be incorrect. Available farms:",
+                ),
+            ],
+            config,
+        )
+
+    elif operation_name in _OPERATION_GROUPS["worker"]["operations"] and farm_id and fleet_id:
+        # Workers use search_workers with special handling for totalResults
+        try:
+            response = search_workers()
+            workers = response.get("workers", [])
+            if workers:
+                suggestions = [f"\nAvailable workers in fleet {fleet_id}:"]
+                for w in workers[:10]:
+                    suggestions.append(f"  {w['workerId']}  {w.get('status', '')}")
+                total = response.get("totalResults", len(workers))
+                if total > 10:
+                    suggestions.append(f"  ... and {total - 10} more")
+        except ClientError:
+            suggestions, list_failed = _try_suggestion_chain(
+                [
+                    (
+                        list_fleets,
+                        "fleets",
+                        "fleetId",
+                        "displayName",
+                        f"Fleet {fleet_id} may be incorrect. Available fleets:",
+                    )
+                ],
+                config,
+            )
+
+    elif operation_name in _OPERATION_GROUPS["job"]["operations"] and farm_id and queue_id:
+        suggestions, list_failed = _try_suggestion_chain(
+            [
+                (list_jobs, "jobs", "jobId", "name", f"Recent jobs in queue {queue_id}:"),
+                (
+                    list_queues,
+                    "queues",
+                    "queueId",
+                    "displayName",
+                    f"Queue {queue_id} may be incorrect. Available queues:",
+                ),
+                (
+                    list_farms,
+                    "farms",
+                    "farmId",
+                    "displayName",
+                    f"Farm {farm_id} may be incorrect. Available farms:",
+                ),
+            ],
+            config,
+        )
+
+    elif (
+        operation_name in _OPERATION_GROUPS["storage_profile"]["operations"]
+        and farm_id
+        and queue_id
+    ):
+        suggestions, list_failed = _try_suggestion_chain(
+            [
+                (
+                    list_storage_profiles,
+                    "storageProfiles",
+                    "storageProfileId",
+                    "displayName",
+                    f"Available storage profiles for queue {queue_id}:",
+                )
+            ],
+            config,
+        )
+
+    # If we couldn't list resources, add a hint about permissions
+    if list_failed and not suggestions:
+        suggestions = [
+            "\nCould not list available resources to suggest alternatives.",
+            "This may indicate your IAM policy is missing List permissions.",
+        ]
+
+    return "\n".join(suggestions)

--- a/test/unit/deadline_client/cli/test_cli_resource_suggestions.py
+++ b/test/unit/deadline_client/cli/test_cli_resource_suggestions.py
@@ -1,0 +1,621 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Tests for CLI resource ID error suggestions.
+"""
+
+import os
+
+from botocore.exceptions import ClientError
+from click.testing import CliRunner
+
+from deadline.client import config
+from deadline.client.cli import main
+
+MOCK_FARM_ID = "farm-0123456789abcdef0123456789abcdef"
+MOCK_QUEUE_ID = "queue-0123456789abcdef0123456789abcdef"
+MOCK_FLEET_ID = "fleet-0123456789abcdef0123456789abcdef"
+
+
+def test_bundle_submit_wrong_queue_suggests_queues(
+    fresh_deadline_config, deadline_mock, temp_job_bundle_dir
+):
+    """
+    Test that when GetQueue fails with AccessDeniedException, the CLI suggests available queues.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", "queue-wrongid12345678901234567890")
+
+    # GetQueue fails with AccessDeniedException
+    deadline_mock.get_queue.side_effect = ClientError(
+        {
+            "Error": {
+                "Code": "AccessDeniedException",
+                "Message": "User is not authorized to perform: deadline:GetQueue",
+            }
+        },
+        "GetQueue",
+    )
+
+    # ListQueues succeeds and returns available queues
+    deadline_mock.list_queues.return_value = {
+        "queues": [
+            {"queueId": MOCK_QUEUE_ID, "displayName": "My Queue"},
+            {"queueId": "queue-anotherid1234567890123456", "displayName": "Another Queue"},
+        ]
+    }
+
+    # Write a minimal JSON template
+    with open(os.path.join(temp_job_bundle_dir, "template.json"), "w", encoding="utf8") as f:
+        f.write('{"specificationVersion": "jobtemplate-2023-09", "name": "Test", "steps": []}')
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["bundle", "submit", temp_job_bundle_dir])
+
+    assert result.exit_code != 0
+    assert "AccessDeniedException" in result.output
+    assert f"Available queues in farm {MOCK_FARM_ID}" in result.output
+    assert MOCK_QUEUE_ID in result.output
+    assert "My Queue" in result.output
+
+
+def test_bundle_submit_wrong_farm_suggests_farms(
+    fresh_deadline_config, deadline_mock, temp_job_bundle_dir
+):
+    """
+    Test that when both GetQueue and ListQueues fail, the CLI suggests available farms.
+    """
+    config.set_setting("defaults.farm_id", "farm-wrongid12345678901234567890")
+    config.set_setting("defaults.queue_id", "queue-wrongid12345678901234567890")
+
+    # GetQueue fails with AccessDeniedException
+    deadline_mock.get_queue.side_effect = ClientError(
+        {
+            "Error": {
+                "Code": "AccessDeniedException",
+                "Message": "User is not authorized to perform: deadline:GetQueue",
+            }
+        },
+        "GetQueue",
+    )
+
+    # ListQueues also fails
+    deadline_mock.list_queues.side_effect = ClientError(
+        {
+            "Error": {
+                "Code": "AccessDeniedException",
+                "Message": "User is not authorized to perform: deadline:ListQueues",
+            }
+        },
+        "ListQueues",
+    )
+
+    # ListFarms succeeds
+    deadline_mock.list_farms.return_value = {
+        "farms": [
+            {"farmId": MOCK_FARM_ID, "displayName": "Correct Farm"},
+            {"farmId": "farm-anotherid1234567890123456", "displayName": "Another Farm"},
+        ]
+    }
+
+    # Write a minimal JSON template
+    with open(os.path.join(temp_job_bundle_dir, "template.json"), "w", encoding="utf8") as f:
+        f.write('{"specificationVersion": "jobtemplate-2023-09", "name": "Test", "steps": []}')
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["bundle", "submit", temp_job_bundle_dir])
+
+    assert result.exit_code != 0
+    assert "AccessDeniedException" in result.output
+    assert "may be incorrect. Available farms:" in result.output
+    assert MOCK_FARM_ID in result.output
+    assert "Correct Farm" in result.output
+
+
+def test_queue_list_wrong_farm_suggests_farms(fresh_deadline_config, deadline_mock):
+    """
+    Test that when ListQueues fails, the CLI suggests available farms.
+    """
+    config.set_setting("defaults.farm_id", "farm-wrongid12345678901234567890")
+
+    # ListQueues fails
+    deadline_mock.list_queues.side_effect = ClientError(
+        {
+            "Error": {
+                "Code": "AccessDeniedException",
+                "Message": "User is not authorized to perform: deadline:ListQueues",
+            }
+        },
+        "ListQueues",
+    )
+
+    # ListFarms succeeds
+    deadline_mock.list_farms.return_value = {
+        "farms": [
+            {"farmId": MOCK_FARM_ID, "displayName": "Correct Farm"},
+        ]
+    }
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["queue", "list"])
+
+    assert result.exit_code != 0
+    assert "Failed to get Queues from Deadline" in result.output
+    assert "may be incorrect. Available farms:" in result.output
+    assert MOCK_FARM_ID in result.output
+
+
+def test_worker_list_wrong_fleet_suggests_fleets(fresh_deadline_config, deadline_mock):
+    """
+    Test that when SearchWorkers fails, the CLI suggests available fleets.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+
+    # SearchWorkers fails
+    deadline_mock.search_workers.side_effect = ClientError(
+        {
+            "Error": {
+                "Code": "ResourceNotFoundException",
+                "Message": "Resource of type fleet with id fleet-00000000000000000000000000000000 does not exist.",
+            }
+        },
+        "SearchWorkers",
+    )
+
+    # ListFleets succeeds
+    deadline_mock.list_fleets.return_value = {
+        "fleets": [
+            {"fleetId": MOCK_FLEET_ID, "displayName": "GPU Fleet"},
+            {"fleetId": "fleet-anotherid1234567890123456", "displayName": "CPU Fleet"},
+        ]
+    }
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["worker", "list", "--fleet-id", "fleet-00000000000000000000000000000000"]
+    )
+
+    assert result.exit_code != 0
+    assert "Failed to get Workers from Deadline" in result.output
+    assert "may be incorrect. Available fleets:" in result.output
+    assert MOCK_FLEET_ID in result.output
+    assert "GPU Fleet" in result.output
+
+
+def test_worker_list_suggestion_uses_correct_api_params(fresh_deadline_config, deadline_mock):
+    """
+    Test that when suggesting workers, the API call is made correctly.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+
+    # First SearchWorkers call fails, second one (for suggestions) succeeds
+    deadline_mock.search_workers.side_effect = [
+        ClientError(
+            {
+                "Error": {
+                    "Code": "ResourceNotFoundException",
+                    "Message": "Resource of type fleet with id fleet-wrongid does not exist.",
+                }
+            },
+            "SearchWorkers",
+        ),
+        # Second call for suggestions via api.search_workers
+        {
+            "workers": [{"workerId": "worker-abc123", "status": "RUNNING"}],
+            "totalResults": 1,
+        },
+    ]
+
+    runner = CliRunner()
+    runner.invoke(main, ["worker", "list", "--fleet-id", "fleet-wrongid00000000000000000000"])
+
+    # Verify the suggestion call was made
+    assert deadline_mock.search_workers.call_count == 2
+
+
+def test_suggestion_truncates_long_lists(fresh_deadline_config, deadline_mock):
+    """
+    Test that suggestions are truncated when there are more than 10 results.
+    """
+    config.set_setting("defaults.farm_id", "farm-wrongid12345678901234567890")
+
+    # ListQueues fails
+    deadline_mock.list_queues.side_effect = ClientError(
+        {
+            "Error": {
+                "Code": "AccessDeniedException",
+                "Message": "User is not authorized to perform: deadline:ListQueues",
+            }
+        },
+        "ListQueues",
+    )
+
+    # ListFarms returns many farms
+    deadline_mock.list_farms.return_value = {
+        "farms": [{"farmId": f"farm-{i:032d}", "displayName": f"Farm {i}"} for i in range(15)]
+    }
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["queue", "list"])
+
+    assert result.exit_code != 0
+    assert "... and 5 more" in result.output
+
+
+def test_no_suggestion_on_other_errors(fresh_deadline_config, deadline_mock):
+    """
+    Test that non-access errors don't trigger suggestions.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+
+    # ListQueues fails with a different error type
+    deadline_mock.list_queues.side_effect = ClientError(
+        {
+            "Error": {
+                "Code": "ServiceUnavailable",
+                "Message": "Service is temporarily unavailable",
+            }
+        },
+        "ListQueues",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["queue", "list"])
+
+    assert result.exit_code != 0
+    assert "Failed to get Queues from Deadline" in result.output
+    assert "Available" not in result.output
+
+
+def test_suggestion_failure_silent(fresh_deadline_config, deadline_mock):
+    """
+    Test that if List API also fails, we show a hint about permissions.
+    """
+    config.set_setting("defaults.farm_id", "farm-wrongid12345678901234567890")
+
+    # ListQueues fails
+    deadline_mock.list_queues.side_effect = ClientError(
+        {
+            "Error": {
+                "Code": "AccessDeniedException",
+                "Message": "User is not authorized to perform: deadline:ListQueues",
+            }
+        },
+        "ListQueues",
+    )
+
+    # ListFarms also fails
+    deadline_mock.list_farms.side_effect = ClientError(
+        {
+            "Error": {
+                "Code": "AccessDeniedException",
+                "Message": "User is not authorized to perform: deadline:ListFarms",
+            }
+        },
+        "ListFarms",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["queue", "list"])
+
+    assert result.exit_code != 0
+    assert "Failed to get Queues from Deadline" in result.output
+    assert "Could not list available resources" in result.output
+    assert "IAM policy is missing List permissions" in result.output
+
+
+def test_farm_get_wrong_farm_suggests_farms(fresh_deadline_config, deadline_mock):
+    """
+    Test that when GetFarm fails, the CLI suggests available farms.
+    """
+    config.set_setting("defaults.farm_id", "farm-wrongid12345678901234567890")
+
+    deadline_mock.get_farm.side_effect = ClientError(
+        {
+            "Error": {
+                "Code": "ResourceNotFoundException",
+                "Message": "Resource of type farm does not exist.",
+            }
+        },
+        "GetFarm",
+    )
+
+    deadline_mock.list_farms.return_value = {
+        "farms": [
+            {"farmId": MOCK_FARM_ID, "displayName": "Correct Farm"},
+        ]
+    }
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["farm", "get"])
+
+    assert result.exit_code != 0
+    assert "Failed to get Farm from Deadline" in result.output
+    assert "Available farms:" in result.output
+    assert MOCK_FARM_ID in result.output
+
+
+def test_fleet_get_wrong_fleet_suggests_fleets(fresh_deadline_config, deadline_mock):
+    """
+    Test that when GetFleet fails, the CLI suggests available fleets.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+
+    deadline_mock.get_fleet.side_effect = ClientError(
+        {
+            "Error": {
+                "Code": "ResourceNotFoundException",
+                "Message": "Resource of type fleet does not exist.",
+            }
+        },
+        "GetFleet",
+    )
+
+    deadline_mock.list_fleets.return_value = {
+        "fleets": [
+            {"fleetId": MOCK_FLEET_ID, "displayName": "GPU Fleet"},
+        ]
+    }
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["fleet", "get", "--fleet-id", "fleet-wrongid12345678901234567890"]
+    )
+
+    assert result.exit_code != 0
+    assert "Failed to get Fleet from Deadline" in result.output
+    assert f"Available fleets in farm {MOCK_FARM_ID}" in result.output
+    assert MOCK_FLEET_ID in result.output
+
+
+def test_queue_get_wrong_queue_suggests_queues(fresh_deadline_config, deadline_mock):
+    """
+    Test that when GetQueue fails, the CLI suggests available queues.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", "queue-wrongid12345678901234567890")
+
+    deadline_mock.get_queue.side_effect = ClientError(
+        {
+            "Error": {
+                "Code": "ResourceNotFoundException",
+                "Message": "Resource of type queue does not exist.",
+            }
+        },
+        "GetQueue",
+    )
+
+    deadline_mock.list_queues.return_value = {
+        "queues": [
+            {"queueId": MOCK_QUEUE_ID, "displayName": "My Queue"},
+        ]
+    }
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["queue", "get"])
+
+    assert result.exit_code != 0
+    assert "Failed to get Queue from Deadline" in result.output
+    assert f"Available queues in farm {MOCK_FARM_ID}" in result.output
+    assert MOCK_QUEUE_ID in result.output
+
+
+def test_job_get_wrong_job_suggests_jobs(fresh_deadline_config, deadline_mock):
+    """
+    Test that when GetJob fails, the CLI suggests recent jobs.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+
+    deadline_mock.get_job.side_effect = ClientError(
+        {
+            "Error": {
+                "Code": "ResourceNotFoundException",
+                "Message": "Resource of type job does not exist.",
+            }
+        },
+        "GetJob",
+    )
+
+    deadline_mock.list_jobs.return_value = {
+        "jobs": [
+            {"jobId": "job-0123456789abcdef0123456789abcdef", "name": "Recent Job"},
+        ]
+    }
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["job", "get", "--job-id", "job-wrongid12345678901234567890"])
+
+    assert result.exit_code != 0
+    assert "Failed to get Job from Deadline" in result.output
+    assert f"Recent jobs in queue {MOCK_QUEUE_ID}" in result.output
+    assert "job-0123456789abcdef0123456789abcdef" in result.output
+
+
+def test_worker_get_wrong_worker_suggests_workers(fresh_deadline_config, deadline_mock):
+    """
+    Test that when GetWorker fails, the CLI suggests available workers.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+
+    deadline_mock.get_worker.side_effect = ClientError(
+        {
+            "Error": {
+                "Code": "ResourceNotFoundException",
+                "Message": "Resource of type worker does not exist.",
+            }
+        },
+        "GetWorker",
+    )
+
+    deadline_mock.search_workers.return_value = {
+        "workers": [
+            {"workerId": "worker-0123456789abcdef0123456789ab", "status": "RUNNING"},
+        ],
+        "totalResults": 1,
+    }
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "worker",
+            "get",
+            "--fleet-id",
+            MOCK_FLEET_ID,
+            "--worker-id",
+            "worker-wrongid12345678901234567890",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "Failed to get Worker from Deadline" in result.output
+    assert f"Available workers in fleet {MOCK_FLEET_ID}" in result.output
+    assert "worker-0123456789abcdef0123456789ab" in result.output
+
+
+def test_farm_list_wrong_farm_suggests_farms(fresh_deadline_config, deadline_mock):
+    """
+    Test that when ListFarms fails with AccessDeniedException, the CLI suggests available farms.
+    """
+    # First call fails, second (for suggestions) succeeds
+    deadline_mock.list_farms.side_effect = [
+        ClientError(
+            {
+                "Error": {
+                    "Code": "AccessDeniedException",
+                    "Message": "User is not authorized to perform: deadline:ListFarms",
+                }
+            },
+            "ListFarms",
+        ),
+        {"farms": [{"farmId": MOCK_FARM_ID, "displayName": "Available Farm"}]},
+    ]
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["farm", "list"])
+
+    assert result.exit_code != 0
+    assert "Failed to get Farms from Deadline" in result.output
+    assert "Available farms:" in result.output
+    assert MOCK_FARM_ID in result.output
+
+
+def test_fleet_list_wrong_farm_suggests_fleets(fresh_deadline_config, deadline_mock):
+    """
+    Test that when ListFleets fails, the CLI suggests available fleets.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+
+    # First call fails, second (for suggestions) succeeds
+    deadline_mock.list_fleets.side_effect = [
+        ClientError(
+            {
+                "Error": {
+                    "Code": "AccessDeniedException",
+                    "Message": "User is not authorized to perform: deadline:ListFleets",
+                }
+            },
+            "ListFleets",
+        ),
+        {"fleets": [{"fleetId": MOCK_FLEET_ID, "displayName": "GPU Fleet"}]},
+    ]
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["fleet", "list"])
+
+    assert result.exit_code != 0
+    assert "Failed to get Fleets from Deadline" in result.output
+    assert f"Available fleets in farm {MOCK_FARM_ID}" in result.output
+    assert MOCK_FLEET_ID in result.output
+
+
+def test_job_list_wrong_queue_suggests_jobs(fresh_deadline_config, deadline_mock):
+    """
+    Test that when SearchJobs fails, the CLI suggests recent jobs.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+
+    # SearchJobs fails
+    deadline_mock.search_jobs.side_effect = ClientError(
+        {
+            "Error": {
+                "Code": "AccessDeniedException",
+                "Message": "User is not authorized to perform: deadline:SearchJobs",
+            }
+        },
+        "SearchJobs",
+    )
+
+    # ListJobs for suggestions succeeds
+    deadline_mock.list_jobs.return_value = {
+        "jobs": [{"jobId": "job-0123456789abcdef0123456789abcdef", "name": "Recent Job"}]
+    }
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["job", "list"])
+
+    assert result.exit_code != 0
+    assert "Failed to get Jobs from Deadline" in result.output
+    assert f"Recent jobs in queue {MOCK_QUEUE_ID}" in result.output
+
+
+def test_job_cancel_wrong_job_suggests_jobs(fresh_deadline_config, deadline_mock):
+    """
+    Test that when GetJob fails in job cancel, the CLI suggests recent jobs.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+
+    deadline_mock.get_job.side_effect = ClientError(
+        {
+            "Error": {
+                "Code": "ResourceNotFoundException",
+                "Message": "Resource of type job does not exist.",
+            }
+        },
+        "GetJob",
+    )
+
+    deadline_mock.list_jobs.return_value = {
+        "jobs": [{"jobId": "job-0123456789abcdef0123456789abcdef", "name": "Recent Job"}]
+    }
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["job", "cancel", "--job-id", "job-wrongid12345678901234567890"])
+
+    assert result.exit_code != 0
+    assert "Failed to get Job from Deadline" in result.output
+    assert f"Recent jobs in queue {MOCK_QUEUE_ID}" in result.output
+
+
+def test_queue_paramdefs_wrong_queue_suggests_queues(fresh_deadline_config, deadline_mock):
+    """
+    Test that when list_queue_environments fails, the CLI suggests available queues.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", "queue-wrongid12345678901234567890")
+
+    # get_queue_parameter_definitions calls list_queue_environments internally
+    deadline_mock.list_queue_environments.side_effect = ClientError(
+        {
+            "Error": {
+                "Code": "ResourceNotFoundException",
+                "Message": "Resource of type queue does not exist.",
+            }
+        },
+        "ListQueueEnvironments",
+    )
+
+    deadline_mock.list_queues.return_value = {
+        "queues": [{"queueId": MOCK_QUEUE_ID, "displayName": "My Queue"}]
+    }
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["queue", "paramdefs"])
+
+    assert result.exit_code != 0
+    assert "Failed to get Queue Parameter Definitions from Deadline" in result.output
+    assert f"Available queues in farm {MOCK_FARM_ID}" in result.output
+    assert MOCK_QUEUE_ID in result.output

--- a/test/unit/deadline_client/cli/test_cli_worker.py
+++ b/test/unit/deadline_client/cli/test_cli_worker.py
@@ -320,7 +320,9 @@ def test_cli_worker_list_api_error(fresh_deadline_config, deadline_mock):
     assert result.exit_code != 0
 
     # Verify API was called with the incorrect parameter values
-    deadline_mock.search_workers.assert_called_once_with(
+    # Note: search_workers may be called multiple times - once for the original request
+    # and potentially again when trying to suggest available workers
+    deadline_mock.search_workers.assert_any_call(
         farmId=MOCK_FARM_ID, fleetIds=["incorrect-fleet-id"], itemOffset=0, pageSize=5
     )
 
@@ -640,9 +642,7 @@ def test_cli_worker_get_api_error_network_timeout(fresh_deadline_config, deadlin
         ],
     )
 
-    # Test network and service error scenarios
-    # The @_handle_error decorator shows the full exception traceback
-    assert "The AWS Deadline Cloud CLI encountered the following exception:" in result.output
+    assert "Failed to get Worker from Deadline" in result.output
     assert "RequestTimeout" in result.output
     assert "Request timed out" in result.output
     assert result.exit_code == 1
@@ -678,9 +678,7 @@ def test_cli_worker_get_api_error_throttling(fresh_deadline_config, deadline_moc
         ],
     )
 
-    # Test network and service error scenarios
-    # The @_handle_error decorator shows the full exception traceback
-    assert "The AWS Deadline Cloud CLI encountered the following exception:" in result.output
+    assert "Failed to get Worker from Deadline" in result.output
     assert "ThrottlingException" in result.output
     assert "Rate exceeded" in result.output
     assert result.exit_code == 1
@@ -721,9 +719,7 @@ def test_cli_worker_get_api_error_service_unavailable(fresh_deadline_config, dea
         ],
     )
 
-    # Test network and service error scenarios
-    # The @_handle_error decorator shows the full exception traceback
-    assert "The AWS Deadline Cloud CLI encountered the following exception:" in result.output
+    assert "Failed to get Worker from Deadline" in result.output
     assert "ServiceUnavailableException" in result.output
     assert "Service temporarily unavailable" in result.output
     assert result.exit_code == 1


### PR DESCRIPTION
When users provide an incorrect resource ID and receive an access denied or not found error, the CLI now suggests available resources they have access to. This helps users quickly identify typos in resource IDs.

- Add _suggest_resources_on_client_error() helper in _common.py
- Add api.list_workers() for consistent worker listing
- Update CLI groups to show suggestions on ClientError
- Add design doc and unit tests

Fixes: *<insert link to GitHub issue here>*

### What was the problem/requirement? (What/Why)
In Deadline Cloud, when a resourceId is specified that doesn't exist it is sometimes looks like an authorization error because of how our authorization system works. This can lead a user to waste time exploring their authz setup when they just made a typo

### What was the solution? (How)
When a resourceId isn't found or is unauthorized, the CLI will print a list of valid options with their names

### What is the impact of this change?
This should help users who accidently mistype.IDs to get back on track

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests? Yes
- Have you run the integration tests? No
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass. No

### Was this change documented?

- Are relevant docstrings in the code base updated? Yes
- Has the README.md been updated? If you modified CLI arguments, for instance.  No

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x ] This PR does not add any new dependencies.

### Is this a breaking change?

A breaking change is one that modifies a public contract in a way that is not backwards compatible. See the 
[Public Contracts](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#public-contracts) section
of the DEVELOPMENT.md for more information on the public contracts.

If so, then please describe the changes that users of this package must make to update their scripts, or Python applications.
No I don't think so. technically error messages are changed but I doubt anyone is parsing this

### Does this change impact security?

- Does the change need to be threat modeled? For example, does it create or modify files/directories that must only be readable by the process owner?
    - If so, then please label this pull request with the "security" label. We'll work with you to analyze the threats.
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
