### PR TITLE
docs: add AGENTS.md instruction to always sign commits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,7 @@ class _PrivateClass:  # Private
 ```
 
 ### Commit Messages
+Always sign commits with `git commit -s`.
 Use [conventional commits](https://www.conventionalcommits.org/):
 - `feat:` - New features
 - `fix:` - Bug fixes


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Agents forget to sign commits.

### What was the solution? (How)
Remind them

### What is the impact of this change?
Agents can raise PRs more independently

### How was this change tested?
n/a

### Was this change documented?
n/a

### Does this PR introduce new dependencies?
No

### Is this a breaking change?
No

### Does this change impact security?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
