### PR TITLE
chore: Use bundled certificate by default for checking manifest version + UX fixes for update available dialog

### DIFF
--- a/src/deadline/client/api/_update_checker.py
+++ b/src/deadline/client/api/_update_checker.py
@@ -113,11 +113,10 @@ def _is_update_notification_enabled() -> bool:
 def _fetch_manifest() -> Dict[str, Any]:
     """Fetch and parse the remote manifest JSON.
 
-    On macOS, bundled Python environments (e.g. inside Cinema 4D) often
-    cannot locate the system CA certificate store.  When the default SSL
-    context fails, this function retries using botocore's bundled CA
-    certificate bundle (which includes Amazon Root CA 1) so that the
-    connection is still fully verified.
+    Uses botocore's bundled CA certificate bundle (which includes Amazon
+    Root CA 1) so that the connection succeeds even in bundled Python
+    environments (e.g. inside Cinema 4D or Blender) that cannot locate
+    the system CA certificate store.
 
     Raises:
         urllib.error.URLError: On network errors.
@@ -127,16 +126,6 @@ def _fetch_manifest() -> Dict[str, Any]:
         UnicodeDecodeError: On encoding errors.
     """
     req = urllib.request.Request(MANIFEST_URL)
-
-    try:
-        with urllib.request.urlopen(req, timeout=MANIFEST_TIMEOUT_SECONDS) as resp:
-            return json.loads(resp.read().decode("utf-8"))
-    except urllib.error.URLError:
-        if sys.platform != "darwin":
-            raise
-
-    # macOS fallback: retry with botocore's bundled CA certificate bundle.
-    logger.debug("Default SSL verification failed on macOS, retrying with botocore CA bundle")
     ctx = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
     ctx.minimum_version = ssl.TLSVersion.TLSv1_2
     ctx.load_verify_locations(_get_botocore_ca_bundle())

--- a/src/deadline/client/ui/dialogs/update_available_dialog.py
+++ b/src/deadline/client/ui/dialogs/update_available_dialog.py
@@ -12,10 +12,11 @@ from typing import Optional
 
 from qtpy.QtWidgets import (  # pylint: disable=import-error; type: ignore
     QDialog,
-    QDialogButtonBox,
+    QHBoxLayout,
     QLabel,
     QMessageBox,
     QPushButton,
+    QSizePolicy,
     QVBoxLayout,
     QWidget,
 )
@@ -79,7 +80,7 @@ class UpdateAvailableDialog(QDialog):
         self.user_downloaded = False
 
         self.setWindowTitle(tr("New version available"))
-        self.setMinimumWidth(400)
+        self.setMinimumWidth(450)
 
         self._build_ui()
 
@@ -131,30 +132,34 @@ class UpdateAvailableDialog(QDialog):
         # Add spacing before buttons
         layout.addSpacing(12)
 
-        # Button box - consistent with other dialogs
-        self.button_box = QDialogButtonBox(Qt.Horizontal)
-
+        # Manual button layout for consistent ordering across platforms
         _button_base = "border: 1px solid #888; border-radius: 6px; padding: 3px 12px;"
-
-        self.dismiss_button = self.button_box.addButton(QDialogButtonBox.Close)
-        self.dismiss_button.setText(tr("Dismiss"))
-        self.dismiss_button.setStyleSheet(f"QPushButton {{ {_button_base} }}")
 
         self.dont_remind_button = QPushButton(tr("Don't remind me again"))
         self.dont_remind_button.setStyleSheet(f"QPushButton {{ {_button_base} }}")
-        self.button_box.addButton(self.dont_remind_button, QDialogButtonBox.DestructiveRole)
+        self.dont_remind_button.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
         self.dont_remind_button.clicked.connect(self._on_dont_remind_clicked)
+
+        self.dismiss_button = QPushButton(tr("Dismiss"))
+        self.dismiss_button.setStyleSheet(f"QPushButton {{ {_button_base} }}")
+        self.dismiss_button.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+        self.dismiss_button.clicked.connect(self.accept)
 
         self.download_button = QPushButton(tr("Download installer"))
         self.download_button.setStyleSheet(
             f"QPushButton {{ {_button_base} background-color: {_COLOR_ACCENT}; color: white; }}"
         )
-        self.button_box.addButton(self.download_button, QDialogButtonBox.AcceptRole)
+        self.download_button.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
         self.download_button.clicked.connect(self._on_download_clicked)
 
-        self.button_box.rejected.connect(self.accept)
+        button_layout = QHBoxLayout()
+        button_layout.setSpacing(8)
+        button_layout.addWidget(self.dont_remind_button)
+        button_layout.addStretch(1)
+        button_layout.addWidget(self.dismiss_button)
+        button_layout.addWidget(self.download_button)
 
-        layout.addWidget(self.button_box)
+        layout.addLayout(button_layout)
         self.setLayout(layout)
 
     def _on_download_clicked(self) -> None:

