### PR TITLE
feat: add job_id parameter to get_session_logs for MCP

### DIFF
--- a/src/deadline/_mcp/registry.py
+++ b/src/deadline/_mcp/registry.py
@@ -65,6 +65,7 @@ TOOL_REGISTRY: Dict[str, ToolDefinition] = {
             "farm_id",
             "queue_id",
             "session_id",
+            "job_id",
             "limit",
             "start_time",
             "end_time",

--- a/src/deadline/client/api/_job_monitoring.py
+++ b/src/deadline/client/api/_job_monitoring.py
@@ -201,7 +201,8 @@ def wait_for_job_completion(
 def get_session_logs(
     farm_id: str,
     queue_id: str,
-    session_id: str,
+    session_id: Optional[str] = None,
+    job_id: Optional[str] = None,
     limit: int = 100,
     start_time: Optional[datetime.datetime] = None,
     end_time: Optional[datetime.datetime] = None,
@@ -215,10 +216,17 @@ def get_session_logs(
     By default, it returns the most recent 100 log lines, but this can be
     adjusted using the limit parameter.
 
+    If session_id is not provided but job_id is, the function will automatically
+    select a session using the following priority:
+    1. Ongoing sessions (no endedAt time) are preferred
+    2. Among ongoing sessions, the most recently started one is selected
+    3. If no ongoing sessions, the most recently completed session is selected
+
     Args:
         farm_id: The ID of the farm containing the session.
         queue_id: The ID of the queue containing the session.
-        session_id: The ID of the session to get logs for.
+        session_id: The ID of the session to get logs for. Optional if job_id is provided.
+        job_id: The ID of the job. Used to auto-select a session if session_id is not provided.
         limit: Maximum number of log lines to return.
         start_time: Optional start time for logs as a datetime object.
         end_time: Optional end time for logs as a datetime object.
@@ -233,6 +241,40 @@ def get_session_logs(
     """
     # Get the Deadline client to use for getting queue credentials
     deadline = get_boto3_client("deadline", config=config)
+
+    # Auto-select session if not provided but job_id is
+    if not session_id:
+        if not job_id:
+            raise DeadlineOperationError("Either session_id or job_id must be provided")
+        try:
+            paginator = deadline.get_paginator("list_sessions")
+            sessions = []
+            for page in paginator.paginate(farmId=farm_id, queueId=queue_id, jobId=job_id):
+                sessions.extend(page.get("sessions", []))
+
+            if not sessions:
+                raise DeadlineOperationError(f"No sessions found for job {job_id}")
+
+            # Prioritize ongoing sessions, then most recent
+            ongoing = [s for s in sessions if "endedAt" not in s]
+            if ongoing:
+                session_id = max(
+                    ongoing,
+                    key=lambda s: s.get(
+                        "startedAt", datetime.datetime.min.replace(tzinfo=datetime.timezone.utc)
+                    ),
+                )["sessionId"]
+            else:
+                session_id = max(
+                    sessions,
+                    key=lambda s: s.get(
+                        "endedAt", datetime.datetime.min.replace(tzinfo=datetime.timezone.utc)
+                    ),
+                )["sessionId"]
+        except ClientError as exc:
+            raise DeadlineOperationError(f"Failed to list sessions: {exc}") from exc
+
+    assert session_id is not None  # Guaranteed by logic above
 
     # Check if we have user and identity store ID (from Deadline Cloud monitor)
     user_id, identity_store_id = get_user_and_identity_store_id(config=config)


### PR DESCRIPTION
Allow MCP clients to call get_session_logs with just a job_id instead of requiring a session_id. The function will auto-select the most relevant session (preferring ongoing sessions, then most recently started/ended).

This makes the MCP tool more usable since clients typically have job IDs but not session IDs.

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests? Yes
- Have you run the integration tests? No
- Have you made changes to the `download` or `asset_sync` modules? No

### Was this change documented?

- Are relevant docstrings in the code base updated? N/A
- Has the README.md been updated? N/A

### Does this PR introduce new dependencies? 

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [X] This PR does not add any new dependencies.

### Is this a breaking change? No

### Does this change impact security? No


----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
