### PR TITLE
fix: sts and s3 endpoint url overrides were not being respected

### DIFF
--- a/src/deadline/client/api/_session.py
+++ b/src/deadline/client/api/_session.py
@@ -81,7 +81,10 @@ def get_boto3_session(
 
 @lru_cache
 def _get_boto3_session_for_profile(profile_name: str):
-    session = boto3.Session(profile_name=profile_name)
+    # Use regional STS endpoint to avoid cross-region calls to the global endpoint.
+    botocore_session = get_botocore_session()
+    botocore_session.set_config_variable("sts_regional_endpoints", "regional")
+    session = boto3.Session(profile_name=profile_name, botocore_session=botocore_session)
 
     # By default, DCM returns creds that expire after 15 minutes, and boto3's RefreshableCredentials
     # class refreshes creds that are within 15 minutes of expiring, so credentials would never be reused.

--- a/src/deadline/job_attachments/_aws/aws_clients.py
+++ b/src/deadline/job_attachments/_aws/aws_clients.py
@@ -29,7 +29,13 @@ MAX_SIZE_CACHE = 128
 # Should create a new botocore session since botocore session may be modified by boto3 session/client using it
 # https://github.com/boto/boto3/blob/61de529b5f9a7bdcc8c76debb472a7f934d048e6/boto3/session.py#L79
 def get_botocore_session() -> botocore.session.Session:
-    return botocore.session.get_session()
+    session = botocore.session.get_session()
+    # Use regional endpoints by default for STS and S3 (us-east-1) to avoid
+    # cross-region calls to the global endpoint. This is the default in newer verisons,
+    # but older botocore versions default to "legacy" which routes through us-east-1.
+    session.set_config_variable("sts_regional_endpoints", "regional")
+    session.set_config_variable("s3", {"us_east_1_regional_endpoint": "regional"})
+    return session
 
 
 @lru_cache(maxsize=MAX_SIZE_CACHE)
@@ -72,7 +78,6 @@ def get_s3_client(session: Optional[boto3.Session] = None) -> BaseClient:
             user_agent_extra=f"S3A/Deadline/NA/JobAttachments/{version}",
             max_pool_connections=s3_max_pool_connections,
         ),
-        endpoint_url=f"https://s3.{session.region_name}.amazonaws.com",
     )
 
     def add_expected_bucket_owner(params, model, **kwargs):
@@ -115,10 +120,8 @@ def get_sts_client(session: Optional[boto3.session.Session] = None) -> BaseClien
     """
     if session is None:
         session = get_boto3_session()
-    return session.client(
-        "sts",
-        endpoint_url=f"https://sts.{session.region_name}.amazonaws.com",
-    )
+
+    return session.client("sts")
 
 
 @lru_cache(maxsize=MAX_SIZE_CACHE)

--- a/test/unit/deadline_client/api/test_api_session.py
+++ b/test/unit/deadline_client/api/test_api_session.py
@@ -23,7 +23,9 @@ def test_get_boto3_session(fresh_deadline_config):
 
         # Confirm it returned the mocked value, and was called with the correct args
         assert result == mock_session
-        boto3_session.assert_called_once_with(profile_name="SomeRandomProfileName")
+        boto3_session.assert_called_once_with(
+            profile_name="SomeRandomProfileName", botocore_session=ANY
+        )
 
 
 def test_get_boto3_session_caching_behavior(fresh_deadline_config):
@@ -33,7 +35,7 @@ def test_get_boto3_session_caching_behavior(fresh_deadline_config):
     """
 
     # mock boto3.Session to return a fresh object based on the input profile name
-    def mock_create_session(profile_name: Optional[str]):
+    def mock_create_session(profile_name: Optional[str], botocore_session=None):
         session = MagicMock()
         session._profile_name = profile_name
         return session
