### PR TITLE
chore: add submitter version to user agent string

### DIFF
--- a/src/deadline/client/api/_session.py
+++ b/src/deadline/client/api/_session.py
@@ -46,6 +46,7 @@ class AwsAuthenticationStatus(Enum):
 # Place for stashing context to be attached to boto clients.
 session_context: dict[str, Optional[str]] = {
     "submitter-name": None,
+    "submitter-version": None,
     "cli-command-name": None,
 }
 
@@ -121,7 +122,10 @@ def get_default_client_config(**kwargs) -> botocore.config.Config:
     """
     user_agent_extra = f"app/deadline-client#{version}"
     if session_context.get("submitter-name"):
-        user_agent_extra += f" submitter/{session_context['submitter-name']}"
+        submitter_extra = f" submitter/{session_context['submitter-name']}"
+        if session_context.get("submitter-version"):
+            submitter_extra += f"#{session_context['submitter-version']}"
+        user_agent_extra += submitter_extra
     if session_context.get("cli-command-name"):
         user_agent_extra += f" cli-command/{session_context['cli-command-name']}"
     client_config = botocore.config.Config(user_agent_extra=user_agent_extra, **kwargs)

--- a/src/deadline/client/api/_submit_job_bundle.py
+++ b/src/deadline/client/api/_submit_job_bundle.py
@@ -386,6 +386,7 @@ def create_job_from_job_bundle(
     target_task_run_status: Optional[str] = None,
     require_paths_exist: bool = False,
     submitter_name: Optional[str] = None,
+    submitter_version: Optional[str] = None,
     known_asset_paths: Collection[str] = [],
     debug_snapshot_dir: Optional[str] = None,
     from_gui: bool = False,
@@ -477,6 +478,7 @@ def create_job_from_job_bundle(
         submitter_name = "Custom"
 
     session_context["submitter-name"] = submitter_name
+    session_context["submitter-version"] = submitter_version
 
     # Ensure the job bundle doesn't contain files that resolve outside of the bundle directory
     validate_directory_symlink_containment(job_bundle_dir)

--- a/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
@@ -32,6 +32,7 @@ from .submit_job_progress_dialog import SubmitJobProgressDialog
 from ..dataclasses import HostRequirements
 from ...dataclasses import SubmitterInfo
 from ... import api
+from ...api._session import session_context as _session_context
 from ..deadline_authentication_status import DeadlineAuthenticationStatus
 from .._utils import block_signals, tr
 from ...config import get_setting, set_setting, config_file
@@ -139,6 +140,9 @@ class SubmitJobToDeadlineDialog(QDialog):
         self.submitter_info = submitter_info or SubmitterInfo(
             submitter_name=self.job_settings_type().submitter_name
         )
+        _session_context["submitter-name"] = self.submitter_info.submitter_name
+        _session_context["submitter-version"] = self.submitter_info.submitter_package_version
+
         self.on_create_job_bundle_callback = on_create_job_bundle_callback
         self.job_id = None
         self.job_history_bundle_dir: Optional[str] = None

--- a/test/unit/deadline_client/cli/test_cli.py
+++ b/test/unit/deadline_client/cli/test_cli.py
@@ -211,3 +211,37 @@ def test_context_tracking_command_sets_boto_user_agent_extra():
     config = get_default_client_config()
 
     assert "cli-command/main.subcommand.command" in config.user_agent_extra
+
+
+def test_submitter_version_in_user_agent():
+    """
+    Verifies that the submitter version is included in the user_agent_extra when set.
+    """
+    from deadline.client.api._session import session_context
+
+    # Save original state
+    original_context = session_context.copy()
+
+    try:
+        # Test: submitter name + version
+        session_context["submitter-name"] = "Blender"
+        session_context["submitter-version"] = "0.5.0"
+        session_context["cli-command-name"] = None
+        config = get_default_client_config()
+        assert "submitter/Blender#0.5.0" in config.user_agent_extra
+
+        # Test: submitter name only (no version)
+        session_context["submitter-name"] = "Blender"
+        session_context["submitter-version"] = None
+        config = get_default_client_config()
+        assert "submitter/Blender" in config.user_agent_extra
+        assert "submitter/Blender#" not in config.user_agent_extra
+
+        # Test: no submitter
+        session_context["submitter-name"] = None
+        session_context["submitter-version"] = None
+        config = get_default_client_config()
+        assert "submitter/" not in config.user_agent_extra
+    finally:
+        # Restore original state
+        session_context.update(original_context)


### PR DESCRIPTION
Add submitter package version to the user agent string for API calls.

### What was the problem/requirement? (What/Why)
- The user agent string for API calls (e.g., CreateJob) included the submitter name but not the submitter package version. Adding the version provides telemetry data for tracking which submitter versions are in use.

### What was the solution? (How)
- Added submitter-version to the session_context dictionary in _session.py
- Updated get_default_client_config() to append the version to the user agent as submitter/Name#Version (e.g., submitter/Cinema4D#0.9.2)
- Set session_context in SubmitJobToDeadlineDialog.__init__() to cover all GUI submitters (DCC submitters like Blender, Cinema 4D, etc. create the dialog directly)
- Added submitter_version parameter to create_job_from_job_bundle() for the API path

Submitters that already pass submitter_package_version via SubmitterInfo (e.g., Blender, Cinema 4D) will automatically get the version in the user agent without any changes on their side.

### What is the impact of this change?
The version will be appended in the telemetry information. 

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests? yes
- Have you run the integration tests? no 
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass.

- Unit test added in test_cli.py covering: name+version, name only, and no submitter cases. End-to-end verified with Cinema 4D submitter -  submitter/Cinema4D#0.9.2 is appended. 
```
"Boto3/1.42.59 md/Botocore#1.42.59 ua/2.1 os/macos#24.6.0 md/arch#arm64 lang/python#3.11.4 md/pyimpl#CPython m/b,D,Z cfg/retry-mode#legacy Botocore/1.42.59 app/deadline-client#0.54.1 submitter/Cinema4D#0.9.2"
```

### Was this change documented?

- Are relevant docstrings in the code base updated? 
- Has the README.md been updated? If you modified CLI arguments, for instance.
No CLI argument changes

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x ] This PR does not add any new dependencies.

### Is this a breaking change?

A breaking change is one that modifies a public contract in a way that is not backwards compatible. See the 
[Public Contracts](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#public-contracts) section
of the DEVELOPMENT.md for more information on the public contracts.

If so, then please describe the changes that users of this package must make to update their scripts, or Python applications.

No, the `submitter_version` parameter defaults to None.  Existing callers are unaffected. 

### Does this change impact security?

- Does the change need to be threat modeled? For example, does it create or modify files/directories that must only be readable by the process owner?
    - If so, then please label this pull request with the "security" label. We'll work with you to analyze the threats.
    
No, this change only modifies the user agent string metadata sent with API calls. 
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