--- a/test/unit/deadline_client/api/test_update_checker.py
+++ b/test/unit/deadline_client/api/test_update_checker.py
@@ -100,76 +100,41 @@ PLATFORM_INSTALLER_URLS = {
 class TestFetchManifest:
     """Tests for _fetch_manifest() SSL context behavior."""
 
+    @patch(
+        "deadline.client.api._update_checker._get_botocore_ca_bundle",
+        return_value="/fake/cacert.pem",
+    )
+    @patch("deadline.client.api._update_checker.ssl.create_default_context")
     @patch("deadline.client.api._update_checker.urllib.request.urlopen")
-    def test_success_default_ssl(self, mock_urlopen_fn):
-        """When default SSL works, no fallback is needed."""
+    def test_success_with_bundled_ca(self, mock_urlopen_fn, mock_ssl_ctx, mock_ca_bundle):
+        """Always uses botocore's bundled CA bundle for SSL verification."""
         mock_urlopen_fn.return_value = _mock_urlopen(SAMPLE_MANIFEST)
 
         result = _fetch_manifest()
 
         assert result == SAMPLE_MANIFEST
         assert mock_urlopen_fn.call_count == 1
-
-    @patch(
-        "deadline.client.api._update_checker._get_botocore_ca_bundle",
-        return_value="/fake/cacert.pem",
-    )
-    @patch("deadline.client.api._update_checker.ssl.create_default_context")
-    @patch("deadline.client.api._update_checker.urllib.request.urlopen")
-    @patch("deadline.client.api._update_checker.sys")
-    def test_macos_falls_back_to_bundled_ca(
-        self, mock_sys, mock_urlopen_fn, mock_ssl_ctx, mock_ca_bundle
-    ):
-        """On macOS, when default SSL fails, retries with botocore's CA bundle."""
-        mock_sys.platform = "darwin"
-        # First call fails with SSL error, second succeeds with botocore CA bundle
-        mock_urlopen_fn.side_effect = [
-            urllib.error.URLError("SSL: CERTIFICATE_VERIFY_FAILED"),
-            _mock_urlopen(SAMPLE_MANIFEST),
-        ]
-
-        result = _fetch_manifest()
-
-        assert result == SAMPLE_MANIFEST
-        assert mock_urlopen_fn.call_count == 2
-        # Second call should have an explicit SSL context
-        second_call_kwargs = mock_urlopen_fn.call_args_list[1]
-        ctx = second_call_kwargs.kwargs.get("context") or second_call_kwargs[1].get("context")
+        # Should always use an explicit SSL context with botocore CA bundle
+        call_kwargs = mock_urlopen_fn.call_args
+        ctx = call_kwargs.kwargs.get("context") or call_kwargs[1].get("context")
         assert ctx is not None
-        # Verify botocore CA bundle was used
         mock_ca_bundle.assert_called_once()
         mock_ssl_ctx.return_value.load_verify_locations.assert_called_once_with("/fake/cacert.pem")
 
-    @patch("deadline.client.api._update_checker.urllib.request.urlopen")
-    @patch("deadline.client.api._update_checker.sys")
-    def test_non_macos_does_not_fallback(self, mock_sys, mock_urlopen_fn):
-        """On non-macOS, SSL errors are raised without fallback."""
-        mock_sys.platform = "linux"
-        mock_urlopen_fn.side_effect = urllib.error.URLError("SSL: CERTIFICATE_VERIFY_FAILED")
-
-        with pytest.raises(urllib.error.URLError):
-            _fetch_manifest()
-
-        assert mock_urlopen_fn.call_count == 1
-
     @patch(
         "deadline.client.api._update_checker._get_botocore_ca_bundle",
         return_value="/fake/cacert.pem",
     )
     @patch("deadline.client.api._update_checker.ssl.create_default_context")
     @patch("deadline.client.api._update_checker.urllib.request.urlopen")
-    @patch("deadline.client.api._update_checker.sys")
-    def test_macos_fallback_also_fails(
-        self, mock_sys, mock_urlopen_fn, mock_ssl_ctx, mock_ca_bundle
-    ):
-        """On macOS, if both attempts fail, the error propagates."""
-        mock_sys.platform = "darwin"
+    def test_ssl_error_propagates(self, mock_urlopen_fn, mock_ssl_ctx, mock_ca_bundle):
+        """If the request fails, the error propagates."""
         mock_urlopen_fn.side_effect = urllib.error.URLError("SSL error")
 
         with pytest.raises(urllib.error.URLError):
             _fetch_manifest()
 
-        assert mock_urlopen_fn.call_count == 2
+        assert mock_urlopen_fn.call_count == 1
 
 
 class TestCheckForUpdates:


### PR DESCRIPTION
### What was the problem/requirement and solution? (What/Why)

There were 2 minor issues that I wanted to fix from the previous change:
1. We were only going for fallback if the OS was Mac. But instead we could just make it consistent so that we always use the bundled certificate to keep the failure modes low. 
2. The UX was a little janky in Windows so made them fixed everywhere. 

### What is the impact of this change?

Lower failure modes and consistent UX in all OSes. 

### How was this change tested?

Ran the tests manually. 

#### Before

Mac:

<img width="952" height="394" alt="image" src="https://github.com/user-attachments/assets/1c7134e0-09db-4e15-a107-d6a283cb204d" />

Windows:

<img width="408" height="203" alt="image" src="https://github.com/user-attachments/assets/83e99ea8-a572-46e1-b6af-71ae40c8d8bc" />


#### After 

Mac:

<img width="459" height="201" alt="image" src="https://github.com/user-attachments/assets/a90c398b-7898-4d24-b0fa-56018c242b4b" />


Windows:

<img width="462" height="202" alt="image" src="https://github.com/user-attachments/assets/30f8239d-5177-4fe9-b246-46b67e5b57fc" />



### Was this change documented?

This change does not require documentation. 

### Does this PR introduce new dependencies?

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [X] This PR does not add any new dependencies.

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
