### PR TITLE
fix: show friendly OS name instead of sys.platform in error messages

### DIFF
--- a/src/deadline/client/cli/_deadline_web_url.py
+++ b/src/deadline/client/cli/_deadline_web_url.py
@@ -232,7 +232,7 @@ x-scheme-handler/{DEADLINE_URL_SCHEME_NAME}={DEADLINE_URL_SCHEME_NAME}.desktop;
 
     else:
         raise DeadlineOperationError(
-            f"Installing the web URL handler is not supported on OS {sys.platform}"
+            "Installing the web URL handler is only supported on Windows and Linux"
         )
 
 
@@ -300,5 +300,5 @@ def uninstall_deadline_web_url_handler(all_users: bool) -> None:
 
     else:
         raise DeadlineOperationError(
-            f"Uninstalling the web URL handler is not supported on OS {sys.platform}"
+            "Uninstalling the web URL handler is only supported on Windows and Linux"
         )


### PR DESCRIPTION
fix: show friendly OS name instead of sys.platform in error messages (#1004)

Fixes: https://github.com/aws-deadline/deadline-cloud/issues/1004

### What was the problem/requirement? (What/Why)

The error message when attempting to install/uninstall the web URL handler on macOS displayed the raw `sys.platform` value: `"Installing the web URL handler is not supported on OS darwin"`. "darwin" is not user-friendly — most users know their OS as "macOS".

### What was the solution? (How)

Changed the error messages in `_deadline_web_url.py` to say `"Installing the web URL handler is only supported on Windows and Linux"` and `"Uninstalling the web URL handler is only supported on Windows and Linux"`. This is clearer and avoids exposing internal platform identifiers.

### What is the impact of this change?

Error message text only. No functional changes.

### How was this change tested?

- [x] Have you run the unit tests?
- Have you run the integration tests? N/A — error message change only.
- Have you made changes to the `download` or `asset_sync` modules? No.

Added a unit test `test_install_handler_unsupported_os_error_message` that patches `sys.platform` to `"darwin"` and verifies the error message contains `"only supported on Windows and Linux"`.

### Was this change documented?

- No docstring or README changes needed. This is an error message improvement only.

### Does this PR introduce new dependencies?

*   [x] This PR does not add any new dependencies.

### Is this a breaking change?

No. Only the text of an error message changed. No public API contracts are affected.

### Does this change impact security?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*