### PR TITLE
fix: prevent double .exe extension in handle-web-url --install

### DIFF
--- a/src/deadline/client/cli/_deadline_web_url.py
+++ b/src/deadline/client/cli/_deadline_web_url.py
@@ -124,13 +124,18 @@ def install_deadline_web_url_handler(all_users: bool) -> None:
     if sys.platform == "win32":
         import winreg
 
-        # Get the CLI program path, either an .exe or a .py with the Python interpreter
-        deadline_cli_program = os.path.abspath(sys.argv[0])
-        if deadline_cli_program.endswith(".py"):
-            deadline_cli_prefix = f'"{sys.executable}" "{deadline_cli_program}"'
-        else:
-            deadline_cli_program = deadline_cli_program + ".exe"
+        # Get the CLI program path
+        if getattr(sys, "frozen", False):
+            # PyInstaller frozen binary: sys.executable is the .exe itself
+            deadline_cli_program = sys.executable
             deadline_cli_prefix = f'"{deadline_cli_program}"'
+        else:
+            deadline_cli_program = os.path.abspath(sys.argv[0])
+            if deadline_cli_program.endswith(".py"):
+                deadline_cli_prefix = f'"{sys.executable}" "{deadline_cli_program}"'
+            else:
+                deadline_cli_program = deadline_cli_program + ".exe"
+                deadline_cli_prefix = f'"{deadline_cli_program}"'
 
         if not os.path.isfile(deadline_cli_program):
             raise DeadlineOperationError(

--- a/src/deadline/client/cli/_deadline_web_url.py
+++ b/src/deadline/client/cli/_deadline_web_url.py
@@ -4,6 +4,7 @@ import os
 import re
 import sys
 import urllib.parse
+from pathlib import Path
 from logging import getLogger
 from typing import Any, Dict, List
 
@@ -124,18 +125,14 @@ def install_deadline_web_url_handler(all_users: bool) -> None:
     if sys.platform == "win32":
         import winreg
 
-        # Get the CLI program path
-        if getattr(sys, "frozen", False):
-            # PyInstaller frozen binary: sys.executable is the .exe itself
-            deadline_cli_program = sys.executable
-            deadline_cli_prefix = f'"{deadline_cli_program}"'
-        else:
-            deadline_cli_program = os.path.abspath(sys.argv[0])
-            if deadline_cli_program.endswith(".py"):
-                deadline_cli_prefix = f'"{sys.executable}" "{deadline_cli_program}"'
-            else:
-                deadline_cli_program = deadline_cli_program + ".exe"
-                deadline_cli_prefix = f'"{deadline_cli_program}"'
+        # Get the CLI program path as a .exe. Handles both PyInstaller frozen
+        # binaries (sys.argv[0] is already "deadline.exe") and pip/uv console_scripts
+        # (sys.argv[0] is extensionless "deadline" but the actual file is .exe).
+        # with_suffix(".exe") is idempotent so both cases resolve correctly.
+        # The .exe path is required because the Windows registry shell handler
+        # won't resolve via PATHEXT like the shell does.
+        deadline_cli_program = str(Path(sys.argv[0]).resolve().with_suffix(".exe"))
+        deadline_cli_prefix = f'"{deadline_cli_program}"'
 
         if not os.path.isfile(deadline_cli_program):
             raise DeadlineOperationError(

--- a/test/unit/deadline_client/cli/test_cli_handle_web_url.py
+++ b/test/unit/deadline_client/cli/test_cli_handle_web_url.py
@@ -515,8 +515,8 @@ def test_cli_handle_web_url_install_frozen_exe(fresh_deadline_config, monkeypatc
 
         install_deadline_web_url_handler(all_users=False)
 
-    # Should use sys.executable directly, no .exe.exe
-    os.path.isfile.assert_called_once_with(exe_path)
+        # Should use sys.executable directly, no .exe.exe
+        os.path.isfile.assert_called_once_with(exe_path)
 
 
 @pytest.mark.parametrize("install_command", ["install", "uninstall"])

--- a/test/unit/deadline_client/cli/test_cli_handle_web_url.py
+++ b/test/unit/deadline_client/cli/test_cli_handle_web_url.py
@@ -493,9 +493,8 @@ def test_handle_web_url_require_url_or_install_option(fresh_deadline_config):
 
 def test_cli_handle_web_url_install_frozen_exe(fresh_deadline_config, monkeypatch):
     """
-    When running as a PyInstaller frozen binary, sys.frozen is True and
-    sys.executable is the .exe path. The handler should use it directly
-    without appending .exe.
+    When running as a PyInstaller frozen binary, sys.argv[0] is already
+    "deadline.exe". with_suffix(".exe") should be a no-op.
     """
     winreg_mock = MagicMock()
     monkeypatch.setitem(sys.modules, "winreg", winreg_mock)
@@ -503,9 +502,34 @@ def test_cli_handle_web_url_install_frozen_exe(fresh_deadline_config, monkeypatc
     exe_path = r"C:\Program Files\DeadlineClient\deadline.exe"
 
     with patch.object(sys, "platform", "win32"), patch.object(
-        sys, "frozen", True, create=True
-    ), patch.object(sys, "executable", exe_path), patch.object(
-        os.path, "isfile", return_value=True
+        sys, "argv", [exe_path]
+    ), patch.object(os.path, "isfile", return_value=True):
+        winreg_mock.HKEY_CURRENT_USER = "HKEY_CURRENT_USER"
+        winreg_mock.REG_SZ = "REG_SZ"
+        winreg_mock.CreateKeyEx.side_effect = ["FIRST_CREATED_KEY", "SECOND_CREATED_KEY"]
+
+        from deadline.client.cli._deadline_web_url import install_deadline_web_url_handler
+
+        install_deadline_web_url_handler(all_users=False)
+
+        # with_suffix(".exe") is a no-op when already .exe
+        os.path.isfile.assert_called_once_with(exe_path)
+
+
+def test_cli_handle_web_url_install_pip_console_script(fresh_deadline_config, monkeypatch):
+    """
+    When running from a pip/uv-installed console_script, sys.argv[0] is
+    extensionless (e.g. "deadline"). The handler should append .exe.
+    """
+    winreg_mock = MagicMock()
+    monkeypatch.setitem(sys.modules, "winreg", winreg_mock)
+
+    script_path = r"C:\Scripts\deadline"
+
+    with patch.object(sys, "platform", "win32"), patch.object(
+        sys, "argv", [script_path]
+    ), patch.object(os.path, "isfile", return_value=True), patch(
+        "os.path.abspath", return_value=script_path
     ):
         winreg_mock.HKEY_CURRENT_USER = "HKEY_CURRENT_USER"
         winreg_mock.REG_SZ = "REG_SZ"
@@ -515,8 +539,8 @@ def test_cli_handle_web_url_install_frozen_exe(fresh_deadline_config, monkeypatc
 
         install_deadline_web_url_handler(all_users=False)
 
-        # Should use sys.executable directly, no .exe.exe
-        os.path.isfile.assert_called_once_with(exe_path)
+        # Should append .exe to the extensionless console_script path
+        os.path.isfile.assert_called_once_with(script_path + ".exe")
 
 
 @pytest.mark.parametrize("install_command", ["install", "uninstall"])

--- a/test/unit/deadline_client/cli/test_cli_handle_web_url.py
+++ b/test/unit/deadline_client/cli/test_cli_handle_web_url.py
@@ -8,6 +8,7 @@ import os
 import shutil
 import subprocess
 import sys
+from pathlib import Path
 from typing import Dict, List
 from unittest.mock import ANY, MagicMock, call, patch
 
@@ -502,8 +503,9 @@ def test_cli_handle_web_url_install_frozen_exe(fresh_deadline_config, monkeypatc
     exe_path = r"C:\Program Files\DeadlineClient\deadline.exe"
 
     with patch.object(sys, "platform", "win32"), patch.object(sys, "argv", [exe_path]), patch(
-        "os.path.isfile", return_value=True
-    ) as isfile_mock:
+        "deadline.client.cli._deadline_web_url.Path.resolve",
+        return_value=Path(exe_path),
+    ), patch("os.path.isfile", return_value=True) as isfile_mock:
         winreg_mock.HKEY_CURRENT_USER = "HKEY_CURRENT_USER"
         winreg_mock.REG_SZ = "REG_SZ"
         winreg_mock.CreateKeyEx.side_effect = ["FIRST_CREATED_KEY", "SECOND_CREATED_KEY"]
@@ -527,8 +529,9 @@ def test_cli_handle_web_url_install_pip_console_script(fresh_deadline_config, mo
     script_path = r"C:\Scripts\deadline"
 
     with patch.object(sys, "platform", "win32"), patch.object(sys, "argv", [script_path]), patch(
-        "os.path.isfile", return_value=True
-    ) as isfile_mock:
+        "deadline.client.cli._deadline_web_url.Path.resolve",
+        return_value=Path(script_path),
+    ), patch("os.path.isfile", return_value=True) as isfile_mock:
         winreg_mock.HKEY_CURRENT_USER = "HKEY_CURRENT_USER"
         winreg_mock.REG_SZ = "REG_SZ"
         winreg_mock.CreateKeyEx.side_effect = ["FIRST_CREATED_KEY", "SECOND_CREATED_KEY"]

--- a/test/unit/deadline_client/cli/test_cli_handle_web_url.py
+++ b/test/unit/deadline_client/cli/test_cli_handle_web_url.py
@@ -491,6 +491,34 @@ def test_handle_web_url_require_url_or_install_option(fresh_deadline_config):
     assert result.exit_code != 0
 
 
+def test_cli_handle_web_url_install_frozen_exe(fresh_deadline_config, monkeypatch):
+    """
+    When running as a PyInstaller frozen binary, sys.frozen is True and
+    sys.executable is the .exe path. The handler should use it directly
+    without appending .exe.
+    """
+    winreg_mock = MagicMock()
+    monkeypatch.setitem(sys.modules, "winreg", winreg_mock)
+
+    exe_path = r"C:\Program Files\DeadlineClient\deadline.exe"
+
+    with patch.object(sys, "platform", "win32"), patch.object(
+        sys, "frozen", True, create=True
+    ), patch.object(sys, "executable", exe_path), patch.object(
+        os.path, "isfile", return_value=True
+    ):
+        winreg_mock.HKEY_CURRENT_USER = "HKEY_CURRENT_USER"
+        winreg_mock.REG_SZ = "REG_SZ"
+        winreg_mock.CreateKeyEx.side_effect = ["FIRST_CREATED_KEY", "SECOND_CREATED_KEY"]
+
+        from deadline.client.cli._deadline_web_url import install_deadline_web_url_handler
+
+        install_deadline_web_url_handler(all_users=False)
+
+    # Should use sys.executable directly, no .exe.exe
+    os.path.isfile.assert_called_once_with(exe_path)
+
+
 @pytest.mark.parametrize("install_command", ["install", "uninstall"])
 @pytest.mark.parametrize("all_users", [True, False])
 def test_cli_handle_web_url_install(fresh_deadline_config, install_command, all_users):

--- a/test/unit/deadline_client/cli/test_cli_handle_web_url.py
+++ b/test/unit/deadline_client/cli/test_cli_handle_web_url.py
@@ -501,9 +501,9 @@ def test_cli_handle_web_url_install_frozen_exe(fresh_deadline_config, monkeypatc
 
     exe_path = r"C:\Program Files\DeadlineClient\deadline.exe"
 
-    with patch.object(sys, "platform", "win32"), patch.object(
-        sys, "argv", [exe_path]
-    ), patch.object(os.path, "isfile", return_value=True):
+    with patch.object(sys, "platform", "win32"), patch.object(sys, "argv", [exe_path]), patch(
+        "os.path.isfile", return_value=True
+    ) as isfile_mock:
         winreg_mock.HKEY_CURRENT_USER = "HKEY_CURRENT_USER"
         winreg_mock.REG_SZ = "REG_SZ"
         winreg_mock.CreateKeyEx.side_effect = ["FIRST_CREATED_KEY", "SECOND_CREATED_KEY"]
@@ -513,7 +513,7 @@ def test_cli_handle_web_url_install_frozen_exe(fresh_deadline_config, monkeypatc
         install_deadline_web_url_handler(all_users=False)
 
         # with_suffix(".exe") is a no-op when already .exe
-        os.path.isfile.assert_called_once_with(exe_path)
+        isfile_mock.assert_called_once_with(exe_path)
 
 
 def test_cli_handle_web_url_install_pip_console_script(fresh_deadline_config, monkeypatch):
@@ -526,11 +526,9 @@ def test_cli_handle_web_url_install_pip_console_script(fresh_deadline_config, mo
 
     script_path = r"C:\Scripts\deadline"
 
-    with patch.object(sys, "platform", "win32"), patch.object(
-        sys, "argv", [script_path]
-    ), patch.object(os.path, "isfile", return_value=True), patch(
-        "os.path.abspath", return_value=script_path
-    ):
+    with patch.object(sys, "platform", "win32"), patch.object(sys, "argv", [script_path]), patch(
+        "os.path.isfile", return_value=True
+    ) as isfile_mock:
         winreg_mock.HKEY_CURRENT_USER = "HKEY_CURRENT_USER"
         winreg_mock.REG_SZ = "REG_SZ"
         winreg_mock.CreateKeyEx.side_effect = ["FIRST_CREATED_KEY", "SECOND_CREATED_KEY"]
@@ -540,7 +538,7 @@ def test_cli_handle_web_url_install_pip_console_script(fresh_deadline_config, mo
         install_deadline_web_url_handler(all_users=False)
 
         # Should append .exe to the extensionless console_script path
-        os.path.isfile.assert_called_once_with(script_path + ".exe")
+        isfile_mock.assert_called_once_with(script_path + ".exe")
 
 
 @pytest.mark.parametrize("install_command", ["install", "uninstall"])


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

When running from a PyInstaller binary, sys.argv[0] already ends with .exe (e.g. deadline.exe). The install_deadline_web_url_handler function unconditionally appended .exe, resulting in `deadline.exe.exe` which fails the `os.path.isfile` check.

### What was the solution? (How)
Add `.exe` only if it's not present on the path.

This change also drops support for using a Python script as the web handler. We'll support `deadline` being run from a Pyinstaller binary or a pip installed command.

### What is the impact of this change?
Fixes the `deadline handle-web-url --install` command on Windows from the installer.

### How was this change tested?
Ran the command from a pip install and from a Pyinstaller'd binary.

### Was this change documented?
n/a

### Does this PR introduce new dependencies?
No

### Is this a breaking change?
No

### Does this change impact security?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
