### PR TITLE
chore: bump manual pypi publish to use python 3.13, and fix workflow deps

### DIFF
--- a/.github/workflows/manual_pypi_release.yml
+++ b/.github/workflows/manual_pypi_release.yml
@@ -22,12 +22,14 @@ jobs:
           echo "Tag validation successful"
                 
   UnitTests:
+    needs: ValidateTag
     name: Unit Tests
     uses: ./.github/workflows/code_quality.yml
     with:
       tag: ${{ inputs.tag }}
       
   PublishToPyPI:
+    needs: UnitTests
     runs-on: ubuntu-latest
     environment: release
     permissions:
@@ -49,10 +51,10 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.9'
+          python-version: '3.13'
       - name: Install dependencies
         run: |
-          pip install --upgrade hatch "click<8.3"
+          pip install --upgrade hatch
       - name: Build
         run: hatch -v build
       # # See https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

manual pypi publish was failing due to using python 3.9 and therefore being affected by the hatch/virtualenv compatibility issue.

ref: https://github.com/aws-deadline/deadline-cloud/actions/runs/23456373491

release publish also suffers from this, but updating this first to verify

### What was the solution? (How)

Upgrade python for this action so we no longer have to care

### What is the impact of this change?

Hopefully a working manual publish to get 0.54.3 released without doing a whole nother release.

### How was this change tested?

Will test once merged.

### Was this change documented?
N/A

### Does this PR introduce new dependencies?
N/A

### Is this a breaking change?
N/A

### Does this change impact security?

N/A
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
