### PR TITLE
fix: update attributions for OS-specific dependencies

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -38,3 +38,16 @@ jobs:
       ref: ${{inputs.tag}}
       # The incremental output download and mcp feature doesn't run on Python 3.8, so test coverage is lower
       cov-fail-under: "74"
+
+  Attributions:
+    name: Attributions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{inputs.tag}}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - run: pip install hatch
+      - run: hatch run attributions:check

--- a/hatch.toml
+++ b/hatch.toml
@@ -53,7 +53,7 @@ python {root}/scripts/attributions/cli.py \
 --versions-file {root}/software-versions.json \
 {args:}
 """
-generate_local = "python {root}/scripts/attributions/cli.py -o {root}/THIRD_PARTY_LICENSES --dev --python uv {args:}"
+check = "python {root}/scripts/attributions/cli.py -o {root}/THIRD_PARTY_LICENSES --dev --python uv {args:}"
 update_approved_text = "python {root}/scripts/attributions/cli.py -o {root}/THIRD_PARTY_LICENSES --dev --python uv --update-approved-text {args:}"
 merge_versions = """
 python {root}/scripts/attributions/merge_versions.py \

--- a/hatch.toml
+++ b/hatch.toml
@@ -54,6 +54,7 @@ python {root}/scripts/attributions/cli.py \
 {args:}
 """
 generate_local = "python {root}/scripts/attributions/cli.py -o {root}/THIRD_PARTY_LICENSES --dev --python uv {args:}"
+update_approved_text = "python {root}/scripts/attributions/cli.py -o {root}/THIRD_PARTY_LICENSES --dev --python uv --update-approved-text {args:}"
 merge_versions = """
 python {root}/scripts/attributions/merge_versions.py \
 --python-dependencies-file {root}/python-dependencies.json \

--- a/scripts/attributions/README.md
+++ b/scripts/attributions/README.md
@@ -37,6 +37,16 @@ pip-licenses (auto-discovers pip packages)
 | Golden file diff                         | Any change to the generated output           | `cli.py` at generation time |
 | Bundled dependency check                 | Bundled dependency missing from attributions | `cli.py` at generation time |
 
+### Cross-Platform Generation
+
+The generator always validates golden files for all three platforms (Darwin, Linux, Windows)
+in a single invocation. It creates one venv, installs all platform-conditional dependencies
+(e.g., `colorama` for Windows), and then generates and validates the output for each platform
+by varying which additional attributions and pip packages are included.
+
+This means any change to attributions is validated against all platforms regardless of which
+OS you're running on.
+
 ### Key Data Structures in cli.py
 
 - **`_ATTRIBUTIONS_ALLOW_LIST`** — Pip-discoverable packages with SHA256 hashes of their
@@ -45,6 +55,10 @@ pip-licenses (auto-discovers pip packages)
 - **`_ADDITIONAL_ATTRIBUTIONS`** — Manually attributed packages. Each entry has a `name`,
   `attribution_path` (file in `additional/`), and optional `platforms`, `spdx`, `url`,
   and `sort_key` fields.
+- **`_PLATFORM_CONDITIONAL_PACKAGES`** — Pip packages that are only installed as transitive
+  dependencies on certain platforms (e.g., `colorama` on Windows via `click`). These are
+  always installed in the venv so pip-licenses can discover them, then filtered per-platform
+  when assembling the output.
 - **`_EXPECTED_MISSING_LICENSE`** — Packages where pip-licenses won't find a license file
   (e.g., pywin32). These must have entries in `_ADDITIONAL_ATTRIBUTIONS`.
 
@@ -61,10 +75,13 @@ These three components are LGPL-licensed and attributed separately:
 ## Commands
 
 ```bash
-# Generate attributions (local dev) — also validates bundled deps have attributions
+# Generate and validate attributions for all platforms (local dev)
 hatch run attributions:generate_local
 
-# Generate attributions (CI / pinned Python)
+# Update golden files for all platforms
+hatch run attributions:update_approved_text
+
+# Generate and validate attributions (CI / pinned Python)
 hatch run attributions:generate
 
 # Generate LGPL source tarballs (version read from requirements-installer.txt)
@@ -89,9 +106,11 @@ under `deadline-cloud/`.
    ```
    Then replace the third-party section in `additional/QT_LICENSE.txt` (everything after
    the LGPLv3 full text) with the generated output.
