### PR TITLE
fix: Remove XFAIL from consistently passing test cases

### DIFF
--- a/test/integ/cli/test_cli_incremental_download.py
+++ b/test/integ/cli/test_cli_incremental_download.py
@@ -245,10 +245,6 @@ def test_incremental_download_many_small_files(incremental_download_test, tmp_pa
 
 @pytest.mark.integ
 @pytest.mark.timeout(1200)  # 20 minute timeout
-@pytest.mark.xfail(
-    reason="Edge case in scheduling step-step dependencies is sometimes causing timeouts",
-    strict=False,
-)
 def test_incremental_download_dep_data_flow(incremental_download_test, tmp_path):
     """Test incremental download with dep_data_flow template."""
 
@@ -426,9 +422,6 @@ def test_incremental_download_dependency_chain(incremental_download_test, tmp_pa
 
 @pytest.mark.integ
 @pytest.mark.timeout(1200)  # 20 minutes timeout, update step & task add latency
-@pytest.mark.xfail(
-    reason="Soft-fail until edge case is root caused and fixed in sync-output CLI", strict=False
-)
 @pytest.mark.parametrize("requeue_level", ["job", "step", "task"])
 def test_conflict_resolution_with_requeue(incremental_download_test, requeue_level, tmp_path):
     """Test incremental download with re-queuing at different levels and conflict resolution."""


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Three integration tests were marked with @pytest.mark.xfail due to edge cases causing intermittent failures:
- test_incremental_download_dep_data_flow
- test_conflict_resolution_with_requeue[step]
- test_conflict_resolution_with_requeue[task]

These tests have been passing consistently (100% XPASS) for 5 days, indicating the underlying issues have been resolved.

While investigating, I found 3 test cases that have been consistently passing.

5-day sweep IsenLink (Feb 26 → Mar 3, Windows canary)

The 3 XPASSing tests have been passing on every single run for the entire 5-day window — 137 XPASS out of 137 runs for these tests. The xfail markers are definitively stale.

Tests covered:

test_incremental_download_dep_data_flow — XPASS 100% of runs
test_conflict_resolution_with_requeue[step] — XPASS 100% of runs
test_conflict_resolution_with_requeue[task] — XPASS 100% of runs

### What was the solution? (How)

Removed the @pytest.mark.xfail decorators from both test functions so they run as regular tests.

### What is the impact of this change?

These tests will now fail the build if they regress, providing proper CI coverage.

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests? N/A - no unit test changes
- Have you run the integration tests? Tests have been monitored passing for 5 days
- Have you made changes to the download or asset_sync modules? No

### Was this change documented?

- Are relevant docstrings in the code base updated? N/A
- Has the README.md been updated? N/A

### Does this PR introduce new dependencies?

* [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#
dependencies).
* [x] This PR does not add any new dependencies.

### Is this a breaking change?

No.

### Does this change impact security?

No.
