### PR TITLE
[WIP] chore: remove VFS dependencies on Deadline Cloud

### DIFF
--- a/src/deadline/job_attachments/asset_sync.py
+++ b/src/deadline/job_attachments/asset_sync.py
@@ -262,6 +262,7 @@ class AssetSync:
         fs_permission_settings: Optional[FileSystemPermissionSettings] = None,
         merged_manifests_by_root: dict[str, BaseAssetManifest] = dict(),
         os_env_vars: dict[str, str] | None = None,
+        on_mount_complete: Optional[Callable[[bool], None]] = None,
     ) -> bool:
         """
         Args:
@@ -284,6 +285,7 @@ class AssetSync:
                 fs_permission_settings=fs_permission_settings,  # type: ignore[arg-type]
                 os_env_vars=os_env_vars,  # type: ignore[arg-type]
                 cas_prefix=s3_settings.full_cas_prefix(),
+                on_mount_complete=on_mount_complete,
             )
             return True
         except VFSExecutableMissingError:
@@ -396,6 +398,7 @@ class AssetSync:
         step_dependencies: Optional[list[str]] = None,
         on_downloading_files: Optional[Callable[[ProgressReportMetadata], bool]] = None,
         os_env_vars: Dict[str, str] | None = None,
+        on_vfs_mount_complete: Optional[Callable[[bool], None]] = None,
     ) -> Tuple[SummaryStatistics, List[Dict[str, str]]]:
         """
         Depending on the fileSystem in the Attachments this will perform two
@@ -425,6 +428,8 @@ class AssetSync:
                 for each file being downloaded. If the function returns False, the download will be
                 cancelled. If it returns True, the download will continue.
             os_env_vars: environment variables to set for launched subprocesses
+            on_vfs_mount_complete: optional callback invoked with a bool indicating whether
+                each VFS mount succeeded. Callers can use this for telemetry or logging.
 
         Returns:
             COPIED / None : a tuple of (1) final summary statistics for file downloads,
@@ -487,6 +492,7 @@ class AssetSync:
                 fs_permission_settings=fs_permission_settings,
                 merged_manifests_by_root=merged_manifests_by_root,
                 os_env_vars=os_env_vars,
+                on_mount_complete=on_vfs_mount_complete,
             )
         else:
             # Copied Download flow
@@ -771,6 +777,7 @@ class AssetSync:
         step_dependencies: Optional[list[str]] = None,
         on_downloading_files: Optional[Callable[[ProgressReportMetadata], bool]] = None,
         os_env_vars: Dict[str, str] | None = None,
+        on_vfs_mount_complete: Optional[Callable[[bool], None]] = None,
     ) -> Tuple[SummaryStatistics, List[Dict[str, str]]]:
         """
         Depending on the fileSystem in the Attachments this will perform two
@@ -796,6 +803,8 @@ class AssetSync:
                 for each file being downloaded. If the function returns False, the download will be
                 cancelled. If it returns True, the download will continue.
             os_env_vars: environment variables to set for launched subprocesses
+            on_vfs_mount_complete: optional callback invoked with a bool indicating whether
+                each VFS mount succeeded. Callers can use this for telemetry or logging.
 
         Returns:
             COPIED / None : a tuple of (1) final summary statistics for file downloads,
@@ -908,6 +917,7 @@ class AssetSync:
                     fs_permission_settings=fs_permission_settings,  # type: ignore[arg-type]
                     os_env_vars=os_env_vars,  # type: ignore[arg-type]
                     cas_prefix=s3_settings.full_cas_prefix(),
+                    on_mount_complete=on_vfs_mount_complete,
                 )
                 summary_statistics = SummaryStatistics()
                 self._record_attachment_mtimes(merged_manifests_by_root)

--- a/src/deadline/job_attachments/download.py
+++ b/src/deadline/job_attachments/download.py
@@ -1162,6 +1162,7 @@ def mount_vfs_from_manifests(
     os_env_vars: dict[str, str],
     fs_permission_settings: FileSystemPermissionSettings,
     cas_prefix: Optional[str] = None,
+    on_mount_complete: Optional[Callable[[bool], None]] = None,
 ) -> None:
     """
     Given manifests, downloads all files from a CAS in those manifests.
