### PR TITLE
test(gui): update login flow test suite to use newer auth widget

### DIFF
--- a/test/squish/suite_deadline_gui/shared/scripts/loginout_helpers.py
+++ b/test/squish/suite_deadline_gui/shared/scripts/loginout_helpers.py
@@ -59,43 +59,33 @@ def set_aws_profile_name_and_verify_auth(profile_name: str):
     # select AWS profile
     squish.mouseClick(workstation_config_locators.profile_name_locator(profile_name))
     test.log("Selected AWS profile name.")
-    # verify user is authenticated - confirm statuses appear and text is correct
+
+    # verify user is authenticated using the new DeadlineAuthenticationStatusWidget
+    # The widget shows authentication status via:
+    # 1. The widget being visible
+    # 2. The login button being hidden (not visible when authenticated)
+    # 3. The profile name displayed on the profile button
     test.log("Verifying user is authenticated...")
+
+    # Wait for the authentication status widget to be visible
     test.compare(
-        squish.waitForObjectExists(loginout_locators.credential_source_hostprovided_label).visible,
+        squish.waitForObjectExists(loginout_locators.authentication_status_widget).visible,
         True,
-        "Expect `Credential source: HOST_PROVIDED` to be visible when selected aws profile.",
+        "Expect authentication status widget to be visible.",
     )
+
+    # When authenticated, the login button should be hidden (visible=False)
+    # Use the hidden locator to find the button even when not visible
+    login_button = squish.waitForObjectExists(loginout_locators.authentication_login_button_hidden)
     test.compare(
-        str(
-            squish.waitForObjectExists(loginout_locators.credential_source_hostprovided_label).text
-        ),
-        "<b style='color:green;'>HOST_PROVIDED</b>",
-        "Expect `Credential source: HOST_PROVIDED` text to be correct when selected aws profile.",
+        login_button.visible,
+        False,
+        "Expect login button to be hidden when authenticated.",
     )
-    test.compare(
-        squish.waitForObjectExists(
-            loginout_locators.authentication_status_authenticated_label
-        ).visible,
-        True,
-        "Expect `Authentication status: AUTHENTICATED` to be visible.",
-    )
-    test.compare(
-        str(
-            squish.waitForObjectExists(
-                loginout_locators.authentication_status_authenticated_label
-            ).text
-        ),
-        "<b style='color:green;'>AUTHENTICATED</b>",
-        "Expect `Authentication status: AUTHENTICATED` text to be correct.",
-    )
-    test.compare(
-        squish.waitForObjectExists(loginout_locators.deadlinecloud_api_authorized_label).visible,
-        True,
-        "Expect `AWS Deadline Cloud API: AUTHORIZED` to be visible.",
-    )
-    test.compare(
-        str(squish.waitForObjectExists(loginout_locators.deadlinecloud_api_authorized_label).text),
-        "<b style='color:green;'>AUTHORIZED</b>",
-        "Expect `AWS Deadline Cloud API: AUTHORIZED` text to be correct.",
+
+    # Verify the profile button shows the expected profile name
+    profile_button = squish.waitForObjectExists(loginout_locators.authentication_profile_button)
+    test.verify(
+        profile_name in str(profile_button.text),
+        f"Expect profile button to contain profile name '{profile_name}'.",
     )

--- a/test/squish/suite_deadline_gui/shared/scripts/loginout_locators.py
+++ b/test/squish/suite_deadline_gui/shared/scripts/loginout_locators.py
@@ -3,53 +3,32 @@
 
 import workstation_config_locators
 
-# authentication status
-credential_source_auth_group = {
-    "title": "Credential source",
-    "type": "AuthenticationStatusGroup",
+# authentication status widget (replaces the old AuthenticationStatusGroup widgets)
+# The new DeadlineAuthenticationStatusWidget is a single widget that shows:
+# - A status icon (green checkmark when authenticated)
+# - The profile name
+# - Action buttons (login, switch profile, etc.)
+authentication_status_widget = {
+    "type": "DeadlineAuthenticationStatusWidget",
     "unnamed": 1,
     "visible": 1,
     "window": workstation_config_locators.deadline_config_dialog,
 }
-authentication_status_auth_group = {
-    "title": "Authentication status",
-    "type": "AuthenticationStatusGroup",
+
+# Login button - exists but hidden when user is authenticated
+# Note: visible is set to 0 to find the button even when hidden
+authentication_login_button_hidden = {
+    "container": authentication_status_widget,
+    "text": "Log in",
+    "type": "QPushButton",
     "unnamed": 1,
-    "visible": 1,
-    "window": workstation_config_locators.deadline_config_dialog,
+    "visible": 0,
 }
-deadlinecloud_api_auth_group = {
-    "title": "AWS Deadline Cloud API",
-    "type": "AuthenticationStatusGroup",
-    "unnamed": 1,
-    "visible": 1,
-    "window": workstation_config_locators.deadline_config_dialog,
-}
-credential_source_hostprovided_label = {
-    "container": credential_source_auth_group,
-    "text": "<b style='color:green;'>HOST_PROVIDED</b>",
-    "type": "QLabel",
-    "unnamed": 1,
-    "visible": 1,
-}
-credential_source_dcmlogin_label = {
-    "container": credential_source_auth_group,
-    "text": "<b style='color:green;'>DEADLINE_CLOUD_MONITOR_LOGIN</b>",
-    "type": "QLabel",
-    "unnamed": 1,
-    "visible": 1,
-}
-authentication_status_authenticated_label = {
-    "container": authentication_status_auth_group,
-    "text": "<b style='color:green;'>AUTHENTICATED</b>",
-    "type": "QLabel",
-    "unnamed": 1,
-    "visible": 1,
-}
-deadlinecloud_api_authorized_label = {
-    "container": deadlinecloud_api_auth_group,
-    "text": "<b style='color:green;'>AUTHORIZED</b>",
-    "type": "QLabel",
+
+# Profile button - shows the profile name and has dropdown menu
+authentication_profile_button = {
+    "container": authentication_status_widget,
+    "type": "QPushButton",
     "unnamed": 1,
     "visible": 1,
 }

--- a/test/squish/suite_deadline_gui/shared/scripts/workstation_config_locators.py
+++ b/test/squish/suite_deadline_gui/shared/scripts/workstation_config_locators.py
@@ -9,7 +9,7 @@ deadline_config_dialog = {
 }
 # OK button
 deadlinedialog_ok_button = {
-    "text": "OK",
+    "text": "Ok",
     "type": "QPushButton",
     "unnamed": 1,
     "visible": 1,


### PR DESCRIPTION
Fixes: *<insert link to GitHub issue here>*

### What was the problem/requirement? (What/Why)

The existing squish UI tests were checking for the presence of UI elements that no longer exist, specifically the AUTHENTICATED and AUTHORIZED components, and the "OK" button, which is now "Ok".

### What was the solution? (How)

Update the selectors to target existing elements

### What is the impact of this change?

Squish test suite will pass. 

### How was this change tested?

I ran the Squish tests locally.

### Was this change documented?

No changes to documentation, but docstrings were added to clarify the functionality of the selectors

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [ x ] This PR does not add any new dependencies.

### Is this a breaking change?

No

### Does this change impact security?

- Does the change need to be threat modeled? For example, does it create or modify files/directories that must only be readable by the process owner? No
    - If so, then please label this pull request with the "security" label. We'll work with you to analyze the threats.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
