### PR TITLE
chore: remove pywin32 from expected missing license set

### DIFF
--- a/scripts/attributions/cli.py
+++ b/scripts/attributions/cli.py
@@ -248,7 +248,7 @@ _ADDITIONAL_ATTRIBUTIONS = [
 
 # Some packages specify their license but do not include it in the repository/package
 # We attribute these manually using _ADDITIONAL_ATTRIBUTIONS
-_EXPECTED_MISSING_LICENSE = {"pywin32"}
+_EXPECTED_MISSING_LICENSE: set[str] = set()
 
 # Mapping from import/module names used in the PyInstaller allowlist's DEPENDENCIES
 # to the package names used in attributions. Only needed when they differ.


### PR DESCRIPTION
### Summary

pip-licenses now correctly detects pywin32's license when packages are installed via uv. The `_EXPECTED_MISSING_LICENSE` set was originally added because older tooling couldn't find pywin32's license metadata. This is no longer the case.

### Changes

- Removed `pywin32` from `_EXPECTED_MISSING_LICENSE` in the attributions script

### Testing

This fixes the Windows installer build failure where the attributions generation was failing with:
```
RuntimeError: Expected pip-licenses to not find a license for pywin32 but one was found.
```