### PR TITLE
chore: Update to support Python 3.14

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
     uses: aws-deadline/.github/.github/workflows/reusable_python_build.yml@mainline
     with:
       os: ${{ matrix.os }}

--- a/hatch.toml
+++ b/hatch.toml
@@ -13,7 +13,7 @@ fmt = ["ruff format {args:.}", "style"]
 lint = ["style", "typing"]
 
 [[envs.all.matrix]]
-python = ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+python = ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
 [envs.integ]
 pre-install-commands = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [{ name = "Amazon Web Services" }]
 dynamic = ["version"]
 readme = "README.md"
 license = "Apache-2.0"
-requires-python = ">=3.8, <3.14"
+requires-python = ">=3.8, <3.15"
 # https://pypi.org/classifiers/
 classifiers = [
   "Development Status :: 5 - Production/Stable",
@@ -21,6 +21,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Operating System :: POSIX :: Linux",
   "Operating System :: Microsoft :: Windows",
   "Operating System :: MacOS",
@@ -42,7 +43,7 @@ dependencies = [
   # Job Attachments
   "typing_extensions >= 4.8",
   "xxhash >= 3.4,< 3.7",
-  "pywin32 >= 307,< 311; sys_platform == 'win32'",
+  "pywin32 >= 307; sys_platform == 'win32'",
   "QtPy == 2.4.*",
   "psutil >= 7.0.0"
 ]

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,5 +1,4 @@
-coverage[toml] == 7.*; python_version > '3.7'
-coverage[toml] ~= 7.6; python_version == '3.7'
+coverage[toml] == 7.*
 coverage-conditional-plugin == 0.9.*
 pytest == 9.*; python_version > '3.9'
 pytest == 8.*; python_version <= '3.9'
@@ -9,10 +8,8 @@ pytest-timeout == 2.*
 pytest-xdist == 3.*
 freezegun == 1.*
 types-pyyaml == 6.*
-twine == 4.*; python_version == '3.7'
-twine == 6.*; python_version > '3.7'
-mypy == 1.13.*; python_version == '3.7'
-mypy == 1.*; python_version > '3.7'
+twine == 6.*
+mypy == 1.*
 ruff == 0.15.*
 moto == 5.*
 jsondiff == 2.*


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Can't install deadline-cloud on Python 3.14.

### What was the solution? (How)

- Allow 3.14 installation, add it to the test matrix and classifier
- Remove upper bound on pywin32. See reasoning in https://github.com/OpenJobDescription/openjd-adaptor-runtime-for-python/pull/162#discussion_r1862680554

### What is the impact of this change?

Can install in more environments.

### How was this change tested?

Added Python 3.14 to the test matrix.

### Was this change documented?

Added Python 3.14 to the classifier.

### Does this PR introduce new dependencies?

No

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