@@ -65,8 +67,8 @@ def test_get_boto3_session_caching_behavior(fresh_deadline_config):
         # value of AWS profile name that was configured.
         boto3_session.assert_has_calls(
             [
-                call(profile_name=None),
-                call(profile_name="SomeRandomProfileName"),
+                call(profile_name=None, botocore_session=ANY),
+                call(profile_name="SomeRandomProfileName", botocore_session=ANY),
             ]
         )
 

--- a/test/unit/deadline_client/cli/test_cli_bundle_submit.py
+++ b/test/unit/deadline_client/cli/test_cli_bundle_submit.py
@@ -119,7 +119,7 @@ def test_cli_bundle_explicit_parameters(fresh_deadline_config, temp_job_bundle_d
             ],
         )
 
-    session_mock.assert_called_with(profile_name="NonDefaultProfileName")
+    session_mock.assert_called_with(profile_name="NonDefaultProfileName", botocore_session=ANY)
     session_mock().client().create_job.assert_called_once_with(
         farmId=MOCK_FARM_ID,
         queueId=MOCK_QUEUE_ID,

--- a/test/unit/deadline_client/cli/test_cli_farm.py
+++ b/test/unit/deadline_client/cli/test_cli_farm.py
@@ -4,7 +4,7 @@
 Tests for the CLI farm commands.
 """
 
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 import os
 
 import boto3  # type: ignore[import]
@@ -71,7 +71,7 @@ def test_cli_farm_list_override_profile(fresh_deadline_config):
         result = runner.invoke(main, ["farm", "list", "--profile", "NonDefaultProfileName"])
 
         assert result.exit_code == 0
-        session_mock.assert_called_with(profile_name="NonDefaultProfileName")
+        session_mock.assert_called_with(profile_name="NonDefaultProfileName", botocore_session=ANY)
         session_mock().client().list_farms.assert_called_once_with()
 
 
@@ -132,7 +132,9 @@ def test_cli_farm_get_override_profile(fresh_deadline_config):
         result = runner.invoke(main, ["farm", "get", "--profile", "NonDefaultProfileName"])
 
         assert result.exit_code == 0
-        session_mock.assert_called_once_with(profile_name="NonDefaultProfileName")
+        session_mock.assert_called_once_with(
+            profile_name="NonDefaultProfileName", botocore_session=ANY
+        )
         session_mock().client().get_farm.assert_called_once_with(farmId="farm-overriddenid")
 
 

--- a/test/unit/deadline_client/cli/test_cli_fleet.py
+++ b/test/unit/deadline_client/cli/test_cli_fleet.py
@@ -4,7 +4,7 @@
 Tests for the CLI fleet commands.
 """
 
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 from copy import deepcopy
 import os
 from datetime import datetime
@@ -230,7 +230,9 @@ def test_cli_fleet_get_override_profile(fresh_deadline_config):
             ["fleet", "get", "--profile", "NonDefaultProfileName", "--fleet-id", MOCK_FLEET_ID],
         )
 
-        session_mock.assert_called_once_with(profile_name="NonDefaultProfileName")
+        session_mock.assert_called_once_with(
+            profile_name="NonDefaultProfileName", botocore_session=ANY
+        )
         session_mock().client().get_fleet.assert_called_once_with(
             farmId="farm-overriddenid", fleetId=MOCK_FLEET_ID
         )

--- a/test/unit/deadline_client/cli/test_cli_job.py
+++ b/test/unit/deadline_client/cli/test_cli_job.py
@@ -181,7 +181,9 @@ def test_cli_job_list_override_profile(fresh_deadline_config):
         result = runner.invoke(main, ["job", "list", "--profile", "NonDefaultProfileName"])
 
         assert result.exit_code == 0
