### PR TITLE
chore: make default cache path cross os

### DIFF
--- a/src/deadline/job_attachments/caches/cache_db.py
+++ b/src/deadline/job_attachments/caches/cache_db.py
@@ -158,10 +158,10 @@ class CacheDB(ABC):
         Gets the expected directory for the cache database file based on OS environment variables.
         If a directory cannot be found, defaults to the working directory.
         """
-        default_path = os.environ.get("HOME")
-        if default_path:
-            default_path = os.path.join(default_path, CONFIG_ROOT, COMPONENT_NAME)
-        return default_path
+        default_path = os.path.expanduser("~")
+        if default_path and default_path != "~":
+            return os.path.join(default_path, CONFIG_ROOT, COMPONENT_NAME)
+        return None
 
     def remove_cache(self) -> None:
         """

--- a/test/unit/deadline_job_attachments/caches/test_caches.py
+++ b/test/unit/deadline_job_attachments/caches/test_caches.py
@@ -30,20 +30,19 @@ class TestCacheDB:
         """
         Tests that when an environment variable exists, it uses that path for the hash cache
         """
-        expected_path = tmpdir.join(".deadline").join("job_attachments")
-        with patch("os.environ.get", side_effect=[tmpdir]):
+        expected_path = os.path.join(str(tmpdir), ".deadline", "job_attachments")
+        with patch(
+            "deadline.job_attachments.caches.cache_db.os.path.expanduser", return_value=str(tmpdir)
+        ):
             assert CacheDB.get_default_cache_db_file_dir() == expected_path
 
     def test_init_empty_path_no_default_throws_error(self):
         """
-        Tests that when no cache file path is given, the default is used.
+        Tests that when no cache file path is given and home dir cannot be resolved, an error is raised.
         """
-        os.environ.pop("APPDATA", None)
-        os.environ.pop("HOME", None)
-        os.environ.pop("XDG_CONFIG_HOME", None)
-
-        with pytest.raises(JobAttachmentsError):
-            CacheDB("name", "table", "query")
+        with patch("deadline.job_attachments.caches.cache_db.os.path.expanduser", return_value="~"):
+            with pytest.raises(JobAttachmentsError):
+                CacheDB("name", "table", "query")
 
     def test_enter_bad_cache_path_throws_error(self, tmpdir):
         """


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
`CacheDB.get_default_cache_db_file_dir()` uses `os.environ.get("HOME")` to resolve the user's home directory. On Windows, the `HOME` environment variable is typically not set — Windows uses `USERPROFILE` instead. This causes the method to return `None`, which raises a `JobAttachmentsError("No default cache path found...")` when constructing `HashCache` or `S3CheckCache` without an explicit `cache_dir`.

This was observed in Windows integration tests (`test_manifest_upload`, `test_manifest_upload_by_farm_queue`) failing with:
```
deadline.job_attachments.exceptions.JobAttachmentsError: No default cache path found. Please provide a directory for hash_cache.
```

### What was the solution? (How)
Replaced `os.environ.get("HOME")` with `os.path.expanduser("~")` in `get_default_cache_db_file_dir()`. `os.path.expanduser("~")` is cross-platform — it checks `USERPROFILE` on Windows and `HOME` on Unix — and is already used throughout the rest of the codebase for home directory resolution.

### What is the impact of this change?
Fixes cache initialization on Windows when `HOME` is not set. No behavior change on Linux/macOS where `HOME` is always available.

### How was this change tested?
- Have you run the unit tests?
```
============================= slowest 5 durations ==============================
2.78s call     test/unit/deadline_job_attachments/caches/test_caches.py::TestCacheDB::test_get_local_connection_handles_sqlite_error
2.18s call     test/unit/deadline_client/api/test_api_session.py::test_precache_clients_warms_asset_uploader_client
2.13s call     test/unit/deadline_job_attachments/caches/test_caches.py::TestCacheDB::test_enter_fails_after_max_retries
2.13s call     test/unit/deadline_job_attachments/caches/test_caches.py::TestCacheDB::test_get_local_connection_retries_on_operational_error
1.96s call     test/unit/deadline_job_attachments/caches/test_caches.py::TestS3CheckCache::test_large_db_concurrent_operations_expose_timeout_issues
============================= 61 passed in 25.48s ==============================
```


### Was this change documented?
Yes

### Does this PR introduce new dependencies?

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?
No

### Does this change impact security?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
