### PR TITLE
chore: update typing in job_attachments _path_mapping to appease mypy 1.20.0

### DIFF
--- a/src/deadline/job_attachments/_path_mapping.py
+++ b/src/deadline/job_attachments/_path_mapping.py
@@ -148,7 +148,7 @@ class _PathMappingRuleApplier:
         parts = self._split_source_path(path)
 
         matched_destination_path = None
-        matched_remaining_parts = None
+        matched_remaining_parts: tuple[str, ...] = ()
 
         # Traverse the trie using trie_entry
         trie_entry: dict = self._path_mapping_trie


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

mypy 1.20.0 released 4 hours ago (as of writing), and is flagging one error in job_attachments

```
cmd [3] | mypy src test --always-false=PYQT5 --always-false=PYSIDE2 --always-false=PYQT6 --always-true=PYSIDE6 --exclude=PySide6
src/deadline/job_attachments/_path_mapping.py:171: error: Expected iterable as variadic argument  [misc]
                return matched_destination_path.joinpath(*matched_remaining_parts)
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Found 1 error in 1 file (checked 310 source files)
```

### What was the solution? (How)

`matched_remaining_parts` is always a tuple of strings after it's been set, so we set the typing appropriately

### What is the impact of this change?

linting passes

### How was this change tested?


```
hatch run lint
hatch run test
```

### Was this change documented?
N/A

### Does this PR introduce new dependencies?
N/A

### Is this a breaking change?
N/A

### Does this change impact security?
N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
