### PR TITLE
fix: Remove _ProgressBarCallbackManager import from Job Attachments

### DIFF
--- a/docs/design/progress-callback-decoupling.md
+++ b/docs/design/progress-callback-decoupling.md
@@ -1,0 +1,121 @@
+# Design: Progress Callback Decoupling from Job Attachments
+
+## Overview
+
+Decouple progress reporting from the Job Attachments library by removing its direct dependency on `_ProgressBarCallbackManager` from `deadline.client.cli`. Progress reporting is now an optional callback that callers provide, following dependency inversion.
+
+## Problem Statement
+
+`_create_manifest_for_single_root` in `job_attachments` had two upward dependencies into `deadline.client`:
+
+1. Imported `_ProgressBarCallbackManager` from `deadline.client.cli._common`
+2. Imported `_hash_attachments` from `deadline.client.api._job_attachment`
+
+This created a circular dependency: `job_attachments` is a lower-level library that `client.cli` consumes. Having it reach back up into `client.cli` for a UI concern (progress bars) violates the dependency hierarchy.
+
+```
+BEFORE (circular):
+
+deadline.client.cli.manifest_group
+        │
+        ▼
+deadline.job_attachments._create_manifest
+        │
+        ▼  (circular!)
+deadline.client.cli._common._ProgressBarCallbackManager
+deadline.client.api._job_attachment._hash_attachments
+```
+
+## Solution
+
+Apply dependency inversion: the lower-level library defines the callback interface, and the higher-level caller provides the implementation.
+
+```
+AFTER (clean):
+
+deadline.client.cli.manifest_group
+        │  creates _ProgressBarCallbackManager
+        │  passes .callback, telemetry_callback, and hash_cache_dir down
+        ▼
+deadline.job_attachments._create_manifest
+        │  accepts Optional[Callable[[ProgressReportMetadata], bool]]
+        │  accepts Optional[Callable[[SummaryStatistics], None]]
+        │  accepts Optional[str] for hash_cache_dir
+        ▼
+deadline.job_attachments.api._hashing._hash_attachments
+        │  (within job_attachments package)
+        ▼
+deadline.job_attachments.upload.S3AssetManager
+        │  hash_assets_and_create_manifest
+        ▼
+deadline.job_attachments.progress_tracker
+        (ProgressReportMetadata defined here)
+```
+
+## Key Changes
+
+| File | Change |
+|------|--------|
+| `job_attachments/asset_manifests/_create_manifest.py` | Removed imports of `_ProgressBarCallbackManager`. Added optional `hashing_progress_callback`, `telemetry_callback`, and `hash_cache_dir` parameters. Calls `_hash_attachments` from `job_attachments.api._hashing` (within the same package). |
+| `job_attachments/api/manifest.py` | Added `hashing_progress_callback`, `telemetry_callback`, and `hash_cache_dir` parameters to `_manifest_snapshot` and threads them through to `_create_manifest_for_single_root`. |
+| `client/cli/_groups/manifest_group.py` | Creates `_ProgressBarCallbackManager` and passes `.callback`, `hashing_telemetry_callback`, and `config_file.get_cache_directory()` to `_manifest_snapshot`. |
+
+## Callback Interface
+
+The callback uses the existing `ProgressReportMetadata` type already defined in `job_attachments.progress_tracker`:
+
+```python
+# Signature
+hashing_progress_callback: Optional[Callable[[ProgressReportMetadata], bool]] = None
+```
+
+- Input: `ProgressReportMetadata` with `status`, `progress` (%), `transferRate`, `progressMessage`, `processedFiles`
+- Return: `bool` — `True` to continue, `False` to cancel the operation
+- Default: `None` (no progress reporting, hashing proceeds silently)
+
+## Usage Examples
+
+### CLI caller (with progress bar and telemetry)
+```python
+from deadline.client.cli._common import _ProgressBarCallbackManager
+from deadline.client.api._submit_job_bundle import hashing_telemetry_callback
+
+hash_callback_manager = _ProgressBarCallbackManager(length=100, label="Hashing Attachments")
+
+_manifest_snapshot(
+    root=root,
+    # ...
+    hashing_progress_callback=hash_callback_manager.callback,
+    telemetry_callback=hashing_telemetry_callback,
+    hash_cache_dir=config_file.get_cache_directory(),
+)
+```
+
+### Library caller (no progress reporting)
+```python
+# Simply omit the callback — hashing runs silently
+_manifest_snapshot(
+    root=root,
+    # ...
+)
+```
+
+### Custom caller (e.g. GUI or logging)
+```python
+def my_progress_handler(metadata: ProgressReportMetadata) -> bool:
+    print(f"{metadata.progress}% - {metadata.progressMessage}")
+    return True  # continue
+
+_manifest_snapshot(
+    root=root,
+    # ...
+    hashing_progress_callback=my_progress_handler,
+)
+```
+
+## Design Principles
+
+- **Dependency inversion**: Lower-level modules define interfaces, higher-level modules provide implementations
+- **Optional by default**: Progress reporting is opt-in. Callers that don't need it pay no cost
+- **Existing types**: Uses `ProgressReportMetadata` already defined in `job_attachments.progress_tracker` — no new types introduced
+- **Cancellation support**: The `bool` return value preserves the existing cancellation mechanism

