### PR TITLE
chore: Revert "chore: temporary pin virtualenv<21 to fix build (#1009)"

### DIFF
--- a/.github/workflows/api-change-detection.yml
+++ b/.github/workflows/api-change-detection.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Install Hatch
         run: |
-          pip install --upgrade hatch "virtualenv<21"
+          pip install --upgrade hatch
 
       - name: Check for API breaking changes (griffe)
         run: |

--- a/.github/workflows/manual_pypi_release.yml
+++ b/.github/workflows/manual_pypi_release.yml
@@ -52,7 +52,7 @@ jobs:
           python-version: '3.9'
       - name: Install dependencies
         run: |
-          pip install --upgrade hatch "click<8.3" "virtualenv<21"
+          pip install --upgrade hatch "click<8.3"
       - name: Build
         run: hatch -v build
       # # See https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install Hatch
         run: |
-          pip install --upgrade hatch "virtualenv<21"
+          pip install --upgrade hatch
 
       - name: Build and deploy documentation
         run: hatch run docs:deploy --force

--- a/.github/workflows/mkdocs_quality.yml
+++ b/.github/workflows/mkdocs_quality.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install Hatch
         run: |
-          pip install --upgrade hatch "virtualenv<21"
+          pip install --upgrade hatch
 
       - name: Build documentation
         run: hatch run docs:build

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -124,7 +124,7 @@ jobs:
           python-version: '3.9'
       - name: Install dependencies
         run: |
-          pip install --upgrade hatch "virtualenv<21"
+          pip install --upgrade hatch
       - name: Build
         run: hatch -v build
       # # See https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi

--- a/.github/workflows/reusable_python_build_coverage_override.yml
+++ b/.github/workflows/reusable_python_build_coverage_override.yml
@@ -70,7 +70,7 @@ jobs:
 
     - name: Install Hatch
       run: |
-        pip install --upgrade hatch
+        pip install --upgrade hatch "virtualenv<21"
 
     - name: Run Linting
       run: hatch -v run lint

--- a/.github/workflows/reusable_python_build_coverage_override.yml
+++ b/.github/workflows/reusable_python_build_coverage_override.yml
@@ -70,7 +70,7 @@ jobs:
 
     - name: Install Hatch
       run: |
-        pip install --upgrade hatch "virtualenv<21"
+        pip install --upgrade hatch
 
     - name: Run Linting
       run: hatch -v run lint

--- a/pipeline/build.ps1
+++ b/pipeline/build.ps1
@@ -6,7 +6,7 @@ $ErrorActionPreference = "Stop"
 # Install/upgrade packages
 python -m pip install --upgrade pip
 if ($LASTEXITCODE -ne 0) { throw "Failed to update pip" }
-python -m pip install --upgrade hatch "virtualenv<21"
+python -m pip install --upgrade hatch
 if ($LASTEXITCODE -ne 0) { throw "Failed to update hatch" }
 python -m pip install --upgrade twine
 if ($LASTEXITCODE -ne 0) { throw "Failed to update twine" }

--- a/pipeline/build.sh
+++ b/pipeline/build.sh
@@ -4,7 +4,7 @@
 set -e
 
 pip install --upgrade pip
-pip install --upgrade hatch "virtualenv<21"
+pip install --upgrade hatch
 pip install --upgrade twine
 hatch -v run lint
 hatch run test

--- a/pipeline/build_pyinstaller_artifact.ps1
+++ b/pipeline/build_pyinstaller_artifact.ps1
@@ -7,7 +7,7 @@ if ($LASTEXITCODE -ne 0) { throw "Failed to generate attributions document" }
 
 pip install --upgrade pip
 if ($LASTEXITCODE -ne 0) { throw "Failed to update pip" }
-pip install --upgrade hatch "virtualenv<21"
+pip install --upgrade hatch
 if ($LASTEXITCODE -ne 0) { throw "Failed to update hatch" }
 
 hatch build

--- a/pipeline/build_pyinstaller_artifact.sh
+++ b/pipeline/build_pyinstaller_artifact.sh
@@ -4,7 +4,7 @@
 set -e
 
 pip3 install --upgrade pip
-pip3 install --upgrade hatch "virtualenv<21"
+pip3 install --upgrade hatch
 
 hatch run attributions:generate
 hatch build

--- a/pipeline/e2e.sh
+++ b/pipeline/e2e.sh
@@ -4,5 +4,5 @@
 set -e
 
 pip install --upgrade pip
-pip install --upgrade hatch "virtualenv<21"
+pip install --upgrade hatch
 hatch run e2e:test

--- a/pipeline/integ.ps1
+++ b/pipeline/integ.ps1
@@ -3,6 +3,6 @@
 $ErrorActionPreference = "Stop"
 
 pip install --upgrade pip
-pip install --upgrade hatch "virtualenv<21"
+pip install --upgrade hatch
 hatch run integ:test
 if ($LASTEXITCODE -ne 0) { throw "Failed to run integration tests" }

--- a/pipeline/integ.sh
+++ b/pipeline/integ.sh
@@ -4,5 +4,5 @@
 set -e
 
 pip install --upgrade pip
-pip install --upgrade hatch "virtualenv<21"
+pip install --upgrade hatch
 hatch run integ:test

--- a/testing_containers/localuser_sudo_environment/run_tests.sh
+++ b/testing_containers/localuser_sudo_environment/run_tests.sh
@@ -10,5 +10,5 @@ cp -r /code/.git /home/hostuser/code/
 cd code
 python -m venv .venv
 source .venv/bin/activate
-pip install hatch "virtualenv<21"
+pip install hatch
 hatch run pytest --cov=src/deadline --cov-report=html:build/coverage --cov-report=xml:build/coverage/coverage.xml --cov-report=term-missing --cov-fail-under=25 -m docker


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The original commit temporarily pinned `virtualenv<21` to fix a build issue. This workaround is no longer needed as the underlying issue has been fixed in [hatch v1.16.5](https://github.com/pypa/hatch/releases/tag/hatch-v1.16.5).

### What was the solution? (How)

Reverted the commit that added the `virtualenv<21` pin across all workflow files and build scripts.

### What is the impact of this change?

Build and test workflows will now use the latest compatible version of `virtualenv` instead of being pinned to versions below 21.

### How was this change tested?

GitHub actions still succeed

### Was this change documented?

N/A

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*