### PR TITLE
fix: handle-web-url installs from command on PATH on linux

### DIFF
--- a/src/deadline/client/cli/_deadline_web_url.py
+++ b/src/deadline/client/cli/_deadline_web_url.py
@@ -184,10 +184,13 @@ def install_deadline_web_url_handler(all_users: bool) -> None:
                 f"Failed to install the handler for {DEADLINE_URL_SCHEME_NAME} URLs: update-desktop-database is not installed."
             )
 
-        # Get the CLI program path. Use shutil.which to resolve the full path when
-        # invoked via PATH (e.g. bare "deadline"), falling back to os.path.abspath
-        # for relative or absolute paths (e.g. "./deadline" or "/opt/bin/deadline").
-        deadline_cli_program = shutil.which(sys.argv[0]) or os.path.abspath(sys.argv[0])
+        # Resolve the full path to the CLI program via PATH lookup.
+        deadline_cli_program = shutil.which(sys.argv[0])
+        if not deadline_cli_program:
+            raise DeadlineOperationError(
+                f"Failed to install the handler for {DEADLINE_URL_SCHEME_NAME} URLs: "
+                f"could not find '{sys.argv[0]}' on PATH."
+            )
 
         if all_users:
             entry_dir = "/usr/share/applications"

--- a/src/deadline/client/cli/_deadline_web_url.py
+++ b/src/deadline/client/cli/_deadline_web_url.py
@@ -176,16 +176,18 @@ def install_deadline_web_url_handler(all_users: bool) -> None:
                 winreg.CloseKey(hkey)
 
     elif sys.platform == "linux":
-        import subprocess
         import shutil
+        import subprocess
 
         if shutil.which("update-desktop-database") is None:
             raise DeadlineOperationError(
                 f"Failed to install the handler for {DEADLINE_URL_SCHEME_NAME} URLs: update-desktop-database is not installed."
             )
 
-        # Get the CLI program path
-        deadline_cli_program = os.path.abspath(sys.argv[0])
+        # Get the CLI program path. Use shutil.which to resolve the full path when
+        # invoked via PATH (e.g. bare "deadline"), falling back to os.path.abspath
+        # for relative or absolute paths (e.g. "./deadline" or "/opt/bin/deadline").
+        deadline_cli_program = shutil.which(sys.argv[0]) or os.path.abspath(sys.argv[0])
 
         if all_users:
             entry_dir = "/usr/share/applications"
@@ -204,7 +206,6 @@ def install_deadline_web_url_handler(all_users: bool) -> None:
 Type=Application
 Name={DEADLINE_URL_SCHEME_NAME}
 Exec={deadline_cli_program} handle-web-url %u
-Type=Application
 Terminal=true
 MimeType=x-scheme-handler/{DEADLINE_URL_SCHEME_NAME}
 """
@@ -263,8 +264,8 @@ def uninstall_deadline_web_url_handler(all_users: bool) -> None:
                 winreg.CloseKey(hkey)
 
     elif sys.platform == "linux":
-        import subprocess
         import shutil
+        import subprocess
 
         if shutil.which("update-desktop-database") is None:
             raise DeadlineOperationError(

--- a/test/unit/deadline_client/cli/test_cli_handle_web_url.py
+++ b/test/unit/deadline_client/cli/test_cli_handle_web_url.py
@@ -5,6 +5,8 @@ Tests for the CLI handle-web-url command.
 """
 
 import os
+import shutil
+import subprocess
 import sys
 from typing import Dict, List
 from unittest.mock import ANY, MagicMock, call, patch
@@ -678,3 +680,78 @@ def test_cli_handle_web_url_uninstall_all_users_monkeypatched_windows(
             ]
         )
         assert result.output.strip() == ""