@@ -1173,6 +1174,8 @@ def mount_vfs_from_manifests(
         session_dir: the directory that the session is going to use.
         os_env_vars: environment variables to set for launched subprocesses
         cas_prefix: The CAS prefix of the files.
+        on_mount_complete: optional callback invoked with a bool indicating whether
+            each VFS mount succeeded. Callers can use this for telemetry or logging.
 
     Returns:
         None
@@ -1228,6 +1231,7 @@ def mount_vfs_from_manifests(
             getattr(fs_permission_settings, "os_group", ""),
             cas_prefix,
             str(vfs_cache_dir),
+            on_mount_complete=on_mount_complete,
         )
         vfs_manager.start(session_dir=session_dir)
 

--- a/src/deadline/job_attachments/vfs.py
+++ b/src/deadline/job_attachments/vfs.py
@@ -7,7 +7,7 @@ import subprocess
 import time
 from pathlib import Path
 import threading
-from typing import Dict, Union, Optional
+from typing import Callable, Dict, Union, Optional
 
 from .exceptions import (
     VFSExecutableMissingError,
@@ -17,10 +17,6 @@ from .exceptions import (
 )
 
 from .os_file_permission import PosixFileSystemPermissionSettings
-
-from deadline.client.api import (
-    get_deadline_cloud_library_telemetry_client as _get_deadline_cloud_library_telemetry_client,
-)
 
 log = logging.getLogger(__name__)
 
@@ -76,6 +72,7 @@ class VFSProcessManager(object):
         os_group: Optional[str] = None,
         cas_prefix: Optional[str] = None,
         asset_cache_path: Optional[str] = None,
+        on_mount_complete: Optional[Callable[[bool], None]] = None,
     ):
         self._mount_point = mount_point
         self._vfs_proc = None
@@ -90,6 +87,7 @@ class VFSProcessManager(object):
         self._os_env_vars = os_env_vars
         self._cas_prefix = cas_prefix
         self._asset_cache_path = asset_cache_path
+        self._on_mount_complete = on_mount_complete
 
     @classmethod
     def kill_all_processes(cls, session_dir: Path, os_user: str) -> None:
@@ -503,9 +501,8 @@ class VFSProcessManager(object):
         log.info(f"Launched VFS as pid {self._vfs_proc.pid}")
 
         is_mounted = VFSProcessManager.wait_for_mount(self.get_mount_point(), session_dir)
-        _get_deadline_cloud_library_telemetry_client().record_vfs_mounting(
-            successfully_mounted=is_mounted
-        )
+        if self._on_mount_complete is not None:
+            self._on_mount_complete(is_mounted)
 
         if not is_mounted:
             log.error("Failed to mount, shutting down")


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The `VFSProcessManager` in `job_attachments/vfs.py` imported `get_deadline_cloud_library_telemetry_client` from `deadline.client.api` to call `record_vfs_mounting()` after each VFS mount. This created a dependency from the job attachments layer back into the client layer, which is undesirable for modularity.

### What was the solution? (How)
This PR removes that import by introducing an `on_mount_complete` callback parameter. Instead of `VFSProcessManager` directly calling the telemetry client, callers now pass in a callback that handles telemetry (or any other post-mount logic) externally.

The callback is threaded through the following chain:
- `AssetSync.sync_inputs()` / `AssetSync.attachment_sync_inputs()` accept `on_vfs_mount_complete`
- `AssetSync._launch_vfs()` accepts `on_mount_complete`
- `mount_vfs_from_manifests()` accepts `on_mount_complete`
- `VFSProcessManager.__init__()` accepts `on_mount_complete`

All new parameters are optional with `None` default, so existing callers (including the worker agent) require no changes. When no callback is provided, the mount-complete event is simply not reported — matching the current behavior for callers that don't use telemetry.

### What is the impact of this change?
Decouple VFS from Deadline Cloud

### How was this change tested?
- Have you run the unit tests?
```
========================================================================== slowest 5 durations ==========================================================================
5.78s call     test/unit/deadline_job_attachments/test_upload.py::TestUpload::test_asset_management_many_inputs[2023-03-03-200]
4.99s call     test/unit/deadline_job_attachments/test_upload.py::TestUpload::test_asset_management_no_outputs_large_number_of_inputs_already_uploaded[2023-03-03-200]
3.80s call     test/unit/deadline_job_attachments/test_upload.py::TestUpload::test_get_asset_groups[input_paths5-output_paths5-referenced_paths5-local_type_locations5-shared_type_locations5-expected_result5]
3.02s call     test/unit/deadline_job_attachments/test_upload.py::TestUpload::test_asset_management_many_inputs[2023-03-03-100]
2.61s call     test/unit/deadline_job_attachments/test_upload.py::TestUpload::test_asset_management_no_outputs_large_number_of_inputs_already_uploaded[2023-03-03-100]
========================================================================== 2346 passed, 62 skipped, 1 xfailed in 61.25s (0:01:01) ==========================================================================
```
- Have you run the integration tests?
```
========================================================================== slowest 5 durations ==========================================================================
609.05s call     test/integ/cli/test_cli_incremental_download.py::test_incremental_download_dependency_chain
456.57s call     test/integ/cli/test_cli_incremental_download.py::test_conflict_resolution_with_requeue[job]
406.18s call     test/integ/cli/test_cli_incremental_download.py::test_incremental_download_dep_data_flow
334.63s call     test/integ/cli/test_cli_incremental_download.py::test_conflict_resolution_with_requeue[step]
331.06s call     test/integ/cli/test_cli_incremental_download.py::test_conflict_resolution_with_requeue[task]
========================================================================== 56 passed, 4 skipped, 1 xfailed, 4 xpassed in 2504.15s (0:41:44) ==========================================================================
```

### Was this change documented?
Yes

### Does this PR introduce new dependencies?

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?
No.

### Does this change impact security?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
