### PR TITLE
fix: missing newline in terminal output when submitting a job with no…

### DIFF
--- a/src/deadline/client/api/_submit_job_bundle.py
+++ b/src/deadline/client/api/_submit_job_bundle.py
@@ -751,11 +751,13 @@ def create_job_from_job_bundle(
 
     if not files_processed:
         # Call each callback once indicating nothing to do.
+        # Use progress=100 to ensure the progress bar is properly closed
+        # and a newline is emitted. (See https://github.com/aws-deadline/deadline-cloud/issues/1008)
         if hashing_progress_callback is not None:
             hashing_progress_callback(
                 ProgressReportMetadata(
                     status=ProgressStatus.PREPARING_IN_PROGRESS,
-                    progress=0,
+                    progress=100,
                     transferRate=0,
                     progressMessage="No files to hash",
                     processedFiles=0,
@@ -765,7 +767,7 @@ def create_job_from_job_bundle(
             upload_progress_callback(
                 ProgressReportMetadata(
                     status=ProgressStatus.UPLOAD_IN_PROGRESS,
-                    progress=0,
+                    progress=100,
                     transferRate=0,
                     progressMessage="No files to upload",
                     processedFiles=0,

--- a/test/unit/deadline_client/cli/test_cli_common.py
+++ b/test/unit/deadline_client/cli/test_cli_common.py
@@ -234,3 +234,51 @@ class TestParseMultiFormatParameters:
 
         with pytest.raises(click.BadParameter, match="not formatted correctly"):
             _parse_multi_format_parameters(params)
+
+
+class TestProgressBarCallbackManager:
+    """Tests for _ProgressBarCallbackManager"""
+
+    def test_progress_bar_closes_on_completion(self):
+        """
+        Regression test for https://github.com/aws-deadline/deadline-cloud/issues/1008
+        When the progress bar callback is called with progress equal to the bar length,
+        the bar should be properly closed (emitting a newline).
+        """
+        from deadline.client.cli._common import _ProgressBarCallbackManager
+        from deadline.job_attachments.progress_tracker import ProgressReportMetadata, ProgressStatus
+
+        manager = _ProgressBarCallbackManager(length=100, label="Uploading Attachments")
+        manager.callback(
+            ProgressReportMetadata(
+                status=ProgressStatus.UPLOAD_IN_PROGRESS,
+                progress=100,
+                transferRate=0,
+                progressMessage="No files to upload",
+                processedFiles=0,
+            )
+        )
+
+        assert manager._bar_status == manager.BAR_CLOSED
+
+    def test_progress_bar_not_closed_at_zero(self):
+        """
+        Verifies that calling the callback with progress=0 does NOT close the bar.
+        This is the scenario that caused the missing newline bug in issue #1008.
+        """
+        from deadline.client.cli._common import _ProgressBarCallbackManager
+        from deadline.job_attachments.progress_tracker import ProgressReportMetadata, ProgressStatus
+
+        manager = _ProgressBarCallbackManager(length=100, label="Uploading Attachments")
+        manager.callback(
+            ProgressReportMetadata(
+                status=ProgressStatus.UPLOAD_IN_PROGRESS,
+                progress=0,
+                transferRate=0,
+                progressMessage="No files to upload",
+                processedFiles=0,
+            )
+        )
+
+        assert manager._bar_status == manager.BAR_CREATED
+        manager._exit_stack.close()


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud/issues/1008

### What was the problem/requirement? (What/Why)
When submitting a job without job attachments, the output formatting missed a newline resulting in messy output.

### What was the solution? (How)
Update progress to 100% in the empty uploads upload event to trigger the upload progress bar to complete.

### What is the impact of this change?
Fixes some formatting.

### How was this change tested?
Unit tests, manual check. Example output now (was previously missing a newline):
```
Hashing Attachments
Uploading Attachments
Waiting for Job to be created...
Submitted job bundle:
   /Users/crowest/github/deadline-cloud-samples/job_bundles/list_available_conda_packages
Job creation completed successfully
```

### Was this change documented?
n/a

### Does this PR introduce new dependencies?
No

### Is this a breaking change?
No

### Does this change impact security?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
