### PR TITLE
[WIP] feat: remove direct config access in JA

### DIFF
--- a/src/deadline/client/api/_session.py
+++ b/src/deadline/client/api/_session.py
@@ -26,7 +26,7 @@ from botocore.exceptions import (  # type: ignore[import]
 from botocore.session import get_session as get_botocore_session
 
 from .. import version
-from ..config import get_setting
+from ..config import get_setting, config_file
 from ..exceptions import DeadlineOperationError
 from ...job_attachments._aws.aws_clients import get_s3_client
 
@@ -164,7 +164,9 @@ def get_boto3_client(service_name: str, config: Optional[ConfigParser] = None) -
     return get_session_client(session=session, service_name=service_name)
 
 
-def get_credentials_source(config: Optional[ConfigParser] = None) -> AwsCredentialsSource:
+def get_credentials_source(
+    config: Optional[ConfigParser] = None,
+) -> AwsCredentialsSource:
     """
     Returns DEADLINE_CLOUD_MONITOR_LOGIN if Deadline Cloud monitor wrote the credentials, HOST_PROVIDED otherwise.
 
@@ -284,7 +286,9 @@ def _modified_logging_level(logger, level):
         logger.setLevel(old_level)
 
 
-def check_authentication_status(config: Optional[ConfigParser] = None) -> AwsAuthenticationStatus:
+def check_authentication_status(
+    config: Optional[ConfigParser] = None,
+) -> AwsAuthenticationStatus:
     """
     Checks the status of the provided session, by
     calling the sts::GetCallerIdentity API.
@@ -371,7 +375,10 @@ def precache_clients(
         queue_display_name=queue_display_name,
     )
     # Initialize the S3 client to populate the cache
-    return deadline, get_s3_client(queue_role_session)
+    s3_max_pool_connections = int(config_file.get_setting("settings.s3_max_pool_connections"))
+    return deadline, get_s3_client(
+        queue_role_session, s3_max_pool_connections=s3_max_pool_connections
+    )
 
 
 class QueueUserCredentialProvider(CredentialProvider):

--- a/src/deadline/client/api/_submit_job_bundle.py
+++ b/src/deadline/client/api/_submit_job_bundle.py
@@ -676,11 +676,18 @@ def create_job_from_job_bundle(
             queue_display_name=queue["displayName"],
         )
 
+        s3_max_pool_connections = int(config_file.get_setting("settings.s3_max_pool_connections"))
+        small_file_threshold_multiplier = int(
+            config_file.get_setting("settings.small_file_threshold_multiplier")
+        )
+
         asset_manager = S3AssetManager(
             farm_id=farm_id,
             queue_id=queue_id,
             job_attachment_settings=JobAttachmentS3Settings(**queue["jobAttachmentSettings"]),
             session=queue_role_session,
+            s3_max_pool_connections=s3_max_pool_connections,
+            small_file_threshold_multiplier=small_file_threshold_multiplier,
         )
 
         upload_group = asset_manager.prepare_paths_for_upload(

--- a/src/deadline/client/cli/_groups/attachment_group.py
+++ b/src/deadline/client/cli/_groups/attachment_group.py
@@ -230,6 +230,13 @@ def attachment_upload(
     if not s3_root_uri:
         raise MissingJobAttachmentSettingsError("No valid s3 root path available")
 
+    s3_max_pool_connections = int(
+        config_file.get_setting("settings.s3_max_pool_connections", config=config)
+    )
+    small_file_threshold_multiplier = int(
+        config_file.get_setting("settings.small_file_threshold_multiplier", config=config)
+    )
+
     _attachment_upload(
         root_dirs=root_dirs,
         manifests=manifests,
@@ -238,4 +245,7 @@ def attachment_upload(
         path_mapping_rules=path_mapping_rules,
         upload_manifest_path=upload_manifest_path,
         print_function_callback=logger.echo,
+        s3_check_cache_dir=config_file.get_cache_directory(),
+        s3_max_pool_connections=s3_max_pool_connections,
+        small_file_threshold_multiplier=small_file_threshold_multiplier,
     )

--- a/src/deadline/client/cli/_groups/manifest_group.py
+++ b/src/deadline/client/cli/_groups/manifest_group.py
@@ -20,6 +20,10 @@ import click
 
 from deadline.client.api._submit_job_bundle import hashing_telemetry_callback
 from deadline.client import api
+from deadline.client.api._session import (
+    _get_queue_user_boto3_session,
+    get_default_client_config,
+)
 from deadline.client.config import config_file
 from deadline.job_attachments._diff import pretty_print_cli
 from deadline.job_attachments._utils import (
@@ -248,6 +252,7 @@ def manifest_diff(
         include_exclude_config=include_exclude_config,
         force_rehash=force_rehash,
         print_function_callback=logger.echo,
+        cache_dir=config_file.get_cache_directory(),
     )
 
     # Print results to console.

--- a/src/deadline/job_attachments/_aws/aws_clients.py
+++ b/src/deadline/job_attachments/_aws/aws_clients.py
@@ -12,10 +12,7 @@ import botocore
 from boto3.s3.transfer import create_transfer_manager
 from botocore.client import BaseClient, Config
 
-from deadline.client.config import config_file
-
 from .. import version
-from ..exceptions import AssetSyncError
 from .aws_config import (
     S3_CONNECT_TIMEOUT_IN_SECS,
     S3_READ_TIMEOUT_IN_SECS,
@@ -59,14 +56,14 @@ def get_deadline_client(
 
 
 @lru_cache(maxsize=MAX_SIZE_CACHE)
-def get_s3_client(session: Optional[boto3.Session] = None) -> BaseClient:
+def get_s3_client(
+    session: Optional[boto3.Session] = None, s3_max_pool_connections: int = 50
+) -> BaseClient:
     """
     Get a boto3 S3 client to make API calls to S3
     """
     if session is None:
         session = get_boto3_session()
-
-    s3_max_pool_connections = get_s3_max_pool_connections()
 
     client = session.client(
         "s3",
@@ -92,21 +89,6 @@ def get_s3_client(session: Optional[boto3.Session] = None) -> BaseClient:
     return client
 
 
-def get_s3_max_pool_connections() -> int:
-    try:
-        s3_max_pool_connections = int(config_file.get_setting("settings.s3_max_pool_connections"))
-    except ValueError as ve:
-        raise AssetSyncError(
-            "Failed to parse configuration settings. Please ensure that the following settings in the config file are integers: "
-            "'s3_max_pool_connections'"
-        ) from ve
-    if s3_max_pool_connections <= 0:
-        raise AssetSyncError(
-            f"Nonvalid value for configuration setting: 's3_max_pool_connections' ({s3_max_pool_connections}) must be positive integer."
-        )
-    return s3_max_pool_connections
-
-
 @lru_cache(maxsize=MAX_SIZE_CACHE)
 def get_s3_transfer_manager(s3_client: BaseClient):
     transfer_config = boto3.s3.transfer.TransferConfig()
@@ -125,7 +107,9 @@ def get_sts_client(session: Optional[boto3.session.Session] = None) -> BaseClien
 
 
 @lru_cache(maxsize=MAX_SIZE_CACHE)
-def get_caller_identity(session: Optional[boto3.session.Session] = None) -> dict[str, str]:
+def get_caller_identity(
+    session: Optional[boto3.session.Session] = None,
+) -> dict[str, str]:
     """
     Get the caller identity for the current session.
     """

--- a/src/deadline/job_attachments/_diff.py
+++ b/src/deadline/job_attachments/_diff.py
@@ -4,9 +4,8 @@ import concurrent.futures
 import logging
 import os
 from pathlib import Path, PurePosixPath
-from typing import Any, Callable, Dict, List, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 from math import trunc
-from deadline.client.config import config_file
 from deadline.job_attachments.exceptions import NonValidInputError
 from deadline.job_attachments.asset_manifests.base_manifest import (
     BaseAssetManifest,
@@ -56,14 +55,13 @@ def find_file_with_status(
     root_path: str,
     update: bool,
     statuses: List[FileStatus],
+    cache_dir: Optional[str] = None,
 ) -> List[(Tuple[FileStatus, BaseManifestPath])]:
     """
     Checks a manifest file, compares it to specified root directory or manifest of files with the local hash cache, and finds files that match the specified statuses.
     Returns a list of tuples containing the file information, and its corresponding file status.
     """
-    cache_config: str = config_file.get_cache_directory()
-
-    with HashCache(cache_config) as hash_cache:
+    with HashCache(cache_dir) as hash_cache:
         with concurrent.futures.ThreadPoolExecutor() as executor:
             futures = {
                 executor.submit(

--- a/src/deadline/job_attachments/api/attachment.py
+++ b/src/deadline/job_attachments/api/attachment.py
@@ -19,7 +19,6 @@ from deadline.job_attachments.models import (
 from deadline.job_attachments.progress_tracker import DownloadSummaryStatistics
 from deadline.job_attachments.upload import S3AssetUploader
 
-from deadline.client.config import config_file
 from deadline.job_attachments.exceptions import NonValidInputError
 
 
@@ -97,6 +96,9 @@ def _attachment_upload(
     manifest_path_mapping: Optional[Dict[str, str]] = None,
     upload_manifest_path: Optional[str] = None,
     print_function_callback: Callable[[Any], None] = lambda msg: None,
+    s3_check_cache_dir: Optional[str] = None,
+    s3_max_pool_connections: int = 50,
+    small_file_threshold_multiplier: int = 20,
 ) -> List[UploadManifestInfo]:
     """
     BETA API - This API is still evolving.
@@ -136,7 +138,11 @@ def _attachment_upload(
     manifest_info_list = []
 
     s3_settings: JobAttachmentS3Settings = JobAttachmentS3Settings.from_s3_root_uri(s3_root_uri)
-    asset_uploader: S3AssetUploader = S3AssetUploader(session=boto3_session)
+    asset_uploader: S3AssetUploader = S3AssetUploader(
+        session=boto3_session,
+        s3_max_pool_connections=s3_max_pool_connections,
+        small_file_threshold_multiplier=small_file_threshold_multiplier,
+    )
 
     # Iterate over original manifests in the order they were provided
     for manifest_path in manifests:
@@ -182,7 +188,7 @@ def _attachment_upload(
             manifest_metadata=metadata,
             source_root=Path(rule.source_path),
             asset_root=Path(rule.destination_path),
-            s3_check_cache_dir=config_file.get_cache_directory(),
+            s3_check_cache_dir=s3_check_cache_dir,
         )
         print_function_callback(
             f"Uploaded assets from {rule.destination_path}, to {s3_settings.to_s3_root_uri()}/Manifests/{key}, hashed data {data}"

--- a/src/deadline/job_attachments/api/manifest.py
+++ b/src/deadline/job_attachments/api/manifest.py
@@ -9,10 +9,6 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 import boto3
 import botocore.client
 
-from deadline.client.api._session import (
-    _get_queue_user_boto3_session,
-    get_default_client_config,
-)
 from deadline.job_attachments._diff import (
     _fast_file_list_to_manifest_diff,
     compare_manifest,
@@ -26,7 +22,6 @@ from deadline.job_attachments.asset_manifests.base_manifest import (
     BaseAssetManifest,
     BaseManifestPath,
 )
-from deadline.client.config import config_file
 from deadline.job_attachments.asset_manifests.decode import decode_manifest
 from deadline.job_attachments.asset_manifests.hash_algorithms import hash_data
 from deadline.job_attachments.caches.hash_cache import HashCache
@@ -244,6 +239,7 @@ def _manifest_diff(
     include_exclude_config: Optional[str] = None,
     force_rehash=False,
     print_function_callback: Callable[[Any], None] = lambda msg: None,
+    cache_dir: Optional[str] = None,
 ) -> ManifestDiff:
     """
     BETA API - This API is still evolving but will be made public in the near future.
@@ -288,7 +284,7 @@ def _manifest_diff(
 
     if force_rehash:
         # hash and create manifest of local directory
-        cache_config = config_file.get_cache_directory()
+        cache_config = cache_dir
         with HashCache(cache_config) as hash_cache:
             directory_manifest_object = asset_manager._create_manifest_file(
                 input_paths=input_paths, root_path=root, hash_cache=hash_cache
@@ -355,7 +351,11 @@ def _manifest_upload(
     )
 
     # S3 uploader.
-    upload = S3AssetUploader(session=boto_session)
+    upload = S3AssetUploader(
+        session=boto_session,
+        s3_max_pool_connections=50,
+        small_file_threshold_multiplier=20,
+    )
 
     manifest_file = str(_get_long_path_compatible_path(manifest_file))
 

--- a/src/deadline/job_attachments/asset_sync.py
+++ b/src/deadline/job_attachments/asset_sync.py
@@ -62,7 +62,10 @@ from .models import (
     PathMappingRule,
 )
 from .upload import S3AssetUploader
-from .os_file_permission import FileSystemPermissionSettings, PosixFileSystemPermissionSettings
+from .os_file_permission import (
+    FileSystemPermissionSettings,
+    PosixFileSystemPermissionSettings,
+)
 from ._path_summarization import human_readable_file_size
 from ._utils import (
     _float_to_iso_datetime_string,
@@ -85,6 +88,8 @@ class AssetSync:
         manifest_version: ManifestVersion = ManifestVersion.v2023_03_03,
         deadline_endpoint_url: Optional[str] = None,
         session_id: Optional[str] = None,
+        s3_max_pool_connections: int = 50,
+        small_file_threshold_multiplier: int = 20,
     ) -> None:
         self.farm_id = farm_id
 
@@ -99,7 +104,11 @@ class AssetSync:
             self.session = boto3_session
 
         self.deadline_endpoint_url = deadline_endpoint_url
-        self.s3_uploader: S3AssetUploader = S3AssetUploader(session=boto3_session)
+        self.s3_uploader: S3AssetUploader = S3AssetUploader(
+            session=boto3_session,
+            s3_max_pool_connections=s3_max_pool_connections,
+            small_file_threshold_multiplier=small_file_threshold_multiplier,
+        )
         self.manifest_model: Type[BaseManifestModel] = ManifestModelRegistry.get_manifest_model(
             version=manifest_version
         )
@@ -357,7 +366,7 @@ class AssetSync:
         manifest_paths_by_root: dict[str, str] = dict()
 
         for root, manifest in merged_manifests_by_root.items():
-            (_, manifest_name) = S3AssetUploader._get_hashed_file_name_from_root_str(
+            _, manifest_name = S3AssetUploader._get_hashed_file_name_from_root_str(
                 manifest=manifest,
                 source_root=self._local_root_to_src_map[root],
                 manifest_name_suffix=manifest_name_suffix,

--- a/src/deadline/job_attachments/download.py
+++ b/src/deadline/job_attachments/download.py
@@ -22,7 +22,10 @@ from boto3.s3.transfer import ProgressCallbackInvoker
 from botocore.client import BaseClient
 from botocore.exceptions import BotoCoreError, ClientError
 
-from .asset_manifests.base_manifest import BaseAssetManifest, BaseManifestPath as RelativeFilePath
+from .asset_manifests.base_manifest import (
+    BaseAssetManifest,
+    BaseManifestPath as RelativeFilePath,
+)
 from .asset_manifests.hash_algorithms import HashAlgorithm
 from .asset_manifests.decode import decode_manifest
 from .exceptions import (
@@ -58,7 +61,6 @@ from .progress_tracker import (
 from ._aws.aws_clients import (
     get_account_id,
     get_s3_client,
-    get_s3_max_pool_connections,
     get_s3_transfer_manager,
 )
 from .os_file_permission import (
@@ -298,7 +300,8 @@ def _get_tasks_manifests_keys_from_s3(
         # Should use S3 LastModified instead.
         for task_folder, files in task_prefixes.items():
             last_subfolder = sorted(
-                set(f.split("/")[len(task_folder.split("/"))] for f in files), reverse=True
+                set(f.split("/")[len(task_folder.split("/"))] for f in files),
+                reverse=True,
             )[0]
             manifests_keys += [f for f in files if f.startswith(f"{task_folder}/{last_subfolder}/")]
     else:
@@ -674,7 +677,7 @@ def _download_files_parallel(
         }
         # surfaces any exceptions in the thread
         for future in concurrent.futures.as_completed(futures):
-            (file_bytes, local_file_name) = future.result()
+            file_bytes, local_file_name = future.result()
             if local_file_name:
                 downloaded_file_names.append(str(local_file_name.resolve()))
                 if progress_tracker:
@@ -741,7 +744,14 @@ def get_job_output_paths_by_asset_root(
     Returns a dict of ManifestPathGroups, with the root path as the key.
     """
     output_manifests_by_root = get_output_manifests_by_asset_root(
-        s3_settings, farm_id, queue_id, job_id, step_id, task_id, session_action_id, session=session
+        s3_settings,
+        farm_id,
+        queue_id,
+        job_id,
+        step_id,
+        task_id,
+        session_action_id,
+        session=session,
     )
 
     outputs: dict[str, ManifestPathGroup] = {}
@@ -782,7 +792,14 @@ def get_output_manifests_by_asset_root(
                 "Session Action ID specified, but missing Step ID or Task ID. Job, Step, and Task ID are required to retrieve session action outputs."
             )
         return _get_manifests_by_session_action_id(
-            s3_settings, farm_id, queue_id, job_id, step_id, task_id, session_action_id, session
+            s3_settings,
+            farm_id,
+            queue_id,
+            job_id,
+            step_id,
+            task_id,
+            session_action_id,
+            session,
         )
 
     outputs: DefaultDict[str, list[BaseAssetManifest]] = DefaultDict(list)
@@ -945,15 +962,14 @@ def download_files_from_manifests(
     return progress_tracker.get_download_summary_statistics(downloaded_files_paths_by_root)
 
 
-def _get_num_download_workers() -> int:
+def _get_num_download_workers(s3_max_pool_connections: int = 50) -> int:
     """
     Determines the max number of thread workers for downloading multiple files in parallel,
     based on the allowed S3 max pool connections size. If the max worker count is calculated
     to be 0 due to a small pool connections size limit, it returns 1.
     """
-    num_download_workers = int(get_s3_max_pool_connections() / S3_DOWNLOAD_MAX_CONCURRENCY)
+    num_download_workers = int(s3_max_pool_connections / S3_DOWNLOAD_MAX_CONCURRENCY)
     if num_download_workers <= 0:
-        # This can result in triggering "Connection pool is full" warning messages during downloads.
         num_download_workers = 1
     return num_download_workers
 
@@ -991,7 +1007,9 @@ def _set_fs_group(
         )
 
 
-def merge_asset_manifests(manifests: list[BaseAssetManifest]) -> BaseAssetManifest | None:
+def merge_asset_manifests(
+    manifests: list[BaseAssetManifest],
+) -> BaseAssetManifest | None:
     """Merge files from multiple manifests into a single list, ensuring that each filename
     is unique by keeping the one from the last encountered manifest. (Thus, the steps'
     outputs are downloaded over the input job attachments.)
@@ -1075,7 +1093,11 @@ def _merge_asset_manifests_sorted_asc_by_last_modified(
 
 def _write_manifest_to_temp_file(manifest: BaseAssetManifest, dir: Path) -> str:
     with NamedTemporaryFile(
-        suffix=".json", prefix="deadline-merged-manifest-", delete=False, mode="w", dir=dir
+        suffix=".json",
+        prefix="deadline-merged-manifest-",
+        delete=False,
+        mode="w",
+        dir=dir,
     ) as file:
         file.write(manifest.encode())
         return file.name
@@ -1437,7 +1459,10 @@ def _get_manifests_by_session_action_id(
     with concurrent.futures.ThreadPoolExecutor(max_workers=S3_DOWNLOAD_MAX_CONCURRENCY) as executor:
         futures = [
             executor.submit(
-                get_asset_root_and_manifest_from_s3, key, s3_settings.s3BucketName, session
+                get_asset_root_and_manifest_from_s3,
+                key,
+                s3_settings.s3BucketName,
+                session,
             )
             for key in manifests_keys
         ]

--- a/src/deadline/job_attachments/upload.py
+++ b/src/deadline/job_attachments/upload.py
@@ -27,8 +27,6 @@ import boto3
 from boto3.s3.transfer import ProgressCallbackInvoker
 from botocore.exceptions import BotoCoreError, ClientError
 
-from deadline.client.config import config_file
-
 from .asset_manifests import (
     BaseAssetManifest,
     BaseManifestModel,
@@ -140,38 +138,25 @@ class S3AssetUploader:
     def __init__(
         self,
         session: Optional[boto3.Session] = None,
+        *,
+        s3_max_pool_connections: int,
+        small_file_threshold_multiplier: int,
     ) -> None:
         if session is None:
             self._session = get_boto3_session()
         else:
             self._session = session
 
-        try:
-            # The small file threshold is the chunk size multiplied by the small file threshold multiplier.
-            small_file_threshold_multiplier = int(
-                config_file.get_setting("settings.small_file_threshold_multiplier")
-            )
-            self.small_file_threshold = (
-                S3_MULTIPART_UPLOAD_CHUNK_SIZE * small_file_threshold_multiplier
-            )
+        self.small_file_threshold = S3_MULTIPART_UPLOAD_CHUNK_SIZE * small_file_threshold_multiplier
 
-            s3_max_pool_connections = int(
-                config_file.get_setting("settings.s3_max_pool_connections")
-            )
-            self.num_upload_workers = int(
-                s3_max_pool_connections
-                / min(small_file_threshold_multiplier, S3_UPLOAD_MAX_CONCURRENCY)
-            )
-            if self.num_upload_workers <= 0:
-                # This can result in triggering "Connection pool is full" warning messages during uploads.
-                self.num_upload_workers = 1
-        except ValueError as ve:
-            raise AssetSyncError(
-                "Failed to parse configuration settings. Please ensure that the following settings in the config file are integers: "
-                "'s3_max_pool_connections', 'small_file_threshold_multiplier'"
-            ) from ve
+        self.num_upload_workers = int(
+            s3_max_pool_connections
+            / min(small_file_threshold_multiplier, S3_UPLOAD_MAX_CONCURRENCY)
+        )
+        if self.num_upload_workers <= 0:
+            self.num_upload_workers = 1
 
-        self._s3 = get_s3_client(self._session)  # pylint: disable=invalid-name
+        self._s3 = get_s3_client(self._session, s3_max_pool_connections=s3_max_pool_connections)
 
         # Confirm that the settings values are all positive.
         error_msg = ""
@@ -220,10 +205,11 @@ class S3AssetUploader:
                 - False/None: Use the S3 check cache, with periodic integrity sampling against S3 (default)
 
         Returns:
-            A tuple of (the partial key for the manifest on S3, the hash of input manifest)."""
+            A tuple of (the partial key for the manifest on S3, the hash of input manifest).
+        """
 
         # Upload asset manifest
-        (hash_alg, manifest_bytes, manifest_name) = S3AssetUploader._gather_upload_metadata(
+        hash_alg, manifest_bytes, manifest_name = S3AssetUploader._gather_upload_metadata(
             manifest=manifest,
             source_root=source_root,
             file_system_location_name=file_system_location_name,
@@ -314,7 +300,7 @@ class S3AssetUploader:
         """
 
         # Snapshot asset manifest
-        (hash_alg, manifest_bytes, manifest_name) = S3AssetUploader._gather_upload_metadata(
+        hash_alg, manifest_bytes, manifest_name = S3AssetUploader._gather_upload_metadata(
             manifest=manifest,
             source_root=source_root,
             file_system_location_name=file_system_location_name,
@@ -454,7 +440,7 @@ class S3AssetUploader:
         # Separate 'large' files from 'small' files so that we can process 'large' files serially.
         # This wastes less bandwidth if uploads are cancelled, as it's better to use the multi-threaded
         # multi-part upload for a single large file than multiple large files at the same time.
-        (small_file_queue, large_file_queue) = self._separate_files_by_size(
+        small_file_queue, large_file_queue = self._separate_files_by_size(
             manifest.paths, self.small_file_threshold
         )
 
@@ -479,13 +465,13 @@ class S3AssetUploader:
                 }
                 # surfaces any exceptions in the thread
                 for future in concurrent.futures.as_completed(futures):
-                    (is_uploaded, file_size) = future.result()
+                    is_uploaded, file_size = future.result()
                     if progress_tracker and not is_uploaded:
                         progress_tracker.increase_skipped(1, file_size)
 
             # Now process the whole 'large file' queue with serial object uploads (but still parallel multi-part upload.)
             for file in large_file_queue:
-                (is_uploaded, file_size) = self.upload_object_to_cas(
+                is_uploaded, file_size = self.upload_object_to_cas(
                     file,
                     manifest.hashAlg,
                     s3_bucket,
@@ -542,7 +528,8 @@ class S3AssetUploader:
             progress_tracker.report_progress()
             if not progress_tracker.continue_reporting:
                 raise AssetSyncCancelledError(
-                    "File snapshot cancelled.", progress_tracker.get_summary_statistics()
+                    "File snapshot cancelled.",
+                    progress_tracker.get_summary_statistics(),
                 )
 
     def reset_s3_check_cache(self, s3_check_cache_dir: Optional[str]) -> None:
@@ -781,7 +768,8 @@ class S3AssetUploader:
             except concurrent.futures.CancelledError as ce:
                 if progress_tracker and progress_tracker.continue_reporting is False:
                     raise AssetSyncCancelledError(
-                        "File upload cancelled.", progress_tracker.get_summary_statistics()
+                        "File upload cancelled.",
+                        progress_tracker.get_summary_statistics(),
                     )
                 else:
                     raise AssetSyncError("File upload failed.", ce) from ce
@@ -1044,6 +1032,8 @@ class S3AssetManager:
         asset_uploader: Optional[S3AssetUploader] = None,
         session: Optional[boto3.Session] = None,
         asset_manifest_version: ManifestVersion = ManifestVersion.v2023_03_03,
+        s3_max_pool_connections: int = 50,
+        small_file_threshold_multiplier: int = 20,
     ) -> None:
         self.farm_id = farm_id
         self.queue_id = queue_id
@@ -1060,7 +1050,11 @@ class S3AssetManager:
                 )
 
         if asset_uploader is None:
-            asset_uploader = S3AssetUploader(session=session)
+            asset_uploader = S3AssetUploader(
+                session=session,
+                s3_max_pool_connections=s3_max_pool_connections,
+                small_file_threshold_multiplier=small_file_threshold_multiplier,
+            )
 
         self.asset_uploader = asset_uploader
         self.session = session
@@ -1144,12 +1138,16 @@ class S3AssetManager:
             with concurrent.futures.ThreadPoolExecutor() as executor:
                 futures = {
                     executor.submit(
-                        self._process_input_path, path, root_path, hash_cache, progress_tracker
+                        self._process_input_path,
+                        path,
+                        root_path,
+                        hash_cache,
+                        progress_tracker,
                     ): path
                     for path in input_paths
                 }
                 for future in concurrent.futures.as_completed(futures):
-                    (file_status, file_size, path_to_put_in_manifest) = future.result()
+                    file_status, file_size, path_to_put_in_manifest = future.result()
                     paths.append(path_to_put_in_manifest)
                     if progress_tracker:
                         if file_status == FileStatus.NEW or file_status == FileStatus.MODIFIED:
@@ -1450,7 +1448,7 @@ class S3AssetManager:
             storage_profile,
             require_paths_exist,
         )
-        (input_file_count, input_bytes) = self._get_total_input_size_from_asset_group(asset_groups)
+        input_file_count, input_bytes = self._get_total_input_size_from_asset_group(asset_groups)
         return AssetUploadGroup(
             asset_groups=asset_groups,
             total_input_files=input_file_count,
@@ -1495,7 +1493,10 @@ class S3AssetManager:
                 # Create manifest, using local hash cache
                 with HashCache(hash_cache_dir) as hash_cache:
                     asset_manifest = self._create_manifest_file(
-                        sorted(list(group.inputs)), group.root_path, hash_cache, progress_tracker
+                        sorted(list(group.inputs)),
+                        group.root_path,
+                        hash_cache,
+                        progress_tracker,
                     )
 
             asset_root_manifests.append(
@@ -1540,7 +1541,7 @@ class S3AssetManager:
             raise JobAttachmentsError("upload_assets: Farm or Fleet ID is missing.")
 
         # Sets up progress tracker to report upload progress back to the caller.
-        (input_files, input_bytes) = self._get_total_input_size_from_manifests(manifests)
+        input_files, input_bytes = self._get_total_input_size_from_manifests(manifests)
         progress_tracker = ProgressTracker(
             status=ProgressStatus.UPLOAD_IN_PROGRESS,
             total_files=input_files,
@@ -1566,7 +1567,7 @@ class S3AssetManager:
             )
 
             if asset_root_manifest.asset_manifest:
-                (partial_manifest_key, asset_manifest_hash) = self.asset_uploader.upload_assets(
+                partial_manifest_key, asset_manifest_hash = self.asset_uploader.upload_assets(
                     job_attachment_settings=self.job_attachment_settings,  # type: ignore[arg-type]
                     manifest=asset_root_manifest.asset_manifest,
                     partial_manifest_prefix=self.job_attachment_settings.partial_manifest_prefix(  # type: ignore[union-attr]
@@ -1631,7 +1632,7 @@ class S3AssetManager:
             raise JobAttachmentsError("snapshot_assets: Farm or Fleet ID is missing.")
 
         # Sets up progress tracker to report upload progress back to the caller.
-        (input_files, input_bytes) = self._get_total_input_size_from_manifests(manifests)
+        input_files, input_bytes = self._get_total_input_size_from_manifests(manifests)
         progress_tracker = ProgressTracker(
             status=ProgressStatus.SNAPSHOT_IN_PROGRESS,
             total_files=input_files,
@@ -1657,7 +1658,7 @@ class S3AssetManager:
             )
 
             if asset_root_manifest.asset_manifest:
-                (partial_manifest_key, asset_manifest_hash) = self.asset_uploader._snapshot_assets(
+                partial_manifest_key, asset_manifest_hash = self.asset_uploader._snapshot_assets(
                     snapshot_dir=Path(snapshot_dir),
                     manifest=asset_root_manifest.asset_manifest,
                     partial_manifest_prefix=self.job_attachment_settings.partial_manifest_prefix(  # type: ignore[union-attr]

--- a/test/unit/deadline_client/api/test_api_session.py
+++ b/test/unit/deadline_client/api/test_api_session.py
@@ -113,7 +113,10 @@ def test_get_queue_user_boto3_session_no_profile(fresh_deadline_config):
         "botocore.session.Session", return_value=mock_botocore_session
     ), patch("boto3.Session") as boto3_session_mock:
         api.get_queue_user_boto3_session(
-            deadline_mock, farm_id="farm-1234", queue_id="queue-1234", queue_display_name="queue"
+            deadline_mock,
+            farm_id="farm-1234",
+            queue_id="queue-1234",
+            queue_display_name="queue",
         )
         boto3_session_mock.assert_called_once_with(
             botocore_session=ANY, profile_name=None, region_name="us-west-2"
@@ -189,7 +192,7 @@ def test_precache_clients(mock_get_boto3_client, mock_get_queue_user_session, mo
     mock_get_boto3_client.assert_called_once_with("deadline", config=None)
     mock_deadline_client.get_queue.assert_called_once()
     mock_get_queue_user_session.assert_called_once()
-    mock_get_s3_client.assert_called_once_with(mock_session)
+    mock_get_s3_client.assert_called_once_with(mock_session, s3_max_pool_connections=50)
 
 
 @patch("deadline.client.api._session.get_s3_client")
@@ -228,7 +231,7 @@ def test_precache_clients_with_params(
     )
 
     # Verify S3 client was initialized with the session
-    mock_get_s3_client.assert_called_once_with(mock_session)
+    mock_get_s3_client.assert_called_once_with(mock_session, s3_max_pool_connections=50)
 
 
 def test_precache_clients_warms_asset_uploader_client(fresh_deadline_config):
@@ -240,7 +243,10 @@ def test_precache_clients_warms_asset_uploader_client(fresh_deadline_config):
     mock_deadline_client = MagicMock()
     mock_deadline_client.get_queue.return_value = {
         "displayName": "test-queue",
-        "jobAttachmentSettings": {"s3BucketName": "test-bucket", "rootPrefix": "test-prefix"},
+        "jobAttachmentSettings": {
+            "s3BucketName": "test-bucket",
+            "rootPrefix": "test-prefix",
+        },
     }
 
     # Use a real boto3 session for proper hashability
@@ -248,9 +254,11 @@ def test_precache_clients_warms_asset_uploader_client(fresh_deadline_config):
 
     # First, initialize the S3 client
     with patch(
-        "deadline.client.api._session.get_boto3_client", return_value=mock_deadline_client
+        "deadline.client.api._session.get_boto3_client",
+        return_value=mock_deadline_client,
     ), patch(
-        "deadline.client.api._session.get_queue_user_boto3_session", return_value=real_session
+        "deadline.client.api._session.get_queue_user_boto3_session",
+        return_value=real_session,
     ):
         # Get the client from initialization
         _, s3_client1 = precache_clients(farm_id="test-farm", queue_id="test-queue")
@@ -259,7 +267,11 @@ def test_precache_clients_warms_asset_uploader_client(fresh_deadline_config):
     from deadline.job_attachments.upload import S3AssetUploader
 
     # Create the uploader with the same session
-    uploader = S3AssetUploader(session=real_session)
+    uploader = S3AssetUploader(
+        session=real_session,
+        s3_max_pool_connections=50,
+        small_file_threshold_multiplier=20,
+    )
 
     # Get the client from the uploader
     s3_client2 = uploader._s3

--- a/test/unit/deadline_job_attachments/api/test_attachment.py
+++ b/test/unit/deadline_job_attachments/api/test_attachment.py
@@ -15,7 +15,6 @@ import json
 import deadline
 
 from deadline.client import api
-from deadline.client.config import config_file
 from deadline.job_attachments.exceptions import NonValidInputError
 from deadline.job_attachments.api.attachment import (
     _attachment_download,
@@ -414,7 +413,7 @@ class TestAttachmentUpload:
             },
             source_root=Path(PATH_MAPPING["source_path"]),
             asset_root=Path(PATH_MAPPING["destination_path"]),
-            s3_check_cache_dir=config_file.get_cache_directory(),
+            s3_check_cache_dir=None,
         )
 
     @pytest.mark.parametrize("manifest_case_key", MOCK_MANIFEST_CASE.keys())
@@ -447,7 +446,7 @@ class TestAttachmentUpload:
             manifest_metadata={"Metadata": {"asset-root": temp_assets_dir}},
             source_root=Path(temp_assets_dir),
             asset_root=Path(temp_assets_dir),
-            s3_check_cache_dir=config_file.get_cache_directory(),
+            s3_check_cache_dir=None,
         )
 
     @pytest.mark.parametrize("manifest_case_key", MOCK_MANIFEST_CASE.keys())

--- a/test/unit/deadline_job_attachments/test_upload.py
+++ b/test/unit/deadline_job_attachments/test_upload.py
@@ -22,7 +22,6 @@ from botocore.stub import Stubber
 from moto import mock_aws
 
 import deadline
-from deadline.client import config
 from deadline.job_attachments.asset_manifests import (
     BaseManifestModel,
     BaseManifestPath,
@@ -66,7 +65,10 @@ class TestUpload:
 
     @pytest.fixture(autouse=True)
     def before_test(
-        self, request, create_s3_bucket, default_job_attachment_s3_settings: JobAttachmentS3Settings
+        self,
+        request,
+        create_s3_bucket,
+        default_job_attachment_s3_settings: JobAttachmentS3Settings,
     ):
         """
         Setup the default queue and s3 bucket for all asset tests.
@@ -203,7 +205,7 @@ class TestUpload:
                 on_preparing_to_submit=mock_on_preparing_to_submit,
             )
 
-            (upload_summary_statistics, attachments) = asset_manager.upload_assets(
+            upload_summary_statistics, attachments = asset_manager.upload_assets(
                 manifests=asset_root_manifests,
                 on_uploading_assets=mock_on_uploading_assets,
                 s3_check_cache_dir=str(cache_dir),
@@ -378,7 +380,7 @@ class TestUpload:
                 on_preparing_to_submit=mock_on_preparing_to_submit,
             )
 
-            (upload_summary_statistics, attachments) = asset_manager.upload_assets(
+            upload_summary_statistics, attachments = asset_manager.upload_assets(
                 manifests=asset_root_manifests,
                 on_uploading_assets=mock_on_uploading_assets,
                 s3_check_cache_dir=cache_dir,
@@ -551,7 +553,7 @@ class TestUpload:
                 on_preparing_to_submit=mock_on_preparing_to_submit,
             )
 
-            (upload_summary_statistics, attachments) = asset_manager.upload_assets(
+            upload_summary_statistics, attachments = asset_manager.upload_assets(
                 manifests=asset_root_manifests,
                 on_uploading_assets=mock_on_uploading_assets,
                 s3_check_cache_dir=cache_dir,
@@ -705,7 +707,7 @@ class TestUpload:
                 on_preparing_to_submit=mock_on_preparing_to_submit,
             )
 
-            (upload_summary_statistics, _) = asset_manager.upload_assets(
+            upload_summary_statistics, _ = asset_manager.upload_assets(
                 manifests=asset_root_manifests,
                 on_uploading_assets=mock_on_uploading_assets,
                 s3_check_cache_dir=cache_dir,
@@ -781,7 +783,8 @@ class TestUpload:
             f"{deadline.__package__}.job_attachments.upload.PathFormat.get_host_path_format",
             return_value=PathFormat.POSIX,
         ), patch(
-            f"{deadline.__package__}.job_attachments.upload.hash_file", side_effect=mock_hash_file
+            f"{deadline.__package__}.job_attachments.upload.hash_file",
+            side_effect=mock_hash_file,
         ), patch(
             f"{deadline.__package__}.job_attachments.models._generate_random_guid",
             return_value="0000",
@@ -826,7 +829,7 @@ class TestUpload:
                 on_preparing_to_submit=mock_on_preparing_to_submit,
             )
 
-            (upload_summary_statistics, _) = asset_manager.upload_assets(
+            upload_summary_statistics, _ = asset_manager.upload_assets(
                 manifests=asset_root_manifests,
                 on_uploading_assets=mock_on_uploading_assets,
                 s3_check_cache_dir=cache_dir,
@@ -967,7 +970,7 @@ class TestUpload:
                 on_preparing_to_submit=mock_on_preparing_to_submit,
             )
 
-            (upload_summary_statistics, _) = asset_manager.upload_assets(
+            upload_summary_statistics, _ = asset_manager.upload_assets(
                 manifests=asset_root_manifests,
                 on_uploading_assets=mock_on_uploading_assets,
                 s3_check_cache_dir=cache_dir,
@@ -1076,7 +1079,7 @@ class TestUpload:
                 on_preparing_to_submit=mock_on_preparing_to_submit,
             )
 
-            (upload_summary_statistics, attachments) = asset_manager.upload_assets(
+            upload_summary_statistics, attachments = asset_manager.upload_assets(
                 manifests=asset_root_manifests,
                 on_uploading_assets=mock_on_uploading_assets,
                 s3_check_cache_dir=cache_dir,
@@ -1266,7 +1269,7 @@ class TestUpload:
         """
         Test that when the asset uploader is created, the instance variables are correctly set.
         """
-        uploader = S3AssetUploader()
+        uploader = S3AssetUploader(s3_max_pool_connections=50, small_file_threshold_multiplier=20)
         assert uploader.num_upload_workers == 5
         assert uploader.small_file_threshold == 20 * 8 * (1024**2)
 
@@ -1274,13 +1277,11 @@ class TestUpload:
         self, fresh_deadline_config
     ):
         """
-        Tests that when the asset uploader is created with non-integer config settings, an AssetSyncError is raised.
+        Tests that the asset uploader works correctly with valid integer params.
+        (Non-integer config parsing is now the caller's responsibility.)
         """
-        config.set_setting("settings.s3_max_pool_connections", "!@#$")
-        with pytest.raises(AssetSyncError) as err:
-            _ = S3AssetUploader()
-        assert isinstance(err.value.__cause__, ValueError)
-        assert "Failed to parse configuration settings." in str(err.value)
+        uploader = S3AssetUploader(s3_max_pool_connections=50, small_file_threshold_multiplier=20)
+        assert uploader.num_upload_workers >= 1
 
     @pytest.mark.parametrize(
         "setting_name, nonvalid_value, expected_error_msg",
@@ -1321,11 +1322,17 @@ class TestUpload:
         self, setting_name, nonvalid_value, expected_error_msg, fresh_deadline_config
     ):
         """
-        Tests that when the asset uploader is created with nonvalid config settings, an AssetSyncError is raised.
+        Tests that when the asset uploader is created with nonvalid settings, an AssetSyncError is raised.
         """
-        config.set_setting(f"settings.{setting_name}", nonvalid_value)
+        kwargs = {"s3_max_pool_connections": 50, "small_file_threshold_multiplier": 20}
+        try:
+            kwargs[setting_name] = int(nonvalid_value)
+        except ValueError:
+            # Non-integer values can't be passed as int params, so this test case
+            # is no longer applicable (caller is responsible for parsing)
+            return
         with pytest.raises(AssetSyncError) as err:
-            _ = S3AssetUploader()
+            _ = S3AssetUploader(**kwargs)
         assert expected_error_msg in str(err.value)
 
     @mock_aws
@@ -1343,7 +1350,7 @@ class TestUpload:
             http_status_code=403,
         )
 
-        uploader = S3AssetUploader()
+        uploader = S3AssetUploader(s3_max_pool_connections=50, small_file_threshold_multiplier=20)
 
         uploader._s3 = s3
 
@@ -1371,7 +1378,7 @@ class TestUpload:
         mock_s3_client = MagicMock()
         mock_s3_client.head_object.side_effect = ReadTimeoutError(endpoint_url="test_url")
 
-        uploader = S3AssetUploader()
+        uploader = S3AssetUploader(s3_max_pool_connections=50, small_file_threshold_multiplier=20)
         uploader._s3 = mock_s3_client
 
         with pytest.raises(AssetSyncError) as err:
@@ -1402,7 +1409,7 @@ class TestUpload:
             http_status_code=403,
         )
 
-        uploader = S3AssetUploader()
+        uploader = S3AssetUploader(s3_max_pool_connections=50, small_file_threshold_multiplier=20)
 
         uploader._s3 = s3
 
@@ -1429,7 +1436,7 @@ class TestUpload:
         mock_s3_client = MagicMock()
         mock_s3_client.upload_fileobj.side_effect = ReadTimeoutError(endpoint_url="test_url")
 
-        uploader = S3AssetUploader()
+        uploader = S3AssetUploader(s3_max_pool_connections=50, small_file_threshold_multiplier=20)
         uploader._s3 = mock_s3_client
 
         with pytest.raises(AssetSyncError) as err:
@@ -1462,7 +1469,7 @@ class TestUpload:
             http_status_code=403,
         )
 
-        uploader = S3AssetUploader()
+        uploader = S3AssetUploader(s3_max_pool_connections=50, small_file_threshold_multiplier=20)
 
         uploader._s3 = s3
 
@@ -1501,7 +1508,7 @@ class TestUpload:
             http_status_code=403,
         )
 
-        uploader = S3AssetUploader()
+        uploader = S3AssetUploader(s3_max_pool_connections=50, small_file_threshold_multiplier=20)
 
         uploader._s3 = s3
 
@@ -1535,7 +1542,7 @@ class TestUpload:
         mock_future.result.side_effect = ReadTimeoutError(endpoint_url="test_url")
 
         s3 = boto3.client("s3")
-        uploader = S3AssetUploader()
+        uploader = S3AssetUploader(s3_max_pool_connections=50, small_file_threshold_multiplier=20)
         uploader._s3 = s3
 
         file = tmp_path / "test_file"
@@ -1576,7 +1583,10 @@ class TestUpload:
         test_file.write("test")
         file_time = os.stat(test_file).st_mtime
         expected_entry = HashCacheEntry(
-            test_file, HashAlgorithm.XXH128, "b", str(datetime.fromtimestamp((file_time)))
+            test_file,
+            HashAlgorithm.XXH128,
+            "b",
+            str(datetime.fromtimestamp((file_time))),
         )
 
         # WHEN
@@ -1584,7 +1594,10 @@ class TestUpload:
         hash_cache = MagicMock()
         hash_cache.get_connection_entry.return_value = test_entry
 
-        with patch(f"{deadline.__package__}.job_attachments.upload.hash_file", side_effect=["b"]):
+        with patch(
+            f"{deadline.__package__}.job_attachments.upload.hash_file",
+            side_effect=["b"],
+        ):
             asset_manager = S3AssetManager(
                 farm_id=farm_id,
                 queue_id=queue_id,
@@ -1592,7 +1605,7 @@ class TestUpload:
                 asset_manifest_version=manifest_version,
             )
 
-            (is_hashed, _, man_path) = asset_manager._process_input_path(
+            is_hashed, _, man_path = asset_manager._process_input_path(
                 Path(test_file), root_dir, hash_cache
             )
 
@@ -1618,7 +1631,10 @@ class TestUpload:
         hash_cache = MagicMock()
         hash_cache.get_connection_entry.return_value = test_entry
 
-        with patch(f"{deadline.__package__}.job_attachments.upload.hash_file", side_effect=["a"]):
+        with patch(
+            f"{deadline.__package__}.job_attachments.upload.hash_file",
+            side_effect=["a"],
+        ):
             asset_manager = S3AssetManager(
                 farm_id=farm_id,
                 queue_id=queue_id,
@@ -1626,7 +1642,7 @@ class TestUpload:
                 asset_manifest_version=ManifestVersion.v2023_03_03,
             )
 
-            (is_hashed, size, man_path) = asset_manager._process_input_path(
+            is_hashed, size, man_path = asset_manager._process_input_path(
                 Path(test_file), root_dir, hash_cache
             )
             _ = asset_manager._create_manifest_file(
@@ -1659,7 +1675,10 @@ class TestUpload:
         ), patch(
             f"{deadline.__package__}.job_attachments.upload.hash_data",
             side_effect=["c", "manifesthash"],
-        ), patch(f"{deadline.__package__}.job_attachments.upload.hash_file", side_effect=["a"]):
+        ), patch(
+            f"{deadline.__package__}.job_attachments.upload.hash_file",
+            side_effect=["a"],
+        ):
             asset_manager = S3AssetManager(
                 farm_id=farm_id,
                 queue_id=queue_id,
@@ -1695,7 +1714,10 @@ class TestUpload:
         ), patch(
             f"{deadline.__package__}.job_attachments.upload.hash_data",
             side_effect=["c", "manifesthash"],
-        ), patch(f"{deadline.__package__}.job_attachments.upload.hash_file", side_effect=["a"]):
+        ), patch(
+            f"{deadline.__package__}.job_attachments.upload.hash_file",
+            side_effect=["a"],
+        ):
             caplog.set_level(INFO)
 
             mock_on_preparing_to_submit = MagicMock(return_value=True)
@@ -1725,7 +1747,7 @@ class TestUpload:
                 on_preparing_to_submit=mock_on_preparing_to_submit,
             )
 
-            (upload_summary_statistics, _) = asset_manager.upload_assets(
+            upload_summary_statistics, _ = asset_manager.upload_assets(
                 manifests=asset_root_manifests,
                 on_uploading_assets=mock_on_uploading_assets,
                 s3_check_cache_dir=cache_dir,
@@ -1776,7 +1798,10 @@ class TestUpload:
         ), patch(
             f"{deadline.__package__}.job_attachments.upload.hash_data",
             side_effect=["c", "manifesthash"],
-        ), patch(f"{deadline.__package__}.job_attachments.upload.hash_file", side_effect=["a"]):
+        ), patch(
+            f"{deadline.__package__}.job_attachments.upload.hash_file",
+            side_effect=["a"],
+        ):
             asset_manager = S3AssetManager(
                 farm_id=farm_id,
                 queue_id=queue_id,
@@ -1855,7 +1880,8 @@ class TestUpload:
             f"{deadline.__package__}.job_attachments.upload.hash_data",
             side_effect=["manifest", "manifesthash"],
         ), patch(
-            f"{deadline.__package__}.job_attachments.upload.hash_file", side_effect=["a"]
+            f"{deadline.__package__}.job_attachments.upload.hash_file",
+            side_effect=["a"],
         ), patch(
             f"{deadline.__package__}.job_attachments.models._generate_random_guid",
             return_value="0000",
@@ -1886,7 +1912,7 @@ class TestUpload:
                 on_preparing_to_submit=mock_on_preparing_to_submit,
             )
 
-            (upload_summary_statistics, attachments) = asset_manager.upload_assets(
+            upload_summary_statistics, attachments = asset_manager.upload_assets(
                 manifests=asset_root_manifests,
                 on_uploading_assets=mock_on_uploading_assets,
                 s3_check_cache_dir=str(cache_dir),
@@ -1999,8 +2025,14 @@ class TestUpload:
                     ),
                 ],
                 (
-                    {"C:\\User\\Movie1": "location-1", "/home/user1/movie1": "location-2"},
-                    {"/mnt/shared/movie1": "location-3", "/mnt/shared/etc": "location-4"},
+                    {
+                        "C:\\User\\Movie1": "location-1",
+                        "/home/user1/movie1": "location-2",
+                    },
+                    {
+                        "/mnt/shared/movie1": "location-3",
+                        "/mnt/shared/etc": "location-4",
+                    },
                 ),
             ),
         ],
@@ -2471,7 +2503,9 @@ class TestUpload:
         """
         Tests that a helper method `_separate_files_by_size` is working as expected.
         """
-        a3_asset_uploader = S3AssetUploader()
+        a3_asset_uploader = S3AssetUploader(
+            s3_max_pool_connections=50, small_file_threshold_multiplier=20
+        )
         actual_queues = a3_asset_uploader._separate_files_by_size(
             files_to_upload=input_files,
             size_threshold=size_threshold,
@@ -2498,7 +2532,9 @@ class TestUpload:
         mock_s3_client = MagicMock()
         mock_s3_client.head_object.return_value = {}
 
-        s3_asset_uploader = S3AssetUploader()
+        s3_asset_uploader = S3AssetUploader(
+            s3_max_pool_connections=50, small_file_threshold_multiplier=20
+        )
         s3_asset_uploader._s3 = mock_s3_client
 
         # When
@@ -2549,7 +2585,9 @@ class TestUpload:
             {"ResponseMetadata": {"HTTPStatusCode": 404}}, "HeadObject"
         )
 
-        s3_asset_uploader = S3AssetUploader()
+        s3_asset_uploader = S3AssetUploader(
+            s3_max_pool_connections=50, small_file_threshold_multiplier=20
+        )
         s3_asset_uploader._s3 = mock_s3_client
 
         # When
@@ -2597,7 +2635,9 @@ class TestUpload:
             return_value=mock_s3_check_cache,
         ):
             # Execute reset_s3_check_cache where the cached hash does not exist in S3
-            s3_asset_uploader = S3AssetUploader()
+            s3_asset_uploader = S3AssetUploader(
+                s3_max_pool_connections=50, small_file_threshold_multiplier=20
+            )
             s3_asset_uploader.reset_s3_check_cache(cache_dir)
 
             # Then
@@ -2611,7 +2651,12 @@ class TestUpload:
         ],
     )
     def test_upload_object_to_cas_skips_upload_with_cache(
-        self, tmpdir, farm_id, queue_id, manifest_version, default_job_attachment_s3_settings
+        self,
+        tmpdir,
+        farm_id,
+        queue_id,
+        manifest_version,
+        default_job_attachment_s3_settings,
     ):
         """
         Tests that objects are not uploaded to S3 if there is a corresponding entry in the S3CheckCache
@@ -2637,7 +2682,7 @@ class TestUpload:
             "_get_current_timestamp",
             side_effect=["345.67"],
         ):
-            (is_uploaded, file_size) = asset_manager.asset_uploader.upload_object_to_cas(
+            is_uploaded, file_size = asset_manager.asset_uploader.upload_object_to_cas(
                 file=BaseManifestPath(path="test-file.txt", hash="test-hash", size=5, mtime=1),
                 hash_algorithm=HashAlgorithm.XXH128,
                 s3_bucket=default_job_attachment_s3_settings.s3BucketName,
@@ -2708,7 +2753,7 @@ class TestUpload:
             asset_manager.asset_uploader,
             "upload_file_to_s3",
         ) as mock_upload_file_to_s3:
-            (is_uploaded, file_size) = asset_manager.asset_uploader.upload_object_to_cas(
+            is_uploaded, file_size = asset_manager.asset_uploader.upload_object_to_cas(
                 file=BaseManifestPath(path="test-file.txt", hash="test-hash", size=5, mtime=1),
                 hash_algorithm=HashAlgorithm.XXH128,
                 s3_bucket=default_job_attachment_s3_settings.s3BucketName,
@@ -2725,7 +2770,8 @@ class TestUpload:
             s3_cache.get_connection_entry.assert_not_called()
             # S3 HEAD should always be called when force_s3_check=True
             mock_file_already_uploaded.assert_called_once_with(
-                default_job_attachment_s3_settings.s3BucketName, "prefix/test-hash.xxh128"
+                default_job_attachment_s3_settings.s3BucketName,
+                "prefix/test-hash.xxh128",
             )
             # Upload should only happen if file doesn't exist in S3
             if expected_upload:
@@ -2740,7 +2786,9 @@ class TestUpload:
         temp_file = tmp_path / "temp_file.txt"
         temp_file.write_text("this is test file")
 
-        a3_asset_uploader = S3AssetUploader()
+        a3_asset_uploader = S3AssetUploader(
+            s3_max_pool_connections=50, small_file_threshold_multiplier=20
+        )
         with a3_asset_uploader._open_non_symlink_file_binary(str(temp_file)) as file_obj:
             assert file_obj is not None
             assert file_obj.read() == b"this is test file"
@@ -2755,7 +2803,9 @@ class TestUpload:
         os.symlink(target_file, symlink_path)
 
         # WHEN
-        a3_asset_uploader = S3AssetUploader()
+        a3_asset_uploader = S3AssetUploader(
+            s3_max_pool_connections=50, small_file_threshold_multiplier=20
+        )
         with a3_asset_uploader._open_non_symlink_file_binary(str(symlink_path)) as file_obj:
             # THEN
             assert file_obj is None
@@ -2810,7 +2860,7 @@ class TestUpload:
             "_get_current_timestamp",
             side_effect=["345.67"],
         ):
-            (is_uploaded, file_size) = asset_manager.asset_uploader.upload_object_to_cas(
+            is_uploaded, file_size = asset_manager.asset_uploader.upload_object_to_cas(
                 file=BaseManifestPath(path="test-file.txt", hash="test-hash", size=5, mtime=1),
                 hash_algorithm=HashAlgorithm.XXH128,
                 s3_bucket=default_job_attachment_s3_settings.s3BucketName,
@@ -2840,12 +2890,15 @@ class TestUpload:
             paths=[
                 BaseManifestPath(path="output_file", hash="a", size=1, mtime=167907934333848),
                 BaseManifestPath(
-                    path="output/nested_output_file", hash="b", size=1, mtime=1479079344833848
+                    path="output/nested_output_file",
+                    hash="b",
+                    size=1,
+                    mtime=1479079344833848,
                 ),
             ],
         )
         # When
-        (hash_alg, _, manifest_name) = S3AssetUploader._gather_upload_metadata(
+        hash_alg, _, manifest_name = S3AssetUploader._gather_upload_metadata(
             manifest, Path("mocksourcerootpath"), "suffix"
         )
         # Then
@@ -2860,12 +2913,15 @@ class TestUpload:
             paths=[
                 BaseManifestPath(path="output_file", hash="a", size=1, mtime=167907934333848),
                 BaseManifestPath(
-                    path="output/nested_output_file", hash="b", size=1, mtime=1479079344833848
+                    path="output/nested_output_file",
+                    hash="b",
+                    size=1,
+                    mtime=1479079344833848,
                 ),
             ],
         )
         # When
-        (hash_alg, manifest_name) = S3AssetUploader._get_hashed_file_name_from_root_str(
+        hash_alg, manifest_name = S3AssetUploader._get_hashed_file_name_from_root_str(
             manifest, "C:\\Program Files\\My App\\data.txt", "suffix"
         )
         # Then


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Job Attachments directly calls `config_file.get_cache_directory()` and `config_file.get_setting(...)` in 5 files (`upload.py`, `_diff.py`, `_aws/aws_clients.py`, `api/attachment.py`, `api/manifest.py`), creating a dependency on the client's config system. This is part of the circular dependency being broken in Milestone 1 of the Client Decoupling project.

### What was the solution? (How)
Breaking changes:
- `S3AssetUploader.__init__` now requires `s3_max_pool_connections` and `small_file_threshold_multiplier` as keyword-only arguments instead of reading them from config internally
- Removed `get_s3_max_pool_connections()` from `_aws/aws_clients.py` entirely — callers pass the value directly
- `get_s3_client()` takes an optional `s3_max_pool_connections` param (default 50)

Non-breaking changes (optional params):
- `_manifest_diff`: added optional `cache_dir` param
- `_attachment_upload`: added optional `s3_check_cache_dir` param
- `find_file_with_status`: added optional `cache_dir` param
- `S3AssetManager`, `AssetSync`: added optional config params with defaults matching current config defaults (50, 20)
- `_get_num_download_workers`: added optional `s3_max_pool_connections` param with default

All callers in the client (`_submit_job_bundle.py`, `manifest_group.py`, `attachment_group.py`, `_session.py`) now read config values and pass them explicitly.

### What is the impact of this change?
Job Attachments no longer imports `config_file` from the client. `S3AssetUploader` and `get_s3_max_pool_connections` have breaking signature changes. All other changes are backwards compatible via optional params with defaults.

### How was this change tested?
- Have you run the unit tests?
```
========================================================================== slowest 5 durations ==========================================================================
5.78s call     test/unit/deadline_job_attachments/test_upload.py::TestUpload::test_asset_management_many_inputs[2023-03-03-200]
4.99s call     test/unit/deadline_job_attachments/test_upload.py::TestUpload::test_asset_management_no_outputs_large_number_of_inputs_already_uploaded[2023-03-03-200]
3.80s call     test/unit/deadline_job_attachments/test_upload.py::TestUpload::test_get_asset_groups[input_paths5-output_paths5-referenced_paths5-local_type_locations5-shared_type_locations5-expected_result5]
3.02s call     test/unit/deadline_job_attachments/test_upload.py::TestUpload::test_asset_management_many_inputs[2023-03-03-100]
2.61s call     test/unit/deadline_job_attachments/test_upload.py::TestUpload::test_asset_management_no_outputs_large_number_of_inputs_already_uploaded[2023-03-03-100]
========================================================================== 2346 passed, 62 skipped, 1 xfailed in 61.25s (0:01:01) ==========================================================================
```
- Have you run the integration tests?
```
========================================================================== slowest 5 durations ==========================================================================
609.05s call     test/integ/cli/test_cli_incremental_download.py::test_incremental_download_dependency_chain
456.57s call     test/integ/cli/test_cli_incremental_download.py::test_conflict_resolution_with_requeue[job]
406.18s call     test/integ/cli/test_cli_incremental_download.py::test_incremental_download_dep_data_flow
334.63s call     test/integ/cli/test_cli_incremental_download.py::test_conflict_resolution_with_requeue[step]
331.06s call     test/integ/cli/test_cli_incremental_download.py::test_conflict_resolution_with_requeue[task]
========================================================================== 56 passed, 4 skipped, 1 xfailed, 4 xpassed in 2504.15s (0:41:44) ==========================================================================
```

### Was this change documented?
Yes

### Does this PR introduce new dependencies?
*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?
**Yes.** `S3AssetUploader.__init__` now requires `s3_max_pool_connections` and `small_file_threshold_multiplier` as keyword-only arguments. `get_s3_max_pool_connections()` is removed from `_aws/aws_clients.py`

### Does this change impact security?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
