### PR TITLE
fix: load job bundle does nothing

### DIFF
--- a/src/deadline/client/ui/widgets/job_bundle_settings_tab.py
+++ b/src/deadline/client/ui/widgets/job_bundle_settings_tab.py
@@ -116,9 +116,9 @@ class JobBundleSettingsWidget(QWidget):
             logger.warning(msg)
             return
 
-        parent = self.parent()
-        if parent is not None and hasattr(parent, "refresh"):
-            parent.refresh(  # type: ignore[union-attr]
+        dialog = self.window()
+        if dialog is not None and hasattr(dialog, "refresh"):
+            dialog.refresh(  # type: ignore[union-attr]
                 job_settings=job_settings,
                 auto_detected_attachments=asset_references,
                 attachments=None,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The "Load Bundle" button in the deadline bundle gui-submit dialog silently fails. Clicking it opens the directory picker, but after selecting a bundle nothing happens

JobBundleSettingsWidget.on_load_bundle() uses self.parent() to find the SubmitJobToDeadlineDialog and call its refresh() method. However, the widget is placed inside a QScrollArea via setWidget(), which reparents it. So self.parent() returns the QScrollArea, not the dialog. The hasattr(parent, "refresh") check fails silently and the refresh
never happens.

### What was the solution? (How)

Replace self.parent() with self.window(), a Qt built-in that returns the top-level ancestor widget

### What is the impact of this change?

### How was this change tested?

Tested on MacOS.


[Before](https://github.com/user-attachments/assets/8aec6c21-6171-482c-a7ac-8dd48d429a79)


[After](https://github.com/user-attachments/assets/0dbf0907-0400-4a6e-a8a0-e4561368ad4d)


### Was this change documented?

N/A

### Does this PR introduce new dependencies?

N/A

### Is this a breaking change?

N/A

### Does this change impact security?

N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
