### PR TITLE
chore: update release publish pypi publish to 3.13

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -121,7 +121,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.9'
+          python-version: '3.13'
       - name: Install dependencies
         run: |
           pip install --upgrade hatch


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

pypi publish was failing due to virtualenv incompatibility with the hatch on python 3.9: https://github.com/aws-deadline/deadline-cloud/actions/runs/23309073348/job/67814852443

### What was the solution? (How)

update to python 3.13

### What is the impact of this change?

Working releases

### How was this change tested?
manual pypi worked once upgraded to 3.13: https://github.com/aws-deadline/deadline-cloud/actions/runs/23457338608

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