+
+
+def test_linux_install_generates_valid_desktop_file(fresh_deadline_config, tmp_path):
+    """
+    Tests that the generated .desktop file on Linux has the expected contents.
+    """
+    entry_dir = tmp_path / "applications"
+    entry_dir.mkdir()
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+
+    desktop_file_path = str(entry_dir / "deadline.desktop")
+
+    with patch.object(sys, "platform", "linux"), patch.object(
+        sys, "argv", ["/usr/bin/deadline"]
+    ), patch.object(
+        shutil, "which", side_effect=lambda cmd: cmd if os.sep in cmd else "/usr/bin/" + cmd
+    ), patch.object(
+        os.path,
+        "expanduser",
+        side_effect=lambda p: p.replace("~/.local/share", str(tmp_path)).replace(
+            "~/.config", str(config_dir)
+        ),
+    ), patch.object(subprocess, "run"), patch.object(os, "makedirs"):
+        from deadline.client.cli._deadline_web_url import install_deadline_web_url_handler
+
+        install_deadline_web_url_handler(all_users=False)
+
+    with open(desktop_file_path) as f:
+        desktop_content = f.read()
+    assert desktop_content == (
+        "[Desktop Entry]\n"
+        "Type=Application\n"
+        "Name=deadline\n"
+        "Exec=/usr/bin/deadline handle-web-url %u\n"
+        "Terminal=true\n"
+        "MimeType=x-scheme-handler/deadline\n"
+    )
+
+
+def test_linux_install_resolves_binary_path_via_shutil_which(fresh_deadline_config, tmp_path):
+    """
+    Tests that on Linux, when sys.argv[0] is a bare command name (e.g. 'deadline'),
+    the install resolves the full path using shutil.which rather than os.path.abspath.
+    """
+    entry_dir = tmp_path / "applications"
+    entry_dir.mkdir()
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+
+    desktop_file_path = str(entry_dir / "deadline.desktop")
+
+    def mock_which(cmd):
+        if cmd == "deadline":
+            return "/opt/deadline/bin/deadline"
+        return "/usr/bin/" + cmd
+
+    with patch.object(sys, "platform", "linux"), patch.object(
+        sys, "argv", ["deadline"]
+    ), patch.object(shutil, "which", side_effect=mock_which), patch.object(
+        os.path,
+        "expanduser",
+        side_effect=lambda p: p.replace("~/.local/share", str(tmp_path)).replace(
+            "~/.config", str(config_dir)
+        ),
+    ), patch.object(subprocess, "run"), patch.object(os, "makedirs"):
+        from deadline.client.cli._deadline_web_url import install_deadline_web_url_handler
+
+        install_deadline_web_url_handler(all_users=False)
+
+    with open(desktop_file_path) as f:
+        desktop_content = f.read()
+    assert "/opt/deadline/bin/deadline" in desktop_content, (
+        f"Expected resolved path in Exec line, got:\n{desktop_content}"
+    )

