### PR TITLE
chore: griffe missing from github action

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -3,5 +3,7 @@ mkdocs-material >= 9.4.0
 mkdocs-section-index >= 0.3.10
 mkdocstrings[python]
 mkdocs-click
+# griffe version will match whichever griffelib mkdocstrings uses
+griffe
 # MCP (Model Context Protocol) library for MCP CLI command
 mcp >= 1.13.0; python_version >= '3.10'


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

griffe cli was missing from github action. 

Discovered here: https://github.com/aws-deadline/deadline-cloud/actions/runs/22409769647/job/64879710402?pr=1005

```bash
hatch run docs:check-api-breaks --against origin/mainline
...
/bin/sh: griffe: command not found
```

Turns out that mkdocstring version 2.0.3 swapped from griffe to griffelib since they don't use the CLI.

### What was the solution? (How)

add griffe to the docs requirements so that we have access to the cli.


```
$ hatch run docs:check-api-breaks --against upstream/mainline
$ echo $?
0
```

### What is the impact of this change?

working github action that checks for api changes

### How was this change tested?

Testing noted above, but also the action passes in this PR

### Was this change documented?
N/A

### Does this PR introduce new dependencies?

N/A

### Is this a breaking change?

N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