-        session_mock.assert_called_once_with(profile_name="NonDefaultProfileName")
+        session_mock.assert_called_once_with(
+            profile_name="NonDefaultProfileName", botocore_session=ANY
+        )
         session_mock().client().search_jobs.assert_called_once_with(
             farmId="farm-overriddenid",
             queueIds=["queue-overriddenid"],

--- a/test/unit/deadline_client/cli/test_cli_queue.py
+++ b/test/unit/deadline_client/cli/test_cli_queue.py
@@ -4,7 +4,7 @@
 Tests for the CLI queue commands.
 """
 
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import boto3  # type: ignore[import]
 from botocore.exceptions import ClientError  # type: ignore[import]
@@ -81,7 +81,7 @@ def test_cli_queue_list_override_profile(fresh_deadline_config):
         result = runner.invoke(main, ["queue", "list", "--profile", "NonDefaultProfileName"])
 
         assert result.exit_code == 0
-        session_mock.assert_called_with(profile_name="NonDefaultProfileName")
+        session_mock.assert_called_with(profile_name="NonDefaultProfileName", botocore_session=ANY)
         session_mock().client().list_queues.assert_called_once_with(farmId="farm-overriddenid")
 
 

--- a/test/unit/deadline_job_attachments/aws/test_aws_clients.py
+++ b/test/unit/deadline_job_attachments/aws/test_aws_clients.py
@@ -2,8 +2,14 @@
 
 """Tests for aws clients"""
 
+import os
 from unittest.mock import Mock, patch
+
+import pytest
+
 from deadline.job_attachments._aws.aws_clients import (
+    get_boto3_session,
+    get_botocore_session,
     get_deadline_client,
     get_s3_client,
     get_sts_client,
@@ -13,6 +19,18 @@ from deadline.job_attachments._aws.aws_config import (
     S3_CONNECT_TIMEOUT_IN_SECS,
     S3_READ_TIMEOUT_IN_SECS,
 )
+
+
+def _make_client(service_name, session=None):
+    """Create a client using the production factory functions with an optional fresh session."""
+    if session is None:
+        session = get_boto3_session(get_botocore_session())
+    factories = {
+        "s3": get_s3_client,
+        "sts": get_sts_client,
+        "deadline": get_deadline_client,
+    }
+    return factories[service_name](session=session)
 
 
 def test_get_deadline_client(boto_config):
@@ -53,7 +71,6 @@ def test_get_s3_client(boto_config):
     """
     s3_client = get_s3_client()
 
-    assert s3_client.meta.endpoint_url == "https://s3.us-west-2.amazonaws.com"
     assert s3_client.meta.config.signature_version == "s3v4"
     assert s3_client.meta.config.connect_timeout == S3_CONNECT_TIMEOUT_IN_SECS
     assert s3_client.meta.config.read_timeout == S3_READ_TIMEOUT_IN_SECS
@@ -62,4 +79,61 @@ def test_get_s3_client(boto_config):
 def test_get_sts_client(boto_config):
     sts_client = get_sts_client()
 
-    assert sts_client.meta.endpoint_url == "https://sts.us-west-2.amazonaws.com"
+    assert sts_client.meta.service_model.service_name == "sts"
+
+
+@pytest.mark.parametrize("service_name", ["s3", "sts", "deadline"])
+def test_default_regional_endpoint(boto_config, service_name):
+    """
+    Test that S3 and STS clients (previously global by default) now use regional endpoints by default.
+    """
+    region = os.environ["AWS_DEFAULT_REGION"]
+    client = _make_client(service_name)
+    assert client.meta.endpoint_url == f"https://{service_name}.{region}.amazonaws.com"
+
+
+@pytest.mark.parametrize(
+    "service_name, env_var",
+    [
+        ("s3", "AWS_ENDPOINT_URL_S3"),
+        ("sts", "AWS_ENDPOINT_URL_STS"),
+        ("deadline", "AWS_ENDPOINT_URL_DEADLINE"),
+    ],
+)
+def test_endpoint_url_override_via_env(boto_config, service_name, env_var):
+    """
+    Test that clients respect service-specific AWS_ENDPOINT_URL_* environment variables.
+    """
+    custom_endpoint = f"https://custom-{service_name}-env.example.com"
+    with patch.dict(os.environ, {env_var: custom_endpoint}):
+        client = _make_client(service_name)
+        assert client.meta.endpoint_url == custom_endpoint
+
+
+@pytest.mark.parametrize(
+    "service_name",
+    ["s3", "sts", "deadline"],
+)
+def test_endpoint_url_override_via_config_profile(boto_config, tmp_path, service_name):
+    """
+    Test that clients respect endpoint_url set in an AWS config profile.
+    """
+    custom_endpoint = f"https://custom-{service_name}-config.example.com"
+    config_file = tmp_path / "config"
+    config_file.write_text(f"""
+[profile testprofile]
+services = testprofile-services
+
+[services testprofile-services]
+{service_name} =
+    endpoint_url = {custom_endpoint}
+""")
+    with patch.dict(
+        os.environ,
+        {
+            "AWS_CONFIG_FILE": str(config_file),
+            "AWS_PROFILE": "testprofile",
+        },
+    ):
+        client = _make_client(service_name)
+        assert client.meta.endpoint_url == custom_endpoint

--- a/test/unit/deadline_job_attachments/conftest.py
+++ b/test/unit/deadline_job_attachments/conftest.py
@@ -59,6 +59,10 @@ def boto_config() -> Generator[None, None, None]:
     os.environ["AWS_SESSION_TOKEN"] = "testing"
     os.environ["AWS_DEFAULT_REGION"] = "us-west-2"
 
+    os.environ.pop("AWS_ENDPOINT_URL_S3", None)
+    os.environ.pop("AWS_ENDPOINT_URL_STS", None)
+    os.environ.pop("AWS_ENDPOINT_URL_DEADLINE", None)
+
     mock = mock_aws()
     mock.start()
     yield


### PR DESCRIPTION
Partially fixes: [#882](https://github.com/aws-deadline/deadline-cloud-worker-agent/issues/882)

### What was the problem/requirement? (What/Why)

The boto3 session clients for sts and s3 were being created with specific endpoint_urls which caused any user overrides to be completely ignored.

### What was the solution? (How)

The endpoint_url was previously specified to ensure that our sts and s3 calls were being made using the regional endpoint. Since this code was originally added, boto3/botocore changed the default behaviour of these services to be regional by default. Therefore we can remove our manual handling of that to ensure overrides are respected for these services.

### What is the impact of this change?

Customers can use endpoint url overrides for s3 and sts

### How was this change tested?

```
hatch run test
```

Manual tests:

```
$ deadline auth status
    Profile Name: monitormadness-us-west-2
          Source: DEADLINE_CLOUD_MONITOR_LOGIN
          Status: AUTHENTICATED
API Availability: True
$ export AWS_ENDPOINT_URL_STS=https://localhost:8080
$ deadline auth status
    Profile Name: monitormadness-us-west-2
          Source: DEADLINE_CLOUD_MONITOR_LOGIN
          Status: NEEDS_LOGIN
API Availability: True
$ unset AWS_ENDPOINT_URL_STS
```
```
$ export AWS_ENDPOINT_URL_S3=https://localhost:8080
$ deadline job download-output
Downloading output from Job 'demo'
Failed to download output:
An issue occurred with AWS service request while listing bucket contents: Could not connect to the endpoint URL: "https://localhost:8080/..."
This could be due to temporary issues with AWS, internet connection, or your AWS credentials. Please verify your credentials and network connection. If the problem persists, try again later or contact support for further assistance.
$ unset AWS_ENDPOINT_URL_S3
$ deadline job download-output
Downloading output from Job 'demo'

Summary of file paths to download:
  /tmp/ViewLayer_Camera_output_%04d.png (250 files, sequence 1-250)

Downloading Outputs  [###############---------------------]   42%  00:00:15
```

### Was this change documented?

N/A

### Does this PR introduce new dependencies?

N/A

### Is this a breaking change?

Fixing :)

### Does this change impact security?

N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