--- a/src/deadline/client/cli/_groups/manifest_group.py
+++ b/src/deadline/client/cli/_groups/manifest_group.py
@@ -45,7 +45,11 @@ from deadline.job_attachments.models import (
 )
 
 from ...exceptions import NonValidInputError
-from .._common import _apply_cli_options_to_config, _handle_error
+from .._common import (
+    _apply_cli_options_to_config,
+    _handle_error,
+    _ProgressBarCallbackManager,
+)
 from .._main import deadline as main
 from .click_logger import ClickLogger
 
@@ -152,8 +156,11 @@ def manifest_snapshot(
         diff=diff,
         force_rehash=force_rehash,
         print_function_callback=logger.echo,
-        hash_cache_dir=hash_cache_dir,
+        hashing_progress_callback=_ProgressBarCallbackManager(
+            length=100, label="Hashing Attachments"
+        ).callback,
         telemetry_callback=hashing_telemetry_callback,
+        hash_cache_dir=hash_cache_dir,
     )
     if manifest_out:
         if (

--- a/src/deadline/job_attachments/api/manifest.py
+++ b/src/deadline/job_attachments/api/manifest.py
@@ -43,8 +43,9 @@ from deadline.job_attachments.models import (
     default_glob_all,
     AssetType,
 )
+from deadline.job_attachments.progress_tracker import ProgressReportMetadata
 from deadline.job_attachments._utils import _get_long_path_compatible_path
-from deadline.job_attachments.upload import S3AssetManager, S3AssetUploader
+from deadline.job_attachments.upload import S3AssetManager, S3AssetUploader, SummaryStatistics
 
 """
 APIs here should be business logic only. It should perform one thing, and one thing well. 
@@ -95,8 +96,9 @@ def _manifest_snapshot(
     diff: Optional[str] = None,
     force_rehash: bool = False,
     print_function_callback: Callable[[Any], None] = lambda msg: None,
+    hashing_progress_callback: Optional[Callable[[ProgressReportMetadata], bool]] = None,
+    telemetry_callback: Optional[Callable[[SummaryStatistics], None]] = None,
     hash_cache_dir: Optional[str] = None,
-    telemetry_callback: Optional[Callable] = None,
 ) -> Optional[ManifestSnapshot]:
     # Get all files in the root.
     glob_config: GlobConfig
@@ -120,8 +122,9 @@ def _manifest_snapshot(
             files=current_files,
             root=root,
             print_function_callback=print_function_callback,
-            hash_cache_dir=hash_cache_dir,
+            hashing_progress_callback=hashing_progress_callback,
             telemetry_callback=telemetry_callback,
+            hash_cache_dir=hash_cache_dir,
         )
         if not output_manifest:
             return None
@@ -155,8 +158,9 @@ def _manifest_snapshot(
                 files=current_files,
                 root=root,
                 print_function_callback=print_function_callback,
-                hash_cache_dir=hash_cache_dir,
+                hashing_progress_callback=hashing_progress_callback,
                 telemetry_callback=telemetry_callback,
+                hash_cache_dir=hash_cache_dir,
             )
             if not output_manifest:
                 return None
@@ -180,8 +184,9 @@ def _manifest_snapshot(
             files=changed_paths,
             root=root,
             print_function_callback=print_function_callback,
-            hash_cache_dir=hash_cache_dir,
+            hashing_progress_callback=hashing_progress_callback,
             telemetry_callback=telemetry_callback,
+            hash_cache_dir=hash_cache_dir,
         )
         if not output_manifest:
             return None

--- a/src/deadline/job_attachments/asset_manifests/_create_manifest.py
+++ b/src/deadline/job_attachments/asset_manifests/_create_manifest.py
@@ -3,7 +3,8 @@
 from typing import Any, Callable, List, Optional
 
 from deadline.job_attachments.asset_manifests.base_manifest import BaseAssetManifest
-from deadline.job_attachments.upload import S3AssetManager
+from deadline.job_attachments.progress_tracker import ProgressReportMetadata
+from deadline.job_attachments.upload import S3AssetManager, SummaryStatistics
 
 from ...job_attachments.api._hashing import _hash_attachments
 
@@ -13,22 +14,21 @@ def _create_manifest_for_single_root(
     files: List[str],
     root: str,
     print_function_callback: Callable[[Any], None] = lambda msg: None,
+    hashing_progress_callback: Optional[Callable[[ProgressReportMetadata], bool]] = None,
+    telemetry_callback: Optional[Callable[[SummaryStatistics], None]] = None,
     hash_cache_dir: Optional[str] = None,
-    telemetry_callback: Optional[Callable] = None,
 ) -> Optional[BaseAssetManifest]:
     """
     Shared logic to create a manifest file from a single root.
     :param files: Input files to create a manifest with.
     :param root: Asset root of the files.
-    :param logger: Click logger for stdout.
-    :return
+    :param print_function_callback: Callback for printing status messages.
+    :param hashing_progress_callback: Optional callback for hashing progress updates.
+    :param telemetry_callback: Optional callback for hashing telemetry reporting.
+    :param hash_cache_dir: Optional directory for the hash cache.
+    :return: The generated manifest, or None if no manifest was generated.
     """
-    # Placeholder Asset Manager
     asset_manager = S3AssetManager()
-
-    from deadline.client.cli._common import _ProgressBarCallbackManager
-
-    hash_callback_manager = _ProgressBarCallbackManager(length=100, label="Hashing Attachments")
 
     upload_group = asset_manager.prepare_paths_for_upload(
         input_paths=files, output_paths=[root], referenced_paths=[]
@@ -36,6 +36,7 @@ def _create_manifest_for_single_root(
     # We only provided 1 root path, so output should only have 1 group.
     assert len(upload_group.asset_groups) == 1
 
+    manifests = None
     if upload_group.asset_groups:
         _, manifests = _hash_attachments(
             asset_manager=asset_manager,
@@ -43,7 +44,7 @@ def _create_manifest_for_single_root(
             total_input_files=upload_group.total_input_files,
             total_input_bytes=upload_group.total_input_bytes,
             print_function_callback=print_function_callback,
-            hashing_progress_callback=hash_callback_manager.callback,
+            hashing_progress_callback=hashing_progress_callback,
             hash_cache_dir=hash_cache_dir,
             telemetry_callback=telemetry_callback,
         )


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
In _create_manifest.py we import _ProgressBarCallbackManager from client/cli/_common.py . The callback manager itself should instead by created in the client code and the callback itself should be passed into the function as an optional argument. Because it is an optional argument this change doesn’t break the interface. The function itself is also underscored so this is not a breaking change.

### What was the solution? (How)
Remove the circular dependency where Job Attachments imports _ProgressBarCallbackManager from deadline.client.cli._common.

### What is the impact of this change?
The callback is now an optional parameter that callers can provide if they want progress reporting during hashing operations. The client CLI now creates the progress bar and passes it to Job Attachments.


### How was this change tested?
- Have you run the unit tests?
```
=================================================================== slowest 5 durations ====================================================================
3.67s call     test/unit/deadline_job_attachments/test_upload.py::TestUpload::test_asset_management_many_inputs[2023-03-03-200]
2.89s call     test/unit/deadline_job_attachments/caches/test_caches.py::TestCacheDB::test_enter_bad_cache_path_throws_error
2.88s call     test/unit/deadline_job_attachments/caches/test_caches.py::TestCacheDB::test_enter_retries_on_operational_error
2.51s call     test/unit/deadline_job_attachments/caches/test_caches.py::TestCacheDB::test_get_local_connection_retries_on_operational_error
2.45s call     test/unit/deadline_job_attachments/caches/test_caches.py::TestCacheDB::test_get_local_connection_handles_sqlite_error
====================================================== 2134 passed, 111 skipped, 1 xfailed in 29.18s =======================================================
```
- Have you run the integration tests?
```

===================================== slowest 5 durations =====================================
609.25s call     test/integ/cli/test_cli_incremental_download.py::test_incremental_download_dependency_chain
439.30s call     test/integ/cli/test_cli_incremental_download.py::test_incremental_download_dep_data_flow
429.89s call     test/integ/cli/test_cli_incremental_download.py::test_conflict_resolution_with_requeue[job]
300.12s call     test/integ/cli/test_cli_incremental_download.py::test_conflict_resolution_with_requeue[task]
296.95s call     test/integ/cli/test_cli_incremental_download.py::test_conflict_resolution_with_requeue[step]
============== 56 passed, 4 skipped, 1 xfailed, 4 xpassed in 2412.38s (0:40:12) ===============

```
- Manual testing
```
(deadline) stangch@842f5790e719 deadline-cloud-fork % which deadline
/Users/stangch/Library/Application Support/hatch/env/virtual/deadline/QDkx7YNw/deadline/bin/deadline

(deadline) stangch@842f5790e719 deadline-cloud-fork % deadline manifest snapshot --root /Users/stangch/Desktop
Manifest creation path defaulted to /Users/stangch/Desktop 

Hashing Attachments  [####################################]  100%          
Manifest generated at /Users/stangch/Desktop/Users_stangch_Desktop-8f1308277de39e6a541aa86d9fa07bf9-2026-03-17T09-57-56.manifest
```
### Was this change documented?

- Are relevant docstrings in the code base updated?
- Has the README.md been updated? If you modified CLI arguments, for instance.

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?
Not a breaking change; this codepath only affects the CLI command `deadline manifest snapshot`. Users see no difference, everything works the same.
The modified functions (_create_manifest_for_single_root and _manifest_snapshot) are both underscore-prefixed, meaning they're private/internal APIs. The new hashing_progress_callback parameter is optional with a default of None, so existing callers continue to work without modification.

### Does this change impact security?

N/A
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
