### PR TITLE
[WIP] fix: Remove Client error types from Job Attachments

### DIFF
--- a/src/deadline/client/cli/_groups/attachment_group.py
+++ b/src/deadline/client/cli/_groups/attachment_group.py
@@ -24,7 +24,9 @@ from ....job_attachments.api.attachment import (
     _attachment_upload,
 )
 from ....job_attachments._aws.deadline import get_queue
-from ....job_attachments.exceptions import MissingJobAttachmentSettingsError
+from ....job_attachments.exceptions import (
+    MissingJobAttachmentSettingsError,
+)
 from ....job_attachments.models import FileConflictResolution, JobAttachmentS3Settings
 from ....job_attachments.progress_tracker import DownloadSummaryStatistics
 
@@ -50,13 +52,15 @@ def cli_attachment():
     help="File path(s) to manifest formatted file(s). File name has to contain the hash of corresponding source path.",
 )
 @click.option(
-    "--s3-root-uri", help="Job Attachments S3 root uri including bucket name and root prefix."
+    "--s3-root-uri",
+    help="Job Attachments S3 root uri including bucket name and root prefix.",
 )
 @click.option("--path-mapping-rules", help="Path to a file with the path mapping rules to use.")
 @click.option("--farm-id", help="The AWS Deadline Cloud Farm to use. ")
 @click.option("--queue-id", help="The AWS Deadline Cloud Queue to use. ")
 @click.option(
-    "--profile", help="The AWS profile to use for interacting with Job Attachments S3 bucket."
+    "--profile",
+    help="The AWS profile to use for interacting with Job Attachments S3 bucket.",
 )
 @click.option(
     "--conflict-resolution",
@@ -73,7 +77,12 @@ def cli_attachment():
     "SKIP: Do not download the file\n"
     "OVERWRITE: Download and replace the existing file",
 )
