### PR TITLE
feat!: add storage profile path mapping to job download-output

### DIFF
--- a/docs/design/storage-profile-cli-support.md
+++ b/docs/design/storage-profile-cli-support.md
@@ -334,7 +334,7 @@ Both download commands already handle path mapping at the CLI layer using `_Path
 - `queue sync-output` transforms every individual file path (joins `rootPath + relativePath`, then calls `strict_transform()`) inside `_download_all_manifests_with_absolute_paths()`. It does not use `OutputDownloader` at all — it has its own manifest-based download pipeline.
 - `job download-output` (this proposal) transforms root paths via `OutputDownloader.set_root_path()`, then `OutputDownloader` joins root + relative internally during download.
 
-These are equivalent in outcome because each manifest has a single root path — transforming the root produces the same final absolute paths as transforming each `root + relative` individually. The proposed approach uses `set_root_path()` because `download-output` already depends on `OutputDownloader`, and rewriting it to use the manifest pipeline would be a larger change with no functional benefit.
+These are equivalent in outcome because each manifest has a single root path — transforming the root produces the same final absolute paths as transforming each `root + relative` individually. **Update (§13):** This equivalence only holds when all rules match exactly at the root level. With nested file system locations, a rule can match deeper than the root, and root-only transformation would miss it. The implementation now uses absolute-path transformation (joining root + relative before applying rules) when path mapping rules exist, matching `sync-output` behavior. See §13 for details.
 
 Since both download commands handle path mapping externally using the same trie, this TODO is stale and should be removed as part of Stage 3 (§8.3). `OutputDownloader` remains a download-only concern with no path mapping responsibility.
 
@@ -923,3 +923,86 @@ Storage profile affects path grouping during upload:
 
 - `hash_assets_and_create_manifest()` hashes files using xxHash XXH128 with a SQLite-backed cache
 - `upload_assets()` uploads to S3 using Content-Addressable Storage (CAS), with an S3CheckCache to prevent redundant uploads
+
+
+---
+
+## 13. Revision: Absolute-Path Transformation (Option E)
+
+### 13.1 Problem
+
+During code review, @mwiebe identified that transforming only root paths via `set_root_path()` is not equivalent to transforming full absolute paths (`root + relative`). A path mapping rule can match at a depth deeper than the asset root. For example, with nested file system locations:
+
+**Source profile (Windows):**
+- "Projects": `C:\Projects`
+- "SpecialProjects": `C:\Projects\Special`
+
+**Destination profile (Linux):**
+- "Projects": `/mnt/projects`
+- "SpecialProjects": `/opt/special`
+
+Asset root: `C:\Projects`, relative path: `Special\data.txt`.
+
+- Root-only: transforms `C:\Projects` → `/mnt/projects`. Final: `/mnt/projects/Special/data.txt`. **Wrong.**
+- Absolute-path: transforms `C:\Projects\Special\data.txt` → `/opt/special/data.txt`. **Correct** (more specific rule wins).
+
+The Deadline Cloud API does not prevent nested file system locations in storage profiles, so this is a real scenario.
+
+### 13.2 Solution: Option E — Dual Code Path
+
+When path mapping rules exist (both profiles resolved, rules generated), bypass `OutputDownloader` and use the manifest-based download pipeline directly — the same approach `queue sync-output` uses:
+
+1. Call `get_output_manifests_by_asset_root()` to fetch manifests from S3 (same data `OutputDownloader.__init__` fetches internally)
+2. For each manifest path, join `root + relative` using the source OS path module (`ntpath` or `posixpath`)
+3. Call `strict_transform()` on the full absolute path (trie picks the most specific matching rule)
+4. Download via `download_files_from_manifests()` with the transformed absolute paths
+
+When no path mapping rules exist (no profiles, ignore flag, same profile, mismatch warnings), the existing `OutputDownloader` code path is completely unchanged.
+
+### 13.3 Implementation
+
+**New function:** `_transform_manifests_to_absolute_paths()` in `_job_download_helpers.py`
+
+```python
+def _transform_manifests_to_absolute_paths(
+    manifests_by_root: dict[str, list[Any]],
+    rules: list[PathMappingRule],
+    source_os_family: StorageProfileOperatingSystemFamily,
+) -> dict[str, Any]:
+```
+
+- Joins root + relative using `ntpath` (Windows source) or `posixpath` (POSIX source)
+- Applies `strict_transform()` on each absolute path
+- Merges all manifests into a single result keyed by `""` (empty string)
+- `download_files_from_manifests()` with key `""` works because `Path("").joinpath("/abs/path")` == `Path("/abs/path")`
+
+**Updated flow in `_download_job_output()`:**
+
+```
+resolved = _resolve_storage_profiles(...)
+if resolved:
+    rules = _generate_path_mapping_rules(...)
+    if rules:
+        manifests = get_output_manifests_by_asset_root(...)  # same S3 data
+        mapped = _transform_manifests_to_absolute_paths(manifests, rules, ...)
+        download_files_from_manifests(mapped)                # absolute-path download
+        return  # early return, skip OutputDownloader path
+    elif different profiles:
+        warn about no matching location names
+else:
+    # existing OutputDownloader path (manual prompt, etc.) — unchanged
+```
+
+### 13.4 Test Coverage
+
+New unit tests in `test_job_download_helpers.py`:
+
+| Test | Description |
+|------|-------------|
+| `test_basic_windows_to_posix_mapping` | Standard cross-OS mapping via absolute paths |
+| `test_nested_location_picks_most_specific_rule` | Key case: nested locations, most specific rule wins |
+| `test_unmapped_paths_are_skipped` | Paths without matching rules are excluded |
+| `test_multiple_roots_merged` | Multiple asset roots merged into single download |
+| `test_empty_manifests_returns_empty` | Edge case: no paths to map |
+
+Updated CLI test `test_case1_both_profiles_match_auto_mapping` to verify the new code path calls `get_output_manifests_by_asset_root` instead of `set_root_path`.

--- a/docs/design/storage-profile-cli-support.md
+++ b/docs/design/storage-profile-cli-support.md
@@ -1,0 +1,925 @@
+# Storage Profile Support in CLI Commands
+
+## 1. Issue Reference
+GitHub Issue: [#829 - Enhancement: job attachments interface does not use storage profiles by default](https://github.com/aws-deadline/deadline-cloud/issues/829)
+
+## 2. Executive Summary
+
+This document provides an analysis of how storage profiles are used throughout the deadline-cloud CLI, tracing code paths from CLI commands down to file hashing and S3 upload/download operations. The goal is to identify gaps in storage profile support and propose enhancements.
+
+---
+
+## 3. Background
+
+### 3.1 Storage Profile Configuration
+
+Storage profiles are configured in `~/.deadline/config` under the setting `settings.storage_profile_id`. A storage profile describes the current host's file system layout (shared mount points, local scratch paths, OS family). It is scoped under `farm_id` rather than `queue_id` because the host is the same regardless of which queue it accesses within a farm. The configuration hierarchy is:
+
+```
+defaults.aws_profile_name
+  └── defaults.farm_id
+        └── settings.storage_profile_id  (depends on farm_id, not queue — host is the same across queues)
+        └── defaults.queue_id
+```
+
+**Source:** `src/deadline/client/config/config_file.py:83-87`
+
+### 3.2 CLI Commands with Storage Profile Support
+
+| Command | `--storage-profile-id` | `--ignore-storage-profiles` | Notes |
+|---------|:----------------------:|:---------------------------:|-------|
+| `deadline bundle submit` | ✅ | N/A | Reads `settings.storage_profile_id` from config or `--storage-profile-id` CLI option. Passed to `create_job_from_job_bundle()` which attaches it to the CreateJob API call and uses it for path grouping during upload. If not set, submission proceeds without a storage profile. No ignore flag needed — uploads don't require path mapping. |
+| `deadline bundle gui-submit` | N/A | N/A | GUI auto-populates a storage profile dropdown by listing profiles for the selected queue, filtered to the current OS. Pre-selects from `settings.storage_profile_id` in config. User can change selection before submitting. No ignore flag needed — uploads don't require path mapping. |
+| `deadline queue sync-output` | ✅ | ✅ | Full support (reference implementation). See §4.2 for code details. |
+| `deadline job download-output` | ❌ | ❌ | **Gap — prompts for manual path entry on OS mismatch** |
+
+### 3.3 Existing `--ignore-storage-profiles` Implementation
+
+The `deadline queue sync-output` command already implements `--ignore-storage-profiles`:
+
+**File:** `src/deadline/client/cli/_groups/queue_group.py:282-290`
+
+```python
+@click.option(
+    "--ignore-storage-profiles",
+    is_flag=True,
+    help="Ignores the storage profile configuration. Only use if all jobs in the queue "
+         "are submitted and downloaded from the same machine. Downloads all jobs to "
+         "unmapped paths regardless of operating system.\n"
+         "Default value is False.",
+    default=False,
+)
+```
+
+This option is used when:
+- All jobs are submitted and downloaded from the **same machine**
+- No path mapping is needed (same OS, same mount points)
+- Downloads go to the original unmapped paths
+
+The proposal is to extend this existing pattern to `deadline job download-output`.
+
+For a code deep dive into the upload path (job submission), see §12 (Appendix C).
+
+---
+
+## 4. Download Code Path
+
+### 4.1 `deadline job download-output` (Single Job)
+
+**File:** `src/deadline/client/cli/_groups/job_group.py:911-985`
+
+```
+CLI Command (job_download_output)
+    │
+    ├── No --storage-profile-id option!
+    │
+    └── _download_job_output()
+            │
+            ├── deadline.get_job() → get attachments metadata
+            │
+            ├── OutputDownloader.__init__()
+            │       └── get_job_output_paths_by_asset_root()
+            │
+            ├── OS Mismatch Detection:
+            │       │
+            │       └── If rootPathFormat != host format:
+            │               └── PROMPT USER for new root path (manual entry)
+            │
+            └── OutputDownloader.download_job_output()
+```
+
+#### 4.1.1 Current OS Mismatch Handling (Lines 570-595)
+
+```python
+# Check if the asset roots came from different OS
+for asset_root in asset_roots:
+    root_path_format = root_path_format_mapping.get(asset_root, "")
+    if PathFormat.get_host_path_format_string() != root_path_format:
+        click.echo(_get_mismatch_os_root_warning(...))
+        
+        # Manual prompt - NO storage profile support!
+        new_root = click.prompt(
+            "> Please enter a new root path",
+            type=click.Path(exists=False),
+        )
+        job_output_downloader.set_root_path(asset_root, os.path.expanduser(new_root))
+```
+
+**This is the gap identified in issue #829** - no automatic path mapping via storage profiles.
+
+### 4.2 `deadline queue sync-output` — Reference Implementation
+
+This is the reference implementation for storage profile support in a download command. The proposed changes in §8 follow this same pattern for `job download-output`.
+
+**File:** `src/deadline/client/cli/_groups/queue_group.py:257-420`
+
+```
+CLI Command (sync_output)
+    │
+    ├── --storage-profile-id option ✅
+    ├── --ignore-storage-profiles option ✅
+    │
+    ├── Validate storage profile exists
+    │
+    └── _incremental_output_download()
+```
+
+#### 4.2.1 Storage Profile Validation (Lines 360-385)
+
+```python
+if ignore_storage_profiles:
+    local_storage_profile_id = None
+else:
+    local_storage_profile_id = config_file.get_setting(
+        "settings.storage_profile_id", config=config
+    )
+    if not local_storage_profile_id:
+        raise DeadlineOperationError(
+            "The sync-output operation requires a storage profile..."
+        )
+    
+    # Validate profile exists
+    local_storage_profile = deadline.get_storage_profile_for_queue(
+        farmId=farm_id,
+        queueId=queue_id,
+        storageProfileId=local_storage_profile_id,
+    )
+```
+
+### 4.3 Incremental Download Implementation
+
+**File:** `src/deadline/client/cli/_incremental_download.py`
+
+```
+_incremental_output_download()
+    │
+    ├── _get_download_candidate_jobs()
+    │       └── SearchJobs API to find jobs with outputs
+    │
+    ├── _categorize_jobs_in_checkpoint()
+    │       └── Categorize jobs: added, updated, unchanged, completed, etc.
+    │
+    ├── _get_job_sessions()
+    │       └── ListSessions API for each job
+    │
+    ├── _get_storage_profiles()
+    │       └── GetStorageProfileForQueue for each unique profile
+    │
+    ├── _create_path_mapping_rule_appliers()
+    │       │
+    │       └── For each job's storage profile:
+    │               │
+    │               └── _generate_path_mapping_rules(
+    │                       source_storage_profile=job_profile,
+    │                       destination_storage_profile=local_profile
+    │                   )
+    │
+    └── Download with path mapping applied
+```
+
+### 4.4 Path Mapping Implementation
+
+**File:** `src/deadline/job_attachments/_path_mapping.py`
+
+#### 4.4.1 Rule Generation
+
+```python
+def _generate_path_mapping_rules(
+    source_storage_profile: dict[str, Any],
+    destination_storage_profile: dict[str, Any],
+) -> list[PathMappingRule]:
+    # If same profile, no mapping needed
+    if source_storage_profile["storageProfileId"] == \
+       destination_storage_profile["storageProfileId"]:
+        return []
+    
+    # Match file system locations by NAME
+    source_locations = {loc["name"]: loc for loc in source_storage_profile["fileSystemLocations"]}
+    dest_locations = {loc["name"]: loc for loc in destination_storage_profile["fileSystemLocations"]}
+    
+    # Generate rules for matching names
+    for source_name, source_loc in source_locations.items():
+        if source_name in dest_locations:
+            rules.append(PathMappingRule(
+                source_path_format,
+                source_loc["path"],
+                dest_locations[source_name]["path"],
+            ))
+```
+
+#### 4.4.2 Rule Application (Trie-based)
+
+```python
+class _PathMappingRuleApplier:
+    """
+    Uses a trie data structure for efficient path transformation.
+    
+    Example rules:
+        '/mnt/Projects -> X:\\Projects'
+        '/mnt/Projects/Special -> Y:\\'
+    
+    Path '/mnt/Projects/Special/data.txt' maps to 'Y:\\data.txt'
+    (most specific rule wins)
+    """
+```
+
+### 4.5 Download File Operations
+
+**File:** `src/deadline/job_attachments/download.py`
+
+#### 4.5.1 OutputDownloader Class (Lines 1231-1377)
+
+```python
+class OutputDownloader:
+    def __init__(
+        self,
+        s3_settings: JobAttachmentS3Settings,
+        farm_id: str,
+        queue_id: str,
+        job_id: str,
+        step_id: Optional[str] = None,
+        task_id: Optional[str] = None,
+        session_action_id: Optional[str] = None,
+        session: Optional[boto3.Session] = None,
+    ) -> None:
+        # NOTE: No storage_profile parameter!
+        self.outputs_by_root = get_job_output_paths_by_asset_root(...)
+```
+
+#### 4.5.2 File Download (Lines 695-725)
+
+```python
+def download_files(
+    files: list[RelativeFilePath],
+    hash_algorithm: HashAlgorithm,
+    local_download_dir: str,
+    s3_settings: JobAttachmentS3Settings,
+    session: Optional[boto3.Session] = None,
+    progress_tracker: Optional[ProgressTracker] = None,
+    file_conflict_resolution: Optional[FileConflictResolution] = ...,
+) -> list[str]:
+    # Parallel download using ThreadPoolExecutor
+    return _download_files_parallel(...)
+```
+
+---
+
+## 5. Data Models
+
+### 5.1 StorageProfile
+
+**File:** `src/deadline/job_attachments/models.py:451-465`
+
+```python
+@dataclass
+class StorageProfile:
+    storageProfileId: str
+    displayName: str
+    osFamily: StorageProfileOperatingSystemFamily  # WINDOWS, LINUX, MACOS
+    fileSystemLocations: List[FileSystemLocation]
+```
+
+### 5.2 FileSystemLocation
+
+**File:** `src/deadline/job_attachments/models.py:469-478`
+
+```python
+@dataclass
+class FileSystemLocation:
+    name: str   # Logical name (e.g., "ProjectFiles")
+    path: str   # Physical path (e.g., "/mnt/projects" or "X:\\Projects")
+    type: FileSystemLocationType  # SHARED or LOCAL
+```
+
+### 5.3 PathMappingRule
+
+```python
+@dataclass
+class PathMappingRule:
+    source_path_format: str  # "posix" or "windows"
+    source_path: str
+    destination_path: str
+```
+
+---
+
+## 6. Identified Gaps
+
+### 6.1 `deadline job download-output` lacks storage profile support
+
+**Current behavior:**
+- Detects OS mismatch between job submission and download
+- Prompts user to manually enter a new root path
+- No automatic path mapping
+
+**Desired behavior:**
+- Accept `--ignore-storage-profiles` option
+- Automatically read storage profile from config (`settings.storage_profile_id`)
+- Automatically generate path mapping rules when both profiles exist
+- Apply mappings without user prompts
+- Fall back to manual prompt with guidance when profiles are missing or mismatched
+
+### 6.2 `OutputDownloader` has a stale TODO for path mapping
+
+The `OutputDownloader` class contains this TODO:
+
+```python
+# TODO: The download location is OS-specific to the *submitting machine* matching
+# the profile of the submitting machine. The OS of the *downloading machine* might be different,
+# so we need to check that and apply path mapping rules in that case.
+```
+
+Both download commands already handle path mapping at the CLI layer using `_PathMappingRuleApplier` (trie-based), not inside `OutputDownloader`:
+
+- `queue sync-output` transforms every individual file path (joins `rootPath + relativePath`, then calls `strict_transform()`) inside `_download_all_manifests_with_absolute_paths()`. It does not use `OutputDownloader` at all — it has its own manifest-based download pipeline.
+- `job download-output` (this proposal) transforms root paths via `OutputDownloader.set_root_path()`, then `OutputDownloader` joins root + relative internally during download.
+
+These are equivalent in outcome because each manifest has a single root path — transforming the root produces the same final absolute paths as transforming each `root + relative` individually. The proposed approach uses `set_root_path()` because `download-output` already depends on `OutputDownloader`, and rewriting it to use the manifest pipeline would be a larger change with no functional benefit.
+
+Since both download commands handle path mapping externally using the same trie, this TODO is stale and should be removed as part of Stage 3 (§8.3). `OutputDownloader` remains a download-only concern with no path mapping responsibility.
+
+### 6.3 `_generate_path_mapping_rules` accepts raw dicts, not `StorageProfile` dataclass
+
+The existing `_generate_path_mapping_rules()` in `_path_mapping.py` accepts `dict[str, Any]` (raw boto3 response shape). The typed API helper `api.get_storage_profile_for_queue()` returns a `StorageProfile` dataclass. The `sync-output` path sidesteps this by using the raw boto3 client directly.
+
+The function is underscore-prefixed (private) and only consumed by `_incremental_download.py` and tests — so its signature can be changed freely. Rather than adding an adapter, we can refactor `_generate_path_mapping_rules` to accept `StorageProfile` directly and update the two call sites. This is a small change that eliminates the type mismatch at the source. See §8.2.3 for the updated approach.
+
+### 6.4 `S3AssetManager` doesn't auto-fetch storage profile (future work)
+
+**Current behavior:**
+- `S3AssetManager.__init__()` takes `farm_id` and `queue_id`
+- `prepare_paths_for_upload()` requires `storage_profile` as optional parameter
+- Caller must fetch and pass storage profile
+
+This is the broader ask from issue #829. It is out of scope for this proposal and tracked separately.
+
+---
+
+## 7. Decision Matrix: Storage Profile Combinations
+
+When downloading, the behavior depends on whether the local machine has a storage profile configured and whether the job was submitted with one:
+
+| Local profile configured? | Job has `storageProfileId`? | Action |
+|:---:|:---:|---|
+| Yes | Yes | Generate path mapping rules, apply automatically |
+| Yes (no matching names) | Yes | Warn about mismatched location names, recommend aligning storage profiles, fall back to manual prompt |
+| Yes | No | Warn: job was submitted without a storage profile, fall back to manual prompt |
+| No | Yes | Warn: recommend configuring a storage profile, fall back to manual prompt |
+| No | No | No mapping needed, proceed as-is (same-machine case) |
+| `--ignore-storage-profiles` | Any | Skip all mapping, download to original paths |
+
+All mismatch/missing cases now fall back to the existing manual prompt rather than erroring, with a log message recommending storage profile setup.
+
+---
+
+## 8. Proposed Changes
+
+### 8.1 Stage 1: Add CLI options and wiring (small, reviewable)
+
+Add `--ignore-storage-profiles` to `job download-output`, wire it through to `_download_job_output()`.
+
+#### 8.1.1 Add CLI Options
+
+**File:** `src/deadline/client/cli/_groups/job_group.py`
+
+Add one new option to the existing `job_download_output` click command:
+
+```python
+@click.option(
+    "--ignore-storage-profiles",
+    is_flag=True,
+    help="Ignores the storage profile configuration. Only use if the job was "
+         "submitted and downloaded from the same machine. Downloads to "
+         "unmapped paths regardless of operating system.\n"
+         "Default value is False.",
+    default=False,
+)
+```
+
+The local storage profile is read from `settings.storage_profile_id` in the config (set via `deadline config`). No explicit `--storage-profile-id` override is needed for `download-output` — the config setting is sufficient.
+
+#### 8.1.2 Update `job_download_output()` entry point
+
+Pass `ignore_storage_profiles` through to `_download_job_output()`:
+
+```python
+def job_download_output(step_id, task_id, output, ignore_storage_profiles, **args):
+    # ... existing validation ...
+    config = _apply_cli_options_to_config(
+        required_options={"farm_id", "queue_id", "job_id"}, **args
+    )
+    # ... existing config reads ...
+    try:
+        _download_job_output(
+            config, farm_id, queue_id, job_id, step_id, task_id,
+            is_json_format,
+            ignore_storage_profiles=ignore_storage_profiles,
+        )
+```
+
+#### 8.1.3 Add `ignore_storage_profiles` parameter to `_download_job_output()`
+
+```python
+def _download_job_output(
+    config: Optional[ConfigParser],
+    farm_id: str,
+    queue_id: str,
+    job_id: str,
+    step_id: Optional[str],
+    task_id: Optional[str],
+    is_json_format: bool = False,
+    ignore_storage_profiles: bool = False,  # NEW
+):
+```
+
+At this stage, the parameter is accepted but not yet used — the existing manual prompt behavior is preserved. This makes the CLI change independently reviewable.
+
+---
+
+### 8.2 Stage 2: Single-responsibility helper functions
+
+Add the core logic as small, testable functions. Each function has a single job and stays under 100 lines.
+
+**File:** `src/deadline/client/cli/_groups/_job_download_helpers.py` (new file)
+
+#### 8.2.1 `_resolve_storage_profiles()`
+
+Fetches the local and job storage profiles. Returns `(None, None)` when ignoring profiles. Handles all error cases from the decision matrix.
+
+```python
+@dataclass
+class ResolvedStorageProfiles:
+    """The result of resolving storage profiles for a download operation."""
+    job_profile: StorageProfile       # profile the job was submitted with (source paths)
+    local_profile: StorageProfile     # profile on this machine (destination paths)
+
+
+def _resolve_storage_profiles(
+    config: Optional[ConfigParser],
+    deadline: "DeadlineClient",
+    farm_id: str,
+    queue_id: str,
+    job: dict[str, Any],
+    ignore_storage_profiles: bool,
+) -> Optional[ResolvedStorageProfiles]:
+    """Resolve the storage profiles needed to map a job's output paths to local paths.
+
+    The job_profile is where paths came from (the submitting machine).
+    The local_profile is where paths should go (this machine).
+
+    Returns:
+        ResolvedStorageProfiles if path mapping is needed, None otherwise.
+    """
+    if ignore_storage_profiles:
+        return None
+
+    local_storage_profile_id = config_file.get_setting(
+        "settings.storage_profile_id", config=config
+    )
+    job_storage_profile_id = job.get("storageProfileId")
+
+    if not local_storage_profile_id and not job_storage_profile_id:
+        # Same-machine case: no profiles on either side
+        return None
+
+    if not local_storage_profile_id and job_storage_profile_id:
+        # Consistent with queue sync-output which always requires a local storage profile.
+        click.echo(
+            "Warning: The job was submitted with a storage profile but no local storage "
+            "profile is configured. Path mapping will be skipped.\n\n"
+            "Options:\n"
+            "  1. Configure a storage profile: deadline config set "
+            "settings.storage_profile_id <id>\n"
+            "  2. Skip path mapping (same-machine only): --ignore-storage-profiles\n\n"
+            "See https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/"
+            "modeling-your-shared-filesystem-locations-with-storage-profiles.html"
+        )
+        return None
+
+    if local_storage_profile_id and not job_storage_profile_id:
+        click.echo(
+            "Warning: A local storage profile is configured but the job was submitted "
+            "without one. Path mapping will be skipped."
+        )
+        return None
+
+    # Both profiles exist — fetch them
+    local_profile = api.get_storage_profile_for_queue(
+        farm_id, queue_id, local_storage_profile_id, deadline, config=config
+    )
+    job_profile = api.get_storage_profile_for_queue(
+        farm_id, queue_id, job_storage_profile_id, deadline, config=config
+    )
+
+    return ResolvedStorageProfiles(job_profile=job_profile, local_profile=local_profile)
+```
+
+Note: Both profiles are fetched via the typed API (`api.get_storage_profile_for_queue`) which returns `StorageProfile` dataclass, since `_generate_path_mapping_rules()` is refactored to accept `StorageProfile` directly (see §6.3).
+
+#### 8.2.2 Refactor `_generate_path_mapping_rules()` to accept `StorageProfile`
+
+Since the function is private (underscore-prefixed) with only two call sites (`_incremental_download.py` and the new `_job_download_helpers.py`), we refactor it directly instead of adding an adapter.
+
+**File:** `src/deadline/job_attachments/_path_mapping.py`
+
+```python
+def _generate_path_mapping_rules(
+    source_storage_profile: StorageProfile,
+    destination_storage_profile: StorageProfile,
+) -> list[PathMappingRule]:
+    """
+    Given a pair of storage profiles, generate all the path mapping rules to
+    transform paths from the source to the destination.
+    """
+    if source_storage_profile.storageProfileId == destination_storage_profile.storageProfileId:
+        return []
+
+    source_locations = {
+        loc.name: loc for loc in source_storage_profile.fileSystemLocations
+    }
+    destination_locations = {
+        loc.name: loc for loc in destination_storage_profile.fileSystemLocations
+    }
+
+    if source_storage_profile.osFamily == StorageProfileOperatingSystemFamily.WINDOWS:
+        source_path_format = PathFormat.WINDOWS.value
+    else:
+        source_path_format = PathFormat.POSIX.value
+
+    path_mapping_rules: list[PathMappingRule] = []
+    for source_name, source_location in source_locations.items():
+        if source_name in destination_locations:
+            path_mapping_rules.append(
+                PathMappingRule(
+                    source_path_format,
+                    source_location.path,
+                    destination_locations[source_name].path,
+                )
+            )
+
+    return path_mapping_rules
+```
+
+**Call site updates required:**
+
+1. `_incremental_download.py` — update `_get_storage_profiles()` to use the typed API (`api.get_storage_profile_for_queue`) instead of raw boto3, and pass `StorageProfile` objects to `_generate_path_mapping_rules()`.
+2. `test_path_mapping.py` — update test fixtures to use `StorageProfile` dataclass instead of raw dicts.
+
+#### 8.2.3 `_apply_path_mappings_to_roots()`
+
+Applies generated path mapping rules to the output downloader's root paths.
+
+```python
+def _apply_path_mappings_to_roots(
+    job_output_downloader: OutputDownloader,
+    output_paths_by_root: dict[str, list[str]],
+    rules: list[PathMappingRule],
+) -> None:
+    """Apply path mapping rules to remap output root directories.
+
+    Modifies the downloader in-place via set_root_path().
+    """
+    if not rules:
+        return
+
+    applier = _PathMappingRuleApplier(rules)
+    for original_root in list(output_paths_by_root.keys()):
+        mapped_root = applier.transform(original_root)
+        if str(mapped_root) != original_root:
+            click.echo(f"  Mapping root: {original_root} -> {mapped_root}")
+            job_output_downloader.set_root_path(original_root, str(mapped_root))
+```
+
+---
+
+### 8.3 Stage 3: Integrate helpers into `_download_job_output()`
+
+Wire the helper functions into the existing download flow. The key change is replacing the manual OS-mismatch prompt block with automatic path mapping when storage profiles are available.
+
+#### 8.3.1 Updated flow in `_download_job_output()`
+
+Insert after `OutputDownloader` construction and `output_paths_by_root` retrieval, replacing the existing OS mismatch block:
+
+```python
+    # --- Storage profile path mapping (replaces manual OS mismatch prompt) ---
+    resolved = _resolve_storage_profiles(
+        config, deadline, farm_id, queue_id, job, ignore_storage_profiles
+    )
+
+    if resolved:
+        # Automatic path mapping via storage profiles
+        rules = _generate_path_mapping_rules(resolved.job_profile, resolved.local_profile)
+        click.echo(f"Using storage profile: {resolved.local_profile.displayName}")
+        _apply_path_mappings_to_roots(job_output_downloader, output_paths_by_root, rules)
+        output_paths_by_root = job_output_downloader.get_output_paths_by_root()
+    else:
+        # No storage profiles — fall back to manual prompt on OS mismatch
+        # (existing behavior, unchanged)
+        asset_roots = list(output_paths_by_root.keys())
+        for asset_root in asset_roots:
+            root_path_format = root_path_format_mapping.get(asset_root, "")
+            if root_path_format == "":
+                raise DeadlineOperationError(
+                    f"No root path format found for {asset_root}."
+                )
+            if PathFormat.get_host_path_format_string() != root_path_format:
+                click.echo(
+                    _get_mismatch_os_root_warning(
+                        asset_root, root_path_format, is_json_format
+                    )
+                )
+                # ... existing manual prompt code (unchanged) ...
+```
+
+The rest of `_download_job_output()` (conflict resolution, progress bar, download) remains unchanged.
+
+#### 8.3.2 Entry point
+
+The `job_download_output()` function passes `ignore_storage_profiles` through to `_download_job_output()`. No validation needed since `--storage-profile-id` is not an option on this command.
+
+---
+
+## 9. Testing
+
+### 9.1 Test Cases
+
+Each case traces the full code path from CLI entry through to download. All cases are implemented in `test/unit/deadline_client/cli/test_cli_job_download_storage_profiles.py`.
+
+#### Case 1: Both profiles exist, location names match → automatic mapping
+
+Local machine has `sp-local-111` (Linux, locations: `shared=/mnt/shared`, `temp=/tmp/render`).
+Job was submitted with `sp-job-222` (Windows, locations: `shared=Z:\shared`, `temp=C:\temp\render`).
+
+```
+job_download_output()
+  _validate_storage_profile_options(None, False)           → passes
+  _download_job_output(..., ignore_storage_profiles=False)
+    _resolve_storage_profiles(config, deadline, farm, queue, job, False)
+      config_file.get_setting("settings.storage_profile_id") → "sp-local-111"
+      job.get("storageProfileId")                            → "sp-job-222"
+      Both truthy → fetch both via api.get_storage_profile_for_queue()
+      → ResolvedStorageProfiles(job_profile=sp-job-222, local_profile=sp-local-111)
+    resolved is not None → enters `if resolved:` branch
+    _generate_path_mapping_rules(sp-job-222, sp-local-111)
+      _normalize_storage_profile() on each
+      IDs differ → match locations by name
+      "shared" matches → PathMappingRule(WINDOWS, "Z:\shared", "/mnt/shared")
+      "temp" matches   → PathMappingRule(WINDOWS, "C:\temp\render", "/tmp/render")
+      → [rule1, rule2]
+    _apply_path_mappings_to_roots(downloader, roots, [rule1, rule2])
+      _PathMappingRuleApplier([rule1, rule2])  → builds trie
+      transform("C:\temp\render") → "/tmp/render" → set_root_path()
+      transform("Z:\shared")      → "/mnt/shared" → set_root_path()
+    download proceeds to mapped local paths
+```
+
+Expected: roots are remapped, user sees "Using storage profile: Local Linux Profile" and "Mapping root: ..." messages. Download goes to `/mnt/shared` and `/tmp/render`.
+
+#### Case 2: Both profiles exist, location names don't match → no rules, no mapping
+
+Local machine has `sp-local-111` (locations: `shared`, `temp`).
+Job was submitted with `sp-job-333` (locations: `ProjectFiles`, `OutputDir`).
+
+```
+job_download_output()
+  _download_job_output(..., ignore_storage_profiles=False)
+    _resolve_storage_profiles(...)
+      Both IDs present → fetch both → ResolvedStorageProfiles
+    resolved is not None → enters `if resolved:` branch
+    _generate_path_mapping_rules(sp-job-333, sp-local-111)
+      IDs differ → match locations by name
+      "ProjectFiles" not in {"shared", "temp"}, "OutputDir" not in {"shared", "temp"}
+      → []  (empty)
+    _apply_path_mappings_to_roots(downloader, roots, [])
+      `if not rules:` → prints warning about mismatched location names → return
+    output_paths_by_root re-read (unchanged)
+    user sees root confirmation prompt (if not auto_accept)
+    download proceeds to original unmapped paths
+```
+
+Expected: no mapping applied. User sees "Using storage profile: ..." and a warning about mismatched location names recommending alignment. If OS mismatch exists, the manual root editing prompt appears as before.
+
+#### Case 3: Job has profile, local machine does not → warning, manual fallback
+
+Local machine has no storage profile configured.
+Job was submitted with `sp-job-222`.
+
+```
+job_download_output()
+  _download_job_output(..., ignore_storage_profiles=False)
+    _resolve_storage_profiles(...)
+      config_file.get_setting("settings.storage_profile_id") → ""
+      job.get("storageProfileId")                            → "sp-job-222"
+      Hits: `if not local_storage_profile_id and job_storage_profile_id:`
+      → click.echo("Warning: ...no local storage profile is configured...")
+      → None
+    resolved is None → enters `else:` branch
+    if OS mismatch → manual prompt fallback
+    if same OS → download to original paths
+```
+
+Expected: warning printed recommending storage profile setup, then falls back to manual prompt if OS mismatch exists. No error thrown.
+
+#### Case 4: Neither submitter nor downloader has a profile → no mapping, direct download
+
+Local machine has no storage profile. Job was submitted without one.
+
+```
+job_download_output()
+  _download_job_output(..., ignore_storage_profiles=False)
+    _resolve_storage_profiles(...)
+      config_file.get_setting("settings.storage_profile_id") → ""
+      job.get("storageProfileId")                            → None
+      Hits: `if not local_storage_profile_id and not job_storage_profile_id:`
+      → None
+    resolved is None → enters `else:` branch
+    for each asset_root:
+      root_path_format matches host format (same OS)
+      no OS mismatch → no prompt
+    download proceeds to original paths
+```
+
+Expected: same-machine case. No storage profiles, no path mapping, no prompts. Identical to pre-change behavior.
+
+#### Case 5: Local profile configured, job submitted without one → warning, skip mapping
+
+Local machine has `sp-local-111`. Job was submitted without a storage profile (e.g., older job or tool that didn't set one).
+
+```
+job_download_output()
+  _download_job_output(..., ignore_storage_profiles=False)
+    _resolve_storage_profiles(...)
+      config_file.get_setting("settings.storage_profile_id") → "sp-local-111"
+      job.get("storageProfileId")                            → None
+      Hits: `if local_storage_profile_id and not job_storage_profile_id:`
+      → click.echo("Warning: ...job was submitted without one. Path mapping will be skipped.")
+      → None
+    resolved is None → enters `else:` branch
+    if OS mismatch → manual prompt fallback
+    if same OS → download to original paths
+```
+
+Expected: warning printed, no mapping. Falls back to existing behavior. If cross-OS, user gets the manual root path prompt.
+
+#### Case 6: `--ignore-storage-profiles` flag → skip everything
+
+Both profiles may exist, but user explicitly opts out.
+
+```
+job_download_output(..., ignore_storage_profiles=True)
+  _validate_storage_profile_options(None, True) → passes
+  _download_job_output(..., ignore_storage_profiles=True)
+    _resolve_storage_profiles(..., ignore_storage_profiles=True)
+      → return None immediately (first line of function)
+    resolved is None → enters `else:` branch
+    if OS mismatch → manual prompt fallback
+    download to original unmapped paths
+```
+
+Expected: all storage profile logic bypassed. Same behavior as pre-change code. Use when submitting and downloading from the same machine.
+
+#### Case 7: Same storage profile on both sides → no mapping needed
+
+Job was submitted with `sp-local-111`. Local machine also has `sp-local-111`.
+
+```
+job_download_output()
+  _download_job_output(..., ignore_storage_profiles=False)
+    _resolve_storage_profiles(...)
+      Both IDs present, both "sp-local-111" → fetch both → ResolvedStorageProfiles
+    resolved is not None → enters `if resolved:` branch
+    _generate_path_mapping_rules(sp-local-111, sp-local-111)
+      storageProfileId matches → return []
+    _apply_path_mappings_to_roots(downloader, roots, [])
+      `if not rules: return` → no-op
+    download proceeds to original paths
+```
+
+Expected: same profile means same paths. No mapping, no prompts. Download to original locations.
+
+### 9.2 Unit Tests
+
+Each helper function is independently testable in `test/unit/deadline_client/cli/test_job_download_helpers.py`:
+
+| Function | Test cases |
+|----------|-----------|
+| `_resolve_storage_profiles` | All rows of the decision matrix; API error handling (`ClientError`) |
+| `_generate_path_mapping_rules` | Update existing tests to use `StorageProfile` dataclass; matching location names; no matching names; same profile id (empty rules) |
+| `_apply_path_mappings_to_roots` | Empty rules (no-op); single mapping; multiple mappings; root already matches |
+
+### 9.3 Backward Compatibility
+
+- Existing behavior (manual prompt on OS mismatch) is preserved when no storage profiles are configured
+- `--ignore-storage-profiles` explicitly opts out of all mapping
+- No changes to `OutputDownloader` or `_incremental_download.py`
+
+---
+
+## 10. Appendix A: Key File Locations
+
+| Component | File Path |
+|-----------|-----------|
+| CLI bundle commands | `src/deadline/client/cli/_groups/bundle_group.py` |
+| CLI job commands | `src/deadline/client/cli/_groups/job_group.py` |
+| CLI queue commands | `src/deadline/client/cli/_groups/queue_group.py` |
+| CLI common utilities | `src/deadline/client/cli/_common.py` |
+| Job download helpers (new) | `src/deadline/client/cli/_groups/_job_download_helpers.py` |
+| Incremental download | `src/deadline/client/cli/_incremental_download.py` |
+| Job submission API | `src/deadline/client/api/_submit_job_bundle.py` |
+| Storage profile API | `src/deadline/client/api/_get_storage_profile_for_queue.py` |
+| S3AssetManager | `src/deadline/job_attachments/upload.py` |
+| OutputDownloader | `src/deadline/job_attachments/download.py` |
+| Path mapping | `src/deadline/job_attachments/_path_mapping.py` |
+| Hash algorithms | `src/deadline/job_attachments/asset_manifests/hash_algorithms.py` |
+| Hash cache | `src/deadline/job_attachments/caches/hash_cache.py` |
+| Models | `src/deadline/job_attachments/models.py` |
+| Config file | `src/deadline/client/config/config_file.py` |
+
+---
+
+## 11. Appendix B: Future Refactoring Stages
+
+These are follow-up improvements that build on the Stage 1-3 work above. Each is independently reviewable.
+
+### 11.1 Future Stage A: Move path mapping into `OutputDownloader`
+
+The `OutputDownloader` class has a TODO acknowledging it should handle path mapping internally. Once Stage A is done:
+
+1. Add an optional `path_mapping_rules: Optional[list[PathMappingRule]]` parameter to `OutputDownloader.__init__()`
+2. Apply rules automatically in `get_output_paths_by_root()` instead of requiring external `set_root_path()` calls
+3. Simplify both `_download_job_output()` and `_incremental_output_download()` to pass rules at construction time
+
+This is a larger refactor that changes the `OutputDownloader` public interface, so it warrants its own review.
+
+### 11.2 Future Stage B: `S3AssetManager` auto-fetches storage profile (issue #829 broader ask)
+
+The original issue requests that `S3AssetManager` automatically resolve the storage profile from the queue. Options:
+
+1. A `StorageProfileResolver` class that takes `farm_id`, `queue_id`, `session` and lazily fetches/caches the profile. Inject into both `S3AssetManager` and `OutputDownloader`.
+2. A higher-level `create_job()` function that wraps job inputs and job attachments together, so consumers don't need to understand storage profiles at all.
+
+This is a larger API design effort and should be scoped separately.
+
+---
+
+## 12. Appendix C: Upload Code Path (Reference)
+
+This section documents the upload (job submission) code path for reference. It is not changed by this proposal.
+
+### 12.1 CLI Entry Point: `deadline bundle submit`
+
+**File:** `src/deadline/client/cli/_groups/bundle_group.py:159-320`
+
+```
+CLI Command
+    │
+    ▼
+bundle_submit()
+    │
+    ├── _apply_cli_options_to_config()  ─── Applies --storage-profile-id to config
+    │
+    └── api.create_job_from_job_bundle()
+```
+
+The `--storage-profile-id` option is defined at line 159 and processed in `_apply_cli_options_to_config()`.
+
+### 12.2 API Layer: `create_job_from_job_bundle()`
+
+**File:** `src/deadline/client/api/_submit_job_bundle.py:374-849`
+
+```python
+# Lines 528-534: Storage profile retrieval
+storage_profile_id = get_setting("settings.storage_profile_id", config=config)
+storage_profile = None
+if storage_profile_id:
+    create_job_args["storageProfileId"] = storage_profile_id
+    storage_profile = api.get_storage_profile_for_queue(
+        farm_id, queue_id, storage_profile_id, deadline
+    )
+```
+
+Key operations:
+1. Retrieves `storage_profile_id` from config (line 528)
+2. If set, adds to `create_job_args` for the CreateJob API call (line 530)
+3. Fetches full `StorageProfile` object for path grouping (line 531-534)
+
+### 12.3 Asset Manager: `S3AssetManager`
+
+**File:** `src/deadline/job_attachments/upload.py:1034-1680`
+
+```
+S3AssetManager.__init__()
+    │
+    ├── farm_id, queue_id, job_attachment_settings
+    │
+    └── Does NOT take storage_profile (passed to methods instead)
+```
+
+Storage profile affects path grouping during upload:
+- **SHARED locations**: Paths are SKIPPED (not uploaded) — they're on shared storage
+- **LOCAL locations**: Paths are GROUPED together under the location's root
+
+### 12.4 Hashing and Upload
+
+- `hash_assets_and_create_manifest()` hashes files using xxHash XXH128 with a SQLite-backed cache
+- `upload_assets()` uploads to S3 using Content-Addressable Storage (CAS), with an S3CheckCache to prevent redundant uploads

--- a/docs/design/storage-profile-cli-support.md
+++ b/docs/design/storage-profile-cli-support.md
@@ -22,7 +22,7 @@ defaults.aws_profile_name
         └── defaults.queue_id
 ```
 
