### PR TITLE
fix: accept hidden parameters with empty string defaults

### DIFF
--- a/src/deadline/client/job_bundle/parameters.py
+++ b/src/deadline/client/job_bundle/parameters.py
@@ -819,10 +819,7 @@ def read_job_bundle_parameters(bundle_dir: str) -> list[JobParameter]:
     invalid_params = []
     for param in parameters:
         if param.get("userInterface", {}).get("control") == "HIDDEN":
-            parameter_value = param.get("value")
-            if parameter_value is None or parameter_value == "":
-                parameter_value = param.get("default")
-            if parameter_value is None or parameter_value == "":
+            if "value" not in param and "default" not in param:
                 invalid_params.append(param["name"])
 
     if invalid_params:

--- a/test/unit/deadline_client/job_bundle/test_job_bundle_loader.py
+++ b/test/unit/deadline_client/job_bundle/test_job_bundle_loader.py
@@ -237,3 +237,67 @@ def test_validate_directory_symlink_containment_fail(tmpdir):
     os.symlink(target_file, test_root.join("symlink_file.txt"))
     with pytest.raises(DeadlineOperationError):
         validate_directory_symlink_containment(str(test_root))
+
+
+class TestHiddenParameterValidation:
+    """Tests for hidden parameter validation in read_job_bundle_parameters."""
+
+    TEMPLATE_HIDDEN_PARAM = """\
+specificationVersion: jobtemplate-2023-09
+name: HiddenTest
+parameterDefinitions:
+- name: HiddenParam
+  type: {type}
+  userInterface:
+    control: HIDDEN
+  description: A hidden parameter
+  {default_line}
+steps:
+- name: step1
+  script:
+    actions:
+      onRun:
+        command: echo
+        args:
+          - test
+"""
+
+    @pytest.mark.parametrize(
+        "param_type,default_line",
+        [
+            pytest.param("STRING", "default: ''", id="string-empty-default"),
+            pytest.param("STRING", "default: some_value", id="string-nonempty-default"),
+            pytest.param("INT", "default: 0", id="int-zero-default"),
+        ],
+    )
+    def test_hidden_param_with_default_succeeds(
+        self, param_type, default_line, fresh_deadline_config, temp_job_bundle_dir
+    ):
+        template = self.TEMPLATE_HIDDEN_PARAM.format(type=param_type, default_line=default_line)
+        with open(os.path.join(temp_job_bundle_dir, "template.yaml"), "w") as f:
+            f.write(template)
+
+        result = read_job_bundle_parameters(temp_job_bundle_dir)
+        assert any(p["name"] == "HiddenParam" for p in result)
+
+    def test_hidden_param_with_value_in_parameter_values_succeeds(
+        self, fresh_deadline_config, temp_job_bundle_dir
+    ):
+        template = self.TEMPLATE_HIDDEN_PARAM.format(type="STRING", default_line="")
+        with open(os.path.join(temp_job_bundle_dir, "template.yaml"), "w") as f:
+            f.write(template)
+        with open(os.path.join(temp_job_bundle_dir, "parameter_values.yaml"), "w") as f:
+            f.write("parameterValues:\n- name: HiddenParam\n  value: provided\n")
+
+        result = read_job_bundle_parameters(temp_job_bundle_dir)
+        assert any(p["name"] == "HiddenParam" and p["value"] == "provided" for p in result)
+
+    def test_hidden_param_no_default_no_value_fails(
+        self, fresh_deadline_config, temp_job_bundle_dir
+    ):
+        template = self.TEMPLATE_HIDDEN_PARAM.format(type="STRING", default_line="")
+        with open(os.path.join(temp_job_bundle_dir, "template.yaml"), "w") as f:
+            f.write(template)
+
+        with pytest.raises(DeadlineOperationError, match="Hidden parameter.*missing a value"):
+            read_job_bundle_parameters(temp_job_bundle_dir)


### PR DESCRIPTION
Hidden parameter validation was rejecting parameters that had a default value of empty string, because it checked `parameter_value == ""` instead of checking whether the 'default' key exists in the parameter dict. This caused job bundles with hidden PATH parameters having `default: ''` to fail submission with a misleading error.

Changed the validation to check for key existence ('value' not in param and 'default' not in param) rather than checking value truthiness.

Fixes: https://github.com/aws-deadline/deadline-cloud/issues/1030

- Have you run the unit tests? Yes
- Have you run the integration tests? No
- Have you made changes to the `download` or `asset_sync` modules? No

 
### Was this change documented?

- Are relevant docstrings in the code base updated? N/A
- Has the README.md been updated? N/A

### Does this PR introduce new dependencies? 

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [X] This PR does not add any new dependencies.

### Is this a breaking change? No

### Does this change impact security? No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
