### PR TITLE
test: fix test collection for python3.14 + windows 

### DIFF
--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -12,6 +12,12 @@ from pathlib import Path
 from deadline.client.config import config_file
 
 
+def pytest_xdist_auto_num_workers(config):
+    # Disable xdist on Windows + Python 3.14+ due to module import race conditions in workers
+    if sys.platform == "win32" and sys.version_info >= (3, 14):
+        return 1
+
+
 @pytest.fixture(scope="function")
 def fresh_deadline_config(monkeypatch):
     """

--- a/test/unit/deadline_client/ui/widgets/test_deadline_list_combo_boxes.py
+++ b/test/unit/deadline_client/ui/widgets/test_deadline_list_combo_boxes.py
@@ -8,16 +8,15 @@ import pytest
 from unittest.mock import patch
 from configparser import ConfigParser
 
-try:
-    from deadline.client.ui.widgets._deadline_list_combo_boxes import (
-        DeadlineFarmListComboBoxController,
-        DeadlineQueueListComboBoxController,
-        DeadlineStorageProfileListComboBoxController,
-    )
-    from deadline.client.ui.controllers._deadline_controller import DeadlineUIController
-    from deadline.client.ui.controllers._thread_pool import DeadlineThreadPool
-except ImportError:
-    pytest.importorskip("deadline.client.ui.widgets._deadline_list_combo_boxes")
+pytest.importorskip("deadline.client.ui.widgets._deadline_list_combo_boxes")
+
+from deadline.client.ui.widgets._deadline_list_combo_boxes import (  # noqa: E402
+    DeadlineFarmListComboBoxController,
+    DeadlineQueueListComboBoxController,
+    DeadlineStorageProfileListComboBoxController,
+)
+from deadline.client.ui.controllers._deadline_controller import DeadlineUIController  # noqa: E402
+from deadline.client.ui.controllers._thread_pool import DeadlineThreadPool  # noqa: E402
 
 
 class TestDeadlineFarmListComboBoxController:

--- a/test/unit/deadline_mcp/test_mcp.py
+++ b/test/unit/deadline_mcp/test_mcp.py
@@ -5,23 +5,20 @@
 
 """Unit tests for MCP server"""
 
-import sys
 from unittest.mock import MagicMock
 
 import pytest
 
-from deadline.client import api
+pytest.importorskip("mcp", reason="MCP dependencies not available")
 
-if sys.version_info >= (3, 10):
-    from deadline._mcp.registry import TOOL_REGISTRY, ToolDefinition
-    from deadline._mcp.utils import (
-        _create_wrapper,
-        _default_error_handler,
-        _default_serializer,
-        register_api_tools,
-    )
-else:
-    pytest.skip("MCP dependencies not available on Python before 3.10", allow_module_level=True)
+from deadline.client import api
+from deadline._mcp.registry import TOOL_REGISTRY, ToolDefinition  # noqa: E402
+from deadline._mcp.utils import (  # noqa: E402
+    _create_wrapper,
+    _default_error_handler,
+    _default_serializer,
+    register_api_tools,
+)
 
 
 class TestToolRegistry:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Windows + Python 3.14 was failing about 50% of the time in test collection. Example errors:

```
_____________ ERROR collecting test/unit/deadline_mcp/test_mcp.py _____________
test\unit\deadline_mcp\test_mcp.py:14: in <module>
    pytest.importorskip("mcp", reason="MCP dependencies not available")
C:\Users\runneradmin\AppData\Local\hatch\env\virtual\deadline\xcl-65dJ\deadline\Lib\site-packages\mcp\__init__.py:1: in <module>
    from .client.session import ClientSession
<frozen importlib._bootstrap>:1371: in _find_and_load
    ???
<frozen importlib._bootstrap>:1342: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:949: in _load_unlocked
    ???
E   KeyError: 'mcp.client.session'
```

```
_____________ ERROR collecting test/unit/deadline_job_attachments _____________
C:\hostedtoolcache\windows\Python\3.14.3\x64\Lib\importlib\__init__.py:88: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
<frozen importlib._bootstrap>:1398: in _gcd_import
    ???
<frozen importlib._bootstrap>:1371: in _find_and_load
    ???
<frozen importlib._bootstrap>:1342: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:938: in _load_unlocked
    ???
C:\Users\runneradmin\AppData\Local\hatch\env\virtual\deadline\xcl-65dJ\deadline\Lib\site-packages\_pytest\assertion\rewrite.py:197: in exec_module
    exec(co, module.__dict__)
test\unit\deadline_job_attachments\conftest.py:22: in <module>
    from deadline.job_attachments.asset_sync import AssetSync  # noqa: E402 isort:skip
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
<frozen importlib._bootstrap>:1371: in _find_and_load
    ???
<frozen importlib._bootstrap>:1342: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:949: in _load_unlocked
    ???
E   KeyError: 'deadline.job_attachments.asset_sync'
```

https://github.com/aws-deadline/deadline-cloud/actions/runs/23569230987/job/68627906030?pr=1076
```
_ ERROR collecting test/unit/deadline_client/ui/widgets/test_deadline_list_combo_boxes.py _
C:\hostedtoolcache\windows\Python\3.14.3\x64\Lib\importlib\__init__.py:88: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
<frozen importlib._bootstrap>:1398: in _gcd_import
    ???
<frozen importlib._bootstrap>:1371: in _find_and_load
    ???
<frozen importlib._bootstrap>:1342: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:949: in _load_unlocked
    ???
E   KeyError: 'test_deadline_list_combo_boxes'
_____________ ERROR collecting test/unit/deadline_mcp/test_mcp.py _____________
test\unit\deadline_mcp\test_mcp.py:16: in <module>
    from deadline._mcp.registry import TOOL_REGISTRY, ToolDefinition
<frozen importlib._bootstrap>:1371: in _find_and_load
    ???
<frozen importlib._bootstrap>:1342: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:949: in _load_unlocked
    ???
E   KeyError: 'deadline._mcp.registry'

```

### What was the solution? (How)

Turn off xdist for python3.14 on windows for now so that it consistently runs and passes. There appears to be a race condition on loading modules.

### What is the impact of this change?

Working test for python 3.14 and windows 

### How was this change tested?

The github checks pass!

I ran it 5 times in a row to ensure I didn't get lucky: https://github.com/aws-deadline/deadline-cloud/actions/runs/23607559914/job/68766341324

### Was this change documented?

N/A

### Does this PR introduce new dependencies?

N/A

### Is this a breaking change?

N/A

### Does this change impact security?

N/A
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
