### PR TITLE
fix: show checkboxes in multiselect combo boxes on macOS

### DIFF
--- a/src/deadline/client/ui/widgets/host_requirements_tab.py
+++ b/src/deadline/client/ui/widgets/host_requirements_tab.py
@@ -1099,6 +1099,8 @@ class OptionalMultiSelectComboBox(QComboBox):
 
     def __init__(self, items: List[str], parent: Optional[QWidget] = None):
         super().__init__(parent=parent)
+        # Use QListView so check indicators render on macOS
+        self.setView(QListView(self))
         self.model().itemChanged.connect(self.handleModelChanged)
         self.setPlaceholderText("-")
         self.addItems(items)


### PR DESCRIPTION
Fixes #1007

### What was the problem/requirement? (What/Why)
The native macOS QComboBox popup does not render check state indicators. 

### What was the solution? (How)
Setting a QListView as the popup view forces Qt to use its own rendering which properly shows checkboxes on all platforms.

### What is the impact of this change?
Fixes UI bug.

### How was this change tested?
<img width="506" height="201" alt="Screenshot 2026-03-17 at 8 32 30 AM" src="https://github.com/user-attachments/assets/84c69c5d-13e6-4dac-9b70-ba429073d4e6" />


### Was this change documented?
n/a

### Does this PR introduce new dependencies?
No

### Is this a breaking change?
No

### Does this change impact security?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