--- a/test/unit/deadline_client/cli/test_cli_handle_web_url.py
+++ b/test/unit/deadline_client/cli/test_cli_handle_web_url.py
@@ -695,9 +695,7 @@ def test_linux_install_generates_valid_desktop_file(fresh_deadline_config, tmp_p
 
     with patch.object(sys, "platform", "linux"), patch.object(
         sys, "argv", ["/usr/bin/deadline"]
-    ), patch.object(
-        shutil, "which", side_effect=lambda cmd: cmd if "/" in cmd else "/usr/bin/" + cmd
-    ), patch.object(
+    ), patch.object(shutil, "which", return_value="/usr/bin/deadline"), patch.object(
         os.path,
         "expanduser",
         side_effect=lambda p: p.replace("~/.local/share", str(tmp_path)).replace(
@@ -720,10 +718,10 @@ def test_linux_install_generates_valid_desktop_file(fresh_deadline_config, tmp_p
     )
 
 
-def test_linux_install_resolves_binary_path_via_shutil_which(fresh_deadline_config, tmp_path):
+def test_linux_install_resolves_bare_command_via_shutil_which(fresh_deadline_config, tmp_path):
     """
     Tests that on Linux, when sys.argv[0] is a bare command name (e.g. 'deadline'),
-    the install resolves the full path using shutil.which rather than os.path.abspath.
+    the install resolves the full path using shutil.which.
     """
     entry_dir = tmp_path / "applications"
     entry_dir.mkdir()
@@ -732,14 +730,15 @@ def test_linux_install_resolves_binary_path_via_shutil_which(fresh_deadline_conf
 
     desktop_file_path = str(entry_dir / "deadline.desktop")
 
-    def mock_which(cmd):
-        if cmd == "deadline":
-            return "/opt/deadline/bin/deadline"
-        return "/usr/bin/" + cmd
-
     with patch.object(sys, "platform", "linux"), patch.object(
         sys, "argv", ["deadline"]
-    ), patch.object(shutil, "which", side_effect=mock_which), patch.object(
+    ), patch.object(
+        shutil,
+        "which",
+        side_effect=lambda cmd: "/opt/deadline/bin/deadline"
+        if cmd == "deadline"
+        else "/usr/bin/" + cmd,
+    ), patch.object(
         os.path,
         "expanduser",
         side_effect=lambda p: p.replace("~/.local/share", str(tmp_path)).replace(
@@ -752,6 +751,21 @@ def test_linux_install_resolves_binary_path_via_shutil_which(fresh_deadline_conf
 
     with open(desktop_file_path) as f:
         desktop_content = f.read()
-    assert "/opt/deadline/bin/deadline" in desktop_content, (
-        f"Expected resolved path in Exec line, got:\n{desktop_content}"
-    )
+    assert "Exec=/opt/deadline/bin/deadline handle-web-url %u" in desktop_content
+
+
+def test_linux_install_raises_when_command_not_found(fresh_deadline_config, tmp_path):
+    """
+    Tests that on Linux, when shutil.which cannot find the command,
+    the install raises a DeadlineOperationError.
+    """
+    with patch.object(sys, "platform", "linux"), patch.object(
+        sys, "argv", ["deadline"]
+    ), patch.object(
+        shutil, "which", side_effect=lambda cmd: None if cmd == "deadline" else "/usr/bin/" + cmd
+    ):
+        from deadline.client.cli._deadline_web_url import install_deadline_web_url_handler
+        from deadline.client.exceptions import DeadlineOperationError
+
+        with pytest.raises(DeadlineOperationError, match="could not find 'deadline' on PATH"):
+            install_deadline_web_url_handler(all_users=False)

--- a/test/unit/deadline_client/cli/test_cli_handle_web_url.py
+++ b/test/unit/deadline_client/cli/test_cli_handle_web_url.py
@@ -735,9 +735,9 @@ def test_linux_install_resolves_bare_command_via_shutil_which(fresh_deadline_con
     ), patch.object(
         shutil,
         "which",
-        side_effect=lambda cmd: "/opt/deadline/bin/deadline"
-        if cmd == "deadline"
-        else "/usr/bin/" + cmd,
+        side_effect=lambda cmd: (
+            "/opt/deadline/bin/deadline" if cmd == "deadline" else "/usr/bin/" + cmd
+        ),
     ), patch.object(
         os.path,
         "expanduser",

--- a/test/unit/deadline_client/cli/test_cli_handle_web_url.py
+++ b/test/unit/deadline_client/cli/test_cli_handle_web_url.py
@@ -696,7 +696,7 @@ def test_linux_install_generates_valid_desktop_file(fresh_deadline_config, tmp_p
     with patch.object(sys, "platform", "linux"), patch.object(
         sys, "argv", ["/usr/bin/deadline"]
     ), patch.object(
-        shutil, "which", side_effect=lambda cmd: cmd if os.sep in cmd else "/usr/bin/" + cmd
+        shutil, "which", side_effect=lambda cmd: cmd if "/" in cmd else "/usr/bin/" + cmd
     ), patch.object(
         os.path,
         "expanduser",


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
On Linux, `deadline handle-web-url --install` detected the wrong path for the `deadline` command if `deadline` invoked via PATH instead of executed from an absolute or relative path. As a result, the handler did nothing.

### What was the solution? (How)
Update the path detection. Removed a duplicate `Type=Application` line.

### What is the impact of this change?
Fixes the URL handler when `deadline` is run via PATH.

### How was this change tested?
Added unit tests. Manually installed the URL handler when running `deadline` via PATH, clicked the Download job output button in DCM, and verified a terminal window popped up to download the outputs.

### Was this change documented?
n/a

### Does this PR introduce new dependencies?
No

### Is this a breaking change?
No

### Does this change impact security?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
