### PR TITLE
chore: manual installer builds were being skipped due to incorrect workflow name

### DIFF
--- a/.github/workflows/build_installers.yml
+++ b/.github/workflows/build_installers.yml
@@ -1,4 +1,4 @@
-name: "Deadline Cloud Client Build Installer"
+name: "Build Installers"
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Manual installer builds were being skipped unless it was the release environment. 
1. mainline env: https://github.com/aws-deadline/deadline-cloud/actions/runs/22638981328
2. release env: https://github.com/aws-deadline/deadline-cloud/actions/runs/22638459018

The re-usable workflow is defined here: https://github.com/aws-deadline/.github/blob/mainline/.github/workflows/reusable_build_installers.yml#L44. Specifically...

```yaml
      - name: Build Installer Manual (Non-Release)
        if: github.workflow == 'Build Installers' && inputs.environment != 'release'
        ...
      - name: Build Installer Manual (Release)
        if: github.workflow == 'Build Installers' && inputs.environment == 'release'
       ...
      - name: Build Installer Release
        if: github.workflow != 'Build Installers' && inputs.environment == 'release'
       ...
```

When doing doing the manual build with the release env, the bottom action was selected, which isn't correct since it should have been the middle one. And if you chose the mainline environment then all of them were skipped.

### What was the solution? (How)

Fix the name of the workflow in the deadline-cloud repo. This then matches all the other repos like deadline-cloud-for-blender which is working: https://github.com/aws-deadline/deadline-cloud-for-blender/actions/runs/22639585979/job/65611665013

### What is the impact of this change?

working manual installer builds

### How was this change tested?

Didn't

### Was this change documented?

N/A

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [ ] This PR does not add any new dependencies.

### Is this a breaking change?

N/A

### Does this change impact security?

N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