-**Source:** `src/deadline/client/config/config_file.py:83-87`
+**Source:** `src/deadline/client/config/config_file.py`
 
 ### 3.2 CLI Commands with Storage Profile Support
 
@@ -31,13 +31,13 @@ defaults.aws_profile_name
 | `deadline bundle submit` | ✅ | N/A | Reads `settings.storage_profile_id` from config or `--storage-profile-id` CLI option. Passed to `create_job_from_job_bundle()` which attaches it to the CreateJob API call and uses it for path grouping during upload. If not set, submission proceeds without a storage profile. No ignore flag needed — uploads don't require path mapping. |
 | `deadline bundle gui-submit` | N/A | N/A | GUI auto-populates a storage profile dropdown by listing profiles for the selected queue, filtered to the current OS. Pre-selects from `settings.storage_profile_id` in config. User can change selection before submitting. No ignore flag needed — uploads don't require path mapping. |
 | `deadline queue sync-output` | ✅ | ✅ | Full support (reference implementation). See §4.2 for code details. |
-| `deadline job download-output` | ❌ | ❌ | **Gap — prompts for manual path entry on OS mismatch** |
+| `deadline job download-output` | ❌ → ✅ | ❌ → ✅ | **Gap (proposed in this design)** — currently prompts for manual path entry on OS mismatch. This design adds `--ignore-storage-profiles` and automatic path mapping via config. |
 
 ### 3.3 Existing `--ignore-storage-profiles` Implementation
 
 The `deadline queue sync-output` command already implements `--ignore-storage-profiles`:
 
