### PR TITLE
docs: updated worker agent migrtion guide for JA decoupling

### DIFF
--- a/docs/design/client-job-attachments-decoupling.md
+++ b/docs/design/client-job-attachments-decoupling.md
@@ -412,6 +412,8 @@ No action needed — all Client callers were updated in the same PR set.
 The Worker Agent imports and uses `S3AssetUploader` from the `deadline-cloud` package (`deadline.job_attachments.upload`). As part of [PR #1040](https://github.com/aws-deadline/deadline-cloud/pull/1040), the `S3AssetUploader.__init__` signature in `deadline-cloud` was changed to require two additional keyword arguments — `s3_max_pool_connections` and `small_file_threshold_multiplier` — which were previously read internally from the Client's config. Since the Worker Agent calls this constructor directly, it must be updated to pass these values explicitly:
 
 ```python
+# For Example:
+
 # Before (deadline-cloud handled config lookup internally)
 uploader = S3AssetUploader(session=my_session)
 
@@ -422,6 +424,14 @@ uploader = S3AssetUploader(
     small_file_threshold_multiplier=20,   # or read from your own config
 )
 ```
+
+The Worker Agent's [`pyproject.toml`](https://github.com/aws-deadline/deadline-cloud-worker-agent/blob/mainline/pyproject.toml) pins the `deadline` package version range in its dependencies. This pin must be updated to require the `deadline` version that includes the breaking signature changes (at minimum the `S3AssetUploader` constructor change from PR #1040 and the `on_vfs_mount_complete` callback from PR #1062). If the version range allows older `deadline` versions, the agent will fail at runtime when it calls `S3AssetUploader()` without the now-required parameters.
+
+Version compatibility must be ensured across both deployment paths:
+
+
+- **Service-managed fleets:** The worker AMI is built using exact version pins for `deadline-cloud-worker-agent`, `deadline`, and `openjd-sessions`. Both the worker agent and `deadline` version pins must be updated together to versions that include the breaking changes. Linux and Windows configurations must stay in sync.
+- **Customer-managed fleets:** Customers install the worker agent via `pip install deadline-cloud-worker-agent`, which resolves the `deadline` dependency from the version range in the worker agent's `pyproject.toml`. As long as the version pin is correct, pip will pull compatible versions automatically.
 
 ### For external consumers importing from `deadline.common.path_utils`
 


### PR DESCRIPTION

### What was the problem/requirement? (What/Why)
Docs update, migration guide for worker agent
### What was the solution? (How)

### What is the impact of this change?

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests?
- Have you run the integration tests?
- Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended
  that you ensure that the docker-based unit tests pass.

### Was this change documented?

- Are relevant docstrings in the code base updated?
- Has the README.md been updated? If you modified CLI arguments, for instance.

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [ ] This PR does not add any new dependencies.

### Is this a breaking change?

A breaking change is one that modifies a public contract in a way that is not backwards compatible. See the 
[Public Contracts](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#public-contracts) section
of the DEVELOPMENT.md for more information on the public contracts.

If so, then please describe the changes that users of this package must make to update their scripts, or Python applications.

### Does this change impact security?

- Does the change need to be threat modeled? For example, does it create or modify files/directories that must only be readable by the process owner?
    - If so, then please label this pull request with the "security" label. We'll work with you to analyze the threats.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
