### PR TITLE
fix: pin mypy to 1.x and fix type error in _path_mapping.py

### DIFF
--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -9,7 +9,8 @@ pytest-xdist == 3.*
 freezegun == 1.*
 types-pyyaml == 6.*
 twine == 6.*
-mypy == 1.*
+mypy == 1.13.*; python_version <= '3.8'
+mypy == 1.*; python_version > '3.8'
 ruff == 0.15.*
 import-linter == 2.*
 moto == 5.*

--- a/src/deadline/job_attachments/_path_mapping.py
+++ b/src/deadline/job_attachments/_path_mapping.py
@@ -162,7 +162,7 @@ class _PathMappingRuleApplier:
             destination_path = next_trie_entry.get(".")
             if destination_path:
                 matched_destination_path = destination_path
-                matched_remaining_parts = parts[i + 1 :]
+                matched_remaining_parts = tuple(parts[i + 1 :])
             trie_entry = next_trie_entry
 
         if matched_destination_path is None:


### PR DESCRIPTION

### What was the problem/requirement? (What/Why)
Ran into a mypy issue in the publish step of deadline [cloud release workflow](https://github.com/aws-deadline/deadline-cloud/actions/runs/23623378266/job/69769790558)


### What was the solution? (How)
- Pin mypy to 1.* 
- Fix mypy 'Expected iterable as variadic argument' error by explicitly casting tuple slice to tuple for joinpath() unpacking

### What is the impact of this change?
Unblocks the 0.55.0 release which failed at the PublishToCodeArtifact step due to mypy 1.20.0 introducing stricter type checking. No functional changes to runtime behavior.

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- [x] Have you run the unit tests?
- [ ] Have you run the integration tests?
- [ ] Have you made changes to the `download` or `asset_sync` modules? If so, then it is highly recommended that you ensure that the docker-based unit tests pass.

N/A - This is a type annotation fix only. No runtime behavior changes.

### Was this change documented?

- [ ] Are relevant docstrings in the code base updated?
- [ ] Has the README.md been updated? If you modified CLI arguments, for instance.

N/A - No documentation changes needed.

### Does this PR introduce new dependencies?

- [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
- [x] This PR does not add any new dependencies.

### Is this a breaking change?

No. This change only pins a dev dependency version and fixes a type annotation. No public contracts are modified.

### Does this change impact security?

No. This is a development tooling fix with no runtime or security implications.


----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