-4. Regenerate attributions: `hatch run attributions:generate_local`
-5. If the golden file diff fails, review the changes and copy the new output to
-   `approved_text/<platform>/THIRD_PARTY_LICENSES`
+4. Regenerate attributions and update golden files:
+   ```bash
+   hatch run attributions:update_approved_text
+   ```
+5. Verify all platforms pass: `hatch run attributions:generate_local`
 6. Generate new source tarballs:
    ```bash
    python scripts/attributions/generate_source_tarballs.py --output-dir ./source-tarballs
@@ -109,8 +128,12 @@ under `deadline-cloud/`.
    - **If pip-licenses doesn't find it**: Add the license file to `additional/` and add an
      entry to `_ADDITIONAL_ATTRIBUTIONS` in `cli.py`. Add the package name to
      `_EXPECTED_MISSING_LICENSE` if needed.
-4. Copy the new generated output to `approved_text/<platform>/THIRD_PARTY_LICENSES`
-5. If the dependency is LGPL/GPL licensed, generate and upload source tarballs
+   - **If the package is only installed on certain platforms** (e.g., a conditional
+     transitive dependency): Add it to `_PLATFORM_CONDITIONAL_PACKAGES` in `cli.py`
+     so cross-platform generation works correctly.
+4. Update golden files: `hatch run attributions:update_approved_text`
+5. Verify all platforms: `hatch run attributions:generate_local`
+6. If the dependency is LGPL/GPL licensed, generate and upload source tarballs
 
 ## File Reference
 

--- a/scripts/attributions/README.md
+++ b/scripts/attributions/README.md
@@ -75,8 +75,8 @@ These three components are LGPL-licensed and attributed separately:
 ## Commands
 
 ```bash
-# Generate and validate attributions for all platforms (local dev)
-hatch run attributions:generate_local
+# Validate attributions and license text for all platforms
+hatch run attributions:check
 
 # Update golden files for all platforms
 hatch run attributions:update_approved_text
@@ -110,7 +110,7 @@ under `deadline-cloud/`.
    ```bash
    hatch run attributions:update_approved_text
    ```
