### PR TITLE
fix: show resource ID in dropdown when user lacks list permission

### DIFF
--- a/src/deadline/client/ui/dialogs/deadline_config_dialog.py
+++ b/src/deadline/client/ui/dialogs/deadline_config_dialog.py
@@ -1030,8 +1030,15 @@ class _DeadlineResourceListComboBox(QWidget):
             index = self.box.findData(selected_id)
             if index >= 0:
                 self.box.setCurrentIndex(index)
+            elif selected_id:
+                # User has a configured ID but it's not in the list. This happens when
+                # the user has permission to use a resource (e.g., queue) but lacks
+                # permission to list resources (e.g., ListFarms). Show the raw ID so
+                # they can still see their configured resource.
+                self.box.insertItem(0, selected_id, userData=selected_id)
+                self.box.setCurrentIndex(0)
             else:
-                # Some cases allow to select "nothing" and insert an item to indicate such
+                # No ID selected
                 index = self.box.findText("<none selected>")
                 if index >= 0:
                     self.box.setCurrentIndex(index)

--- a/test/unit/deadline_client/ui/dialogs/test_deadline_config_dialog.py
+++ b/test/unit/deadline_client/ui/dialogs/test_deadline_config_dialog.py
@@ -1,0 +1,48 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from configparser import ConfigParser
+from unittest.mock import patch
+
+import pytest
+
+try:
+    from deadline.client.ui.dialogs.deadline_config_dialog import _DeadlineResourceListComboBox
+except ImportError:
+    pytest.importorskip("deadline.client.ui.dialogs.deadline_config_dialog")
+
+
+class TestDeadlineResourceListComboBox:
+    """Tests for _DeadlineResourceListComboBox.refresh_selected_id()"""
+
+    @patch("deadline.client.ui.dialogs.deadline_config_dialog.config_file")
+    def test_shows_id_when_not_in_list(self, mock_config_file, qtbot):
+        """
+        When user has a configured ID but lacks permission to list resources,
+        the combobox should display the raw ID instead of '<none selected>'.
+
+        This happens when a user has permission to use a queue but lacks
+        permission to call ListFarms.
+        """
+        mock_config_file.get_setting.return_value = "farm-abc123"
+
+        widget = _DeadlineResourceListComboBox("Farm", "defaults.farm_id")
+        qtbot.addWidget(widget)
+        widget.set_config(ConfigParser())
+
+        widget.refresh_selected_id()
+
+        assert widget.box.currentText() == "farm-abc123"
+        assert widget.box.currentData() == "farm-abc123"
+
+    @patch("deadline.client.ui.dialogs.deadline_config_dialog.config_file")
+    def test_shows_none_selected_when_no_id_configured(self, mock_config_file, qtbot):
+        """When no ID is configured, should show '<none selected>'."""
+        mock_config_file.get_setting.return_value = ""
+
+        widget = _DeadlineResourceListComboBox("Farm", "defaults.farm_id")
+        qtbot.addWidget(widget)
+        widget.set_config(ConfigParser())
+
+        widget.refresh_selected_id()
+
+        assert widget.box.currentText() == "<none selected>"


### PR DESCRIPTION
When a user has a farm/queue ID configured but lacks permission to list farms/queues, the settings dropdown would show '<none selected>'. Now it displays the configured ID instead, allowing users with limited permissions to still see their configured resources.

Fixes: *<insert link to GitHub issue here>*

### What was the problem/requirement? (What/Why)
Trying to improve the experience of queue only users.

### What was the solution? (How)
Showing the farm ID instead of 'none selected' when the user has no permissions to farms.

### What is the impact of this change?
Improved UX

### How was this change tested?
Tests were run and local tests with the houdini submitter

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests? Yes
- Have you run the integration tests? No
- Have you made changes to the `download` or `asset_sync` modules? No

### Was this change documented?

- Are relevant docstrings in the code base updated? N/A
- Has the README.md been updated? N/A

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [X] This PR does not add any new dependencies.

### Is this a breaking change? No

### Does this change impact security? No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
