### PR TITLE
chore: add codeql results for feature branches to unblock PRs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "mainline" ]
+    branches: [ "mainline", "feature_*" ]
   pull_request:
-    branches: [ "mainline" ]
+    branches: [ "mainline", "feature_*" ]
   schedule:
     - cron: '0 8 * * MON'
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

codescanning is required to get a PR merged. We weren't running it for feature branches

### What was the solution? (How)

add codescanning

### What is the impact of this change?

Should unblock PRs

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