-5. Verify all platforms pass: `hatch run attributions:generate_local`
+5. Verify all platforms pass: `hatch run attributions:check`
 6. Generate new source tarballs:
    ```bash
    python scripts/attributions/generate_source_tarballs.py --output-dir ./source-tarballs
@@ -122,7 +122,7 @@ under `deadline-cloud/`.
 1. Add the package to `pyproject.toml`
 2. If it will be bundled in the installer, add it to `scripts/pyinstaller/allowlist.py`'s
    `DEPENDENCIES` list
-3. Run `hatch run attributions:generate_local`
+3. Run `hatch run attributions:check`
    - **If pip-licenses finds it**: Add an entry to `_ATTRIBUTIONS_ALLOW_LIST` in `cli.py`
      with the SHA256 of its license text. Run generation again.
    - **If pip-licenses doesn't find it**: Add the license file to `additional/` and add an
@@ -132,7 +132,7 @@ under `deadline-cloud/`.
      transitive dependency): Add it to `_PLATFORM_CONDITIONAL_PACKAGES` in `cli.py`
      so cross-platform generation works correctly.
 4. Update golden files: `hatch run attributions:update_approved_text`
-5. Verify all platforms: `hatch run attributions:generate_local`
+5. Verify all platforms: `hatch run attributions:check`
 6. If the dependency is LGPL/GPL licensed, generate and upload source tarballs
 
 ## File Reference

--- a/scripts/attributions/approved_text/Linux/THIRD_PARTY_LICENSES
+++ b/scripts/attributions/approved_text/Linux/THIRD_PARTY_LICENSES
@@ -2051,6 +2051,7 @@ Library.
 
 ---
 
+
 Qt Third-Party Licenses
 ==========================================================================
 
@@ -7312,6 +7313,39 @@ libmpdec
  OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  SUCH DAMAGE.
 
+libzstd
+
+BSD License
+
+For Zstandard software
+
+Copyright (c) Meta Platforms, Inc. and affiliates. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+ * Neither the name Facebook, nor Meta, nor the names of its contributors may
+   be used to endorse or promote products derived from this software without
+   specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 ncurses
 
 Copyright 2018-2022,2023 Thomas E. Dickey
@@ -8160,94 +8194,6 @@ sqlite
 All of the code and documentation in SQLite has been dedicated to the public domain by the authors. All code authors, and representatives of the companies they work for, have signed affidavits dedicating their contributions to the public domain and originals of those signed affidavits are stored in a firesafe at the main offices of Hwaci. Anyone is free to copy, modify, publish, use, compile, sell, or distribute the original SQLite code, either in source code form or as a compiled binary, for any purpose, commercial or non-commercial, and by any means. 
 
   The author or authors of this code dedicate any and all copyright interest in this code to the public domain. We make this dedication for the benefit of the public at large and to the detriment of our heirs and successors. We intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this code under copyright law. 
-
-tcl
-
-This software is copyrighted by the Regents of the University of
-California, Sun Microsystems, Inc., Scriptics Corporation, ActiveState
-Corporation and other parties.  The following terms apply to all files
-associated with the software unless explicitly disclaimed in
-individual files.
-
-The authors hereby grant permission to use, copy, modify, distribute,
-and license this software and its documentation for any purpose, provided
-that existing copyright notices are retained in all copies and that this
-notice is included verbatim in any distributions. No written agreement,
-license, or royalty fee is required for any of the authorized uses.
-Modifications to this software may be copyrighted by their authors
-and need not follow the licensing terms described here, provided that
-the new terms are clearly indicated on the first page of each file where
-they apply.
-
-IN NO EVENT SHALL THE AUTHORS OR DISTRIBUTORS BE LIABLE TO ANY PARTY
-FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
-ARISING OUT OF THE USE OF THIS SOFTWARE, ITS DOCUMENTATION, OR ANY
-DERIVATIVES THEREOF, EVEN IF THE AUTHORS HAVE BEEN ADVISED OF THE
-POSSIBILITY OF SUCH DAMAGE.
-
-THE AUTHORS AND DISTRIBUTORS SPECIFICALLY DISCLAIM ANY WARRANTIES,
-INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT.  THIS SOFTWARE
-IS PROVIDED ON AN "AS IS" BASIS, AND THE AUTHORS AND DISTRIBUTORS HAVE
-NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR
-MODIFICATIONS.
-
-GOVERNMENT USE: If you are acquiring this software on behalf of the
-U.S. government, the Government shall have only "Restricted Rights"
-in the software and related documentation as defined in the Federal
-Acquisition Regulations (FARs) in Clause 52.227.19 (c) (2).  If you
-are acquiring the software on behalf of the Department of Defense, the
-software shall be classified as "Commercial Computer Software" and the
-Government shall have only "Restricted Rights" as defined in Clause
-252.227-7014 (b) (3) of DFARs.  Notwithstanding the foregoing, the
-authors grant the U.S. Government and others acting in its behalf
-permission to use and distribute the software in accordance with the
-terms specified in this license.
-
-
-tk
-
-This software is copyrighted by the Regents of the University of
-California, Sun Microsystems, Inc., Scriptics Corporation, ActiveState
-Corporation, Apple Inc. and other parties.  The following terms apply to
-all files associated with the software unless explicitly disclaimed in
-individual files.
-
-The authors hereby grant permission to use, copy, modify, distribute,
-and license this software and its documentation for any purpose, provided
-that existing copyright notices are retained in all copies and that this
-notice is included verbatim in any distributions. No written agreement,
-license, or royalty fee is required for any of the authorized uses.
-Modifications to this software may be copyrighted by their authors
-and need not follow the licensing terms described here, provided that
-the new terms are clearly indicated on the first page of each file where
-they apply.
-
-IN NO EVENT SHALL THE AUTHORS OR DISTRIBUTORS BE LIABLE TO ANY PARTY
-FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
-ARISING OUT OF THE USE OF THIS SOFTWARE, ITS DOCUMENTATION, OR ANY
-DERIVATIVES THEREOF, EVEN IF THE AUTHORS HAVE BEEN ADVISED OF THE
-POSSIBILITY OF SUCH DAMAGE.
-
-THE AUTHORS AND DISTRIBUTORS SPECIFICALLY DISCLAIM ANY WARRANTIES,
-INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT.  THIS SOFTWARE
-IS PROVIDED ON AN "AS IS" BASIS, AND THE AUTHORS AND DISTRIBUTORS HAVE
-NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR
-MODIFICATIONS.
-
-GOVERNMENT USE: If you are acquiring this software on behalf of the
-U.S. government, the Government shall have only "Restricted Rights"
-in the software and related documentation as defined in the Federal
-Acquisition Regulations (FARs) in Clause 52.227.19 (c) (2).  If you
-are acquiring the software on behalf of the Department of Defense, the
-software shall be classified as "Commercial Computer Software" and the
-Government shall have only "Restricted Rights" as defined in Clause
-252.227-7013 (b) (3) of DFARs.  Notwithstanding the foregoing, the
-authors grant the U.S. Government and others acting in its behalf
-permission to use and distribute the software in accordance with the
-terms specified in this license.
-
 
 zlib
 

--- a/scripts/attributions/approved_text/Windows/THIRD_PARTY_LICENSES
+++ b/scripts/attributions/approved_text/Windows/THIRD_PARTY_LICENSES
@@ -1559,6 +1559,7 @@ Library.
 
 ---
 
+
 Qt Third-Party Licenses
 ==========================================================================
 
@@ -6695,6 +6696,22 @@ Source code: https://code.qt.io/cgit/pyside/pyside-setup.git/
 Source code for this component may be downloaded here:
 https://s3.amazonaws.com/amazon-source-code-downloads/deadline-cloud/pyside-setup-6.8.3-src.tar.gz
 
+VCRedist
+
+https://visualstudio.microsoft.com/license-terms/mlt031619/
+© Microsoft 2022
+ 
+Subject to the terms: https://visualstudio.microsoft.com/license-
+terms/mlt031619/
+
+WindowsSDK
+
+https://learn.microsoft.com/en-us/legal/windows-sdk/license-terms-ewdk
+© Microsoft 2022
+ 
+Subject to the terms: https://learn.microsoft.com/en-us/legal/windows-
+sdk/license-terms-ewdk
+
 bzip2
 
 --------------------------------------------------------------------------
@@ -6819,38 +6836,6 @@ libmpdec
  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
  OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  SUCH DAMAGE.
-
-ncurses
-
-Copyright 2018-2022,2023 Thomas E. Dickey
-Copyright 1998-2017,2018 Free Software Foundation, Inc.
-
-Permission is hereby granted, free of charge, to any person obtaining a
-copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, distribute with modifications, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included
-in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE ABOVE COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
-OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR
-THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-Except as contained in this notice, the name(s) of the above copyright
-holders shall not be used in advertising or otherwise to promote the
-sale, use or other dealings in this Software without prior written
-authorization.
-
--- vile:txtmode fc=72
--- $Id: COPYING,v 1.12 2023/01/07 17:55:53 tom Exp $
 
 openssl
 
@@ -7662,6 +7647,19 @@ INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
 LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
 OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 PERFORMANCE OF THIS SOFTWARE.
+
+pywin32
+
+PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2
+
+    1. This LICENSE AGREEMENT is between the Python Software Foundation ("PSF"), and the Individual or Organization ("Licensee") accessing and otherwise using this software ("Python") in source or binary form and its associated documentation.
+    2. Subject to the terms and conditions of this License Agreement, PSF hereby grants Licensee a nonexclusive, royalty-free, world-wide license to reproduce, analyze, test, perform and/or display publicly, prepare derivative works, distribute, and otherwise use Python alone or in any derivative version, provided, however, that PSF's License Agreement and PSF's notice of copyright , i.e., "Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006 Python Software Foundation All Rights Reserved" are retained in Python alone or in any derivative version prepared by Licensee.
+    3. In the event Licensee prepares a derivative work that is based on or incorporates Python or any part thereof, and wants to make the derivative work available to others as provided herein, then Licensee hereby agrees to include in any such work a brief summary of the changes made to Python.
+    4. PSF is making Python available to Licensee on an "AS IS" basis. PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED. BY WAY OF EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF PYTHON WILL NOT INFRINGE ANY THIRD PARTY RIGHTS.
+    5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON, OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+    6. This License Agreement will automatically terminate upon a material breach of its terms and conditions.
+    7. Nothing in this License Agreement shall be deemed to create any relationship of agency, partnership, or joint venture between PSF and Licensee. This License Agreement does not grant permission to use PSF trademarks or trade name in a trademark sense to endorse or promote products or services of Licensee, or any third party.
+    8. By copying, installing or otherwise using Python, Licensee agrees to be bound by the terms and conditions of this License Agreement.
 
 sqlite
 

--- a/scripts/attributions/cli.py
+++ b/scripts/attributions/cli.py
@@ -528,6 +528,22 @@ class _PackageLicenseInfo:
             )
 
 
+_ALL_PLATFORMS = ["Darwin", "Linux", "Windows"]
+
+# Packages that are only installed on certain platforms as transitive
+# dependencies. When generating attributions, these are always installed
+# so that a single venv can produce output for all platforms.
+_PLATFORM_CONDITIONAL_PACKAGES: dict[str, list[str]] = {
+    "Windows": ["colorama"],
+}
+
+# Inverse lookup: package name -> set of platforms it belongs to
+_PACKAGE_PLATFORMS: dict[str, set[str]] = {}
+for _plat, _pkgs in _PLATFORM_CONDITIONAL_PACKAGES.items():
+    for _pkg in _pkgs:
+        _PACKAGE_PLATFORMS.setdefault(_pkg, set()).add(_plat)
+
+
 def _get_license_info(python_interpreter: PythonInstall, dev: bool) -> list[_PackageLicenseInfo]:
     repository_root = Path(__file__).parent.parent.parent
     with tempfile.TemporaryDirectory() as td:
@@ -537,6 +553,11 @@ def _get_license_info(python_interpreter: PythonInstall, dev: bool) -> list[_Pac
         uv_venv_args = ["uv", "venv", venv, *python_args]
         subprocess.check_call(uv_venv_args)
         uv_pip(["install", repository_root], venv, dev)
+        # Install all platform-conditional packages so pip-licenses discovers
+        # them regardless of which OS we're running on.
+        all_conditional = [pkg for pkgs in _PLATFORM_CONDITIONAL_PACKAGES.values() for pkg in pkgs]
+        if all_conditional:
+            uv_pip(["install", *all_conditional], venv, dev)
         if platform.system() == "Windows":
             python_path = venv / "Scripts" / "python.exe"
         else:
@@ -593,7 +614,8 @@ def _get_license_info(python_interpreter: PythonInstall, dev: bool) -> list[_Pac
 
 
 def packages_to_markdown_table(
-    packages: list[_PackageLicenseInfo], additional: list[dict[str, str]]
+    packages: list[_PackageLicenseInfo],
+    additional: list[dict[str, str]],
 ) -> str:
     lines = ["| Name | Version | License | URL |", "| --- | --- | --- | --- |"]
     for pkg in packages:
@@ -648,35 +670,22 @@ def generate_attributions_document(
     dev: bool,
     inventory_file: Optional[Path],
     versions_file: Optional[Path],
+    update_approved_text: bool = False,
 ) -> None:
     """
-    Generate an attributions document for this package and write it to `out_file`
+    Generate an attributions document for this package and write it to `out_file`.
+    Validates (or updates) the approved text golden files for all platforms.
     """
     _validate_bundled_attributions()
     desired_python_version = _get_desired_python_version()
     python_install = PythonInstall(python_arg, desired_python_version, dev)
     license_info = _get_license_info(python_install, dev)
-    attributions = []
     versions: dict[str, str] = {}
 
     for package in sorted(license_info, key=lambda info: info.name):
         versions[package.name] = package.version
         if package.name not in _EXPECTED_MISSING_LICENSE:
             package.check_against_attributions_allow_list()
-            attributions.append(package.get_attribution_text())
-
-    additional_attributions_path = Path(__file__).parent / "additional"
-    for attribution in sorted(
-        _ADDITIONAL_ATTRIBUTIONS,
-        key=lambda attribution: attribution.get("sort_key", attribution["name"]),
-    ):
-        if "platforms" not in attribution or platform.system() in attribution["platforms"]:
-            with open(
-                additional_attributions_path / attribution["attribution_path"], "r", encoding="utf8"
-            ) as f:
-                attributions.append(f"{attribution['name']}\n\n{f.read()}\n")
-
-    attributions = "".join(attributions)
 
     if inventory_file is not None:
         inventory = packages_to_markdown_table(license_info, _ADDITIONAL_ATTRIBUTIONS)
@@ -687,31 +696,71 @@ def generate_attributions_document(
         with open(versions_file, "w", encoding="utf8") as f:
             json.dump(versions, f, indent=2)
 
-    approved_text_path = (
-        Path(__file__).parent / "approved_text" / platform.system() / "THIRD_PARTY_LICENSES"
-    )
+    for target_platform in _ALL_PLATFORMS:
+        # Filter packages to those relevant to this platform
+        platform_packages = [
+            pkg
+            for pkg in license_info
+            if pkg.name not in _PACKAGE_PLATFORMS or target_platform in _PACKAGE_PLATFORMS[pkg.name]
+        ]
 
-    # Read as bytes first, then decode explicitly
-    # because otherwise certain unicode characters
-    # are not decoded properly on Windows
-    with open(approved_text_path, "rb") as f:
-        raw_bytes = f.read()
-    approved_text = raw_bytes.decode("utf-8").replace("\r\n", "\n").replace("\r", "\n")
+        attributions = []
+        for package in sorted(platform_packages, key=lambda info: info.name):
+            if package.name not in _EXPECTED_MISSING_LICENSE:
+                attributions.append(package.get_attribution_text())
 
-    if approved_text != attributions:
-        diff = "".join(
-            difflib.unified_diff(
-                approved_text.splitlines(keepends=True),
-                attributions.replace("\r\n", "\n").replace("\r", "\n").splitlines(keepends=True),
-                lineterm="",
-            )
+        additional_attributions_path = Path(__file__).parent / "additional"
+        for attribution in sorted(
+            _ADDITIONAL_ATTRIBUTIONS,
+            key=lambda attribution: attribution.get("sort_key", attribution["name"]),
+        ):
+            if "platforms" not in attribution or target_platform in attribution["platforms"]:
+                with open(
+                    additional_attributions_path / attribution["attribution_path"],
+                    "r",
+                    encoding="utf8",
+                ) as f:
+                    attributions.append(f"{attribution['name']}\n\n{f.read()}\n")
+
+        attributions_text = "".join(attributions)
+
+        approved_text_path = (
+            Path(__file__).parent / "approved_text" / target_platform / "THIRD_PARTY_LICENSES"
         )
-        print("ERROR: Attributions generated did not match approved text:", file=sys.stderr)
-        print(diff, file=sys.stderr)
-        sys.exit(1)
 
-    with open(out_file, "w", encoding="utf8") as f:
-        f.write(attributions)
+        if update_approved_text:
+            approved_text_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(approved_text_path, "w", encoding="utf8") as f:
+                f.write(attributions_text)
+            print(f"Updated approved text for {target_platform}")
+        else:
+            # Read as bytes first, then decode explicitly
+            # because otherwise certain unicode characters
+            # are not decoded properly on Windows
+            with open(approved_text_path, "rb") as f:
+                raw_bytes = f.read()
+            approved_text = raw_bytes.decode("utf-8").replace("\r\n", "\n").replace("\r", "\n")
+
+            if approved_text != attributions_text:
+                diff = "".join(
+                    difflib.unified_diff(
+                        approved_text.splitlines(keepends=True),
+                        attributions_text.replace("\r\n", "\n")
+                        .replace("\r", "\n")
+                        .splitlines(keepends=True),
+                        lineterm="",
+                    )
+                )
+                print(
+                    f"ERROR: Attributions for {target_platform} did not match approved text:",
+                    file=sys.stderr,
+                )
+                print(diff, file=sys.stderr)
+                sys.exit(1)
+
+        if target_platform == platform.system():
+            with open(out_file, "w", encoding="utf8") as f:
+                f.write(attributions_text)
 
 
 if __name__ == "__main__":
@@ -747,8 +796,19 @@ if __name__ == "__main__":
         required=False,
         help="The path to output the versions file to",
     )
+    parser.add_argument(
+        "--update-approved-text",
+        action="store_true",
+        required=False,
+        help="Update the approved text golden files instead of diffing against them.",
+    )
     args = parser.parse_args()
 
     generate_attributions_document(
-        args.out_file, args.python, args.dev, args.inventory_file, args.versions_file
+        args.out_file,
+        args.python,
+        args.dev,
+        args.inventory_file,
+        args.versions_file,
+        args.update_approved_text,
     )


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Installer builds are failing because license texts don't match on Linux and Windows. The reason is I generated new license texts on a Mac, and the license text scripts used the current platform (i.e. Mac) instead of the target platform.

### What was the solution? (How)
- Fix the scripts, regenerate the golden texts. 
- Update scripts to generate and validate all platforms at the same time, not just the current platform, so we won't make the same mistake in the future.
- Add license text verification to GitHub actions

Note: this PR shows some changes to the Windows and Linux licenses (e.g. removing tcl and tkl, adding PyWin32). These changes are undoing incorrect changes from this PR: https://github.com/aws-deadline/deadline-cloud/pull/1021 

### What is the impact of this change?
Fixes text and the validations of that text.

### How was this change tested?
Recreating the error locally, fixing it, verifying the validations pass.

### Was this change documented?
Yes

### Does this PR introduce new dependencies?
No

### Is this a breaking change?
No

### Does this change impact security?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
