### PR TITLE
[WIP] fix: Auto Accept downloads when triggered from deadline url handler

### DIFF
--- a/src/deadline/client/cli/_groups/handle_web_url_command.py
+++ b/src/deadline/client/cli/_groups/handle_web_url_command.py
@@ -124,6 +124,10 @@ def cli_handle_web_url(
             config = config_file.read_config()
             config_file.set_setting("defaults.aws_profile_name", aws_profile_name, config=config)
 
+            # handle-web-url is always launched non-interactively by the OS protocol handler
+            # (e.g. Deadline Cloud Monitor), so always auto-accept to avoid hanging on prompts.
+            config_file.set_setting("settings.auto_accept", "true", config=config)
+
             _download_job_output(config, farm_id, queue_id, job_id, step_id, task_id)
         else:
             raise DeadlineOperationError(

--- a/test/integ/cli/test_cli_incremental_download.py
+++ b/test/integ/cli/test_cli_incremental_download.py
@@ -245,10 +245,6 @@ def test_incremental_download_many_small_files(incremental_download_test, tmp_pa
 
 @pytest.mark.integ
 @pytest.mark.timeout(1200)  # 20 minute timeout
-@pytest.mark.xfail(
-    reason="Edge case in scheduling step-step dependencies is sometimes causing timeouts",
-    strict=False,
-)
 def test_incremental_download_dep_data_flow(incremental_download_test, tmp_path):
     """Test incremental download with dep_data_flow template."""
 
@@ -426,9 +422,6 @@ def test_incremental_download_dependency_chain(incremental_download_test, tmp_pa
 
 @pytest.mark.integ
 @pytest.mark.timeout(1200)  # 20 minutes timeout, update step & task add latency
-@pytest.mark.xfail(
-    reason="Soft-fail until edge case is root caused and fixed in sync-output CLI", strict=False
-)
 @pytest.mark.parametrize("requeue_level", ["job", "step", "task"])
 def test_conflict_resolution_with_requeue(incremental_download_test, requeue_level, tmp_path):
     """Test incremental download with re-queuing at different levels and conflict resolution."""

--- a/test/unit/deadline_client/cli/test_cli_handle_web_url.py
+++ b/test/unit/deadline_client/cli/test_cli_handle_web_url.py
@@ -378,6 +378,58 @@ def test_cli_handle_web_url_download_output_with_optional_input(fresh_deadline_c
         )
 
 
+def test_cli_handle_web_url_download_output_auto_accept(fresh_deadline_config):
+    """
+    Confirm that handle-web-url always auto-accepts prompts regardless of the user's
+    config setting, since it is always launched non-interactively by the OS protocol
+    handler (e.g. Deadline Cloud Monitor).
+    """
+    # Start with auto_accept disabled in config
+    set_setting("settings.auto_accept", "false")
+
+    with patch.object(api, "get_boto3_client") as boto3_client_mock, patch.object(
+        job_group, "OutputDownloader"
+    ) as MockOutputDownloader, patch.object(api, "get_queue_user_boto3_session"):
+        mock_download = MagicMock()
+        mock_download.return_value = DownloadSummaryStatistics(
+            total_time=12,
+            processed_files=3,
+            processed_bytes=1024,
+        )
+        MockOutputDownloader.return_value.download_job_output = mock_download
+        mock_host_path_format_name = PathFormat.get_host_path_format_string()
+
+        boto3_client_mock().get_job.return_value = {
+            "name": "Mock Job",
+            "attachments": {
+                "manifests": [
+                    {
+                        "rootPath": "/root/path",
+                        "rootPathFormat": PathFormat(mock_host_path_format_name),
+                        "outputRelativeDirectories": ["."],
+                    }
+                ],
+            },
+        }
+        boto3_client_mock().get_queue.side_effect = [MOCK_GET_QUEUE_RESPONSE]
+
+        # No auto-accept param in URL — the CLI should auto-accept unconditionally
+        web_url = (
+            f"deadline://download-output?farm-id={MOCK_FARM_ID}&queue-id={MOCK_QUEUE_ID}"
+            f"&job-id={MOCK_JOB_ID}"
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["handle-web-url", web_url])
+
+        assert result.exit_code == 0, result.output
+        # download should have proceeded without prompts despite auto_accept=false in config
+        mock_download.assert_called_once_with(
+            file_conflict_resolution=FileConflictResolution.CREATE_COPY,
+            on_downloading_files=ANY,
+        )
+
+
 def test_cli_handle_web_url_unsupported_protocol_scheme(fresh_deadline_config):
     """
     Tests that an error is returned when an unsupported url is passed to the handle-web-url command


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

When a user clicks "Download Output" in the Deadline Cloud Monitor, the monitor opens a `deadline://download-output?...` URL. The OS routes this to the `deadline handle-web-url` CLI command, which calls `_download_job_output()`. That function reads `settings.auto_accept` from the user's local config file (default: `false`), and when it is false, it blocks waiting for interactive prompts — but the process was launched non-interactively by the OS protocol handler, so there is no terminal for the user to respond to. The download would hang or fail silently.

The full call stack where interactive prompts were triggered:

```
OS protocol handler (deadline:// URL)
  └── deadline handle-web-url <url>                          # cli/_groups/handle_web_url_command.py: cli_handle_web_url()
        └── _download_job_output(config, farm_id, ...)       # cli/_groups/job_group.py: _download_job_output()
              └── auto_accept = config_file.str2bool(
                      config_file.get_setting("settings.auto_accept", config=config)
                  )                                          # reads user config, default False
              └── if not auto_accept:
                      click.prompt("> Please enter the index of root directory...")   # BLOCKS - no terminal
              └── if not auto_accept:
                      click.prompt("> Please enter your choice (1, 2, 3, or n...)")  # BLOCKS - no terminal
```

A secondary issue reported in the ticket: the `settings.auto_accept` config flag is also exposed as "Auto accept prompt defaults" in the submitter UI. Users who checked that box in the submitter unknowingly affected their monitor download behavior — and vice versa, users who had it off got stuck downloads from the monitor.

### What was the solution? (How)

`handle-web-url` is always launched non-interactively by the OS protocol handler (never from a terminal), so it should always auto-accept. Added a single line in `cli_handle_web_url` to unconditionally set `settings.auto_accept = true` on the in-memory config before calling `_download_job_output`:

```python
# handle-web-url is always launched non-interactively by the OS protocol handler
# (e.g. Deadline Cloud Monitor), so always auto-accept to avoid hanging on prompts.
config_file.set_setting("settings.auto_accept", "true", config=config)
```

This overrides the user's persisted config only for the duration of the URL-triggered download, without modifying the config file on disk.

### What is the impact of this change?

Downloads triggered via `deadline://download-output` (i.e. from Deadline Cloud Monitor) will no longer prompt interactively and will always proceed with default choices (download to the original root path, `CREATE_COPY` conflict resolution). This matches the expected monitor UX and is consistent with how the MCP tool already handles downloads.

No change to `deadline job download-output` CLI behavior — the `--yes` flag there continues to work as before.

### How was this change tested?

- [x] Unit tests — added `test_cli_handle_web_url_download_output_auto_accept` which verifies that a download triggered via `handle-web-url` completes successfully even when `settings.auto_accept=false` is set in the user's config. All 2193 unit tests pass.
- [ ] Integration tests — no integ tests exist for the URL handler.
- [ ] Docker-based unit tests — no changes to `download` or `asset_sync` modules.

### Was this change documented?

- No docstring changes needed — the behavior is self-evident from the inline comment added.
- No README/CLI argument changes — `handle-web-url` gains no new arguments.

### Does this PR introduce new dependencies?

- [x] This PR does not add any new dependencies.

### Is this a breaking change?

No. The `deadline://download-output` URL protocol gains no new required parameters. Existing URLs sent by the monitor continue to work unchanged.

### Does this change impact security?

No new files, directories, or permissions are created or modified. The change only affects the in-memory config for the duration of a URL-triggered download.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
