### PR TITLE
revert: "fix: Remove XFAIL from consistently passing test cases (#1024)"

### DIFF
--- a/test/integ/cli/test_cli_incremental_download.py
+++ b/test/integ/cli/test_cli_incremental_download.py
@@ -245,6 +245,10 @@ def test_incremental_download_many_small_files(incremental_download_test, tmp_pa
 
 @pytest.mark.integ
 @pytest.mark.timeout(1200)  # 20 minute timeout
+@pytest.mark.xfail(
+    reason="Edge case in scheduling step-step dependencies is sometimes causing timeouts",
+    strict=False,
+)
 def test_incremental_download_dep_data_flow(incremental_download_test, tmp_path):
     """Test incremental download with dep_data_flow template."""
 
@@ -422,6 +426,9 @@ def test_incremental_download_dependency_chain(incremental_download_test, tmp_pa
 
 @pytest.mark.integ
 @pytest.mark.timeout(1200)  # 20 minutes timeout, update step & task add latency
+@pytest.mark.xfail(
+    reason="Soft-fail until edge case is root caused and fixed in sync-output CLI", strict=False
+)
 @pytest.mark.parametrize("requeue_level", ["job", "step", "task"])
 def test_conflict_resolution_with_requeue(incremental_download_test, requeue_level, tmp_path):
     """Test incremental download with re-queuing at different levels and conflict resolution."""


### PR DESCRIPTION
This reverts commit 96f6afb78f1c0fe6f83d99e5a5f037d6064d96d2.

These tests are definitely still flakey, still need to put in effort to make them robust

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
