### PR TITLE
chore: temporary pin virtualenv<21 to fix build

### DIFF
--- a/.github/workflows/api-change-detection.yml
+++ b/.github/workflows/api-change-detection.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Install Hatch
         run: |
-          pip install --upgrade hatch
+          pip install --upgrade hatch "virtualenv<21"
 
       - name: Check for API breaking changes (griffe)
         run: |

--- a/.github/workflows/manual_pypi_release.yml
+++ b/.github/workflows/manual_pypi_release.yml
@@ -52,7 +52,7 @@ jobs:
           python-version: '3.9'
       - name: Install dependencies
         run: |
-          pip install --upgrade hatch "click<8.3"
+          pip install --upgrade hatch "click<8.3" "virtualenv<21"
       - name: Build
         run: hatch -v build
       # # See https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install Hatch
         run: |
-          pip install --upgrade hatch
+          pip install --upgrade hatch "virtualenv<21"
 
       - name: Build and deploy documentation
         run: hatch run docs:deploy --force

--- a/.github/workflows/mkdocs_quality.yml
+++ b/.github/workflows/mkdocs_quality.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install Hatch
         run: |
-          pip install --upgrade hatch
+          pip install --upgrade hatch "virtualenv<21"
 
       - name: Build documentation
         run: hatch run docs:build

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -124,7 +124,7 @@ jobs:
           python-version: '3.9'
       - name: Install dependencies
         run: |
-          pip install --upgrade hatch
+          pip install --upgrade hatch "virtualenv<21"
       - name: Build
         run: hatch -v build
       # # See https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi

--- a/.github/workflows/reusable_python_build_coverage_override.yml
+++ b/.github/workflows/reusable_python_build_coverage_override.yml
@@ -70,7 +70,7 @@ jobs:
 
     - name: Install Hatch
       run: |
-        pip install --upgrade hatch
+        pip install --upgrade hatch "virtualenv<21"
 
     - name: Run Linting
       run: hatch -v run lint

--- a/pipeline/build.ps1
+++ b/pipeline/build.ps1
@@ -6,7 +6,7 @@ $ErrorActionPreference = "Stop"
 # Install/upgrade packages
 python -m pip install --upgrade pip
 if ($LASTEXITCODE -ne 0) { throw "Failed to update pip" }
-python -m pip install --upgrade hatch
+python -m pip install --upgrade hatch "virtualenv<21"
 if ($LASTEXITCODE -ne 0) { throw "Failed to update hatch" }
 python -m pip install --upgrade twine
 if ($LASTEXITCODE -ne 0) { throw "Failed to update twine" }

--- a/pipeline/build.sh
+++ b/pipeline/build.sh
@@ -4,7 +4,7 @@
 set -e
 
 pip install --upgrade pip
-pip install --upgrade hatch
+pip install --upgrade hatch "virtualenv<21"
 pip install --upgrade twine
 hatch -v run lint
 hatch run test

--- a/pipeline/build_pyinstaller_artifact.ps1
+++ b/pipeline/build_pyinstaller_artifact.ps1
@@ -7,7 +7,7 @@ if ($LASTEXITCODE -ne 0) { throw "Failed to generate attributions document" }
 
 pip install --upgrade pip
 if ($LASTEXITCODE -ne 0) { throw "Failed to update pip" }
-pip install --upgrade hatch
+pip install --upgrade hatch "virtualenv<21"
 if ($LASTEXITCODE -ne 0) { throw "Failed to update hatch" }
 
 hatch build

--- a/pipeline/build_pyinstaller_artifact.sh
+++ b/pipeline/build_pyinstaller_artifact.sh
@@ -4,7 +4,7 @@
 set -e
 
 pip3 install --upgrade pip
-pip3 install --upgrade hatch
+pip3 install --upgrade hatch "virtualenv<21"
 
 hatch run attributions:generate
 hatch build

--- a/pipeline/e2e.sh
+++ b/pipeline/e2e.sh
@@ -4,5 +4,5 @@
 set -e
 
 pip install --upgrade pip
-pip install --upgrade hatch
+pip install --upgrade hatch "virtualenv<21"
 hatch run e2e:test

--- a/pipeline/integ.ps1
+++ b/pipeline/integ.ps1
@@ -3,6 +3,6 @@
 $ErrorActionPreference = "Stop"
 
 pip install --upgrade pip
-pip install --upgrade hatch
+pip install --upgrade hatch "virtualenv<21"
 hatch run integ:test
 if ($LASTEXITCODE -ne 0) { throw "Failed to run integration tests" }

--- a/pipeline/integ.sh
+++ b/pipeline/integ.sh
@@ -4,5 +4,5 @@
 set -e
 
 pip install --upgrade pip
-pip install --upgrade hatch
+pip install --upgrade hatch "virtualenv<21"
 hatch run integ:test

--- a/testing_containers/localuser_sudo_environment/run_tests.sh
+++ b/testing_containers/localuser_sudo_environment/run_tests.sh
@@ -10,5 +10,5 @@ cp -r /code/.git /home/hostuser/code/
 cd code
 python -m venv .venv
 source .venv/bin/activate
-pip install hatch
+pip install hatch "virtualenv<21"
 hatch run pytest --cov=src/deadline --cov-report=html:build/coverage --cov-report=xml:build/coverage/coverage.xml --cov-report=term-missing --cov-fail-under=25 -m docker


### PR DESCRIPTION
## The failing API change detection
will be fixed by https://github.com/aws-deadline/deadline-cloud/pull/1006

### What was the problem/requirement? (What/Why)

virtualenv 21.0.0 released which is breaking hatch commands. See https://github.com/pypa/hatch/issues/2193

### What was the solution? (How)

Pin virtualenv to <21 for now

### What is the impact of this change?

hatch commands work again

### How was this change tested?

Ran hatch build with virtualenv<21 successfully

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
