### PR TITLE
[WIP] chore: move s3 client and config logic out of _manifest_download

### DIFF
--- a/src/deadline/client/cli/_groups/manifest_group.py
+++ b/src/deadline/client/cli/_groups/manifest_group.py
@@ -18,6 +18,10 @@ from typing import List, Optional
 import boto3
 import click
 
+from deadline.client.api._session import (
+    _get_queue_user_boto3_session,
+    get_default_client_config,
+)
 from deadline.client import api
 from deadline.client.config import config_file
 from deadline.job_attachments._diff import pretty_print_cli
@@ -99,7 +103,12 @@ def cli_manifest():
     help="Rehash all files to compare using file hashes.",
 )
 @click.option("--diff", default=None, help="File Path to Asset Manifest to diff against.")
-@click.option("--json", default=None, is_flag=True, help="Output is printed as JSON for scripting.")
+@click.option(
+    "--json",
+    default=None,
+    is_flag=True,
+    help="Output is printed as JSON for scripting.",
+)
 @_handle_error
 def manifest_snapshot(
     root: str,
@@ -156,7 +165,10 @@ For details and a fix using the registry, see: https://learn.microsoft.com/en-us
                 )
             )
             logger.json(
-                dict(dataclasses.asdict(manifest_out), **{"warning": long_manifest_path_warning})
+                dict(
+                    dataclasses.asdict(manifest_out),
+                    **{"warning": long_manifest_path_warning},
+                )
             )
         else:
             logger.json(dataclasses.asdict(manifest_out))
@@ -195,7 +207,12 @@ For details and a fix using the registry, see: https://learn.microsoft.com/en-us
     is_flag=True,
     help="Rehash all files to compare using file hashes.",
 )
