### PR TITLE
feat: add --name support for gui-submit and improve parametrized job …

### DIFF
--- a/src/deadline/client/cli/_groups/bundle_group.py
+++ b/src/deadline/client/cli/_groups/bundle_group.py
@@ -379,6 +379,10 @@ def bundle_submit(
     help="Opens a folder browser to select a bundle.",
 )
 @click.option(
+    "--name",
+    help="The job name to use in place of the one in the job bundle.",
+)
+@click.option(
     "--install-gui",
     is_flag=True,
     help="Installs GUI dependencies if they are not installed already",
@@ -420,6 +424,7 @@ def bundle_gui_submit(
     parameter,
     job_bundle_dir,
     browse,
+    name,
     output,
     install_gui,
     known_asset_path,
@@ -470,6 +475,7 @@ def bundle_gui_submit(
             submitter_info=submitter_info,
             known_asset_paths=known_asset_path,
             job_parameters=parameter,
+            name=name,
         )
 
         if not submitter:

--- a/src/deadline/client/ui/dataclasses/__init__.py
+++ b/src/deadline/client/ui/dataclasses/__init__.py
@@ -19,7 +19,7 @@ __all__ = [
 
 import os
 from dataclasses import dataclass, field
-from typing import Literal, Dict, List, Union
+from typing import Literal, Dict, List, Optional as _Optional, Union
 
 from ...job_bundle.parameters import JobParameter
 
@@ -45,6 +45,10 @@ class JobBundleSettings:  # pylint: disable=too-many-instance-attributes
 
     # Whether to allow ability to "Load a different job bundle"
     browse_enabled: bool = field(default=False)
+
+    # If the template name is parametrized (e.g., "{{Param.JobName}}"),
+    # this holds the parameter name (e.g., "JobName").
+    name_parameter: _Optional[str] = field(default=None)
 
 
 @dataclass

--- a/src/deadline/client/ui/job_bundle_submitter.py
+++ b/src/deadline/client/ui/job_bundle_submitter.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 import copy
 import os
+import re as _re
 from logging import getLogger
 from typing import Any, Optional, Dict
 
@@ -42,6 +43,20 @@ from ..job_bundle.submission import AssetReferences
 from ..api._session import session_context
 
 logger = getLogger(__name__)
+
+# Pattern to match OpenJD parameter references like {{Param.JobName}}
+_PARAM_REFERENCE_PATTERN = _re.compile(r"\{\{Param\.(\w+)\}\}")
+
+
+def _extract_name_parameter(template_name: str) -> Optional[str]:
+    """
+    Extract the parameter name from a parametrized template name.
+
+    If the template name is exactly "{{Param.X}}", returns "X".
+    Otherwise returns None.
+    """
+    match = _PARAM_REFERENCE_PATTERN.fullmatch(template_name.strip())
+    return match.group(1) if match else None
 
 
 def _validate_job_parameters_against_definitions(
@@ -118,6 +133,7 @@ def show_job_bundle_submitter(
     *,
     input_job_bundle_dir: str = "",
     browse: bool = False,
+    name: Optional[str] = None,
     parent: Optional[QWidget] = None,
     f=Qt.WindowFlags(),
     submitter_info: Optional[SubmitterInfo] = None,
@@ -133,6 +149,7 @@ def show_job_bundle_submitter(
     Args:
         input_job_bundle_dir: Path to the job bundle directory
         browse: Whether to show a file browser dialog
+        name: Optional job name to use instead of the template default
         parent: Parent widget
         f: Qt window flags
         submitter_info: Optional submitter information to display in About dialog.
@@ -192,7 +209,14 @@ def show_job_bundle_submitter(
         template = parse_yaml_or_json_content(
             file_contents, file_type, settings.input_job_bundle_dir, "template"
         )
-        template["name"] = settings.name
+
+        # Handle parametrized names: keep original template name and pass name as parameter
+        if settings.name_parameter:
+            # Template name stays as "{{Param.X}}", name goes into parameter values
+            pass
+        else:
+            template["name"] = settings.name
+
         if settings.description:
             template["description"] = settings.description
         else:
@@ -217,6 +241,10 @@ def show_job_bundle_submitter(
         parameter_values.extend(
             {"name": param["name"], "value": param["value"]} for param in settings.parameters
         )
+
+        # Add name as parameter value when using parametrized name
+        if settings.name_parameter:
+            parameter_values.append({"name": settings.name_parameter, "value": settings.name})
 
         parameters = merge_queue_job_parameters(
             queue_parameters=queue_parameters,
@@ -256,15 +284,42 @@ def show_job_bundle_submitter(
     )
     asset_references = AssetReferences.from_dict(asset_references_obj)
 
-    name = "Job bundle submission"
-    if template:
-        name = template.get("name", name)
+    # Check if the template name is parametrized (e.g., "{{Param.JobName}}")
+    original_template_name = template.get("name", "") if template else ""
+    name_param = _extract_name_parameter(original_template_name)
+
+    # Determine the initial name value
+    if name is not None:
+        # CLI --name option takes precedence
+        initial_name = name
+    elif name_param:
+        # For parametrized names, use the parameter's default value
+        initial_name = "Job bundle submission"  # Will be updated from parameter default below
+    else:
+        # Use template name or fallback
+        initial_name = original_template_name or "Job bundle submission"
 
     if not os.path.isdir(input_job_bundle_dir):
         raise DeadlineOperationError(f"Input Job Bundle Dir is not valid: {input_job_bundle_dir}")
-    initial_settings = JobBundleSettings(input_job_bundle_dir=input_job_bundle_dir, name=name)
+    initial_settings = JobBundleSettings(
+        input_job_bundle_dir=input_job_bundle_dir, name=initial_name
+    )
     initial_settings.parameters = read_job_bundle_parameters(input_job_bundle_dir)
     initial_settings.browse_enabled = browse
+    initial_settings.name_parameter = name_param
+
+    # If name is parametrized, get default from parameter and hide it from parameters list
+    if name_param:
+        for param in initial_settings.parameters:
+            if param["name"] == name_param:
+                if name is None:
+                    # Use parameter's default as initial name
+                    initial_settings.name = param.get("default", param.get("value", ""))
+                break
+        # Remove the name parameter from the displayed parameters list
+        initial_settings.parameters = [
+            p for p in initial_settings.parameters if p["name"] != name_param
+        ]
 
     initial_shared_parameter_values = {}
 

--- a/test/unit/deadline_client/cli/test_cli_bundle_submit.py
+++ b/test/unit/deadline_client/cli/test_cli_bundle_submit.py
@@ -697,6 +697,21 @@ def test_gui_submit_submitter_name(_mock_context, mock_job_bundle_submitter):
     assert kwargs["submitter_info"] == SubmitterInfo(submitter_name="MyDCC")
 
 
+@patch.object(deadline.client.ui, "gui_context_for_cli")
+def test_gui_submit_name_option(_mock_context, mock_job_bundle_submitter):
+    """
+    Verify that the --name arg gets passed through correctly to show_job_bundle_submitter
+    """
+
+    runner = CliRunner()
+    runner.invoke(
+        main,
+        ["bundle", "gui-submit", "--browse", "--name", "My Custom Job Name"],
+    )
+    _args, kwargs = mock_job_bundle_submitter.show_job_bundle_submitter.call_args
+    assert kwargs["name"] == "My Custom Job Name"
+
+
 def test_bundle_submit_with_target_task_run_status(
     fresh_deadline_config, deadline_mock, temp_job_bundle_dir
 ):

--- a/test/unit/deadline_client/ui/test_job_bundle_submitter.py
+++ b/test/unit/deadline_client/ui/test_job_bundle_submitter.py
@@ -1,0 +1,56 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Tests for the job_bundle_submitter module.
+"""
+
+import pytest
+
+# Skip all tests in this module if Qt is not available
+job_bundle_submitter = pytest.importorskip("deadline.client.ui.job_bundle_submitter")
+
+
+class TestExtractNameParameter:
+    """Tests for the _extract_name_parameter helper function."""
+
+    def test_simple_param_reference(self):
+        """Test extraction of a simple parameter reference."""
+        assert job_bundle_submitter._extract_name_parameter("{{Param.JobName}}") == "JobName"
+
+    def test_param_reference_with_whitespace(self):
+        """Test extraction with leading/trailing whitespace."""
+        assert job_bundle_submitter._extract_name_parameter("  {{Param.JobName}}  ") == "JobName"
+
+    def test_different_param_name(self):
+        """Test extraction of different parameter names."""
+        assert (
+            job_bundle_submitter._extract_name_parameter("{{Param.MyCustomName}}") == "MyCustomName"
+        )
+        assert job_bundle_submitter._extract_name_parameter("{{Param.Name123}}") == "Name123"
+
+    def test_non_parametrized_name(self):
+        """Test that non-parametrized names return None."""
+        assert job_bundle_submitter._extract_name_parameter("My Job Name") is None
+        assert job_bundle_submitter._extract_name_parameter("") is None
+
+    def test_partial_param_reference(self):
+        """Test that partial parameter references return None."""
+        # Name with additional text around the parameter
+        assert job_bundle_submitter._extract_name_parameter("Prefix {{Param.JobName}}") is None
+        assert job_bundle_submitter._extract_name_parameter("{{Param.JobName}} Suffix") is None
+        assert (
+            job_bundle_submitter._extract_name_parameter("Prefix {{Param.JobName}} Suffix") is None
+        )
+
+    def test_multiple_param_references(self):
+        """Test that multiple parameter references return None."""
+        assert job_bundle_submitter._extract_name_parameter("{{Param.A}} {{Param.B}}") is None
+
+    def test_invalid_param_syntax(self):
+        """Test that invalid parameter syntax returns None."""
+        assert job_bundle_submitter._extract_name_parameter("{{Param.}}") is None
+        assert job_bundle_submitter._extract_name_parameter("{{Param}}") is None
+        assert job_bundle_submitter._extract_name_parameter("{Param.JobName}") is None
+        assert (
+            job_bundle_submitter._extract_name_parameter("{{param.JobName}}") is None
+        )  # lowercase 'param'


### PR DESCRIPTION
This commit addresses two GitHub issues:

Issue #859: Add --name support for gui-submit
- Added --name option to 'deadline bundle gui-submit' command
- Matches existing functionality in 'deadline bundle submit'

Issue #460: Improved handling of parametrized job names
- When template name is parametrized (e.g., name: '{{Param.JobName}}'):
  - The Name field on Shared job settings uses the parameter's default value
  - The JobName parameter is hidden from Job-specific settings tab
  - The name is passed as a parameter value instead of replacing the template
- This preserves template portability and reusability

Fixes: https://github.com/aws-deadline/deadline-cloud/issues/859 and https://github.com/aws-deadline/deadline-cloud/issues/460

##
See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests? Yes
- Have you run the integration tests? Yes
- Have you made changes to the `download` or `asset_sync` modules? No

### Was this change documented?

- Are relevant docstrings in the code base updated? No
- Has the README.md been updated? No

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [X] This PR does not add any new dependencies.

### Is this a breaking change? No

### Does this change impact security? No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