-@click.option("--json", default=None, is_flag=True, help="Output is printed as JSON for scripting.")
+@click.option(
+    "--json",
+    default=None,
+    is_flag=True,
+    help="Output is printed as JSON for scripting.",
+)
 @_handle_error
 def attachment_download(
     manifests: list[str],
@@ -159,15 +168,19 @@ def attachment_download(
 )
 @click.option("--path-mapping-rules", help="Path to a file with the path mapping rules to use.")
 @click.option(
-    "--s3-root-uri", help="Job Attachments S3 root uri including bucket name and root prefix."
+    "--s3-root-uri",
+    help="Job Attachments S3 root uri including bucket name and root prefix.",
 )
 @click.option(
-    "--upload-manifest-path", default=None, help="File path for uploading the manifests to CAS."
+    "--upload-manifest-path",
+    default=None,
+    help="File path for uploading the manifests to CAS.",
 )
 @click.option("--farm-id", help="The AWS Deadline Cloud Farm to use. ")
 @click.option("--queue-id", help="The AWS Deadline Cloud Queue to use. ")
 @click.option(
-    "--profile", help="The AWS profile to use for interacting with Job Attachments S3 bucket."
+    "--profile",
+    help="The AWS profile to use for interacting with Job Attachments S3 bucket.",
 )
 @click.option("--json", default=None, is_flag=True, help="Output is printed as JSON for scripting")
 @_handle_error

--- a/src/deadline/job_attachments/_diff.py
+++ b/src/deadline/job_attachments/_diff.py
@@ -7,7 +7,7 @@ from pathlib import Path, PurePosixPath
 from typing import Any, Callable, Dict, List, Tuple
 from math import trunc
 from deadline.client.config import config_file
-from deadline.client.exceptions import NonValidInputError
+from deadline.job_attachments.exceptions import NonValidInputError
 from deadline.job_attachments.asset_manifests.base_manifest import (
     BaseAssetManifest,
     BaseManifestPath,
@@ -77,7 +77,7 @@ def find_file_with_status(
             }
             status_paths: List[tuple] = []
             for future in concurrent.futures.as_completed(futures):
-                (file_status, _, manifestPath) = future.result()
+                file_status, _, manifestPath = future.result()
                 if file_status in statuses:
                     status_paths.append((file_status, manifestPath))
 

--- a/src/deadline/job_attachments/_glob.py
+++ b/src/deadline/job_attachments/_glob.py
@@ -5,7 +5,7 @@ import glob
 import json
 from pathlib import Path
 from typing import List, Optional
-from deadline.client.exceptions import NonValidInputError
+from deadline.job_attachments.exceptions import NonValidInputError
 from deadline.job_attachments.models import GlobConfig
 
 

--- a/src/deadline/job_attachments/api/_utils.py
+++ b/src/deadline/job_attachments/api/_utils.py
@@ -5,7 +5,7 @@ import os
 from contextlib import ExitStack
 from typing import List, Dict
 
-from ...client.exceptions import NonValidInputError
+from ..exceptions import NonValidInputError
 from ..asset_manifests.base_manifest import BaseAssetManifest
 from ..asset_manifests.decode import decode_manifest
 

--- a/src/deadline/job_attachments/api/attachment.py
+++ b/src/deadline/job_attachments/api/attachment.py
@@ -20,7 +20,7 @@ from deadline.job_attachments.progress_tracker import DownloadSummaryStatistics
 from deadline.job_attachments.upload import S3AssetUploader
 
 from deadline.client.config import config_file
-from deadline.client.exceptions import NonValidInputError
+from deadline.job_attachments.exceptions import NonValidInputError
 
 
 def _attachment_download(

--- a/src/deadline/job_attachments/exceptions.py
+++ b/src/deadline/job_attachments/exceptions.py
@@ -6,7 +6,6 @@ Exceptions that the Deadline Job Attachments library can raise.
 
 from typing import Optional
 
-
 COMMON_ERROR_GUIDANCE_FOR_S3 = {
     408: "Request timeout. Please consider retrying later, or ensure your network connection is stable.",
     500: "Internal server error. It might be an issue on AWS's side; please consider retrying later or contacting AWS support.",
@@ -182,4 +181,10 @@ class UnsupportedHashingAlgorithmError(JobAttachmentsError):
 class VFSRunPathNotSetError(JobAttachmentsError):
     """
     Exception for when the run path hasn't been set for the vfs
+    """
+
+
+class NonValidInputError(JobAttachmentsError):
+    """
+    Exception for when user input to a Job Attachments function is not valid.
     """

--- a/test/unit/deadline_job_attachments/api/test_attachment.py
+++ b/test/unit/deadline_job_attachments/api/test_attachment.py
@@ -16,7 +16,7 @@ import deadline
 
 from deadline.client import api
 from deadline.client.config import config_file
-from deadline.client.exceptions import NonValidInputError
+from deadline.job_attachments.exceptions import NonValidInputError
 from deadline.job_attachments.api.attachment import (
     _attachment_download,
     _attachment_upload,
@@ -155,7 +155,11 @@ class TestAttachmentDownload:
         ],
     )
     def test_download_conflict_resolution(
-        self, temp_assets_dir, session_mock, mock_download_files_from_manifests, conflict_resolution
+        self,
+        temp_assets_dir,
+        session_mock,
+        mock_download_files_from_manifests,
+        conflict_resolution,
     ):
         with open(
             os.path.join(temp_assets_dir, PATH_MAPPING_HASH),
@@ -195,14 +199,18 @@ class TestAttachmentDownload:
             },
             cas_prefix="assetRoot/Data",
             session=session_mock,
-            conflict_resolution=conflict_resolution
-            if conflict_resolution
-            else FileConflictResolution.CREATE_COPY,
+            conflict_resolution=(
+                conflict_resolution if conflict_resolution else FileConflictResolution.CREATE_COPY
+            ),
         )
 
     @pytest.mark.parametrize("manifest_case_key", MOCK_MANIFEST_CASE.keys())
     def test_download_single_to_current(
-        self, temp_assets_dir, session_mock, mock_download_files_from_manifests, manifest_case_key
+        self,
+        temp_assets_dir,
+        session_mock,
+        mock_download_files_from_manifests,
+        manifest_case_key,
     ):
         with open(
             os.path.join(temp_assets_dir, manifest_case_key),

--- a/test/unit/deadline_job_attachments/api/test_utils.py
+++ b/test/unit/deadline_job_attachments/api/test_utils.py
@@ -6,7 +6,7 @@ from typing import Dict
 import pytest
 from unittest.mock import patch
 
-from deadline.client.exceptions import NonValidInputError
+from deadline.job_attachments.exceptions import NonValidInputError
 from deadline.job_attachments.asset_manifests.base_manifest import BaseAssetManifest
 from deadline.job_attachments.api._utils import _read_manifests
 

--- a/test/unit/deadline_job_attachments/test_glob.py
+++ b/test/unit/deadline_job_attachments/test_glob.py
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 import os
-from deadline.client.exceptions import NonValidInputError
+from deadline.job_attachments.exceptions import NonValidInputError
 import pytest
 from typing import List
 from deadline.job_attachments._glob import _glob_paths, _process_glob_inputs


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Job Attachments imports `NonValidInputError` from `deadline.client.exceptions` and raises it in 4 files. This creates a dependency from Job Attachments on the client, which is part of the circular dependency we're breaking in Milestone 1 of the Client Decoupling project.

### What was the solution? (How)
- Added a new `NonValidInputError` exception class in `job_attachments.exceptions` (inherits from `JobAttachmentsError`)
 - Updated 4 Job Attachments files to import from `job_attachments.exceptions` instead of `client.exceptions`:
   - `api/attachment.py`
   - `api/_utils.py`
   - `_diff.py`
   - `_glob.py`
 - In the client's `attachment_group.py`, wrapped calls to `_attachment_download` and `_attachment_upload` with `try/except` to catch the new JA `NonValidInputError` and re-raise as the client's `NonValidInputError`, preserving existing behavior for client **consumers**

### What is the impact of this change?
Job Attachments no longer imports any error types from the client. This is a breaking change for Job Attachments — any code that catches `deadline.client.exceptions.NonValidInputError` from JA function calls must update to catch `deadline.job_attachments.exceptions.NonValidInputError`. The client itself is not broken because the catch-and-re-raise in `attachment_group.py` preserves the existing exception type at the CLI boundary.

### How was this change tested?

- Have you run the unit tests?
```
==================================================== slowest 5 durations ====================================================
5.26s call     test/unit/deadline_job_attachments/test_upload.py::TestUpload::test_asset_management_many_inputs[2023-03-03-200]
4.83s call     test/unit/deadline_job_attachments/test_upload.py::TestUpload::test_asset_management_no_outputs_large_number_of_inputs_already_uploaded[2023-03-03-200]
4.33s call     test/unit/deadline_job_attachments/test_upload.py::TestUpload::test_get_asset_groups[input_paths5-output_paths5-referenced_paths5-local_type_locations5-shared_type_locations5-expected_result5]
3.32s call     test/unit/deadline_job_attachments/test_upload.py::TestUpload::test_asset_management_many_inputs[2023-03-03-100]
2.69s call     test/unit/deadline_job_attachments/test_upload.py::TestUpload::test_asset_management_no_outputs_large_number_of_inputs_already_uploaded[2023-03-03-100]
==================================================== 2346 passed, 62 skipped, 1 xfailed in 58.36s ====================================================
```
- Have you run the integration tests?
```
=========================================================================== slowest 5 durations ============================================================================
603.34s call     test/integ/cli/test_cli_incremental_download.py::test_incremental_download_dependency_chain
425.75s call     test/integ/cli/test_cli_incremental_download.py::test_conflict_resolution_with_requeue[job]
407.77s call     test/integ/cli/test_cli_incremental_download.py::test_incremental_download_dep_data_flow
338.52s call     test/integ/cli/test_cli_incremental_download.py::test_conflict_resolution_with_requeue[step]
320.80s call     test/integ/cli/test_cli_incremental_download.py::test_conflict_resolution_with_requeue[task]
===================================================== 56 passed, 4 skipped, 1 xfailed, 4 xpassed in 2450.40s (0:40:50) =====================================================
```
- Manual submission test and verify it pass

### Was this change documented?
Yes

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?

**Yes.** `deadline.job_attachments.exceptions.NonValidInputError` is now raised instead of `deadline.client.exceptions.NonValidInputError` from Job Attachments functions. Downstream code that catches the client's `NonValidInputError` from direct JA calls must update to catch the new JA exception type. Per the plan, this will be released as part of a single breaking client release with all other Milestone 1 changes.

### Does this change impact security?
No


----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