-@click.option("--json", default=None, is_flag=True, help="Output is printed as JSON for scripting.")
+@click.option(
+    "--json",
+    default=None,
+    is_flag=True,
+    help="Output is printed as JSON for scripting.",
+)
 @_handle_error
 def manifest_diff(
     root: str,
@@ -266,7 +283,10 @@ def manifest_diff(
     ),
 )
 @click.option(
-    "--json", default=None, is_flag=True, help="Output is printed as JSON for scripting. "
+    "--json",
+    default=None,
+    is_flag=True,
+    help="Output is printed as JSON for scripting. ",
 )
 @_handle_error
 def manifest_download(
@@ -296,15 +316,34 @@ def manifest_download(
     farm_id: str = config_file.get_setting("defaults.farm_id", config=config)
 
     boto3_session: boto3.Session = api.get_boto3_session(config=config)
+    # Deadline Client and get the Queue to download.
+    deadline_client = boto3_session.client("deadline", config=get_default_client_config())
+    queue: dict = deadline_client.get_queue(
+        farmId=farm_id,
+        queueId=queue_id,
+    )
+    # Queue's Job Attachment settings.
+    queue_s3_settings = JobAttachmentS3Settings(**queue["jobAttachmentSettings"])
+
+    # assume queue role - session permissions
+    queue_role_session: boto3.Session = _get_queue_user_boto3_session(
+        deadline=deadline_client,
+        base_session=boto3_session,
+        farm_id=farm_id,
+        queue_id=queue_id,
+        queue_display_name=queue["displayName"],
+    )
 
     output = _manifest_download(
         download_dir=download_dir,
         farm_id=farm_id,
         queue_id=queue_id,
+        queue_s3_settings=queue_s3_settings,
         job_id=job_id,
         step_id=step_id,
         asset_type=AssetType(asset_type),
-        boto3_session=boto3_session,
+        deadline_client=deadline_client,
+        queue_role_session=queue_role_session,
         print_function_callback=logger.echo,
     )
     logger.json(dataclasses.asdict(output))
@@ -313,17 +352,28 @@ def manifest_download(
 @cli_manifest.command(name="upload")
 @click.argument("manifest_file")
 @click.option("--profile", help="The AWS profile to use.")
-@click.option("--s3-cas-uri", help="The URI to the Content Addressable Storage S3 bucket and root.")
 @click.option(
-    "--s3-manifest-prefix", help="Prefix subpath in the manifest folder to upload the manifest."
+    "--s3-cas-uri",
+    help="The URI to the Content Addressable Storage S3 bucket and root.",
 )
 @click.option(
-    "--farm-id", help="The AWS Deadline Cloud Farm to use. Alternative to using --s3-cas-uri."
+    "--s3-manifest-prefix",
+    help="Prefix subpath in the manifest folder to upload the manifest.",
 )
 @click.option(
-    "--queue-id", help="The AWS Deadline Cloud Queue to use. Alternative to using --s3-cas-uri."
+    "--farm-id",
+    help="The AWS Deadline Cloud Farm to use. Alternative to using --s3-cas-uri.",
 )
-@click.option("--json", default=None, is_flag=True, help="Output is printed as JSON for scripting.")
+@click.option(
+    "--queue-id",
+    help="The AWS Deadline Cloud Queue to use. Alternative to using --s3-cas-uri.",
+)
+@click.option(
+    "--json",
+    default=None,
+    is_flag=True,
+    help="Output is printed as JSON for scripting.",
+)
 @_handle_error
 def manifest_upload(
     manifest_file: str,

--- a/src/deadline/job_attachments/api/manifest.py
+++ b/src/deadline/job_attachments/api/manifest.py
@@ -7,9 +7,12 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import boto3
+import botocore.client
 
-from deadline.client.api._session import _get_queue_user_boto3_session, get_default_client_config
-from deadline.job_attachments._diff import _fast_file_list_to_manifest_diff, compare_manifest
+from deadline.job_attachments._diff import (
+    _fast_file_list_to_manifest_diff,
+    compare_manifest,
+)
 from deadline.job_attachments._glob import _process_glob_inputs, _glob_paths
 from deadline.job_attachments.api._utils import _read_manifests
 from deadline.job_attachments.asset_manifests._create_manifest import (
@@ -112,7 +115,9 @@ def _manifest_snapshot(
     # Compute the output manifest immediately and hash.
     if not diff:
         output_manifest = _create_manifest_for_single_root(
-            files=current_files, root=root, print_function_callback=print_function_callback
+            files=current_files,
+            root=root,
+            print_function_callback=print_function_callback,
         )
         if not output_manifest:
             return None
@@ -143,7 +148,9 @@ def _manifest_snapshot(
         else:
             # In "slow / thorough" mode, we check by hash, which is definitive.
             output_manifest = _create_manifest_for_single_root(
-                files=current_files, root=root, print_function_callback=print_function_callback
+                files=current_files,
+                root=root,
+                print_function_callback=print_function_callback,
             )
             if not output_manifest:
                 return None
@@ -164,7 +171,9 @@ def _manifest_snapshot(
 
         # Since the files are already hashed, we can easily re-use has_attachments to remake a diff manifest.
         output_manifest = _create_manifest_for_single_root(
-            files=changed_paths, root=root, print_function_callback=print_function_callback
+            files=changed_paths,
+            root=root,
+            print_function_callback=print_function_callback,
         )
         if not output_manifest:
             return None
@@ -237,7 +246,10 @@ def _manifest_diff(
 
     # Find all files matching our regex
     input_files = _glob_files(
-        root=root, include=include, exclude=exclude, include_exclude_config=include_exclude_config
+        root=root,
+        include=include,
+        exclude=exclude,
+        include_exclude_config=include_exclude_config,
     )
     input_paths = [Path(p) for p in input_files]
 
@@ -271,7 +283,8 @@ def _manifest_diff(
 
         # Hash based compare manifests.
         differences: List[Tuple[FileStatus, BaseManifestPath]] = compare_manifest(
-            reference_manifest=local_manifest_object, compare_manifest=directory_manifest_object
+            reference_manifest=local_manifest_object,
+            compare_manifest=directory_manifest_object,
         )
         # Map to output datastructure.
         for item in differences:
@@ -318,7 +331,12 @@ def _manifest_upload(
 
     # Always upload the manifest file to case root /Manifest with the original file name.
     manifest_path: str = "/".join(
-        [s3_cas_prefix, S3_MANIFEST_FOLDER_NAME, s3_key_prefix, Path(manifest_file).name]
+        [
+            s3_cas_prefix,
+            S3_MANIFEST_FOLDER_NAME,
+            s3_key_prefix,
+            Path(manifest_file).name,
+        ]
         if s3_key_prefix
         else [s3_cas_prefix, S3_MANIFEST_FOLDER_NAME, Path(manifest_file).name]
     )
@@ -339,48 +357,33 @@ def _manifest_upload(
 
 
 def _manifest_download(
+    *,
+    deadline_client: botocore.client.BaseClient,
     download_dir: str,
     farm_id: str,
-    queue_id: str,
     job_id: str,
-    boto3_session: boto3.Session,
-    step_id: Optional[str] = None,
+    queue_id: str,
+    queue_role_session: boto3.Session,
+    queue_s3_settings: JobAttachmentS3Settings,
     asset_type: AssetType = AssetType.ALL,
     print_function_callback: Callable[[Any], None] = lambda msg: None,
+    step_id: Optional[str] = None,
 ) -> ManifestDownloadResponse:
     """
     BETA API - This API is still evolving but will be made public in the near future.
     API to download the Job Attachment manifest for a Job, and optionally dependencies for Step.
+    deadline_client: Deadline client for API calls.
     download_dir: Download directory.
     farm_id: The Deadline Farm to download from.
-    queue_id: The Deadline Queue to download from.
     job_id: Job Id to download.
-    boto_session: Boto3 session.
-    step_id: Optional[str]: Optional, download manifest for a step
+    queue_id: The Deadline Queue to download from.
+    queue_role_session: Boto3 session for the queue role.
+    queue_s3_settings: S3 settings for the queue's job attachments.
     asset_type: Which asset manifests should be downloaded for given job (& optionally step), options are Input, Output, All. Default behaviour is All.
     print_function_callback: Callback function to handle print messages.
+    step_id: Optional, download manifest for a step.
     return ManifestDownloadResponse Downloaded Manifest data. Contains source S3 key and local download path.
     """
-
-    # Deadline Client and get the Queue to download.
-    deadline = boto3_session.client("deadline", config=get_default_client_config())
-
-    queue: dict = deadline.get_queue(
-        farmId=farm_id,
-        queueId=queue_id,
-    )
-
-    # assume queue role - session permissions
-    queue_role_session: boto3.Session = _get_queue_user_boto3_session(
-        deadline=deadline,
-        base_session=boto3_session,
-        farm_id=farm_id,
-        queue_id=queue_id,
-        queue_display_name=queue["displayName"],
-    )
-
-    # Queue's Job Attachment settings.
-    queue_s3_settings = JobAttachmentS3Settings(**queue["jobAttachmentSettings"])
 
     # Get S3 prefix
     s3_prefix: Path = Path(queue_s3_settings.rootPrefix, S3_MANIFEST_FOLDER_NAME)
@@ -407,7 +410,7 @@ def _manifest_download(
         manifests_by_root[root].append(manifest)
 
     # Get the job from deadline api
-    job: dict = deadline.get_job(farmId=farm_id, queueId=queue_id, jobId=job_id)
+    job: dict = deadline_client.get_job(farmId=farm_id, queueId=queue_id, jobId=job_id)
 
     # If input manifests need to be downloaded
     if download_input:
@@ -430,7 +433,9 @@ def _manifest_download(
             if asset_manifest is not None:
                 print_function_callback(f"Found input manifest for root: {root_path}")
                 add_manifest_by_root(
-                    manifests_by_root=manifests_by_root, root=root_path, manifest=asset_manifest
+                    manifests_by_root=manifests_by_root,
+                    root=root_path,
+                    manifest=asset_manifest,
                 )
 
         # Now handle step-step dependencies
@@ -440,7 +445,7 @@ def _manifest_download(
             # Get Step-Step dependencies with pagination
             next_token = ""
             while next_token is not None:
-                step_dep_response = deadline.list_step_dependencies(
+                step_dep_response = deadline_client.list_step_dependencies(
                     farmId=farm_id,
                     queueId=queue_id,
                     jobId=job_id,
@@ -471,7 +476,9 @@ def _manifest_download(
                                 f"Found step-step output manifest for root: {root}"
                             )
                             add_manifest_by_root(
-                                manifests_by_root=manifests_by_root, root=root, manifest=manifest
+                                manifests_by_root=manifests_by_root,
+                                root=root,
+                                manifest=manifest,
                             )
 
                 next_token = step_dep_response.get("nextToken")

--- a/test/unit/deadline_job_attachments/api/test_manifest_download.py
+++ b/test/unit/deadline_job_attachments/api/test_manifest_download.py
@@ -6,7 +6,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from deadline.job_attachments.api.manifest import _manifest_download
-from deadline.job_attachments.models import ManifestDownloadResponse
+from deadline.job_attachments.models import (
+    ManifestDownloadResponse,
+    JobAttachmentS3Settings,
+)
 
 
 class TestManifestDownload:
@@ -15,14 +18,16 @@ class TestManifestDownload:
         with tempfile.TemporaryDirectory() as tmpdir_path:
             yield tmpdir_path
 
-    @patch("deadline.job_attachments.api.manifest._get_queue_user_boto3_session")
     @patch("deadline.job_attachments.api.manifest.get_manifest_from_s3")
     @patch("deadline.job_attachments.api.manifest.get_output_manifests_by_asset_root")
     @pytest.mark.parametrize(
         "job_manifests,step_manifests",
         [
             pytest.param([], []),
-            pytest.param([{"inputManifestPath": "s3://hello/world", "rootPath": "/some/root"}], []),
+            pytest.param(
+                [{"inputManifestPath": "s3://hello/world", "rootPath": "/some/root"}],
+                [],
+            ),
             pytest.param([], [{"stepId": "step-123456"}]),
             pytest.param(
                 [{"inputManifestPath": "s3://hello/world", "rootPath": "/some/root"}],
@@ -34,7 +39,6 @@ class TestManifestDownload:
         self,
         mock_get_output_manifest: MagicMock,
         mock_get_manifest_from_s3: MagicMock,
-        mock_queue_session: MagicMock,
         job_manifests: List,
         step_manifests: List,
         temp_dir: str,
@@ -47,7 +51,7 @@ class TestManifestDownload:
         mock_boto_session = MagicMock()
 
         # Mock Get Queue Credentials
-        mock_queue_session.return_value = MagicMock()
+        mock_queue_session = MagicMock()
 
         # Mock up Deadline.
         mock_deadline_client = MagicMock()
@@ -56,8 +60,14 @@ class TestManifestDownload:
         # Mock the result of get_queue
         mock_deadline_client.get_queue.return_value = {
             "displayName": "queue",
-            "jobAttachmentSettings": {"s3BucketName": "bucket", "rootPrefix": "root_prefix"},
+            "jobAttachmentSettings": {
+                "s3BucketName": "bucket",
+                "rootPrefix": "root_prefix",
+            },
         }
+
+        queue_s3_settings = JobAttachmentS3Settings(s3BucketName="bucket", rootPrefix="root_prefix")
+
         # Mock the result of get_job
         mock_deadline_client.get_job.return_value = {
             "name": "Mock Job",
@@ -74,21 +84,21 @@ class TestManifestDownload:
             queue_id="queue-12345",
             job_id="job-12345",
             step_id="step-12345",
-            boto3_session=mock_boto_session,
+            queue_s3_settings=queue_s3_settings,
+            deadline_client=mock_deadline_client,
+            queue_role_session=mock_queue_session,
         )
         assert output is not None
 
         # list_step_dependencies should have been called once as there is no pagination
         assert mock_deadline_client.list_step_dependencies.call_count == 1
 
-    @patch("deadline.job_attachments.api.manifest._get_queue_user_boto3_session")
     @patch("deadline.job_attachments.api.manifest.get_manifest_from_s3")
     @patch("deadline.job_attachments.api.manifest.get_output_manifests_by_asset_root")
     def test_download_job_paginate_through_step_dependencies(
         self,
         mock_get_output_manifest: MagicMock,
         mock_get_manifest_from_s3: MagicMock,
-        mock_queue_session: MagicMock,
         temp_dir: str,
     ):
         # This is heavily mocked, so return nothing. Integration tests tests full manifest merging.
@@ -99,7 +109,7 @@ class TestManifestDownload:
         mock_boto_session = MagicMock()
 
         # Mock Get Queue Credentials
-        mock_queue_session.return_value = MagicMock()
+        mock_queue_session = MagicMock()
 
         # Mock up Deadline.
         mock_deadline_client = MagicMock()
@@ -108,8 +118,12 @@ class TestManifestDownload:
         # Mock the result of get_queue
         mock_deadline_client.get_queue.return_value = {
             "displayName": "queue",
-            "jobAttachmentSettings": {"s3BucketName": "bucket", "rootPrefix": "root_prefix"},
+            "jobAttachmentSettings": {
+                "s3BucketName": "bucket",
+                "rootPrefix": "root_prefix",
+            },
         }
+        queue_s3_settings = JobAttachmentS3Settings(s3BucketName="bucket", rootPrefix="root_prefix")
         # Mock the result of get_job
         mock_deadline_client.get_job.return_value = {
             "name": "Mock Job",
@@ -119,7 +133,10 @@ class TestManifestDownload:
         }
         # Mock the result of list_step_dependencies, have a nextToken to make sure that our code paginates
         mock_deadline_client.list_step_dependencies.side_effect = [
-            {"dependencies": [{"stepId": f"step-{i}"} for i in range(100)], "nextToken": "abcasd"},
+            {
+                "dependencies": [{"stepId": f"step-{i}"} for i in range(100)],
+                "nextToken": "abcasd",
+            },
             {"dependencies": [{"stepId": f"step-{i}"} for i in range(100, 150)]},
         ]
 
@@ -129,7 +146,9 @@ class TestManifestDownload:
             queue_id="queue-12345",
             job_id="job-12345",
             step_id="step-12345",
-            boto3_session=mock_boto_session,
+            queue_s3_settings=queue_s3_settings,
+            deadline_client=mock_deadline_client,
+            queue_role_session=mock_queue_session,
         )
         assert output is not None
 


### PR DESCRIPTION
Fixes: *<insert link to GitHub issue here>*

### What was the problem/requirement? (What/Why)
The `_manifest_download` function in `job_attachments/api/manifest.py` directly imports and calls `_get_queue_user_boto3_session` and `get_default_client_config` from the client's `_session.py`. This creates a dependency from Job Attachments on the client's session management code.

### What was the solution? (How)
- Removed the `_get_queue_user_boto3_session` and `get_default_client_config` imports from `job_attachments/api/manifest.py`
- Removed the inline session creation, queue lookup, and role assumption logic from `_manifest_download`
- Changed `_manifest_download` to accept `queue_s3_settings`, `deadline_client`, and `queue_role_session` as parameters instead of creating them internally
- Moved the session/client creation logic to the caller in `client/cli/_groups/manifest_group.py`, which is the only place `_manifest_download` is called from the client

### What is the impact of this change?
`_manifest_download` does not create circular dependency anymore

### How was this change tested?

- Have you run the unit tests?
```
============================================================================================ slowest 5 durations =============================================================================================
5.67s call     test/unit/deadline_job_attachments/test_upload.py::TestUpload::test_asset_management_many_inputs[2023-03-03-200]
4.48s call     test/unit/deadline_client/cli/test_cli_handle_web_url.py::test_cli_handle_web_url_download_output_only_required_input
4.46s call     test/unit/deadline_client/api/test_api_farm.py::test_list_farms_paginated
4.38s call     test/unit/deadline_client/api/test_mcp.py::TestSearchJobs::test_search_jobs_with_name_filter
4.38s call     test/unit/deadline_job_attachments/test_upload.py::TestUpload::test_asset_management_no_outputs_large_number_of_inputs_already_uploaded[2023-03-03-200]
================================================================================ 2346 passed, 62 skipped, 1 xfailed in 51.86s ================================================================================
```
- Have you run the integration tests?
```
============================================================================================ slowest 5 durations =============================================================================================
607.70s call     test/integ/cli/test_cli_incremental_download.py::test_incremental_download_dependency_chain
462.95s call     test/integ/cli/test_cli_incremental_download.py::test_conflict_resolution_with_requeue[job]
415.79s call     test/integ/cli/test_cli_incremental_download.py::test_incremental_download_dep_data_flow
348.29s call     test/integ/cli/test_cli_incremental_download.py::test_conflict_resolution_with_requeue[step]
315.27s call     test/integ/cli/test_cli_incremental_download.py::test_conflict_resolution_with_requeue[task]
====================================================================== 56 passed, 4 skipped, 1 xfailed, 4 xpassed in 2529.09s (0:42:09) ======================================================================
```

### Was this change documented?
Yes

### Does this PR introduce new dependencies?

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?
**Yes** `_manifest_download` signature changed — `boto3_session` replaced with `queue_s3_settings`, `deadline_client`, and `queue_role_session`. This function is part of the Beta API so breaking changes are acceptable. Per the TDD, this will be released as part of a single breaking client release with all other Milestone 1 changes.

### Does this change impact security?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