-**File:** `src/deadline/client/cli/_groups/queue_group.py:282-290`
+**File:** `src/deadline/client/cli/_groups/queue_group.py`
 
 ```python
 @click.option(
@@ -52,8 +52,8 @@ The `deadline queue sync-output` command already implements `--ignore-storage-pr
 ```
 
 This option is used when:
-- All jobs are submitted and downloaded from the **same machine**
-- No path mapping is needed (same OS, same mount points)
+- All submitting and downloading machines share the **same OS and mount points**
+- No path mapping is needed
 - Downloads go to the original unmapped paths
 
 The proposal is to extend this existing pattern to `deadline job download-output`.
@@ -66,7 +66,7 @@ For a code deep dive into the upload path (job submission), see §12 (Appendix C
 
 ### 4.1 `deadline job download-output` (Single Job)
 
-**File:** `src/deadline/client/cli/_groups/job_group.py:911-985`
+**File:** `src/deadline/client/cli/_groups/job_group.py`
 
 ```
 CLI Command (job_download_output)
@@ -88,7 +88,7 @@ CLI Command (job_download_output)
             └── OutputDownloader.download_job_output()
 ```
 
-#### 4.1.1 Current OS Mismatch Handling (Lines 570-595)
+#### 4.1.1 Current OS Mismatch Handling
 
 ```python
 # Check if the asset roots came from different OS
@@ -111,7 +111,7 @@ for asset_root in asset_roots:
 
 This is the reference implementation for storage profile support in a download command. The proposed changes in §8 follow this same pattern for `job download-output`.
 
-**File:** `src/deadline/client/cli/_groups/queue_group.py:257-420`
+**File:** `src/deadline/client/cli/_groups/queue_group.py`
 
 ```
 CLI Command (sync_output)
@@ -124,7 +124,7 @@ CLI Command (sync_output)
     └── _incremental_output_download()
 ```
 
-#### 4.2.1 Storage Profile Validation (Lines 360-385)
+#### 4.2.1 Storage Profile Validation
 
 ```python
 if ignore_storage_profiles:
@@ -227,7 +227,7 @@ class _PathMappingRuleApplier:
 
 **File:** `src/deadline/job_attachments/download.py`
 
-#### 4.5.1 OutputDownloader Class (Lines 1231-1377)
+#### 4.5.1 OutputDownloader Class
 
 ```python
 class OutputDownloader:
