### PR TITLE
fix: use string list filter for job download

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 # Applications that consume this library should be the ones that are more strictly
 # limiting dependencies if they want/need to.
 dependencies = [
-  "boto3 >= 1.39.10; python_version >= '3.9'",
+  "boto3 >= 1.42.29; python_version >= '3.9'",
   "boto3 >= 1.36.8; python_version < '3.9'",
   # Click 8.2 dropped python 3.8/3.9 support
   "click >= 8.1.7",

--- a/src/deadline/client/cli/_incremental_download.py
+++ b/src/deadline/client/cli/_incremental_download.py
@@ -95,6 +95,7 @@ def _get_download_candidate_jobs(
     # Construct the full set of jobs that may have new available downloads.
     # - Any active job (job with taskRunStatus in READY, ASSIGNED,
     #   STARTING, SCHEDULED, or RUNNING), that has at least one SUCCEEDED task.
+    # Use stringListFilter with ANY_EQUALS to query all statuses in a single API call
     download_candidate_jobs = {
         job["jobId"]: job
         for job in _list_jobs_by_filter_expression(
@@ -104,42 +105,17 @@ def _get_download_candidate_jobs(
             filter_expression={
                 "filters": [
                     {
-                        "stringFilter": {
+                        "stringListFilter": {
                             "name": "TASK_RUN_STATUS",
-                            "operator": "EQUAL",
-                            "value": status_value,
+                            "operator": "ANY_EQUALS",
+                            "values": ["READY", "ASSIGNED", "STARTING", "SCHEDULED", "RUNNING"],
                         },
                     }
-                    # Maximum of 3 filters are permitted, so the 5 statuses are split
-                    for status_value in ["READY", "ASSIGNED", "STARTING"]
                 ],
                 "operator": "OR",
             },
         )
     }
-    download_candidate_jobs.update(
-        {
-            job["jobId"]: job
-            for job in _list_jobs_by_filter_expression(
-                boto3_session,
-                farm_id,
-                queue_id,
-                filter_expression={
-                    "filters": [
-                        {
-                            "stringFilter": {
-                                "name": "TASK_RUN_STATUS",
-                                "operator": "EQUAL",
-                                "value": status_value,
-                            },
-                        }
-                        for status_value in ["SCHEDULED", "RUNNING"]
-                    ],
-                    "operator": "OR",
-                },
-            )
-        }
-    )
     print(f"DEBUG: Got {len(download_candidate_jobs)} active jobs")
     download_candidate_jobs = {
         job_id: _datetimes_to_str(job)

--- a/test/unit/deadline_client/mock_deadline_job_apis.py
+++ b/test/unit/deadline_client/mock_deadline_job_apis.py
@@ -63,6 +63,25 @@ def _build_filter_function(filter) -> Callable[[dict], bool]:
                     return field_name in job and job[field_name] >= value
             else:
                 raise ValueError(f"fake SearchJobs filter has not implemented operator {operator}")
+        elif "stringListFilter" in filter:
+            filter = filter["stringListFilter"]
+
+            field_name = snake_to_camel(filter["name"].lower())
+            operator = filter["operator"]
+            values = filter["values"]
+
+            assert isinstance(values, list)
+
+            if operator == "ANY_EQUALS":
+
+                def _filter_function(job) -> bool:
+                    return field_name in job and job[field_name] in values
+            elif operator == "ALL_NOT_EQUALS":
+
+                def _filter_function(job) -> bool:
+                    return field_name in job and job[field_name] not in values
+            else:
+                raise ValueError(f"fake SearchJobs filter has not implemented operator {operator}")
         elif "dateTimeFilter" in filter:
             filter = filter["dateTimeFilter"]
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The sync-output CLI command was making two separate SearchJobs API calls to find active jobs - one for statuses READY/ASSIGNED/STARTING and another for SCHEDULED/RUNNING. If a job transitioned between these status groups between the two calls, it could be missed, causing incorrect output downloads. 

### What was the solution? (How)
Use the stringListFilter with ANY_EQUALS operator to query all 5 active statuses in a single API call, eliminating the race condition.

Also upgraded required boto3 version to be compatible with release that added support for stringlistfilter.

### What is the impact of this change?
Jobs will no longer be missed during incremental output downloads when they transition between active statuses.

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests?
```
Required test coverage of 80.0% reached. Total coverage: 83.25%
================================================================================================================ slowest 5 durations ================================================================================================================
4.61s call     test/unit/deadline_client/api/test_job_bundle_submission_asset_refs.py::test_create_job_from_job_bundle_with_all_asset_ref_variants
4.32s call     test/unit/deadline_client/cli/test_cli_handle_web_url.py::test_cli_handle_web_url_download_output_only_required_input
4.29s call     test/unit/deadline_client/api/test_api_farm.py::test_list_farms_paginated
4.26s call     test/unit/deadline_client/cli/test_cli_job.py::test_cli_job_download_output_stdout_with_only_required_input
3.16s call     test/unit/deadline_job_attachments/test_upload.py::TestUpload::test_asset_management_no_outputs_large_number_of_inputs_already_uploaded[2023-03-03-200]
=================================================================================================== 2145 passed, 68 skipped, 1 xfailed in 44.13s ====================================================================================================

```
- Have you run the integration tests?
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass.

### Was this change documented?

- Are relevant docstrings in the code base updated?
Yes
- Has the README.md been updated? If you modified CLI arguments, for instance.
N/A

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [X] This PR does not add any new dependencies.

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