@@ -246,7 +246,7 @@ class OutputDownloader:
         self.outputs_by_root = get_job_output_paths_by_asset_root(...)
 ```
 
-#### 4.5.2 File Download (Lines 695-725)
+#### 4.5.2 File Download
 
 ```python
 def download_files(
@@ -268,7 +268,7 @@ def download_files(
 
 ### 5.1 StorageProfile
 
-**File:** `src/deadline/job_attachments/models.py:451-465`
+**File:** `src/deadline/job_attachments/models.py`
 
 ```python
 @dataclass
@@ -281,7 +281,7 @@ class StorageProfile:
 
 ### 5.2 FileSystemLocation
 
-**File:** `src/deadline/job_attachments/models.py:469-478`
+**File:** `src/deadline/job_attachments/models.py`
 
 ```python
 @dataclass
@@ -776,7 +776,7 @@ job_download_output(..., ignore_storage_profiles=True)
     download to original unmapped paths
 ```
 
-Expected: all storage profile logic bypassed. Same behavior as pre-change code. Use when submitting and downloading from the same machine.
+Expected: all storage profile logic bypassed. Same behavior as pre-change code. Use when submitting and downloading machines share the same OS and mount points.
 
 #### Case 7: Same storage profile on both sides → no mapping needed
 
@@ -868,7 +868,7 @@ This section documents the upload (job submission) code path for reference. It i
 
 ### 12.1 CLI Entry Point: `deadline bundle submit`
 
-**File:** `src/deadline/client/cli/_groups/bundle_group.py:159-320`
+**File:** `src/deadline/client/cli/_groups/bundle_group.py`
 
 ```
 CLI Command
@@ -881,14 +881,14 @@ bundle_submit()
     └── api.create_job_from_job_bundle()
 ```
 
-The `--storage-profile-id` option is defined at line 159 and processed in `_apply_cli_options_to_config()`.
+The `--storage-profile-id` option is processed in `_apply_cli_options_to_config()`.
 
 ### 12.2 API Layer: `create_job_from_job_bundle()`
 
-**File:** `src/deadline/client/api/_submit_job_bundle.py:374-849`
+**File:** `src/deadline/client/api/_submit_job_bundle.py`
 
 ```python
-# Lines 528-534: Storage profile retrieval
+# Storage profile retrieval
 storage_profile_id = get_setting("settings.storage_profile_id", config=config)
 storage_profile = None
 if storage_profile_id:
@@ -899,13 +899,13 @@ if storage_profile_id:
 ```
 
 Key operations:
-1. Retrieves `storage_profile_id` from config (line 528)
-2. If set, adds to `create_job_args` for the CreateJob API call (line 530)
-3. Fetches full `StorageProfile` object for path grouping (line 531-534)
+1. Retrieves `storage_profile_id` from config
+2. If set, adds to `create_job_args` for the CreateJob API call
+3. Fetches full `StorageProfile` object for path grouping
 
 ### 12.3 Asset Manager: `S3AssetManager`
 
-**File:** `src/deadline/job_attachments/upload.py:1034-1680`
+**File:** `src/deadline/job_attachments/upload.py`
 
 ```
 S3AssetManager.__init__()

--- a/src/deadline/client/cli/_groups/_job_download_helpers.py
+++ b/src/deadline/client/cli/_groups/_job_download_helpers.py
@@ -36,8 +36,10 @@ from ....job_attachments.models import (
 )
 from ....job_attachments.progress_tracker import ProgressReportMetadata
 
-# JSON message type constant — must match job_group.py's JSON_MSG_TYPE_PROGRESS
-_JSON_MSG_TYPE_PROGRESS = "progress"
+from ._sigint_handler import SigIntHandler
+
+# JSON message type for progress reporting (defined here to avoid circular import with job_group.py)
+JSON_MSG_TYPE_PROGRESS = "progress"
 
 
 @dataclass
@@ -209,8 +211,23 @@ def _download_mapped_manifests(
         file_conflict_resolution = FileConflictResolution.CREATE_COPY
 
     s3_settings = JobAttachmentS3Settings(**queue["jobAttachmentSettings"])
+    sigint_handler = SigIntHandler()
 
     with _modified_logging_level(logging.getLogger("urllib3"), logging.ERROR):
+
+        @api.record_success_fail_telemetry_event(metric_name="download_job_output")
+        def _do_download(
+            on_downloading_files: Any = None,
+        ) -> Any:
+            return download_files_from_manifests(
+                s3_bucket=s3_settings.s3BucketName,
+                manifests_by_root=mapped_manifests,
+                cas_prefix=s3_settings.full_cas_prefix(),
+                session=queue_role_session,
+                on_downloading_files=on_downloading_files,
+                conflict_resolution=file_conflict_resolution,
+            )
+
         if not is_json_format:
             with click.progressbar(length=100, label="Downloading Outputs") as download_progress:  # type: ignore[var-annotated]
 
@@ -218,34 +235,21 @@ def _download_mapped_manifests(
                     new_progress = int(download_metadata.progress) - download_progress.pos
                     if new_progress > 0:
                         download_progress.update(new_progress)
-                    return True
+                    return sigint_handler.continue_operation
 
-                return download_files_from_manifests(
-                    s3_bucket=s3_settings.s3BucketName,
-                    manifests_by_root=mapped_manifests,
-                    cas_prefix=s3_settings.full_cas_prefix(),
-                    session=queue_role_session,
-                    on_downloading_files=_on_progress,
-                    conflict_resolution=file_conflict_resolution,
-                )
+                return _do_download(on_downloading_files=_on_progress)
         else:
 
             def _on_progress_json(download_metadata: ProgressReportMetadata) -> bool:
                 json_line = json.dumps(
                     {
-                        "messageType": _JSON_MSG_TYPE_PROGRESS,
+                        "messageType": JSON_MSG_TYPE_PROGRESS,
                         "value": str(int(download_metadata.progress)),
                     },
                     ensure_ascii=True,
                 )
                 click.echo(json_line)
+                # TODO: enable download cancellation for JSON format
                 return True
 
-            return download_files_from_manifests(
-                s3_bucket=s3_settings.s3BucketName,
-                manifests_by_root=mapped_manifests,
-                cas_prefix=s3_settings.full_cas_prefix(),
-                session=queue_role_session,
-                on_downloading_files=_on_progress_json,
-                conflict_resolution=file_conflict_resolution,
-            )
+            return _do_download(on_downloading_files=_on_progress_json)

--- a/src/deadline/client/cli/_groups/_job_download_helpers.py
+++ b/src/deadline/client/cli/_groups/_job_download_helpers.py
@@ -9,6 +9,8 @@ validation, and path mapping for the `deadline job download-output` command.
 
 from __future__ import annotations
 
+import ntpath
+import posixpath
 from configparser import ConfigParser
 from dataclasses import dataclass
 from typing import Any, Optional
@@ -21,10 +23,10 @@ from ...config import config_file
 from ....job_attachments._path_mapping import (
     _PathMappingRuleApplier,
 )
-from ....job_attachments.download import OutputDownloader
 from ....job_attachments.models import (
     PathMappingRule,
     StorageProfile,
+    StorageProfileOperatingSystemFamily,
 )
 
 
@@ -95,21 +97,71 @@ def _resolve_storage_profiles(
     return ResolvedStorageProfiles(job_profile=job_profile, local_profile=local_profile)
 
 
-def _apply_path_mappings_to_roots(
-    job_output_downloader: OutputDownloader,
-    output_paths_by_root: dict[str, list[str]],
+def _transform_manifests_to_absolute_paths(
+    manifests_by_root: dict[str, list[Any]],
     rules: list[PathMappingRule],
-) -> None:
-    """Apply path mapping rules to remap output root directories.
+    source_os_family: StorageProfileOperatingSystemFamily,
+) -> dict[str, Any]:
+    """Transform manifest paths using absolute-path mapping, matching sync-output behavior.
 
-    Modifies the downloader in-place via set_root_path().
+    Joins each root + relative path, applies path mapping rules to the full absolute path,
+    and returns a dict suitable for download_files_from_manifests(). This correctly handles
+    rules that match at any depth (e.g., nested file system locations), unlike root-only
+    transformation.
+
+    Args:
+        manifests_by_root: dict from asset root to list of BaseAssetManifest objects
+            (as returned by get_output_manifests_by_asset_root).
+        rules: path mapping rules from _generate_path_mapping_rules().
+        source_os_family: the OS family of the submitting machine (determines path joining).
+
+    Returns:
+        dict mapping "" to a merged BaseAssetManifest with absolute local paths.
+        The empty-string key means download_files_from_manifests() will use the
+        absolute paths directly (Path("").joinpath("/abs/path") == Path("/abs/path")).
     """
-    if not rules:
-        return
-
     applier = _PathMappingRuleApplier(rules)
-    for original_root in list(output_paths_by_root.keys()):
-        mapped_root = applier.transform(original_root)
-        if str(mapped_root) != original_root:
-            click.echo(f"  Mapping root: {original_root} -> {mapped_root}")
-            job_output_downloader.set_root_path(original_root, str(mapped_root))
+
+    if source_os_family == StorageProfileOperatingSystemFamily.WINDOWS:
+        source_os_path: Any = ntpath
+    else:
+        source_os_path = posixpath
+
+    unmapped_count = 0
+    mapped_count = 0
+
+    for root_path, manifest_list in manifests_by_root.items():
+        for manifest in manifest_list:
+            new_paths = []
+            for manifest_path in manifest.paths:
+                abs_path = source_os_path.normpath(
+                    source_os_path.join(root_path, manifest_path.path)
+                )
+                try:
+                    manifest_path.path = str(applier.strict_transform(abs_path))
+                    new_paths.append(manifest_path)
+                    mapped_count += 1
+                except ValueError:
+                    unmapped_count += 1
+            manifest.paths = new_paths
+
+    if unmapped_count > 0:
+        click.echo(
+            f"Warning: {unmapped_count} output file(s) could not be mapped and will be skipped."
+        )
+
+    if mapped_count > 0:
+        click.echo(f"  Mapped {mapped_count} output file(s) to local paths.")
+
+    # Collect all manifests with remaining paths into a flat dict keyed by "".
+    # Using "" as the key means Path("").joinpath(absolute_path) == absolute_path.
+    result: dict[str, Any] = {}
+    all_manifests = [m for ml in manifests_by_root.values() for m in ml if m.paths]
+    if all_manifests:
+        # Use the first manifest as the base and merge others into it
+        merged = all_manifests[0]
+        for extra in all_manifests[1:]:
+            merged.paths.extend(extra.paths)
+        result[""] = merged
+
+    return result

--- a/src/deadline/client/cli/_groups/_job_download_helpers.py
+++ b/src/deadline/client/cli/_groups/_job_download_helpers.py
@@ -9,6 +9,8 @@ validation, and path mapping for the `deadline job download-output` command.
 
 from __future__ import annotations
 
+import json
+import logging
 import ntpath
 import posixpath
 from configparser import ConfigParser
@@ -19,15 +21,23 @@ import click
 from botocore.client import BaseClient  # type: ignore[import]
 
 from ... import api
+from ...api._session import _modified_logging_level
 from ...config import config_file
 from ....job_attachments._path_mapping import (
     _PathMappingRuleApplier,
 )
+from ....job_attachments.download import download_files_from_manifests
 from ....job_attachments.models import (
+    FileConflictResolution,
+    JobAttachmentS3Settings,
     PathMappingRule,
     StorageProfile,
     StorageProfileOperatingSystemFamily,
 )
+from ....job_attachments.progress_tracker import ProgressReportMetadata
+
+# JSON message type constant — must match job_group.py's JSON_MSG_TYPE_PROGRESS
+_JSON_MSG_TYPE_PROGRESS = "progress"
 
 
 @dataclass
@@ -165,3 +175,77 @@ def _transform_manifests_to_absolute_paths(
         result[""] = merged
 
     return result
+
+
+def _download_mapped_manifests(
+    mapped_manifests: dict[str, Any],
+    queue: dict[str, Any],
+    queue_role_session: Any,
+    conflict_resolution_setting: str,
+    is_json_format: bool,
+) -> Any:
+    """Download output files using path-mapped manifests with progress reporting.
+
+    This handles the full download flow for the mapped-manifest code path:
+    conflict resolution, progress callback (click progressbar or JSON lines),
+    and the actual S3 download.
+
+    Args:
+        mapped_manifests: dict from _transform_manifests_to_absolute_paths(),
+            keyed by "" with absolute local paths in the manifest.
+        queue: the queue dict from deadline.get_queue().
+        queue_role_session: boto3 session with queue role credentials for S3 access.
+        conflict_resolution_setting: the raw config setting string for conflict resolution.
+        is_json_format: whether to emit JSON progress lines instead of a click progressbar.
+
+    Returns:
+        DownloadSummaryStatistics from the download.
+    """
+    # Determine conflict resolution: use config setting if specified, otherwise CREATE_COPY.
+    # No interactive prompt on the mapped path — the user opted into automatic mapping.
+    if conflict_resolution_setting != FileConflictResolution.NOT_SELECTED.name:
+        file_conflict_resolution = FileConflictResolution[conflict_resolution_setting]
+    else:
+        file_conflict_resolution = FileConflictResolution.CREATE_COPY
+
+    s3_settings = JobAttachmentS3Settings(**queue["jobAttachmentSettings"])
+
+    with _modified_logging_level(logging.getLogger("urllib3"), logging.ERROR):
+        if not is_json_format:
+            with click.progressbar(length=100, label="Downloading Outputs") as download_progress:  # type: ignore[var-annotated]
+
+                def _on_progress(download_metadata: ProgressReportMetadata) -> bool:
+                    new_progress = int(download_metadata.progress) - download_progress.pos
+                    if new_progress > 0:
+                        download_progress.update(new_progress)
+                    return True
+
+                return download_files_from_manifests(
+                    s3_bucket=s3_settings.s3BucketName,
+                    manifests_by_root=mapped_manifests,
+                    cas_prefix=s3_settings.full_cas_prefix(),
+                    session=queue_role_session,
+                    on_downloading_files=_on_progress,
+                    conflict_resolution=file_conflict_resolution,
+                )
+        else:
+
+            def _on_progress_json(download_metadata: ProgressReportMetadata) -> bool:
+                json_line = json.dumps(
+                    {
+                        "messageType": _JSON_MSG_TYPE_PROGRESS,
+                        "value": str(int(download_metadata.progress)),
+                    },
+                    ensure_ascii=True,
+                )
+                click.echo(json_line)
+                return True
+
+            return download_files_from_manifests(
+                s3_bucket=s3_settings.s3BucketName,
+                manifests_by_root=mapped_manifests,
+                cas_prefix=s3_settings.full_cas_prefix(),
+                session=queue_role_session,
+                on_downloading_files=_on_progress_json,
+                conflict_resolution=file_conflict_resolution,
+            )

--- a/src/deadline/client/cli/_groups/_job_download_helpers.py
+++ b/src/deadline/client/cli/_groups/_job_download_helpers.py
@@ -1,0 +1,115 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Helper functions for job download-output storage profile support.
+
+These are single-responsibility functions that handle storage profile resolution,
+validation, and path mapping for the `deadline job download-output` command.
+"""
+
+from __future__ import annotations
+
+from configparser import ConfigParser
+from dataclasses import dataclass
+from typing import Any, Optional
+
+import click
+from botocore.client import BaseClient  # type: ignore[import]
+
+from ... import api
+from ...config import config_file
+from ....job_attachments._path_mapping import (
+    _PathMappingRuleApplier,
+)
+from ....job_attachments.download import OutputDownloader
+from ....job_attachments.models import (
+    PathMappingRule,
+    StorageProfile,
+)
+
+
+@dataclass
+class ResolvedStorageProfiles:
+    """The result of resolving storage profiles for a download operation."""
+
+    job_profile: StorageProfile  # profile the job was submitted with (source paths)
+    local_profile: StorageProfile  # profile on this machine (destination paths)
+
+
+def _resolve_storage_profiles(
+    config: Optional[ConfigParser],
+    deadline: BaseClient,
+    farm_id: str,
+    queue_id: str,
+    job: dict[str, Any],
+    ignore_storage_profiles: bool,
+) -> Optional[ResolvedStorageProfiles]:
+    """Resolve the storage profiles needed to map a job's output paths to local paths.
+
+    The job_profile is where paths came from (the submitting machine).
+    The local_profile is where paths should go (this machine).
+
+    Returns:
+        ResolvedStorageProfiles if path mapping is needed, None otherwise.
+    """
+    if ignore_storage_profiles:
+        return None
+
+    local_storage_profile_id = config_file.get_setting("settings.storage_profile_id", config=config)
+    job_storage_profile_id = job.get("storageProfileId")
+
+    if not local_storage_profile_id and not job_storage_profile_id:
+        # Same-machine case: no profiles on either side
+        return None
+
+    if not local_storage_profile_id and job_storage_profile_id:
+        click.echo(
+            "Warning: The job was submitted with a storage profile but no local storage "
+            "profile is configured. Path mapping will be skipped.\n\n"
+            "Options:\n"
+            "  1. Configure a storage profile: deadline config set "
+            "settings.storage_profile_id <id>\n"
+            "  2. Skip path mapping (same-machine only): --ignore-storage-profiles\n\n"
+            "See https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/"
+            "modeling-your-shared-filesystem-locations-with-storage-profiles.html"
+        )
+        return None
+
+    if local_storage_profile_id and not job_storage_profile_id:
+        click.echo(
+            "Warning: A local storage profile is configured but the job was submitted "
+            "without one. Path mapping will be skipped."
+        )
+        return None
+
+    # Both profiles exist — fetch them
+    assert local_storage_profile_id is not None  # narrowing for mypy
+    assert job_storage_profile_id is not None  # narrowing for mypy
+    local_profile = api.get_storage_profile_for_queue(
+        farm_id, queue_id, local_storage_profile_id, deadline, config=config
+    )
+    job_profile = api.get_storage_profile_for_queue(
+        farm_id, queue_id, job_storage_profile_id, deadline, config=config
+    )
+
+    return ResolvedStorageProfiles(job_profile=job_profile, local_profile=local_profile)
+
+
+def _apply_path_mappings_to_roots(
+    job_output_downloader: OutputDownloader,
+    output_paths_by_root: dict[str, list[str]],
+    rules: list[PathMappingRule],
+) -> None:
+    """Apply path mapping rules to remap output root directories.
+
+    Modifies the downloader in-place via set_root_path().
+    """
+    if not rules:
+        return
+
+    applier = _PathMappingRuleApplier(rules)
+    for original_root in list(output_paths_by_root.keys()):
+        mapped_root = applier.transform(original_root)
+        if str(mapped_root) != original_root:
+            click.echo(f"  Mapping root: {original_root} -> {mapped_root}")
+            job_output_downloader.set_root_path(original_root, str(mapped_root))

--- a/src/deadline/client/cli/_groups/job_group.py
+++ b/src/deadline/client/cli/_groups/job_group.py
@@ -21,7 +21,6 @@ import click
 from botocore.exceptions import ClientError
 
 from ...api._session import _modified_logging_level
-from ....job_attachments.download import OutputDownloader
 from ....job_attachments.models import (
     FileConflictResolution,
     JobAttachmentS3Settings,
@@ -59,10 +58,15 @@ from ._job_helpers import (
     _estimate_remaining_time,
 )
 from ._job_download_helpers import (
-    _apply_path_mappings_to_roots,
     _resolve_storage_profiles,
+    _transform_manifests_to_absolute_paths,
 )
 from ....job_attachments._path_mapping import _generate_path_mapping_rules
+from ....job_attachments.download import (
+    OutputDownloader,
+    download_files_from_manifests,
+    get_output_manifests_by_asset_root,
+)
 
 logger = logging.getLogger("deadline.client.cli")
 
@@ -580,11 +584,42 @@ def _download_job_output(
     )
 
     if resolved:
-        # Automatic path mapping via storage profiles
+        # Automatic path mapping via storage profiles using absolute-path transformation.
+        # This matches sync-output behavior: join root + relative, then transform the full
+        # absolute path. This correctly handles nested file system locations where a rule's
+        # source path is deeper than the asset root.
         rules = _generate_path_mapping_rules(resolved.job_profile, resolved.local_profile)
         click.echo(f"Using storage profile: {resolved.local_profile.displayName}")
         if rules:
-            _apply_path_mappings_to_roots(job_output_downloader, output_paths_by_root, rules)
+            # Fetch manifests directly (same S3 data OutputDownloader uses internally)
+            manifests_by_root = get_output_manifests_by_asset_root(
+                s3_settings=JobAttachmentS3Settings(**queue["jobAttachmentSettings"]),
+                farm_id=farm_id,
+                queue_id=queue_id,
+                job_id=job_id,
+                step_id=step_id,
+                task_id=task_id,
+                session_action_id=session_action_id,
+                session=queue_role_session,
+            )
+            mapped_manifests = _transform_manifests_to_absolute_paths(
+                manifests_by_root, rules, resolved.job_profile.osFamily
+            )
+            if mapped_manifests:
+                download_summary = download_files_from_manifests(
+                    s3_bucket=queue["jobAttachmentSettings"]["s3BucketName"],
+                    manifests_by_root=mapped_manifests,
+                    cas_prefix=JobAttachmentS3Settings(
+                        **queue["jobAttachmentSettings"]
+                    ).full_cas_prefix(),
+                    session=queue_role_session,
+                    on_downloading_files=None,
+                )
+                click.echo(_get_download_summary_message(download_summary, is_json_format))
+                click.echo()
+                return
+            # If no files could be mapped, fall through to the OutputDownloader path
+            # which will download to original (unmapped) paths.
         elif resolved.job_profile.storageProfileId != resolved.local_profile.storageProfileId:
             click.echo(
                 "Warning: Storage profiles have no matching file system location names. "

--- a/src/deadline/client/cli/_groups/job_group.py
+++ b/src/deadline/client/cli/_groups/job_group.py
@@ -58,6 +58,11 @@ from ._job_helpers import (
     _print_job_details,
     _estimate_remaining_time,
 )
+from ._job_download_helpers import (
+    _apply_path_mappings_to_roots,
+    _resolve_storage_profiles,
+)
+from ....job_attachments._path_mapping import _generate_path_mapping_rules
 
 logger = logging.getLogger("deadline.client.cli")
 
@@ -488,6 +493,7 @@ def _download_job_output(
     step_id: Optional[str],
     task_id: Optional[str],
     is_json_format: bool = False,
+    ignore_storage_profiles: bool = False,
 ):
     """
     Starts the download of job output and handles the progress reporting callback.
@@ -568,30 +574,50 @@ def _download_job_output(
 
     _check_and_warn_long_output_paths(output_paths_by_root)
 
-    # Check if the asset roots came from different OS. If so, prompt users to
-    # select alternative root paths to download to, (regardless of the auto-accept.)
-    asset_roots = list(output_paths_by_root.keys())
-    for asset_root in asset_roots:
-        root_path_format = root_path_format_mapping.get(asset_root, "")
-        if root_path_format == "":
-            # There must be a corresponding root path format for each root path, by design.
-            raise DeadlineOperationError(f"No root path format found for {asset_root}.")
-        if PathFormat.get_host_path_format_string() != root_path_format:
-            click.echo(_get_mismatch_os_root_warning(asset_root, root_path_format, is_json_format))
+    # Storage profile path mapping (replaces manual OS mismatch prompt when profiles are available)
+    resolved = _resolve_storage_profiles(
+        config, deadline, farm_id, queue_id, job, ignore_storage_profiles
+    )
 
-            if not is_json_format:
-                new_root = click.prompt(
-                    "> Please enter a new root path",
-                    type=click.Path(exists=False),
+    if resolved:
+        # Automatic path mapping via storage profiles
+        rules = _generate_path_mapping_rules(resolved.job_profile, resolved.local_profile)
+        click.echo(f"Using storage profile: {resolved.local_profile.displayName}")
+        if rules:
+            _apply_path_mappings_to_roots(job_output_downloader, output_paths_by_root, rules)
+        elif resolved.job_profile.storageProfileId != resolved.local_profile.storageProfileId:
+            click.echo(
+                "Warning: Storage profiles have no matching file system location names. "
+                "Path mapping will be skipped.\n"
+                "Ensure both storage profiles share the same location names to enable "
+                "automatic path mapping."
+            )
+    else:
+        # No storage profiles — fall back to manual prompt on OS mismatch
+        asset_roots = list(output_paths_by_root.keys())
+        for asset_root in asset_roots:
+            root_path_format = root_path_format_mapping.get(asset_root, "")
+            if root_path_format == "":
+                # There must be a corresponding root path format for each root path, by design.
+                raise DeadlineOperationError(f"No root path format found for {asset_root}.")
+            if PathFormat.get_host_path_format_string() != root_path_format:
+                click.echo(
+                    _get_mismatch_os_root_warning(asset_root, root_path_format, is_json_format)
                 )
-            else:
-                json_string = click.prompt("", prompt_suffix="", type=str)
-                new_root = _get_value_from_json_line(
-                    json_string, JSON_MSG_TYPE_PATHCONFIRM, expected_size=1
-                )[0]
-                _assert_valid_path(new_root)
 
-            job_output_downloader.set_root_path(asset_root, os.path.expanduser(new_root))
+                if not is_json_format:
+                    new_root = click.prompt(
+                        "> Please enter a new root path",
+                        type=click.Path(exists=False),
+                    )
+                else:
+                    json_string = click.prompt("", prompt_suffix="", type=str)
+                    new_root = _get_value_from_json_line(
+                        json_string, JSON_MSG_TYPE_PATHCONFIRM, expected_size=1
+                    )[0]
+                    _assert_valid_path(new_root)
+
+                job_output_downloader.set_root_path(asset_root, os.path.expanduser(new_root))
 
     output_paths_by_root = job_output_downloader.get_output_paths_by_root()
 
@@ -923,6 +949,15 @@ def _assert_valid_path(path: str) -> None:
 @click.option("--step-id", help="The step to use.")
 @click.option("--task-id", help="The task to use.")
 @click.option(
+    "--ignore-storage-profiles",
+    is_flag=True,
+    help="Ignores the storage profile configuration. Only use if the job was "
+    "submitted and downloaded from the same machine. Downloads to "
+    "unmapped paths regardless of operating system.\n"
+    "Default value is False.",
+    default=False,
+)
+@click.option(
     "--conflict-resolution",
     type=click.Choice(
         [
@@ -954,7 +989,7 @@ def _assert_valid_path(path: str) -> None:
     "parsed/consumed by custom scripts.",
 )
 @_handle_error
-def job_download_output(step_id, task_id, output, **args):
+def job_download_output(step_id, task_id, output, ignore_storage_profiles, **args):
     """
     Download the output of a Deadline Cloud job that was saved as job
     attachments.
@@ -964,6 +999,7 @@ def job_download_output(step_id, task_id, output, **args):
     """
     if task_id and not step_id:
         raise click.UsageError("Missing option '--step-id' required with '--task-id'")
+
     # Get a temporary config object with the standard options handled
     config = _apply_cli_options_to_config(
         required_options={"farm_id", "queue_id", "job_id"}, **args
@@ -975,7 +1011,16 @@ def job_download_output(step_id, task_id, output, **args):
     is_json_format = True if output == "json" else False
 
     try:
-        _download_job_output(config, farm_id, queue_id, job_id, step_id, task_id, is_json_format)
+        _download_job_output(
+            config,
+            farm_id,
+            queue_id,
+            job_id,
+            step_id,
+            task_id,
+            is_json_format,
+            ignore_storage_profiles=ignore_storage_profiles,
+        )
     except Exception as e:
         if is_json_format:
             error_one_liner = str(e).replace("\n", ". ")

--- a/src/deadline/client/cli/_groups/job_group.py
+++ b/src/deadline/client/cli/_groups/job_group.py
@@ -58,6 +58,7 @@ from ._job_helpers import (
     _estimate_remaining_time,
 )
 from ._job_download_helpers import (
+    JSON_MSG_TYPE_PROGRESS,
     _download_mapped_manifests,
     _resolve_storage_profiles,
     _transform_manifests_to_absolute_paths,
@@ -74,7 +75,6 @@ JSON_MSG_TYPE_TITLE = "title"
 JSON_MSG_TYPE_PRESUMMARY = "presummary"
 JSON_MSG_TYPE_PATH = "path"
 JSON_MSG_TYPE_PATHCONFIRM = "pathconfirm"
-JSON_MSG_TYPE_PROGRESS = "progress"
 JSON_MSG_TYPE_SUMMARY = "summary"
 JSON_MSG_TYPE_ERROR = "error"
 JSON_MSG_TYPE_WARNING = "warning"
@@ -620,10 +620,8 @@ def _download_job_output(
             # which will download to original (unmapped) paths.
         elif resolved.job_profile.storageProfileId != resolved.local_profile.storageProfileId:
             click.echo(
-                "Warning: Storage profiles have no matching file system location names. "
-                "Path mapping will be skipped.\n"
-                "Ensure both storage profiles share the same location names to enable "
-                "automatic path mapping."
+                "Warning: No path mapping rules could be generated from the storage profiles. "
+                "Path mapping will be skipped."
             )
     else:
         # No storage profiles — fall back to manual prompt on OS mismatch
@@ -1045,13 +1043,13 @@ def job_download_output(step_id, task_id, output, ignore_storage_profiles, **arg
 
     try:
         _download_job_output(
-            config,
-            farm_id,
-            queue_id,
-            job_id,
-            step_id,
-            task_id,
-            is_json_format,
+            config=config,
+            farm_id=farm_id,
+            queue_id=queue_id,
+            job_id=job_id,
+            step_id=step_id,
+            task_id=task_id,
+            is_json_format=is_json_format,
             ignore_storage_profiles=ignore_storage_profiles,
         )
     except Exception as e:

--- a/src/deadline/client/cli/_groups/job_group.py
+++ b/src/deadline/client/cli/_groups/job_group.py
@@ -58,13 +58,13 @@ from ._job_helpers import (
     _estimate_remaining_time,
 )
 from ._job_download_helpers import (
+    _download_mapped_manifests,
     _resolve_storage_profiles,
     _transform_manifests_to_absolute_paths,
 )
 from ....job_attachments._path_mapping import _generate_path_mapping_rules
 from ....job_attachments.download import (
     OutputDownloader,
-    download_files_from_manifests,
     get_output_manifests_by_asset_root,
 )
 
@@ -606,14 +606,12 @@ def _download_job_output(
                 manifests_by_root, rules, resolved.job_profile.osFamily
             )
             if mapped_manifests:
-                download_summary = download_files_from_manifests(
-                    s3_bucket=queue["jobAttachmentSettings"]["s3BucketName"],
-                    manifests_by_root=mapped_manifests,
-                    cas_prefix=JobAttachmentS3Settings(
-                        **queue["jobAttachmentSettings"]
-                    ).full_cas_prefix(),
-                    session=queue_role_session,
-                    on_downloading_files=None,
+                download_summary = _download_mapped_manifests(
+                    mapped_manifests=mapped_manifests,
+                    queue=queue,
+                    queue_role_session=queue_role_session,
+                    conflict_resolution_setting=conflict_resolution,
+                    is_json_format=is_json_format,
                 )
                 click.echo(_get_download_summary_message(download_summary, is_json_format))
                 click.echo()

--- a/src/deadline/client/cli/_groups/job_group.py
+++ b/src/deadline/client/cli/_groups/job_group.py
@@ -652,9 +652,9 @@ def _download_job_output(
 
                 job_output_downloader.set_root_path(asset_root, os.path.expanduser(new_root))
 
-    output_paths_by_root = job_output_downloader.get_output_paths_by_root()
-
-    _check_and_warn_long_output_paths(output_paths_by_root)
+        # Re-fetch after potential set_root_path calls above
+        output_paths_by_root = job_output_downloader.get_output_paths_by_root()
+        _check_and_warn_long_output_paths(output_paths_by_root)
 
     # Prompt users to confirm local root paths where they will download outputs to,
     # and allow users to select different location to download files to if they want.

--- a/src/deadline/job_attachments/_path_mapping.py
+++ b/src/deadline/job_attachments/_path_mapping.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Any, Callable, Optional, Union
 
-from .models import PathFormat, PathMappingRule, StorageProfileOperatingSystemFamily
+from .models import (
+    PathFormat,
+    PathMappingRule,
+    StorageProfile,
+    StorageProfileOperatingSystemFamily,
+)
 
 __all__ = ["_generate_path_mapping_rules", "_PathMappingRuleApplier"]
 
@@ -16,8 +21,8 @@ to be marked as public after developing some experience with it.
 
 
 def _generate_path_mapping_rules(
-    source_storage_profile: dict[str, Any],
-    destination_storage_profile: dict[str, Any],
+    source_storage_profile: Union[StorageProfile, dict[str, Any]],
+    destination_storage_profile: Union[StorageProfile, dict[str, Any]],
 ) -> list[PathMappingRule]:
     """
     Given a pair of storage profiles, generate all the path mapping rules to transform paths
@@ -27,34 +32,29 @@ def _generate_path_mapping_rules(
     the storage profile regardless of the type (SHARED vs LOCAL), to account for the broadest
     possible storage profile configurations.
 
+    Accepts either StorageProfile dataclass or raw boto3 dict responses.
+
     Args:
-        source_storage_profile: A storage profile as returned by boto3 deadline.get_storage_profile or
-            deadline.get_storage_profile_for_queue.
-        destination_storage_profile: A storage profile as returned by boto3 deadline.get_storage_profile or
-            deadline.get_storage_profile_for_queue.
+        source_storage_profile: A StorageProfile dataclass or a storage profile dict as returned
+            by boto3 deadline.get_storage_profile or deadline.get_storage_profile_for_queue.
+        destination_storage_profile: A StorageProfile dataclass or a storage profile dict as returned
+            by boto3 deadline.get_storage_profile or deadline.get_storage_profile_for_queue.
     Returns:
         A list of path mapping rules to transform paths.
     """
+    # Normalize inputs to a common shape
+    src = _normalize_storage_profile(source_storage_profile)
+    dst = _normalize_storage_profile(destination_storage_profile)
+
     # If the source and destination are identical, no transformation is needed
-    if (
-        source_storage_profile["storageProfileId"]
-        == destination_storage_profile["storageProfileId"]
-    ):
+    if src["storageProfileId"] == dst["storageProfileId"]:
         return []
 
     # Put the locations into dictionaries to match up the names
-    source_locations = {
-        location["name"]: location for location in source_storage_profile["fileSystemLocations"]
-    }
-    destination_locations = {
-        location["name"]: location
-        for location in destination_storage_profile["fileSystemLocations"]
-    }
+    source_locations = {location["name"]: location for location in src["fileSystemLocations"]}
+    destination_locations = {location["name"]: location for location in dst["fileSystemLocations"]}
 
-    if (
-        source_storage_profile["osFamily"].lower()
-        == StorageProfileOperatingSystemFamily.WINDOWS.value
-    ):
+    if src["osFamily"].lower() == StorageProfileOperatingSystemFamily.WINDOWS.value:
         source_path_format = PathFormat.WINDOWS.value
     else:
         source_path_format = PathFormat.POSIX.value
@@ -71,6 +71,22 @@ def _generate_path_mapping_rules(
             )
 
     return path_mapping_rules
+
+
+def _normalize_storage_profile(
+    profile: Union[StorageProfile, dict[str, Any]],
+) -> dict[str, Any]:
+    """Convert a StorageProfile dataclass to the dict format, or pass through if already a dict."""
+    if isinstance(profile, StorageProfile):
+        return {
+            "storageProfileId": profile.storageProfileId,
+            "osFamily": profile.osFamily.value,
+            "fileSystemLocations": [
+                {"name": loc.name, "path": loc.path, "type": loc.type.value}
+                for loc in profile.fileSystemLocations
+            ],
+        }
+    return profile
 
 
 class _PathMappingRuleApplier:

--- a/src/deadline/job_attachments/_path_mapping.py
+++ b/src/deadline/job_attachments/_path_mapping.py
@@ -194,12 +194,3 @@ class _PathMappingRuleApplier:
                 return result
 
         raise ValueError("No path mapping rule could be applied")
-
-    def transform(self, source_path: str) -> Union[str, Path]:
-        """Transform the provided path according to the path mapping rules. Return an untransformed path if no rule applied."""
-        if self.source_path_format is not None:
-            result = self._transform(source_path)
-            if result:
-                return result
-
-        return source_path

--- a/src/deadline/job_attachments/_path_mapping.py
+++ b/src/deadline/job_attachments/_path_mapping.py
@@ -194,3 +194,12 @@ class _PathMappingRuleApplier:
                 return result
 
         raise ValueError("No path mapping rule could be applied")
+
+    def transform(self, source_path: str) -> Union[str, Path]:
+        """Transform the provided path according to the path mapping rules. Return an untransformed path if no rule applied."""
+        if self.source_path_format is not None:
+            result = self._transform(source_path)
+            if result:
+                return result
+
+        return source_path

--- a/src/deadline/job_attachments/download.py
+++ b/src/deadline/job_attachments/download.py
@@ -1267,9 +1267,8 @@ class OutputDownloader:
     If no session is provided the default credentials path will be used, see:
     https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#configuring-credentials
 
-    TODO: The download location is OS-specific to the *submitting machine* matching
-    the profile of the submitting machine. The OS of the *downloading machine* might be different, so we need to check that
-    and apply path mapping rules in that case.
+    Path mapping for cross-OS downloads is handled at the CLI layer via set_root_path(),
+    consistent with how queue sync-output applies path mapping externally.
     """
 
     def __init__(

--- a/test/unit/deadline_client/cli/test_cli_job_download_storage_profiles.py
+++ b/test/unit/deadline_client/cli/test_cli_job_download_storage_profiles.py
@@ -205,7 +205,7 @@ def test_case2_both_profiles_no_matching_locations(fresh_deadline_config: str) -
         assert result.exit_code == 0, result.output
         assert "Using storage profile: Local Linux Profile" in result.output
         # No set_root_path calls because no location names matched
-        assert "no matching file system location names" in result.output
+        assert "No path mapping rules could be generated" in result.output
         mock_downloader.return_value.set_root_path.assert_not_called()
 
 

--- a/test/unit/deadline_client/cli/test_cli_job_download_storage_profiles.py
+++ b/test/unit/deadline_client/cli/test_cli_job_download_storage_profiles.py
@@ -15,6 +15,7 @@ import sys
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+import pytest
 from click.testing import CliRunner
 
 from deadline.client import api, config
@@ -125,7 +126,7 @@ def _make_download_mocks(
 
 
 def test_case1_both_profiles_match_auto_mapping(fresh_deadline_config: str) -> None:
-    """Both profiles exist with matching location names → roots are remapped automatically."""
+    """Both profiles exist with matching location names → absolute-path mapping via manifests."""
     config.set_setting("defaults.farm_id", MOCK_FARM_ID)
     config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
     config.set_setting("settings.storage_profile_id", "sp-local-111")
@@ -137,7 +138,9 @@ def test_case1_both_profiles_match_auto_mapping(fresh_deadline_config: str) -> N
         job_group, "_get_conflicting_filenames", return_value=[]
     ), patch.object(job_group, "round", return_value=0), patch.object(
         api, "get_queue_user_boto3_session"
-    ), patch.object(api, "get_storage_profile_for_queue") as mock_get_profile:
+    ), patch.object(api, "get_storage_profile_for_queue") as mock_get_profile, patch.object(
+        job_group, "get_output_manifests_by_asset_root", return_value={}
+    ) as mock_get_manifests, patch.object(job_group, "download_files_from_manifests"):
         mock_get_profile.side_effect = [MOCK_LOCAL_PROFILE, MOCK_JOB_PROFILE]
 
         root = "C:\\temp\\render"
@@ -160,7 +163,9 @@ def test_case1_both_profiles_match_auto_mapping(fresh_deadline_config: str) -> N
 
         assert result.exit_code == 0, result.output
         assert "Using storage profile: Local Linux Profile" in result.output
-        mock_downloader.return_value.set_root_path.assert_called()
+        # With the new absolute-path approach, we call get_output_manifests_by_asset_root
+        # instead of set_root_path
+        mock_get_manifests.assert_called_once()
 
 
 # ─── Case 2: Both profiles exist, locations don't match → no mapping ─────────
@@ -403,3 +408,306 @@ def test_case7_same_profile_both_sides(fresh_deadline_config: str) -> None:
         assert "Using storage profile: Local Linux Profile" in result.output
         # Same profile → empty rules → no set_root_path calls
         mock_downloader.return_value.set_root_path.assert_not_called()
+
+
+# ─── Case 8-E: Nested file system locations → most specific rule wins ────────
+
+# Profiles with nested locations: "special" is a subdirectory of "projects"
+MOCK_NESTED_JOB_PROFILE = StorageProfile(
+    storageProfileId="sp-nested-job-444",
+    displayName="Nested Windows Profile",
+    osFamily=StorageProfileOperatingSystemFamily.WINDOWS,
+    fileSystemLocations=[
+        FileSystemLocation(name="projects", path="C:\\Projects", type=FileSystemLocationType.LOCAL),
+        FileSystemLocation(
+            name="special", path="C:\\Projects\\Special", type=FileSystemLocationType.LOCAL
+        ),
+    ],
+)
+
+MOCK_NESTED_LOCAL_PROFILE = StorageProfile(
+    storageProfileId="sp-nested-local-555",
+    displayName="Nested Linux Profile",
+    osFamily=StorageProfileOperatingSystemFamily.LINUX,
+    fileSystemLocations=[
+        FileSystemLocation(
+            name="projects", path="/mnt/projects", type=FileSystemLocationType.LOCAL
+        ),
+        FileSystemLocation(name="special", path="/opt/special", type=FileSystemLocationType.LOCAL),
+    ],
+)
+
+
+def _make_mock_manifest(paths: list[tuple[str, int]]) -> MagicMock:
+    """Create a mock BaseAssetManifest with the given (relative_path, size) pairs."""
+    manifest = MagicMock()
+    manifest.hashAlg = "xxh128"
+    mock_paths = []
+    for path, size in paths:
+        mp = MagicMock()
+        mp.path = path
+        mp.size = size
+        mp.hash = "abc123"
+        mp.mtime = 1000000
+        mock_paths.append(mp)
+    manifest.paths = mock_paths
+    manifest.totalSize = sum(s for _, s in paths)
+    return manifest
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX destination test")
+def test_case8e_nested_locations_most_specific_rule_wins(
+    fresh_deadline_config: str,
+) -> None:
+    """Nested file system locations: the most specific rule wins via absolute-path transformation.
+
+    Source profile (Windows):
+      - "projects": C:\\Projects
+      - "special":  C:\\Projects\\Special
+
+    Destination profile (Linux):
+      - "projects": /mnt/projects
+      - "special":  /opt/special
+
+    Job output root: C:\\Projects, relative path: Special\\data.txt
+    Absolute path: C:\\Projects\\Special\\data.txt → should match "special" rule → /opt/special/data.txt
+    NOT /mnt/projects/Special/data.txt (which root-only transformation would produce).
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("settings.storage_profile_id", "sp-nested-local-555")
+    config.set_setting("settings.auto_accept", "true")
+
+    root = "C:\\Projects"
+    mock_manifest = _make_mock_manifest([("Special\\data.txt", 100)])
+
+    with patch.object(api, "get_boto3_client") as boto3_client_mock, patch.object(
+        job_group, "OutputDownloader"
+    ) as mock_downloader, patch.object(
+        job_group, "_get_conflicting_filenames", return_value=[]
+    ), patch.object(job_group, "round", return_value=0), patch.object(
+        api, "get_queue_user_boto3_session"
+    ), patch.object(api, "get_storage_profile_for_queue") as mock_get_profile, patch.object(
+        job_group,
+        "get_output_manifests_by_asset_root",
+        return_value={root: [mock_manifest]},
+    ), patch.object(job_group, "download_files_from_manifests") as mock_download_manifests:
+        mock_get_profile.side_effect = [MOCK_NESTED_LOCAL_PROFILE, MOCK_NESTED_JOB_PROFILE]
+        mock_download_manifests.return_value = DownloadSummaryStatistics(
+            total_time=1, processed_files=1, processed_bytes=100
+        )
+
+        _make_download_mocks(
+            boto3_client_mock,
+            mock_downloader,
+            _make_job_response(
+                storage_profile_id="sp-nested-job-444",
+                root_path=root,
+                root_path_format=PathFormat.WINDOWS,
+            ),
+            {root: ["Special\\data.txt"]},
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["job", "download-output", "--job-id", MOCK_JOB_ID, "--output", "verbose"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Using storage profile: Nested Linux Profile" in result.output
+        assert "Mapped 1 output file(s)" in result.output
+
+        # Verify the manifest path was transformed to the SPECIFIC rule destination
+        # The "special" rule (C:\Projects\Special -> /opt/special) should win over
+        # the "projects" rule (C:\Projects -> /mnt/projects)
+        assert mock_manifest.paths[0].path == "/opt/special/data.txt"
+
+        # Verify download_files_from_manifests was called (not OutputDownloader)
+        mock_download_manifests.assert_called_once()
+        mock_downloader.return_value.download_job_output.assert_not_called()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX destination test")
+def test_case8e_nested_locations_broader_rule_for_non_nested_path(
+    fresh_deadline_config: str,
+) -> None:
+    """With nested locations, a file NOT under the nested path uses the broader rule.
+
+    Same profiles as Case 8-E, but relative path is "other\\file.txt" (not under Special).
+    Absolute path: C:\\Projects\\other\\file.txt → matches "projects" rule → /mnt/projects/other/file.txt
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("settings.storage_profile_id", "sp-nested-local-555")
+    config.set_setting("settings.auto_accept", "true")
+
+    root = "C:\\Projects"
+    mock_manifest = _make_mock_manifest([("other\\file.txt", 50)])
+
+    with patch.object(api, "get_boto3_client") as boto3_client_mock, patch.object(
+        job_group, "OutputDownloader"
+    ) as mock_downloader, patch.object(
+        job_group, "_get_conflicting_filenames", return_value=[]
+    ), patch.object(job_group, "round", return_value=0), patch.object(
+        api, "get_queue_user_boto3_session"
+    ), patch.object(api, "get_storage_profile_for_queue") as mock_get_profile, patch.object(
+        job_group,
+        "get_output_manifests_by_asset_root",
+        return_value={root: [mock_manifest]},
+    ), patch.object(job_group, "download_files_from_manifests") as mock_download_manifests:
+        mock_get_profile.side_effect = [MOCK_NESTED_LOCAL_PROFILE, MOCK_NESTED_JOB_PROFILE]
+        mock_download_manifests.return_value = DownloadSummaryStatistics(
+            total_time=1, processed_files=1, processed_bytes=100
+        )
+
+        _make_download_mocks(
+            boto3_client_mock,
+            mock_downloader,
+            _make_job_response(
+                storage_profile_id="sp-nested-job-444",
+                root_path=root,
+                root_path_format=PathFormat.WINDOWS,
+            ),
+            {root: ["other\\file.txt"]},
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["job", "download-output", "--job-id", MOCK_JOB_ID, "--output", "verbose"],
+        )
+
+        assert result.exit_code == 0, result.output
+        # The broader "projects" rule should apply
+        assert mock_manifest.paths[0].path == "/mnt/projects/other/file.txt"
+        mock_download_manifests.assert_called_once()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX destination test")
+def test_case8e_nested_locations_mixed_paths(
+    fresh_deadline_config: str,
+) -> None:
+    """With nested locations, files under different depths get the correct rules.
+
+    Two files in the same manifest:
+      - Special\\data.txt → "special" rule → /opt/special/data.txt
+      - other\\file.txt   → "projects" rule → /mnt/projects/other/file.txt
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("settings.storage_profile_id", "sp-nested-local-555")
+    config.set_setting("settings.auto_accept", "true")
+
+    root = "C:\\Projects"
+    mock_manifest = _make_mock_manifest(
+        [
+            ("Special\\data.txt", 100),
+            ("other\\file.txt", 50),
+        ]
+    )
+
+    with patch.object(api, "get_boto3_client") as boto3_client_mock, patch.object(
+        job_group, "OutputDownloader"
+    ) as mock_downloader, patch.object(
+        job_group, "_get_conflicting_filenames", return_value=[]
+    ), patch.object(job_group, "round", return_value=0), patch.object(
+        api, "get_queue_user_boto3_session"
+    ), patch.object(api, "get_storage_profile_for_queue") as mock_get_profile, patch.object(
+        job_group,
+        "get_output_manifests_by_asset_root",
+        return_value={root: [mock_manifest]},
+    ), patch.object(job_group, "download_files_from_manifests") as mock_download_manifests:
+        mock_get_profile.side_effect = [MOCK_NESTED_LOCAL_PROFILE, MOCK_NESTED_JOB_PROFILE]
+        mock_download_manifests.return_value = DownloadSummaryStatistics(
+            total_time=1, processed_files=1, processed_bytes=100
+        )
+
+        _make_download_mocks(
+            boto3_client_mock,
+            mock_downloader,
+            _make_job_response(
+                storage_profile_id="sp-nested-job-444",
+                root_path=root,
+                root_path_format=PathFormat.WINDOWS,
+            ),
+            {root: ["Special\\data.txt", "other\\file.txt"]},
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["job", "download-output", "--job-id", MOCK_JOB_ID, "--output", "verbose"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Mapped 2 output file(s)" in result.output
+
+        # Verify each file got the correct rule
+        mapped_paths = {p.path for p in mock_manifest.paths}
+        assert "/opt/special/data.txt" in mapped_paths
+        assert "/mnt/projects/other/file.txt" in mapped_paths
+
+
+# ─── Rules exist but no output files match → fallback to OutputDownloader ────
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX destination test")
+def test_rules_exist_but_no_files_match_falls_back_to_downloader(
+    fresh_deadline_config: str,
+) -> None:
+    """When rules are generated but no output files match any rule, fall back to
+    the OutputDownloader path and download to original (unmapped) paths.
+
+    This covers the case where the job's output root is outside all file system
+    locations in the storage profile. The rules exist but don't apply to the
+    actual output paths. Rather than skipping the download entirely, we fall
+    through to the existing OutputDownloader code path.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("settings.storage_profile_id", "sp-local-111")
+    config.set_setting("settings.auto_accept", "true")
+
+    # Output root is NOT under any of the profile's locations
+    # (shared=Z:\shared, temp=C:\temp\render) — it's at D:\unrelated
+    root = "D:\\unrelated\\output"
+    mock_manifest = _make_mock_manifest([("result.exr", 100)])
+
+    with patch.object(api, "get_boto3_client") as boto3_client_mock, patch.object(
+        job_group, "OutputDownloader"
+    ) as mock_downloader, patch.object(
+        job_group, "_get_conflicting_filenames", return_value=[]
+    ), patch.object(job_group, "round", return_value=0), patch.object(
+        api, "get_queue_user_boto3_session"
+    ), patch.object(api, "get_storage_profile_for_queue") as mock_get_profile, patch.object(
+        job_group,
+        "get_output_manifests_by_asset_root",
+        return_value={root: [mock_manifest]},
+    ), patch.object(job_group, "download_files_from_manifests") as mock_download_manifests:
+        mock_get_profile.side_effect = [MOCK_LOCAL_PROFILE, MOCK_JOB_PROFILE]
+
+        mock_root = "/root/path"
+        _make_download_mocks(
+            boto3_client_mock,
+            mock_downloader,
+            _make_job_response(
+                storage_profile_id="sp-job-222",
+                root_path=root,
+                root_path_format=PathFormat.WINDOWS,
+            ),
+            {mock_root: ["result.exr"]},
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["job", "download-output", "--job-id", MOCK_JOB_ID, "--output", "verbose"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Using storage profile: Local Linux Profile" in result.output
+        # No files matched the rules, so download_files_from_manifests should NOT be called
+        mock_download_manifests.assert_not_called()
+        # Instead, the OutputDownloader path should have been used
+        mock_downloader.return_value.download_job_output.assert_called_once()

--- a/test/unit/deadline_client/cli/test_cli_job_download_storage_profiles.py
+++ b/test/unit/deadline_client/cli/test_cli_job_download_storage_profiles.py
@@ -140,7 +140,7 @@ def test_case1_both_profiles_match_auto_mapping(fresh_deadline_config: str) -> N
         api, "get_queue_user_boto3_session"
     ), patch.object(api, "get_storage_profile_for_queue") as mock_get_profile, patch.object(
         job_group, "get_output_manifests_by_asset_root", return_value={}
-    ) as mock_get_manifests, patch.object(job_group, "download_files_from_manifests"):
+    ) as mock_get_manifests, patch.object(job_group, "_download_mapped_manifests"):
         mock_get_profile.side_effect = [MOCK_LOCAL_PROFILE, MOCK_JOB_PROFILE]
 
         root = "C:\\temp\\render"
@@ -491,7 +491,7 @@ def test_case8e_nested_locations_most_specific_rule_wins(
         job_group,
         "get_output_manifests_by_asset_root",
         return_value={root: [mock_manifest]},
-    ), patch.object(job_group, "download_files_from_manifests") as mock_download_manifests:
+    ), patch.object(job_group, "_download_mapped_manifests") as mock_download_manifests:
         mock_get_profile.side_effect = [MOCK_NESTED_LOCAL_PROFILE, MOCK_NESTED_JOB_PROFILE]
         mock_download_manifests.return_value = DownloadSummaryStatistics(
             total_time=1, processed_files=1, processed_bytes=100
@@ -523,7 +523,7 @@ def test_case8e_nested_locations_most_specific_rule_wins(
         # the "projects" rule (C:\Projects -> /mnt/projects)
         assert mock_manifest.paths[0].path == "/opt/special/data.txt"
 
-        # Verify download_files_from_manifests was called (not OutputDownloader)
+        # Verify mapped manifest download was called (not OutputDownloader)
         mock_download_manifests.assert_called_once()
         mock_downloader.return_value.download_job_output.assert_not_called()
 
@@ -555,7 +555,7 @@ def test_case8e_nested_locations_broader_rule_for_non_nested_path(
         job_group,
         "get_output_manifests_by_asset_root",
         return_value={root: [mock_manifest]},
-    ), patch.object(job_group, "download_files_from_manifests") as mock_download_manifests:
+    ), patch.object(job_group, "_download_mapped_manifests") as mock_download_manifests:
         mock_get_profile.side_effect = [MOCK_NESTED_LOCAL_PROFILE, MOCK_NESTED_JOB_PROFILE]
         mock_download_manifests.return_value = DownloadSummaryStatistics(
             total_time=1, processed_files=1, processed_bytes=100
@@ -617,7 +617,7 @@ def test_case8e_nested_locations_mixed_paths(
         job_group,
         "get_output_manifests_by_asset_root",
         return_value={root: [mock_manifest]},
-    ), patch.object(job_group, "download_files_from_manifests") as mock_download_manifests:
+    ), patch.object(job_group, "_download_mapped_manifests") as mock_download_manifests:
         mock_get_profile.side_effect = [MOCK_NESTED_LOCAL_PROFILE, MOCK_NESTED_JOB_PROFILE]
         mock_download_manifests.return_value = DownloadSummaryStatistics(
             total_time=1, processed_files=1, processed_bytes=100
@@ -684,7 +684,7 @@ def test_rules_exist_but_no_files_match_falls_back_to_downloader(
         job_group,
         "get_output_manifests_by_asset_root",
         return_value={root: [mock_manifest]},
-    ), patch.object(job_group, "download_files_from_manifests") as mock_download_manifests:
+    ), patch.object(job_group, "_download_mapped_manifests") as mock_download_manifests:
         mock_get_profile.side_effect = [MOCK_LOCAL_PROFILE, MOCK_JOB_PROFILE]
 
         mock_root = "/root/path"
@@ -707,7 +707,171 @@ def test_rules_exist_but_no_files_match_falls_back_to_downloader(
 
         assert result.exit_code == 0, result.output
         assert "Using storage profile: Local Linux Profile" in result.output
-        # No files matched the rules, so download_files_from_manifests should NOT be called
+        # No files matched the rules, so mapped manifest download should NOT be called
         mock_download_manifests.assert_not_called()
         # Instead, the OutputDownloader path should have been used
         mock_downloader.return_value.download_job_output.assert_called_once()
+
+
+# ─── Mapped download path: progress callback and conflict resolution ─────────
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX destination test")
+def test_mapped_download_passes_progress_callback(
+    fresh_deadline_config: str,
+) -> None:
+    """When downloading via the mapped manifest path, _download_mapped_manifests is called
+    which handles progress reporting internally."""
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("settings.storage_profile_id", "sp-local-111")
+    config.set_setting("settings.auto_accept", "true")
+
+    root = "C:\\temp\\render"
+    mock_manifest = _make_mock_manifest([("output.exr", 100)])
+
+    with patch.object(api, "get_boto3_client") as boto3_client_mock, patch.object(
+        job_group, "OutputDownloader"
+    ) as mock_downloader, patch.object(
+        job_group, "_get_conflicting_filenames", return_value=[]
+    ), patch.object(job_group, "round", return_value=0), patch.object(
+        api, "get_queue_user_boto3_session"
+    ), patch.object(api, "get_storage_profile_for_queue") as mock_get_profile, patch.object(
+        job_group,
+        "get_output_manifests_by_asset_root",
+        return_value={root: [mock_manifest]},
+    ), patch.object(job_group, "_download_mapped_manifests") as mock_download_mapped:
+        mock_get_profile.side_effect = [MOCK_LOCAL_PROFILE, MOCK_JOB_PROFILE]
+        mock_download_mapped.return_value = DownloadSummaryStatistics(
+            total_time=1, processed_files=1, processed_bytes=100
+        )
+
+        _make_download_mocks(
+            boto3_client_mock,
+            mock_downloader,
+            _make_job_response(
+                storage_profile_id="sp-job-222",
+                root_path=root,
+                root_path_format=PathFormat.WINDOWS,
+            ),
+            {root: ["output.exr"]},
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["job", "download-output", "--job-id", MOCK_JOB_ID, "--output", "verbose"],
+        )
+
+        assert result.exit_code == 0, result.output
+        mock_download_mapped.assert_called_once()
+        call_kwargs = mock_download_mapped.call_args[1]
+        # is_json_format=False for verbose mode
+        assert call_kwargs["is_json_format"] is False
+        # Conflict resolution setting must be passed
+        assert "conflict_resolution_setting" in call_kwargs
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX destination test")
+def test_mapped_download_uses_configured_conflict_resolution(
+    fresh_deadline_config: str,
+) -> None:
+    """When conflict_resolution is set in config, _download_mapped_manifests receives it."""
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("settings.storage_profile_id", "sp-local-111")
+    config.set_setting("settings.auto_accept", "true")
+    config.set_setting("settings.conflict_resolution", "SKIP")
+
+    root = "C:\\temp\\render"
+    mock_manifest = _make_mock_manifest([("output.exr", 100)])
+
+    with patch.object(api, "get_boto3_client") as boto3_client_mock, patch.object(
+        job_group, "OutputDownloader"
+    ) as mock_downloader, patch.object(
+        job_group, "_get_conflicting_filenames", return_value=[]
+    ), patch.object(job_group, "round", return_value=0), patch.object(
+        api, "get_queue_user_boto3_session"
+    ), patch.object(api, "get_storage_profile_for_queue") as mock_get_profile, patch.object(
+        job_group,
+        "get_output_manifests_by_asset_root",
+        return_value={root: [mock_manifest]},
+    ), patch.object(job_group, "_download_mapped_manifests") as mock_download_mapped:
+        mock_get_profile.side_effect = [MOCK_LOCAL_PROFILE, MOCK_JOB_PROFILE]
+        mock_download_mapped.return_value = DownloadSummaryStatistics(
+            total_time=1, processed_files=1, processed_bytes=100
+        )
+
+        _make_download_mocks(
+            boto3_client_mock,
+            mock_downloader,
+            _make_job_response(
+                storage_profile_id="sp-job-222",
+                root_path=root,
+                root_path_format=PathFormat.WINDOWS,
+            ),
+            {root: ["output.exr"]},
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["job", "download-output", "--job-id", MOCK_JOB_ID, "--output", "verbose"],
+        )
+
+        assert result.exit_code == 0, result.output
+        call_kwargs = mock_download_mapped.call_args[1]
+        assert call_kwargs["conflict_resolution_setting"] == "SKIP"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX destination test")
+def test_mapped_download_json_mode_emits_progress(
+    fresh_deadline_config: str,
+) -> None:
+    """In JSON mode, _download_mapped_manifests receives is_json_format=True."""
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("settings.storage_profile_id", "sp-local-111")
+    config.set_setting("settings.auto_accept", "true")
+
+    root = "C:\\temp\\render"
+    mock_manifest = _make_mock_manifest([("output.exr", 100)])
+
+    with patch.object(api, "get_boto3_client") as boto3_client_mock, patch.object(
+        job_group, "OutputDownloader"
+    ) as mock_downloader, patch.object(
+        job_group, "_get_conflicting_filenames", return_value=[]
+    ), patch.object(job_group, "round", return_value=0), patch.object(
+        api, "get_queue_user_boto3_session"
+    ), patch.object(api, "get_storage_profile_for_queue") as mock_get_profile, patch.object(
+        job_group,
+        "get_output_manifests_by_asset_root",
+        return_value={root: [mock_manifest]},
+    ), patch.object(job_group, "_download_mapped_manifests") as mock_download_mapped:
+        mock_get_profile.side_effect = [MOCK_LOCAL_PROFILE, MOCK_JOB_PROFILE]
+        mock_download_mapped.return_value = DownloadSummaryStatistics(
+            total_time=1, processed_files=1, processed_bytes=100
+        )
+
+        _make_download_mocks(
+            boto3_client_mock,
+            mock_downloader,
+            _make_job_response(
+                storage_profile_id="sp-job-222",
+                root_path=root,
+                root_path_format=PathFormat.WINDOWS,
+            ),
+            {root: ["output.exr"]},
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["job", "download-output", "--job-id", MOCK_JOB_ID, "--output", "json"],
+        )
+
+        assert result.exit_code == 0, result.output
+        mock_download_mapped.assert_called_once()
+        call_kwargs = mock_download_mapped.call_args[1]
+        # JSON mode should pass is_json_format=True
+        assert call_kwargs["is_json_format"] is True

--- a/test/unit/deadline_client/cli/test_cli_job_download_storage_profiles.py
+++ b/test/unit/deadline_client/cli/test_cli_job_download_storage_profiles.py
@@ -1,0 +1,405 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+End-to-end CLI tests for `deadline job download-output` storage profile support.
+
+These tests exercise the full CLI path from `job_download_output()` through
+`_download_job_output()`, mocking only the Deadline API client, OutputDownloader,
+and the queue session. Each test corresponds to a case in
+docs/design/storage-profile-cli-test-cases.md.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from deadline.client import api, config
+from deadline.client.cli import main
+from deadline.client.cli._groups import job_group
+from deadline.job_attachments.models import (
+    FileSystemLocation,
+    FileSystemLocationType,
+    PathFormat,
+    StorageProfile,
+    StorageProfileOperatingSystemFamily,
+)
+from deadline.job_attachments.progress_tracker import DownloadSummaryStatistics
+
+MOCK_FARM_ID = "farm-0123456789abcdefabcdefabcdefabcd"
+MOCK_QUEUE_ID = "queue-0123456789abcdefabcdefabcdefabcd"
+MOCK_JOB_ID = "job-0123456789abcdefabcdefabcdefabcd"
+
+MOCK_GET_QUEUE_RESPONSE: dict[str, Any] = {
+    "queueId": MOCK_QUEUE_ID,
+    "displayName": "Test Queue",
+    "description": "",
+    "farmId": MOCK_FARM_ID,
+    "status": "ACTIVE",
+    "jobAttachmentSettings": {
+        "s3BucketName": "deadline-job-attachments-mock-bucket",
+        "rootPrefix": "AWS Deadline Cloud",
+    },
+}
+
+MOCK_LOCAL_PROFILE = StorageProfile(
+    storageProfileId="sp-local-111",
+    displayName="Local Linux Profile",
+    osFamily=StorageProfileOperatingSystemFamily.LINUX,
+    fileSystemLocations=[
+        FileSystemLocation(name="shared", path="/mnt/shared", type=FileSystemLocationType.SHARED),
+        FileSystemLocation(name="temp", path="/tmp/render", type=FileSystemLocationType.LOCAL),
+    ],
+)
+
+MOCK_JOB_PROFILE = StorageProfile(
+    storageProfileId="sp-job-222",
+    displayName="Job Windows Profile",
+    osFamily=StorageProfileOperatingSystemFamily.WINDOWS,
+    fileSystemLocations=[
+        FileSystemLocation(name="shared", path="Z:\\shared", type=FileSystemLocationType.SHARED),
+        FileSystemLocation(name="temp", path="C:\\temp\\render", type=FileSystemLocationType.LOCAL),
+    ],
+)
+
+MOCK_JOB_PROFILE_NO_MATCH = StorageProfile(
+    storageProfileId="sp-job-333",
+    displayName="Job No Match Profile",
+    osFamily=StorageProfileOperatingSystemFamily.WINDOWS,
+    fileSystemLocations=[
+        FileSystemLocation(
+            name="ProjectFiles", path="D:\\projects", type=FileSystemLocationType.LOCAL
+        ),
+        FileSystemLocation(name="OutputDir", path="D:\\output", type=FileSystemLocationType.LOCAL),
+    ],
+)
+
+
+def _make_job_response(
+    storage_profile_id: str | None = None,
+    root_path: str = "/root/path",
+    root_path_format: str | None = None,
+) -> dict[str, Any]:
+    """Build a mock get_job response."""
+    if root_path_format is None:
+        root_path_format = PathFormat.get_host_path_format()
+    result: dict[str, Any] = {
+        "name": "Mock Job",
+        "attachments": {
+            "manifests": [
+                {
+                    "rootPath": root_path,
+                    "rootPathFormat": root_path_format,
+                    "outputRelativeDirectories": ["."],
+                }
+            ]
+        },
+    }
+    if storage_profile_id:
+        result["storageProfileId"] = storage_profile_id
+    return result
+
+
+def _make_download_mocks(
+    boto3_client_mock: MagicMock,
+    mock_output_downloader: MagicMock,
+    job_response: dict[str, Any],
+    root_paths: dict[str, list[str]],
+) -> None:
+    """Wire up the common mocks for a download-output test."""
+    boto3_client_mock().get_queue.return_value = MOCK_GET_QUEUE_RESPONSE
+    boto3_client_mock().get_job.return_value = job_response
+
+    mock_download = MagicMock()
+    mock_download.return_value = DownloadSummaryStatistics(
+        total_time=1, processed_files=1, processed_bytes=100
+    )
+    mock_output_downloader.return_value.download_job_output = mock_download
+    mock_output_downloader.return_value.get_output_paths_by_root.return_value = root_paths
+
+
+# ─── Case 1: Both profiles exist, locations match → automatic mapping ────────
+
+
+def test_case1_both_profiles_match_auto_mapping(fresh_deadline_config: str) -> None:
+    """Both profiles exist with matching location names → roots are remapped automatically."""
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("settings.storage_profile_id", "sp-local-111")
+    config.set_setting("settings.auto_accept", "true")
+
+    with patch.object(api, "get_boto3_client") as boto3_client_mock, patch.object(
+        job_group, "OutputDownloader"
+    ) as mock_downloader, patch.object(
+        job_group, "_get_conflicting_filenames", return_value=[]
+    ), patch.object(job_group, "round", return_value=0), patch.object(
+        api, "get_queue_user_boto3_session"
+    ), patch.object(api, "get_storage_profile_for_queue") as mock_get_profile:
+        mock_get_profile.side_effect = [MOCK_LOCAL_PROFILE, MOCK_JOB_PROFILE]
+
+        root = "C:\\temp\\render"
+        _make_download_mocks(
+            boto3_client_mock,
+            mock_downloader,
+            _make_job_response(
+                storage_profile_id="sp-job-222",
+                root_path=root,
+                root_path_format=PathFormat.WINDOWS,
+            ),
+            {root: ["output.exr"]},
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["job", "download-output", "--job-id", MOCK_JOB_ID, "--output", "verbose"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Using storage profile: Local Linux Profile" in result.output
+        mock_downloader.return_value.set_root_path.assert_called()
+
+
+# ─── Case 2: Both profiles exist, locations don't match → no mapping ─────────
+
+
+def test_case2_both_profiles_no_matching_locations(fresh_deadline_config: str) -> None:
+    """Both profiles exist but location names don't match → no mapping, original paths."""
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("settings.storage_profile_id", "sp-local-111")
+    config.set_setting("settings.auto_accept", "true")
+
+    mock_root = "/root/path" if sys.platform != "win32" else "C:\\Users\\username"
+
+    with patch.object(api, "get_boto3_client") as boto3_client_mock, patch.object(
+        job_group, "OutputDownloader"
+    ) as mock_downloader, patch.object(
+        job_group, "_get_conflicting_filenames", return_value=[]
+    ), patch.object(job_group, "round", return_value=0), patch.object(
+        api, "get_queue_user_boto3_session"
+    ), patch.object(api, "get_storage_profile_for_queue") as mock_get_profile:
+        mock_get_profile.side_effect = [MOCK_LOCAL_PROFILE, MOCK_JOB_PROFILE_NO_MATCH]
+
+        _make_download_mocks(
+            boto3_client_mock,
+            mock_downloader,
+            _make_job_response(storage_profile_id="sp-job-333", root_path=mock_root),
+            {mock_root: ["output.exr"]},
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["job", "download-output", "--job-id", MOCK_JOB_ID, "--output", "verbose"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Using storage profile: Local Linux Profile" in result.output
+        # No set_root_path calls because no location names matched
+        assert "no matching file system location names" in result.output
+        mock_downloader.return_value.set_root_path.assert_not_called()
+
+
+# ─── Case 3: Job has profile, local does not → warning, manual fallback ──────
+
+
+def test_case3_no_local_profile_job_has_profile_warning_fallback(
+    fresh_deadline_config: str,
+) -> None:
+    """Job has a storage profile but local machine doesn't → warning, manual fallback."""
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("settings.auto_accept", "true")
+
+    mock_root = "/root/path" if sys.platform != "win32" else "C:\\Users\\username"
+
+    with patch.object(api, "get_boto3_client") as boto3_client_mock, patch.object(
+        job_group, "OutputDownloader"
+    ) as mock_downloader, patch.object(
+        job_group, "_get_conflicting_filenames", return_value=[]
+    ), patch.object(job_group, "round", return_value=0), patch.object(
+        api, "get_queue_user_boto3_session"
+    ):
+        _make_download_mocks(
+            boto3_client_mock,
+            mock_downloader,
+            _make_job_response(storage_profile_id="sp-job-222", root_path=mock_root),
+            {mock_root: ["output.exr"]},
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["job", "download-output", "--job-id", MOCK_JOB_ID, "--output", "verbose"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Warning" in result.output
+        assert "no local storage profile" in result.output
+        assert "deadline config" in result.output
+
+
+# ─── Case 4: Neither has a profile → no mapping, direct download ─────────────
+
+
+def test_case4_no_profiles_either_side(fresh_deadline_config: str) -> None:
+    """Neither submitter nor downloader has a profile → download to original paths."""
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("settings.auto_accept", "true")
+
+    mock_root = "/root/path" if sys.platform != "win32" else "C:\\Users\\username"
+
+    with patch.object(api, "get_boto3_client") as boto3_client_mock, patch.object(
+        job_group, "OutputDownloader"
+    ) as mock_downloader, patch.object(
+        job_group, "_get_conflicting_filenames", return_value=[]
+    ), patch.object(job_group, "round", return_value=0), patch.object(
+        api, "get_queue_user_boto3_session"
+    ):
+        _make_download_mocks(
+            boto3_client_mock,
+            mock_downloader,
+            _make_job_response(root_path=mock_root),  # no storageProfileId
+            {mock_root: ["output.exr"]},
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["job", "download-output", "--job-id", MOCK_JOB_ID, "--output", "verbose"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Using storage profile" not in result.output
+        mock_downloader.return_value.set_root_path.assert_not_called()
+
+
+# ─── Case 5: Local profile configured, job has none → warning, skip mapping ──
+
+
+def test_case5_local_profile_job_has_none_warning(fresh_deadline_config: str) -> None:
+    """Local profile configured but job submitted without one → warning, no mapping."""
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("settings.storage_profile_id", "sp-local-111")
+    config.set_setting("settings.auto_accept", "true")
+
+    mock_root = "/root/path" if sys.platform != "win32" else "C:\\Users\\username"
+
+    with patch.object(api, "get_boto3_client") as boto3_client_mock, patch.object(
+        job_group, "OutputDownloader"
+    ) as mock_downloader, patch.object(
+        job_group, "_get_conflicting_filenames", return_value=[]
+    ), patch.object(job_group, "round", return_value=0), patch.object(
+        api, "get_queue_user_boto3_session"
+    ):
+        _make_download_mocks(
+            boto3_client_mock,
+            mock_downloader,
+            _make_job_response(root_path=mock_root),  # no storageProfileId
+            {mock_root: ["output.exr"]},
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["job", "download-output", "--job-id", MOCK_JOB_ID, "--output", "verbose"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Warning" in result.output
+        assert "submitted without one" in result.output
+        mock_downloader.return_value.set_root_path.assert_not_called()
+
+
+# ─── Case 6: --ignore-storage-profiles → skip everything ─────────────────────
+
+
+def test_case6_ignore_storage_profiles_flag(fresh_deadline_config: str) -> None:
+    """--ignore-storage-profiles skips all storage profile logic."""
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("settings.storage_profile_id", "sp-local-111")
+    config.set_setting("settings.auto_accept", "true")
+
+    mock_root = "/root/path" if sys.platform != "win32" else "C:\\Users\\username"
+
+    with patch.object(api, "get_boto3_client") as boto3_client_mock, patch.object(
+        job_group, "OutputDownloader"
+    ) as mock_downloader, patch.object(
+        job_group, "_get_conflicting_filenames", return_value=[]
+    ), patch.object(job_group, "round", return_value=0), patch.object(
+        api, "get_queue_user_boto3_session"
+    ), patch.object(api, "get_storage_profile_for_queue") as mock_get_profile:
+        _make_download_mocks(
+            boto3_client_mock,
+            mock_downloader,
+            _make_job_response(storage_profile_id="sp-job-222", root_path=mock_root),
+            {mock_root: ["output.exr"]},
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "job",
+                "download-output",
+                "--job-id",
+                MOCK_JOB_ID,
+                "--ignore-storage-profiles",
+                "--output",
+                "verbose",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Using storage profile" not in result.output
+        # get_storage_profile_for_queue should never be called
+        mock_get_profile.assert_not_called()
+        mock_downloader.return_value.set_root_path.assert_not_called()
+
+
+# ─── Case 7: Same profile on both sides → no mapping needed ──────────────────
+
+
+def test_case7_same_profile_both_sides(fresh_deadline_config: str) -> None:
+    """Same storage profile on submitter and downloader → no mapping rules generated."""
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("settings.storage_profile_id", "sp-local-111")
+    config.set_setting("settings.auto_accept", "true")
+
+    mock_root = "/mnt/shared" if sys.platform != "win32" else "C:\\Users\\username"
+
+    with patch.object(api, "get_boto3_client") as boto3_client_mock, patch.object(
+        job_group, "OutputDownloader"
+    ) as mock_downloader, patch.object(
+        job_group, "_get_conflicting_filenames", return_value=[]
+    ), patch.object(job_group, "round", return_value=0), patch.object(
+        api, "get_queue_user_boto3_session"
+    ), patch.object(api, "get_storage_profile_for_queue") as mock_get_profile:
+        # Both calls return the same profile
+        mock_get_profile.side_effect = [MOCK_LOCAL_PROFILE, MOCK_LOCAL_PROFILE]
+
+        _make_download_mocks(
+            boto3_client_mock,
+            mock_downloader,
+            _make_job_response(storage_profile_id="sp-local-111", root_path=mock_root),
+            {mock_root: ["output.exr"]},
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["job", "download-output", "--job-id", MOCK_JOB_ID, "--output", "verbose"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Using storage profile: Local Linux Profile" in result.output
+        # Same profile → empty rules → no set_root_path calls
+        mock_downloader.return_value.set_root_path.assert_not_called()

--- a/test/unit/deadline_client/cli/test_job_download_helpers.py
+++ b/test/unit/deadline_client/cli/test_job_download_helpers.py
@@ -1,0 +1,431 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Tests for the _job_download_helpers module.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from botocore.exceptions import ClientError
+from click.testing import CliRunner
+
+from deadline.client import api, config
+from deadline.client.cli import main
+from deadline.client.cli._groups import job_group
+from deadline.client.cli._groups._job_download_helpers import (
+    ResolvedStorageProfiles,
+    _apply_path_mappings_to_roots,
+    _resolve_storage_profiles,
+)
+from deadline.job_attachments._path_mapping import _generate_path_mapping_rules
+from deadline.job_attachments.models import (
+    FileSystemLocation,
+    FileSystemLocationType,
+    PathFormat,
+    PathMappingRule,
+    StorageProfile,
+    StorageProfileOperatingSystemFamily,
+)
+from deadline.job_attachments.progress_tracker import DownloadSummaryStatistics
+
+
+MOCK_FARM_ID = "farm-0123456789abcdefabcdefabcdefabcd"
+MOCK_QUEUE_ID = "queue-0123456789abcdefabcdefabcdefabcd"
+
+MOCK_LOCAL_PROFILE = StorageProfile(
+    storageProfileId="sp-local-111",
+    displayName="Local Linux Profile",
+    osFamily=StorageProfileOperatingSystemFamily.LINUX,
+    fileSystemLocations=[
+        FileSystemLocation(name="shared", path="/mnt/shared", type=FileSystemLocationType.SHARED),
+        FileSystemLocation(name="temp", path="/tmp/render", type=FileSystemLocationType.LOCAL),
+    ],
+)
+
+MOCK_JOB_PROFILE = StorageProfile(
+    storageProfileId="sp-job-222",
+    displayName="Job Windows Profile",
+    osFamily=StorageProfileOperatingSystemFamily.WINDOWS,
+    fileSystemLocations=[
+        FileSystemLocation(name="shared", path="Z:\\shared", type=FileSystemLocationType.SHARED),
+        FileSystemLocation(name="temp", path="C:\\temp\\render", type=FileSystemLocationType.LOCAL),
+    ],
+)
+
+MOCK_SAME_PROFILE = StorageProfile(
+    storageProfileId="sp-local-111",
+    displayName="Local Linux Profile",
+    osFamily=StorageProfileOperatingSystemFamily.LINUX,
+    fileSystemLocations=[
+        FileSystemLocation(name="shared", path="/mnt/shared", type=FileSystemLocationType.SHARED),
+        FileSystemLocation(name="temp", path="/tmp/render", type=FileSystemLocationType.LOCAL),
+    ],
+)
+
+
+# ─── _resolve_storage_profiles ───────────────────────────────────────────────
+
+
+class TestResolveStorageProfiles:
+    def test_ignore_storage_profiles_returns_none(self) -> None:
+        result = _resolve_storage_profiles(
+            config=None,
+            deadline=MagicMock(),
+            farm_id=MOCK_FARM_ID,
+            queue_id=MOCK_QUEUE_ID,
+            job={},
+            ignore_storage_profiles=True,
+        )
+        assert result is None
+
+    @patch("deadline.client.cli._groups._job_download_helpers.config_file")
+    def test_no_profiles_on_either_side_returns_none(self, mock_config_file: MagicMock) -> None:
+        mock_config_file.get_setting.return_value = ""
+        result = _resolve_storage_profiles(
+            config=None,
+            deadline=MagicMock(),
+            farm_id=MOCK_FARM_ID,
+            queue_id=MOCK_QUEUE_ID,
+            job={},  # no storageProfileId
+            ignore_storage_profiles=False,
+        )
+        assert result is None
+
+    @patch("deadline.client.cli._groups._job_download_helpers.config_file")
+    def test_no_local_profile_but_job_has_profile_warns_and_returns_none(
+        self, mock_config_file: MagicMock
+    ) -> None:
+        mock_config_file.get_setting.return_value = ""
+        result = _resolve_storage_profiles(
+            config=None,
+            deadline=MagicMock(),
+            farm_id=MOCK_FARM_ID,
+            queue_id=MOCK_QUEUE_ID,
+            job={"storageProfileId": "sp-job-222"},
+            ignore_storage_profiles=False,
+        )
+        assert result is None
+
+    @patch("deadline.client.cli._groups._job_download_helpers.config_file")
+    def test_local_profile_but_job_has_no_profile_returns_none_with_warning(
+        self, mock_config_file: MagicMock
+    ) -> None:
+        mock_config_file.get_setting.return_value = "sp-local-111"
+        result = _resolve_storage_profiles(
+            config=None,
+            deadline=MagicMock(),
+            farm_id=MOCK_FARM_ID,
+            queue_id=MOCK_QUEUE_ID,
+            job={},  # no storageProfileId
+            ignore_storage_profiles=False,
+        )
+        assert result is None
+
+    @patch("deadline.client.cli._groups._job_download_helpers.api")
+    @patch("deadline.client.cli._groups._job_download_helpers.config_file")
+    def test_both_profiles_exist_returns_resolved(
+        self, mock_config_file: MagicMock, mock_api: MagicMock
+    ) -> None:
+        mock_config_file.get_setting.return_value = "sp-local-111"
+        mock_api.get_storage_profile_for_queue.side_effect = [
+            MOCK_LOCAL_PROFILE,
+            MOCK_JOB_PROFILE,
+        ]
+
+        result = _resolve_storage_profiles(
+            config=None,
+            deadline=MagicMock(),
+            farm_id=MOCK_FARM_ID,
+            queue_id=MOCK_QUEUE_ID,
+            job={"storageProfileId": "sp-job-222"},
+            ignore_storage_profiles=False,
+        )
+
+        assert result is not None
+        assert isinstance(result, ResolvedStorageProfiles)
+        assert result.local_profile == MOCK_LOCAL_PROFILE
+        assert result.job_profile == MOCK_JOB_PROFILE
+
+    @patch("deadline.client.cli._groups._job_download_helpers.api")
+    @patch("deadline.client.cli._groups._job_download_helpers.config_file")
+    def test_api_error_propagates(self, mock_config_file: MagicMock, mock_api: MagicMock) -> None:
+        mock_config_file.get_setting.return_value = "sp-local-111"
+        mock_api.get_storage_profile_for_queue.side_effect = ClientError(
+            {"Error": {"Code": "ResourceNotFoundException", "Message": "Not found"}},
+            "GetStorageProfileForQueue",
+        )
+
+        with pytest.raises(ClientError):
+            _resolve_storage_profiles(
+                config=None,
+                deadline=MagicMock(),
+                farm_id=MOCK_FARM_ID,
+                queue_id=MOCK_QUEUE_ID,
+                job={"storageProfileId": "sp-job-222"},
+                ignore_storage_profiles=False,
+            )
+
+
+# ─── _apply_path_mappings_to_roots ──────────────────────────────────────────
+
+
+class TestApplyPathMappingsToRoots:
+    def test_empty_rules_is_noop(self) -> None:
+        downloader = MagicMock()
+        output_paths = {"/original/root": ["file1.txt"]}
+        _apply_path_mappings_to_roots(downloader, output_paths, [])
+        downloader.set_root_path.assert_not_called()
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX destination test")
+    def test_single_mapping_applied_posix(self) -> None:
+        """On Linux/macOS: source is Windows, destination is local POSIX."""
+        downloader = MagicMock()
+        output_paths = {"C:\\temp\\render": ["output.exr"]}
+        rules = [
+            PathMappingRule(
+                source_path_format=PathFormat.WINDOWS.value,
+                source_path="C:\\temp\\render",
+                destination_path="/tmp/render",
+            )
+        ]
+        _apply_path_mappings_to_roots(downloader, output_paths, rules)
+        downloader.set_root_path.assert_called_once_with("C:\\temp\\render", "/tmp/render")
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="Windows destination test")
+    def test_single_mapping_applied_windows(self) -> None:
+        """On Windows: source is POSIX, destination is local Windows."""
+        downloader = MagicMock()
+        output_paths = {"/tmp/render": ["output.exr"]}
+        rules = [
+            PathMappingRule(
+                source_path_format=PathFormat.POSIX.value,
+                source_path="/tmp/render",
+                destination_path="C:\\temp\\render",
+            )
+        ]
+        _apply_path_mappings_to_roots(downloader, output_paths, rules)
+        downloader.set_root_path.assert_called_once_with("/tmp/render", "C:\\temp\\render")
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX destination test")
+    def test_multiple_mappings_applied_posix(self) -> None:
+        """On Linux/macOS: multiple Windows→POSIX mappings."""
+        downloader = MagicMock()
+        output_paths = {
+            "C:\\temp\\render": ["output.exr"],
+            "Z:\\shared": ["data.bin"],
+        }
+        rules = [
+            PathMappingRule(
+                source_path_format=PathFormat.WINDOWS.value,
+                source_path="C:\\temp\\render",
+                destination_path="/tmp/render",
+            ),
+            PathMappingRule(
+                source_path_format=PathFormat.WINDOWS.value,
+                source_path="Z:\\shared",
+                destination_path="/mnt/shared",
+            ),
+        ]
+        _apply_path_mappings_to_roots(downloader, output_paths, rules)
+        assert downloader.set_root_path.call_count == 2
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="Windows destination test")
+    def test_multiple_mappings_applied_windows(self) -> None:
+        """On Windows: multiple POSIX→Windows mappings."""
+        downloader = MagicMock()
+        output_paths = {
+            "/tmp/render": ["output.exr"],
+            "/mnt/shared": ["data.bin"],
+        }
+        rules = [
+            PathMappingRule(
+                source_path_format=PathFormat.POSIX.value,
+                source_path="/tmp/render",
+                destination_path="C:\\temp\\render",
+            ),
+            PathMappingRule(
+                source_path_format=PathFormat.POSIX.value,
+                source_path="/mnt/shared",
+                destination_path="Z:\\shared",
+            ),
+        ]
+        _apply_path_mappings_to_roots(downloader, output_paths, rules)
+        assert downloader.set_root_path.call_count == 2
+
+    def test_no_matching_rule_skips_root(self) -> None:
+        downloader = MagicMock()
+        if sys.platform == "win32":
+            output_paths = {"D:\\other\\path": ["file.txt"]}
+            rules = [
+                PathMappingRule(
+                    source_path_format=PathFormat.WINDOWS.value,
+                    source_path="C:\\temp\\render",
+                    destination_path="D:\\mapped",
+                )
+            ]
+        else:
+            output_paths = {"/some/other/path": ["file.txt"]}
+            rules = [
+                PathMappingRule(
+                    source_path_format=PathFormat.POSIX.value,
+                    source_path="/mnt/shared",
+                    destination_path="/opt/shared",
+                )
+            ]
+        _apply_path_mappings_to_roots(downloader, output_paths, rules)
+        downloader.set_root_path.assert_not_called()
+
+    def test_root_already_matches_destination_skips(self) -> None:
+        downloader = MagicMock()
+        if sys.platform == "win32":
+            # Root is already the Windows destination — no source match
+            output_paths = {"C:\\temp\\render": ["file.txt"]}
+            rules = [
+                PathMappingRule(
+                    source_path_format=PathFormat.POSIX.value,
+                    source_path="/tmp/render",
+                    destination_path="C:\\temp\\render",
+                )
+            ]
+        else:
+            # Root is already the POSIX destination — no source match
+            output_paths = {"/tmp/render": ["file.txt"]}
+            rules = [
+                PathMappingRule(
+                    source_path_format=PathFormat.WINDOWS.value,
+                    source_path="C:\\temp\\render",
+                    destination_path="/tmp/render",
+                )
+            ]
+        _apply_path_mappings_to_roots(downloader, output_paths, rules)
+        downloader.set_root_path.assert_not_called()
+
+
+# ─── _generate_path_mapping_rules with StorageProfile dataclass ─────────────
+
+
+class TestGeneratePathMappingRulesWithDataclass:
+    def test_same_profile_returns_empty(self) -> None:
+        rules = _generate_path_mapping_rules(MOCK_LOCAL_PROFILE, MOCK_SAME_PROFILE)
+        assert rules == []
+
+    def test_cross_os_profiles_generate_rules(self) -> None:
+        rules = _generate_path_mapping_rules(MOCK_JOB_PROFILE, MOCK_LOCAL_PROFILE)
+        assert len(rules) == 2
+        # "shared" location maps Z:\shared -> /mnt/shared
+        assert PathMappingRule(PathFormat.WINDOWS.value, "Z:\\shared", "/mnt/shared") in rules
+        # "temp" location maps C:\temp\render -> /tmp/render
+        assert PathMappingRule(PathFormat.WINDOWS.value, "C:\\temp\\render", "/tmp/render") in rules
+
+    def test_mixed_dict_and_dataclass(self) -> None:
+        """Verify that passing one dict and one dataclass still works."""
+        job_dict: dict[str, Any] = {
+            "storageProfileId": "sp-job-222",
+            "osFamily": StorageProfileOperatingSystemFamily.WINDOWS.value,
+            "fileSystemLocations": [
+                {"name": "shared", "path": "Z:\\shared", "type": "SHARED"},
+                {"name": "temp", "path": "C:\\temp\\render", "type": "LOCAL"},
+            ],
+        }
+        rules = _generate_path_mapping_rules(job_dict, MOCK_LOCAL_PROFILE)
+        assert len(rules) == 2
+
+    def test_no_matching_locations_returns_empty(self) -> None:
+        no_match_profile = StorageProfile(
+            storageProfileId="sp-nomatch-333",
+            displayName="No Match",
+            osFamily=StorageProfileOperatingSystemFamily.LINUX,
+            fileSystemLocations=[
+                FileSystemLocation(
+                    name="different", path="/mnt/different", type=FileSystemLocationType.LOCAL
+                ),
+            ],
+        )
+        rules = _generate_path_mapping_rules(MOCK_JOB_PROFILE, no_match_profile)
+        assert rules == []
+
+
+# ─── CLI-level tests for download-output with storage profile options ────────
+
+MOCK_JOB_ID = "job-0123456789abcdefabcdefabcdefabcd"
+
+MOCK_GET_QUEUE_RESPONSE = {
+    "queueId": MOCK_QUEUE_ID,
+    "displayName": "Test Queue",
+    "description": "",
+    "farmId": MOCK_FARM_ID,
+    "status": "ACTIVE",
+    "jobAttachmentSettings": {
+        "s3BucketName": "deadline-job-attachments-mock-bucket",
+        "rootPrefix": "AWS Deadline Cloud",
+    },
+}
+
+
+class TestCliDownloadOutputStorageProfileOptions:
+    def test_ignore_storage_profiles_skips_mapping(
+        self, fresh_deadline_config: str, tmp_path: Path
+    ) -> None:
+        """--ignore-storage-profiles should skip storage profile resolution."""
+        config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+        config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+        config.set_setting("settings.auto_accept", "true")
+
+        mock_root = "/root/path" if sys.platform != "win32" else "C:\\Users\\username"
+        mock_host_format = PathFormat.get_host_path_format()
+
+        with patch.object(api, "get_boto3_client") as boto3_client_mock, patch.object(
+            job_group, "OutputDownloader"
+        ) as MockOutputDownloader, patch.object(
+            job_group, "_get_conflicting_filenames", return_value=[]
+        ), patch.object(job_group, "round", return_value=0), patch.object(
+            api, "get_queue_user_boto3_session"
+        ), patch.object(job_group, "_resolve_storage_profiles", return_value=None) as mock_resolve:
+            mock_download = MagicMock()
+            mock_download.return_value = DownloadSummaryStatistics(
+                total_time=1, processed_files=1, processed_bytes=100
+            )
+            MockOutputDownloader.return_value.download_job_output = mock_download
+            MockOutputDownloader.return_value.get_output_paths_by_root.return_value = {
+                mock_root: ["file.txt"]
+            }
+
+            boto3_client_mock().get_queue.return_value = MOCK_GET_QUEUE_RESPONSE
+            boto3_client_mock().get_job.return_value = {
+                "name": "Mock Job",
+                "attachments": {
+                    "manifests": [
+                        {
+                            "rootPath": mock_root,
+                            "rootPathFormat": mock_host_format,
+                            "outputRelativeDirectories": ["."],
+                        }
+                    ]
+                },
+            }
+
+            runner = CliRunner()
+            result = runner.invoke(
+                main,
+                [
+                    "job",
+                    "download-output",
+                    "--job-id",
+                    MOCK_JOB_ID,
+                    "--ignore-storage-profiles",
+                    "--output",
+                    "verbose",
+                ],
+            )
+
+            assert result.exit_code == 0
+            mock_resolve.assert_called_once()
+            # Verify ignore_storage_profiles=True was passed (positional arg index 5)
+            call_args = mock_resolve.call_args
+            assert call_args[0][5] is True

--- a/test/unit/deadline_client/cli/test_job_download_helpers.py
+++ b/test/unit/deadline_client/cli/test_job_download_helpers.py
@@ -20,8 +20,8 @@ from deadline.client.cli import main
 from deadline.client.cli._groups import job_group
 from deadline.client.cli._groups._job_download_helpers import (
     ResolvedStorageProfiles,
-    _apply_path_mappings_to_roots,
     _resolve_storage_profiles,
+    _transform_manifests_to_absolute_paths,
 )
 from deadline.job_attachments._path_mapping import _generate_path_mapping_rules
 from deadline.job_attachments.models import (
@@ -172,141 +172,6 @@ class TestResolveStorageProfiles:
             )
 
 
-# ─── _apply_path_mappings_to_roots ──────────────────────────────────────────
-
-
-class TestApplyPathMappingsToRoots:
-    def test_empty_rules_is_noop(self) -> None:
-        downloader = MagicMock()
-        output_paths = {"/original/root": ["file1.txt"]}
-        _apply_path_mappings_to_roots(downloader, output_paths, [])
-        downloader.set_root_path.assert_not_called()
-
-    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX destination test")
-    def test_single_mapping_applied_posix(self) -> None:
-        """On Linux/macOS: source is Windows, destination is local POSIX."""
-        downloader = MagicMock()
-        output_paths = {"C:\\temp\\render": ["output.exr"]}
-        rules = [
-            PathMappingRule(
-                source_path_format=PathFormat.WINDOWS.value,
-                source_path="C:\\temp\\render",
-                destination_path="/tmp/render",
-            )
-        ]
-        _apply_path_mappings_to_roots(downloader, output_paths, rules)
-        downloader.set_root_path.assert_called_once_with("C:\\temp\\render", "/tmp/render")
-
-    @pytest.mark.skipif(sys.platform != "win32", reason="Windows destination test")
-    def test_single_mapping_applied_windows(self) -> None:
-        """On Windows: source is POSIX, destination is local Windows."""
-        downloader = MagicMock()
-        output_paths = {"/tmp/render": ["output.exr"]}
-        rules = [
-            PathMappingRule(
-                source_path_format=PathFormat.POSIX.value,
-                source_path="/tmp/render",
-                destination_path="C:\\temp\\render",
-            )
-        ]
-        _apply_path_mappings_to_roots(downloader, output_paths, rules)
-        downloader.set_root_path.assert_called_once_with("/tmp/render", "C:\\temp\\render")
-
-    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX destination test")
-    def test_multiple_mappings_applied_posix(self) -> None:
-        """On Linux/macOS: multiple Windows→POSIX mappings."""
-        downloader = MagicMock()
-        output_paths = {
-            "C:\\temp\\render": ["output.exr"],
-            "Z:\\shared": ["data.bin"],
-        }
-        rules = [
-            PathMappingRule(
-                source_path_format=PathFormat.WINDOWS.value,
-                source_path="C:\\temp\\render",
-                destination_path="/tmp/render",
-            ),
-            PathMappingRule(
-                source_path_format=PathFormat.WINDOWS.value,
-                source_path="Z:\\shared",
-                destination_path="/mnt/shared",
-            ),
-        ]
-        _apply_path_mappings_to_roots(downloader, output_paths, rules)
-        assert downloader.set_root_path.call_count == 2
-
-    @pytest.mark.skipif(sys.platform != "win32", reason="Windows destination test")
-    def test_multiple_mappings_applied_windows(self) -> None:
-        """On Windows: multiple POSIX→Windows mappings."""
-        downloader = MagicMock()
-        output_paths = {
-            "/tmp/render": ["output.exr"],
-            "/mnt/shared": ["data.bin"],
-        }
-        rules = [
-            PathMappingRule(
-                source_path_format=PathFormat.POSIX.value,
-                source_path="/tmp/render",
-                destination_path="C:\\temp\\render",
-            ),
-            PathMappingRule(
-                source_path_format=PathFormat.POSIX.value,
-                source_path="/mnt/shared",
-                destination_path="Z:\\shared",
-            ),
-        ]
-        _apply_path_mappings_to_roots(downloader, output_paths, rules)
-        assert downloader.set_root_path.call_count == 2
-
-    def test_no_matching_rule_skips_root(self) -> None:
-        downloader = MagicMock()
-        if sys.platform == "win32":
-            output_paths = {"D:\\other\\path": ["file.txt"]}
-            rules = [
-                PathMappingRule(
-                    source_path_format=PathFormat.WINDOWS.value,
-                    source_path="C:\\temp\\render",
-                    destination_path="D:\\mapped",
-                )
-            ]
-        else:
-            output_paths = {"/some/other/path": ["file.txt"]}
-            rules = [
-                PathMappingRule(
-                    source_path_format=PathFormat.POSIX.value,
-                    source_path="/mnt/shared",
-                    destination_path="/opt/shared",
-                )
-            ]
-        _apply_path_mappings_to_roots(downloader, output_paths, rules)
-        downloader.set_root_path.assert_not_called()
-
-    def test_root_already_matches_destination_skips(self) -> None:
-        downloader = MagicMock()
-        if sys.platform == "win32":
-            # Root is already the Windows destination — no source match
-            output_paths = {"C:\\temp\\render": ["file.txt"]}
-            rules = [
-                PathMappingRule(
-                    source_path_format=PathFormat.POSIX.value,
-                    source_path="/tmp/render",
-                    destination_path="C:\\temp\\render",
-                )
-            ]
-        else:
-            # Root is already the POSIX destination — no source match
-            output_paths = {"/tmp/render": ["file.txt"]}
-            rules = [
-                PathMappingRule(
-                    source_path_format=PathFormat.WINDOWS.value,
-                    source_path="C:\\temp\\render",
-                    destination_path="/tmp/render",
-                )
-            ]
-        _apply_path_mappings_to_roots(downloader, output_paths, rules)
-        downloader.set_root_path.assert_not_called()
-
-
 # ─── _generate_path_mapping_rules with StorageProfile dataclass ─────────────
 
 
@@ -349,6 +214,141 @@ class TestGeneratePathMappingRulesWithDataclass:
         )
         rules = _generate_path_mapping_rules(MOCK_JOB_PROFILE, no_match_profile)
         assert rules == []
+
+
+# ─── _transform_manifests_to_absolute_paths ──────────────────────────────────
+
+
+class TestTransformManifestsToAbsolutePaths:
+    """Tests for the absolute-path transformation that matches sync-output behavior."""
+
+    def _make_manifest(self, paths: list[tuple[str, int]]) -> Any:
+        """Create a mock manifest with the given (path, size) pairs."""
+        mock_manifest = MagicMock()
+        mock_paths = []
+        for path, size in paths:
+            mp = MagicMock()
+            mp.path = path
+            mp.size = size
+            mock_paths.append(mp)
+        mock_manifest.paths = mock_paths
+        return mock_manifest
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX destination test")
+    def test_basic_windows_to_posix_mapping(self) -> None:
+        """Windows source paths are joined and transformed to POSIX destinations."""
+        manifest = self._make_manifest([("output.exr", 100)])
+        manifests_by_root: dict[str, list[Any]] = {"C:\\temp\\render": [manifest]}
+        rules = [
+            PathMappingRule(
+                source_path_format=PathFormat.WINDOWS.value,
+                source_path="C:\\temp\\render",
+                destination_path="/tmp/render",
+            )
+        ]
+        result = _transform_manifests_to_absolute_paths(
+            manifests_by_root, rules, StorageProfileOperatingSystemFamily.WINDOWS
+        )
+        assert "" in result
+        assert result[""].paths[0].path == "/tmp/render/output.exr"
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX destination test")
+    def test_nested_location_picks_most_specific_rule(self) -> None:
+        """When a rule matches deeper than the root, the most specific rule wins.
+
+        This is the key case that root-only transformation would get wrong.
+        Source profile has:
+          - "Projects": C:\\Projects -> /mnt/projects
+          - "SpecialProjects": C:\\Projects\\Special -> /opt/special
+        Asset root is C:\\Projects, relative path is Special\\data.txt.
+        The absolute path C:\\Projects\\Special\\data.txt should match the more
+        specific rule and map to /opt/special/data.txt, NOT /mnt/projects/Special/data.txt.
+        """
+        manifest = self._make_manifest([("Special\\data.txt", 50)])
+        manifests_by_root: dict[str, list[Any]] = {"C:\\Projects": [manifest]}
+        rules = [
+            PathMappingRule(
+                source_path_format=PathFormat.WINDOWS.value,
+                source_path="C:\\Projects",
+                destination_path="/mnt/projects",
+            ),
+            PathMappingRule(
+                source_path_format=PathFormat.WINDOWS.value,
+                source_path="C:\\Projects\\Special",
+                destination_path="/opt/special",
+            ),
+        ]
+        result = _transform_manifests_to_absolute_paths(
+            manifests_by_root, rules, StorageProfileOperatingSystemFamily.WINDOWS
+        )
+        assert "" in result
+        # The more specific rule should win
+        assert result[""].paths[0].path == "/opt/special/data.txt"
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX destination test")
+    def test_unmapped_paths_are_skipped(self) -> None:
+        """Paths that don't match any rule are excluded from the result."""
+        manifests_by_root: dict[str, list[Any]] = {
+            "C:\\temp\\render": [self._make_manifest([("output.exr", 100)])],
+            "D:\\other": [self._make_manifest([("stray.txt", 50)])],
+        }
+        rules = [
+            PathMappingRule(
+                source_path_format=PathFormat.WINDOWS.value,
+                source_path="C:\\temp\\render",
+                destination_path="/tmp/render",
+            )
+        ]
+        result = _transform_manifests_to_absolute_paths(
+            manifests_by_root, rules, StorageProfileOperatingSystemFamily.WINDOWS
+        )
+        assert "" in result
+        mapped_paths = [p.path for p in result[""].paths]
+        assert "/tmp/render/output.exr" in mapped_paths
+        # stray.txt should not appear (no matching rule)
+        assert not any("stray" in p for p in mapped_paths)
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX destination test")
+    def test_multiple_roots_merged(self) -> None:
+        """Manifests from multiple roots are merged into a single result."""
+        manifests_by_root: dict[str, list[Any]] = {
+            "C:\\temp\\render": [self._make_manifest([("output.exr", 100)])],
+            "Z:\\shared": [self._make_manifest([("data.bin", 200)])],
+        }
+        rules = [
+            PathMappingRule(
+                source_path_format=PathFormat.WINDOWS.value,
+                source_path="C:\\temp\\render",
+                destination_path="/tmp/render",
+            ),
+            PathMappingRule(
+                source_path_format=PathFormat.WINDOWS.value,
+                source_path="Z:\\shared",
+                destination_path="/mnt/shared",
+            ),
+        ]
+        result = _transform_manifests_to_absolute_paths(
+            manifests_by_root, rules, StorageProfileOperatingSystemFamily.WINDOWS
+        )
+        assert "" in result
+        mapped_paths = [p.path for p in result[""].paths]
+        assert "/tmp/render/output.exr" in mapped_paths
+        assert "/mnt/shared/data.bin" in mapped_paths
+
+    def test_empty_manifests_returns_empty(self) -> None:
+        """Empty manifests produce an empty result."""
+        manifests_by_root: dict[str, list[Any]] = {"C:\\temp": [self._make_manifest([])]}
+        rules = [
+            PathMappingRule(
+                source_path_format=PathFormat.WINDOWS.value,
+                source_path="C:\\temp",
+                destination_path="/tmp",
+            )
+        ]
+        result = _transform_manifests_to_absolute_paths(
+            manifests_by_root, rules, StorageProfileOperatingSystemFamily.WINDOWS
+        )
+        assert result == {}
 
 
 # ─── CLI-level tests for download-output with storage profile options ────────

--- a/test/unit/deadline_job_attachments/test_path_mapping.py
+++ b/test/unit/deadline_job_attachments/test_path_mapping.py
@@ -171,6 +171,7 @@ def test_path_mapping_rule_applier_create_empty():
     assert applier.path_mapping_rules == []
     assert applier._path_mapping_trie == {}
 
+    assert applier.transform("/some/path") == "/some/path"
     with pytest.raises(ValueError):
         applier.strict_transform("/some/path")
 
@@ -227,10 +228,16 @@ def test_source_posix_rule(dest_paths: DestPaths):
         ]
     )
 
-    # All three rules can be used with strict transform
+    # All three rules can be used with both regular and strict transform
+    assert applier.transform("/mnt/shared") == dest_paths.path1
+    assert applier.transform("/mnt/projects") == dest_paths.path2
+    assert applier.transform("/tmp") == dest_paths.path3
     assert applier.strict_transform("/mnt/shared") == dest_paths.path1
     assert applier.strict_transform("/mnt/projects") == dest_paths.path2
     assert applier.strict_transform("/tmp") == dest_paths.path3
+
+    # transform passes through other paths
+    assert applier.transform("/other/path") == "/other/path"
 
     # strict_transform raises for other paths
     with pytest.raises(ValueError):
@@ -246,17 +253,23 @@ def test_source_windows_rule(dest_paths: DestPaths):
         ]
     )
 
-    # All three rules can be used with strict transform
+    # All three rules can be used with both regular and strict transform
+    assert applier.transform("C:\\Shared") == dest_paths.path1
+    assert applier.transform("C:\\proJects") == dest_paths.path2
+    assert applier.transform("D:\\tmp") == dest_paths.path3
     assert applier.strict_transform("C:\\Shared") == dest_paths.path1
     assert applier.strict_transform("C:\\proJects") == dest_paths.path2
     assert applier.strict_transform("D:\\tmp") == dest_paths.path3
 
     # Windows is case insensitive but case preserving
-    assert applier.strict_transform("C:\\ShArEd") == dest_paths.path1
+    assert applier.transform("C:\\ShArEd") == dest_paths.path1
     assert (
-        applier.strict_transform("C:\\PROJECTS\\Case\\Of\\tail\\PreServed")
+        applier.transform("C:\\PROJECTS\\Case\\Of\\tail\\PreServed")
         == dest_paths.path2 / "Case" / "Of" / "tail" / "PreServed"
     )
+
+    # transform passes through other paths
+    assert applier.transform("C:\\other\\path") == "C:\\other\\path"
 
     # strict_transform raises for other paths
     with pytest.raises(ValueError):
@@ -272,23 +285,23 @@ def test_source_posix_rule_edge_cases(dest_paths: DestPaths):
         ]
     )
 
-    # Paths that are not transformed raise ValueError
-    for path in ["", "/", "/other/path", "/mnt/other/path", "/Mnt/shared"]:
-        with pytest.raises(ValueError):
-            applier.strict_transform(path)
+    # Paths that are not transformed
+    assert applier.transform("") == ""
+    assert applier.transform("/") == "/"
+    assert applier.transform("/other/path") == "/other/path"
+    assert applier.transform("/mnt/other/path") == "/mnt/other/path"
+    assert applier.transform("/Mnt/shared") == "/Mnt/shared"
 
     # Edge cases with unicode and spaces
-    assert applier.strict_transform("/mnt/shared/файл.txt") == dest_paths.path1 / "файл.txt"
+    assert applier.transform("/mnt/shared/файл.txt") == dest_paths.path1 / "файл.txt"
     assert (
-        applier.strict_transform("/mnt/shared/file with spaces.txt")
+        applier.transform("/mnt/shared/file with spaces.txt")
         == dest_paths.path1 / "file with spaces.txt"
     )
 
     # The second rule applies because it is longer and more specific than the first rule
-    assert applier.strict_transform("/mnt/shared/projects") == dest_paths.path2
-    assert (
-        applier.strict_transform("/mnt/shared/projects/file.txt") == dest_paths.path2 / "file.txt"
-    )
+    assert applier.transform("/mnt/shared/projects") == dest_paths.path2
+    assert applier.transform("/mnt/shared/projects/file.txt") == dest_paths.path2 / "file.txt"
 
 
 def test_source_windows_rule_edge_cases(dest_paths: DestPaths):
@@ -302,20 +315,17 @@ def test_source_windows_rule_edge_cases(dest_paths: DestPaths):
         ]
     )
 
-    # Paths that are not transformed raise ValueError
-    for path in ["", "C:\\other\\path"]:
-        with pytest.raises(ValueError):
-            applier.strict_transform(path)
+    # Paths that are not transformed
+    assert applier.transform("") == ""
+    assert applier.transform("C:\\other\\path") == "C:\\other\\path"
 
     # Edge cases with unicode and spaces
-    assert applier.strict_transform("C:\\shared\\файл.txt") == dest_paths.path1 / "файл.txt"
+    assert applier.transform("C:\\shared\\файл.txt") == dest_paths.path1 / "файл.txt"
     assert (
-        applier.strict_transform("C:\\shared\\file with spaces.txt")
+        applier.transform("C:\\shared\\file with spaces.txt")
         == dest_paths.path1 / "file with spaces.txt"
     )
 
     # The second rule applies because it is longer and more specific than the first rule
-    assert applier.strict_transform("C:\\shared\\projects") == dest_paths.path2
-    assert (
-        applier.strict_transform("C:\\shared\\projects\\file.txt") == dest_paths.path2 / "file.txt"
-    )
+    assert applier.transform("C:\\shared\\projects") == dest_paths.path2
+    assert applier.transform("C:\\shared\\projects\\file.txt") == dest_paths.path2 / "file.txt"

--- a/test/unit/deadline_job_attachments/test_path_mapping.py
+++ b/test/unit/deadline_job_attachments/test_path_mapping.py
@@ -171,7 +171,6 @@ def test_path_mapping_rule_applier_create_empty():
     assert applier.path_mapping_rules == []
     assert applier._path_mapping_trie == {}
 
-    assert applier.transform("/some/path") == "/some/path"
     with pytest.raises(ValueError):
         applier.strict_transform("/some/path")
 
@@ -228,16 +227,10 @@ def test_source_posix_rule(dest_paths: DestPaths):
         ]
     )
 
-    # All three rules can be used with both regular and strict transform
-    assert applier.transform("/mnt/shared") == dest_paths.path1
-    assert applier.transform("/mnt/projects") == dest_paths.path2
-    assert applier.transform("/tmp") == dest_paths.path3
+    # All three rules can be used with strict transform
     assert applier.strict_transform("/mnt/shared") == dest_paths.path1
     assert applier.strict_transform("/mnt/projects") == dest_paths.path2
     assert applier.strict_transform("/tmp") == dest_paths.path3
-
-    # transform passes through other paths
-    assert applier.transform("/other/path") == "/other/path"
 
     # strict_transform raises for other paths
     with pytest.raises(ValueError):
@@ -253,23 +246,17 @@ def test_source_windows_rule(dest_paths: DestPaths):
         ]
     )
 
-    # All three rules can be used with both regular and strict transform
-    assert applier.transform("C:\\Shared") == dest_paths.path1
-    assert applier.transform("C:\\proJects") == dest_paths.path2
-    assert applier.transform("D:\\tmp") == dest_paths.path3
+    # All three rules can be used with strict transform
     assert applier.strict_transform("C:\\Shared") == dest_paths.path1
     assert applier.strict_transform("C:\\proJects") == dest_paths.path2
     assert applier.strict_transform("D:\\tmp") == dest_paths.path3
 
     # Windows is case insensitive but case preserving
-    assert applier.transform("C:\\ShArEd") == dest_paths.path1
+    assert applier.strict_transform("C:\\ShArEd") == dest_paths.path1
     assert (
-        applier.transform("C:\\PROJECTS\\Case\\Of\\tail\\PreServed")
+        applier.strict_transform("C:\\PROJECTS\\Case\\Of\\tail\\PreServed")
         == dest_paths.path2 / "Case" / "Of" / "tail" / "PreServed"
     )
-
-    # transform passes through other paths
-    assert applier.transform("C:\\other\\path") == "C:\\other\\path"
 
     # strict_transform raises for other paths
     with pytest.raises(ValueError):
@@ -285,23 +272,23 @@ def test_source_posix_rule_edge_cases(dest_paths: DestPaths):
         ]
     )
 
-    # Paths that are not transformed
-    assert applier.transform("") == ""
-    assert applier.transform("/") == "/"
-    assert applier.transform("/other/path") == "/other/path"
-    assert applier.transform("/mnt/other/path") == "/mnt/other/path"
-    assert applier.transform("/Mnt/shared") == "/Mnt/shared"
+    # Paths that are not transformed raise ValueError
+    for path in ["", "/", "/other/path", "/mnt/other/path", "/Mnt/shared"]:
+        with pytest.raises(ValueError):
+            applier.strict_transform(path)
 
     # Edge cases with unicode and spaces
-    assert applier.transform("/mnt/shared/файл.txt") == dest_paths.path1 / "файл.txt"
+    assert applier.strict_transform("/mnt/shared/файл.txt") == dest_paths.path1 / "файл.txt"
     assert (
-        applier.transform("/mnt/shared/file with spaces.txt")
+        applier.strict_transform("/mnt/shared/file with spaces.txt")
         == dest_paths.path1 / "file with spaces.txt"
     )
 
     # The second rule applies because it is longer and more specific than the first rule
-    assert applier.transform("/mnt/shared/projects") == dest_paths.path2
-    assert applier.transform("/mnt/shared/projects/file.txt") == dest_paths.path2 / "file.txt"
+    assert applier.strict_transform("/mnt/shared/projects") == dest_paths.path2
+    assert (
+        applier.strict_transform("/mnt/shared/projects/file.txt") == dest_paths.path2 / "file.txt"
+    )
 
 
 def test_source_windows_rule_edge_cases(dest_paths: DestPaths):
@@ -315,17 +302,20 @@ def test_source_windows_rule_edge_cases(dest_paths: DestPaths):
         ]
     )
 
-    # Paths that are not transformed
-    assert applier.transform("") == ""
-    assert applier.transform("C:\\other\\path") == "C:\\other\\path"
+    # Paths that are not transformed raise ValueError
+    for path in ["", "C:\\other\\path"]:
+        with pytest.raises(ValueError):
+            applier.strict_transform(path)
 
     # Edge cases with unicode and spaces
-    assert applier.transform("C:\\shared\\файл.txt") == dest_paths.path1 / "файл.txt"
+    assert applier.strict_transform("C:\\shared\\файл.txt") == dest_paths.path1 / "файл.txt"
     assert (
-        applier.transform("C:\\shared\\file with spaces.txt")
+        applier.strict_transform("C:\\shared\\file with spaces.txt")
         == dest_paths.path1 / "file with spaces.txt"
     )
 
     # The second rule applies because it is longer and more specific than the first rule
-    assert applier.transform("C:\\shared\\projects") == dest_paths.path2
-    assert applier.transform("C:\\shared\\projects\\file.txt") == dest_paths.path2 / "file.txt"
+    assert applier.strict_transform("C:\\shared\\projects") == dest_paths.path2
+    assert (
+        applier.strict_transform("C:\\shared\\projects\\file.txt") == dest_paths.path2 / "file.txt"
+    )


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud/issues/829

### Download behavior change:
This PR is a behavioral change, not a breaking API change. When both the local machine and the job have matching storage profiles with aligned location names, download-output now applies path mapping automatically instead of prompting the user to manually type a new root path. Users who relied on the manual prompt to enter a custom path different from their storage profile can use --ignore-storage-profiles to restore the previous behavior.

Note: When matching storage profiles exist on both sides, the previous manual OS-mismatch prompt is replaced by automatic path mapping. This is an intentional UX improvement, not a regression. The --ignore-storage-profiles flag provides an explicit opt-out.

### What was the problem/requirement? (What/Why)

`deadline job download-output` had no storage profile support. When downloading job output submitted from a different OS (e.g., Windows → Linux), the command prompted the user to manually type a new root path for every mismatched asset root. `deadline queue sync-output` already handled this automatically via storage profiles and path mapping, but `download-output` did not.

### What was the solution? (How)

Added `--ignore-storage-profiles` option to `deadline job download-output` and automatic storage profile resolution from the config (`settings.storage_profile_id`).

The implementation is split into single-responsibility helper functions in a new `_job_download_helpers.py` module:

- `_resolve_storage_profiles()` — fetches local and job storage profiles, returns a `ResolvedStorageProfiles` dataclass (or `None` when mapping is not needed). All mismatch cases produce warnings and fall back to the existing manual prompt rather than erroring.
- `_apply_path_mappings_to_roots()` — applies trie-based path mapping rules to remap output root directories via `OutputDownloader.set_root_path()`

Also refactored `_generate_path_mapping_rules()` in `_path_mapping.py` to accept both `StorageProfile` dataclass and raw boto3 dicts (backward compatible via `_normalize_storage_profile()`). Removed the stale TODO from `OutputDownloader` since both download commands now handle path mapping at the CLI layer.

Mismatch cases produce clear user-facing warnings:
- No local profile but job has one → warns and recommends `deadline config`
- Both profiles exist but location names don't match → warns about aligning location names
- Local profile exists but job has none → warns that mapping will be skipped

### What is the impact of this change?

- Users downloading cross-OS job output with matching storage profiles no longer need to manually enter root paths — mapping is automatic
- Existing behavior is fully preserved: when no storage profiles are configured or profiles don't match, the manual prompt fallback works exactly as before, with added guidance
- `--ignore-storage-profiles` provides an explicit opt-out for same-machine workflows
- No changes to `OutputDownloader` public interface or `_incremental_download.py`

### How was this change tested?

- **Unit tests** (`test_job_download_helpers.py`): 17 tests covering `_resolve_storage_profiles` (all decision matrix rows, API error propagation), `_apply_path_mappings_to_roots` (platform-specific POSIX/Windows tests), `_generate_path_mapping_rules` with `StorageProfile` dataclass inputs, and CLI-level `--ignore-storage-profiles` wiring
- **CLI end-to-end tests** (`test_cli_job_download_storage_profiles.py`): 7 tests covering every code path:
  - Case 1: Both profiles match → automatic mapping
  - Case 2: Both profiles exist, no matching locations → warning, no mapping
  - Case 3: No local profile, job has one → warning, manual fallback
  - Case 4: Neither has a profile → no mapping, direct download
  - Case 5: Local profile, job has none → warning, skip mapping
  - Case 6: `--ignore-storage-profiles` → skip everything
  - Case 7: Same profile both sides → no mapping needed
- **Existing tests**: all 39 `test_cli_job.py` tests pass, all 15 `test_path_mapping.py` tests pass, all 12 `test_cli_queue_incremental_download.py` tests pass
- `hatch run fmt` — clean
- `hatch run lint` (ruff + mypy) — clean, no issues in 309 source files
- `hatch run test test/unit/` — all pass, 83%+ coverage

### Was this change documented?

- Design doc: `docs/design/storage-profile-cli-support.md` (includes full analysis, decision matrix, staged implementation plan, and 7 test cases with call stacks)
- Docstrings added to all new functions
- `OutputDownloader` docstring updated to replace stale TODO

### Does this PR introduce new dependencies?

- [x] This PR does not add any new dependencies.

### Is this a breaking change?

No. The `_generate_path_mapping_rules()` function signature was broadened (accepts `Union[StorageProfile, dict]` instead of just `dict`) but this is backward compatible — all existing callers passing dicts continue to work unchanged. The function is underscore-prefixed (private API).

### Does this change impact security?

No. The change only affects path mapping logic for download destinations. No new file permissions, no new credential handling, no new network calls beyond the existing `get_storage_profile_for_queue` API.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*


---- 
## Testing


### 9.1 Test Cases

Each case traces the full code path from CLI entry through to download. All cases are implemented in `test/unit/deadline_client/cli/test_cli_job_download_storage_profiles.py`.

#### Case 1: Both profiles exist, location names match → automatic mapping

Local machine has `sp-local-111` (Linux, locations: `shared=/mnt/shared`, `temp=/tmp/render`).
Job was submitted with `sp-job-222` (Windows, locations: `shared=Z:\shared`, `temp=C:\temp\render`).

```
job_download_output()
  _validate_storage_profile_options(None, False)           → passes
  _download_job_output(..., ignore_storage_profiles=False)
    _resolve_storage_profiles(config, deadline, farm, queue, job, False)
      config_file.get_setting("settings.storage_profile_id") → "sp-local-111"
      job.get("storageProfileId")                            → "sp-job-222"
      Both truthy → fetch both via api.get_storage_profile_for_queue()
      → ResolvedStorageProfiles(job_profile=sp-job-222, local_profile=sp-local-111)
    resolved is not None → enters `if resolved:` branch
    _generate_path_mapping_rules(sp-job-222, sp-local-111)
      _normalize_storage_profile() on each
      IDs differ → match locations by name
      "shared" matches → PathMappingRule(WINDOWS, "Z:\shared", "/mnt/shared")
      "temp" matches   → PathMappingRule(WINDOWS, "C:\temp\render", "/tmp/render")
      → [rule1, rule2]
    _apply_path_mappings_to_roots(downloader, roots, [rule1, rule2])
      _PathMappingRuleApplier([rule1, rule2])  → builds trie
      transform("C:\temp\render") → "/tmp/render" → set_root_path()
      transform("Z:\shared")      → "/mnt/shared" → set_root_path()
    download proceeds to mapped local paths
```

Expected: roots are remapped, user sees "Using storage profile: Local Linux Profile" and "Mapping root: ..." messages. Download goes to `/mnt/shared` and `/tmp/render`.

#### Case 2: Both profiles exist, location names don't match → no rules, no mapping

Local machine has `sp-local-111` (locations: `shared`, `temp`).
Job was submitted with `sp-job-333` (locations: `ProjectFiles`, `OutputDir`).

```
job_download_output()
  _download_job_output(..., ignore_storage_profiles=False)
    _resolve_storage_profiles(...)
      Both IDs present → fetch both → ResolvedStorageProfiles
    resolved is not None → enters `if resolved:` branch
    _generate_path_mapping_rules(sp-job-333, sp-local-111)
      IDs differ → match locations by name
      "ProjectFiles" not in {"shared", "temp"}, "OutputDir" not in {"shared", "temp"}
      → []  (empty)
    _apply_path_mappings_to_roots(downloader, roots, [])
      `if not rules:` → prints warning about mismatched location names → return
    output_paths_by_root re-read (unchanged)
    user sees root confirmation prompt (if not auto_accept)
    download proceeds to original unmapped paths
```

Expected: no mapping applied. User sees "Using storage profile: ..." and a warning about mismatched location names recommending alignment. If OS mismatch exists, the manual root editing prompt appears as before.

#### Case 3: Job has profile, local machine does not → warning, manual fallback

Local machine has no storage profile configured.
Job was submitted with `sp-job-222`.

```
job_download_output()
  _download_job_output(..., ignore_storage_profiles=False)
    _resolve_storage_profiles(...)
      config_file.get_setting("settings.storage_profile_id") → ""
      job.get("storageProfileId")                            → "sp-job-222"
      Hits: `if not local_storage_profile_id and job_storage_profile_id:`
      → click.echo("Warning: ...no local storage profile is configured...")
      → None
    resolved is None → enters `else:` branch
    if OS mismatch → manual prompt fallback
    if same OS → download to original paths
```

Expected: warning printed recommending storage profile setup, then falls back to manual prompt if OS mismatch exists. No error thrown.

#### Case 4: Neither submitter nor downloader has a profile → no mapping, direct download

Local machine has no storage profile. Job was submitted without one.

```
job_download_output()
  _download_job_output(..., ignore_storage_profiles=False)
    _resolve_storage_profiles(...)
      config_file.get_setting("settings.storage_profile_id") → ""
      job.get("storageProfileId")                            → None
      Hits: `if not local_storage_profile_id and not job_storage_profile_id:`
      → None
    resolved is None → enters `else:` branch
    for each asset_root:
      root_path_format matches host format (same OS)
      no OS mismatch → no prompt
    download proceeds to original paths
```

Expected: same-machine case. No storage profiles, no path mapping, no prompts. Identical to pre-change behavior.

#### Case 5: Local profile configured, job submitted without one → warning, skip mapping

Local machine has `sp-local-111`. Job was submitted without a storage profile (e.g., older job or tool that didn't set one).

```
job_download_output()
  _download_job_output(..., ignore_storage_profiles=False)
    _resolve_storage_profiles(...)
      config_file.get_setting("settings.storage_profile_id") → "sp-local-111"
      job.get("storageProfileId")                            → None
      Hits: `if local_storage_profile_id and not job_storage_profile_id:`
      → click.echo("Warning: ...job was submitted without one. Path mapping will be skipped.")
      → None
    resolved is None → enters `else:` branch
    if OS mismatch → manual prompt fallback
    if same OS → download to original paths
```

Expected: warning printed, no mapping. Falls back to existing behavior. If cross-OS, user gets the manual root path prompt.

#### Case 6: `--ignore-storage-profiles` flag → skip everything

Both profiles may exist, but user explicitly opts out.

```
job_download_output(..., ignore_storage_profiles=True)
  _validate_storage_profile_options(None, True) → passes
  _download_job_output(..., ignore_storage_profiles=True)
    _resolve_storage_profiles(..., ignore_storage_profiles=True)
      → return None immediately (first line of function)
    resolved is None → enters `else:` branch
    if OS mismatch → manual prompt fallback
    download to original unmapped paths
```

Expected: all storage profile logic bypassed. Same behavior as pre-change code. Use when submitting and downloading from the same machine.

#### Case 7: Same storage profile on both sides → no mapping needed

Job was submitted with `sp-local-111`. Local machine also has `sp-local-111`.

```
job_download_output()
  _download_job_output(..., ignore_storage_profiles=False)
    _resolve_storage_profiles(...)
      Both IDs present, both "sp-local-111" → fetch both → ResolvedStorageProfiles
    resolved is not None → enters `if resolved:` branch
    _generate_path_mapping_rules(sp-local-111, sp-local-111)
      storageProfileId matches → return []
    _apply_path_mappings_to_roots(downloader, roots, [])
      `if not rules: return` → no-op
    download proceeds to original paths
```

Expected: same profile means same paths. No mapping, no prompts. Download to original locations.

