### PR TITLE
fix: External tools corrupting known paths configuration

### DIFF
--- a/src/deadline/client/config/config_file.py
+++ b/src/deadline/client/config/config_file.py
@@ -61,6 +61,7 @@ __config_mtime = None
 SETTINGS: Dict[str, Dict[str, Any]] = {
     "deadline-cloud-monitor.path": {
         "default": "",
+        "is_path": True,
         "description": "The filesystem path to Deadline Cloud monitor, set during login process.",
     },
     "defaults.aws_profile_name": {
@@ -72,6 +73,7 @@ SETTINGS: Dict[str, Dict[str, Any]] = {
     "settings.job_history_dir": {
         "default": DEFAULT_JOB_HISTORY_DIR,
         "depend": "defaults.aws_profile_name",
+        "is_path": True,
         "description": "The directory in which to place the job submission history for this AWS profile name.",
     },
     "defaults.farm_id": {
@@ -139,6 +141,7 @@ SETTINGS: Dict[str, Dict[str, Any]] = {
     },
     "settings.known_asset_paths": {
         "default": "",  # OS-specific path separator delimited list
+        "is_path_list": True,
         "description": "A list of paths that should not generate warnings when outside storage profile locations, separated by the OS path list separator (semicolon on Windows, colon on Linux/macOS).",
     },
     "settings.locale": {
@@ -391,9 +394,45 @@ def get_setting(setting_name: str, config: Optional[ConfigParser] = None) -> str
     result: Optional[str] = config.get(section, name, fallback=None)
 
     if result is None:
-        return _get_default_from_setting_config(setting_config, config=config)
-    else:
-        return result
+        result = _get_default_from_setting_config(setting_config, config=config)
+
+    # Convert stored forward-slash paths back to native OS format.
+    # This also normalizes defaults (e.g. job_history_dir) which use
+    # os.path.join and produce backslashes on Windows.
+    if setting_config.get("is_path") and result:
+        result = _normalize_path_from_config(result)
+    elif setting_config.get("is_path_list") and result:
+        result = os.pathsep.join(
+            _normalize_path_from_config(p) for p in result.split(os.pathsep) if p
+        )
+
+    return result
+
+
+def _normalize_path_for_config(path_value: str) -> str:
+    """
+    Normalizes a filesystem path for storage in the config file by replacing
+    backslashes with forward slashes on Windows. This prevents corruption when
+    the config file is rewritten by tools (like Deadline Cloud Monitor) that may
+    interpret backslashes as escape characters in INI-style config values.
+
+    Forward slashes work correctly on all platforms including Windows.
+    Only performs replacement on Windows.
+    """
+    if os.name == "nt":
+        return path_value.replace("\\", "/")
+    return path_value
+
+
+def _normalize_path_from_config(path_value: str) -> str:
+    """
+    Converts a path read from the config file to the native OS format.
+    Paths are stored with forward slashes to prevent corruption, but consumers
+    on Windows expect native backslash paths.
+    """
+    if os.name == "nt":
+        return path_value.replace("/", "\\")
+    return path_value
 
 
 def set_setting(setting_name: str, value: str, config: Optional[ConfigParser] = None):
@@ -412,6 +451,13 @@ def set_setting(setting_name: str, value: str, config: Optional[ConfigParser] = 
 
     # Get the type of the default to validate it is an AWS Deadline Cloud setting, and retrieve its type
     setting_config = _get_setting_config(setting_name)
+
+    # Normalize path values to use forward slashes, preventing corruption when
+    # the config file is rewritten by tools that interpret backslashes as escapes.
+    if setting_config.get("is_path") and value:
+        value = _normalize_path_for_config(value)
+    elif setting_config.get("is_path_list") and value:
+        value = os.pathsep.join(_normalize_path_for_config(p) for p in value.split(os.pathsep) if p)
 
     # If no config was provided, then read from disk and signal to write it later
     if not config:

--- a/test/unit/deadline_client/cli/test_cli_auth.py
+++ b/test/unit/deadline_client/cli/test_cli_auth.py
@@ -21,14 +21,18 @@ def test_cli_deadline_cloud_monitor_login_and_logout(fresh_deadline_config):
     """
     Confirm that the CLI login/logout command invokes Deadline Cloud monitor as expected
     """
+    if sys.platform.startswith("win"):
+        dcm = "C:/Programs/bin/DeadlineCloudMonitor"
+    else:
+        dcm = "/bin/DeadlineCloudMonitor"
     scoped_config = {
-        "credential_process": "/bin/DeadlineCloudMonitor get-credentials --profile sandbox-us-west-2",
+        "credential_process": f"{dcm} get-credentials --profile sandbox-us-west-2",
         "monitor_id": "monitor-1g9neezauta8ease",
         "region": "us-west-2",
     }
 
     profile_name = "sandbox-us-west-2"
-    config.set_setting("deadline-cloud-monitor.path", "/bin/DeadlineCloudMonitor")
+    config.set_setting("deadline-cloud-monitor.path", dcm)
     config.set_setting("defaults.aws_profile_name", profile_name)
 
     with patch.object(api._session, "get_boto3_session") as session_mock, patch.object(
@@ -54,7 +58,12 @@ def test_cli_deadline_cloud_monitor_login_and_logout(fresh_deadline_config):
 
         if sys.platform.startswith("win"):
             popen_mock.assert_called_once_with(
-                ["/bin/DeadlineCloudMonitor", "login", "--profile", "sandbox-us-west-2"],
+                [
+                    "C:\\Programs\\bin\\DeadlineCloudMonitor",
+                    "login",
+                    "--profile",
+                    "sandbox-us-west-2",
+                ],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.DEVNULL,
                 stdin=subprocess.PIPE,
@@ -79,9 +88,19 @@ def test_cli_deadline_cloud_monitor_login_and_logout(fresh_deadline_config):
         runner = CliRunner()
         result = runner.invoke(main, ["auth", "logout"])
 
-        check_output_mock.assert_called_once_with(
-            ["/bin/DeadlineCloudMonitor", "logout", "--profile", "sandbox-us-west-2"]
-        )
+        if sys.platform.startswith("win"):
+            check_output_mock.assert_called_once_with(
+                [
+                    "C:\\Programs\\bin\\DeadlineCloudMonitor",
+                    "logout",
+                    "--profile",
+                    "sandbox-us-west-2",
+                ]
+            )
+        else:
+            check_output_mock.assert_called_once_with(
+                ["/bin/DeadlineCloudMonitor", "logout", "--profile", "sandbox-us-west-2"]
+            )
 
         assert "Successfully logged out" in result.output
         mock_profile_session_cache_clear.assert_called()

--- a/test/unit/deadline_client/cli/test_cli_bundle_submit_known_paths.py
+++ b/test/unit/deadline_client/cli/test_cli_bundle_submit_known_paths.py
@@ -59,6 +59,8 @@ def test_cli_bundle_known_paths_combine(fresh_deadline_config, temp_job_bundle_d
     config.set_setting("settings.auto_accept", "true")
 
     # Set known paths in config using OS-specific path separator
+    # Note: on Windows, backslashes are normalized to forward slashes in the config file,
+    # but get_setting converts them back to native format on read.
     config_path1 = "/path/from/config/1" if os.name != "nt" else "C:\\path\\from\\config\\1"
     config_path2 = "/path/from/config/2" if os.name != "nt" else "C:\\path\\from\\config\\2"
     config.set_setting("settings.known_asset_paths", os.pathsep.join([config_path1, config_path2]))

--- a/test/unit/deadline_client/cli/test_cli_config.py
+++ b/test/unit/deadline_client/cli/test_cli_config.py
@@ -6,6 +6,7 @@ Tests for the CLI config command.
 
 import json
 import logging
+import os
 
 import pytest
 from click.testing import CliRunner
@@ -113,7 +114,11 @@ def test_cli_config_show_modified_config(fresh_deadline_config):
 
     # We should see all the overridden values in the output
     assert "EnvVarOverrideProfile" in result.output
-    assert "~/alternate/job_history" in result.output
+    # Path settings are stored with forward slashes but displayed in native format
+    if os.name == "nt":
+        assert "~\\alternate\\job_history" in result.output
+    else:
+        assert "~/alternate/job_history" in result.output
     assert result.output.count("False") == 1
     assert result.output.count("True") == 1
     # "true" appears three times: once as the value for force_s3_check,
@@ -125,7 +130,10 @@ def test_cli_config_show_modified_config(fresh_deadline_config):
     assert "CREATE_COPY" in result.output
     assert "DEBUG" in result.output
     assert "user-id-123abc-456def" in result.output
-    assert "/known/asset/path" in result.output
+    if os.name == "nt":
+        assert "\\known\\asset\\path" in result.output
+    else:
+        assert "/known/asset/path" in result.output
     # It shouldn't say anywhere that there is a default setting
     assert "(default)" not in result.output
 

--- a/test/unit/deadline_client/config/test_config_path_normalization.py
+++ b/test/unit/deadline_client/config/test_config_path_normalization.py
@@ -1,0 +1,190 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Tests that path settings in the config file are normalized to use forward slashes
+on disk (Windows only), preventing corruption when the config file is rewritten by
+external tools (like Deadline Cloud Monitor) that may interpret backslashes as escape
+characters.
+
+On read, paths are converted back to native OS format (backslashes on Windows).
+"""
+
+import os
+from configparser import ConfigParser
+
+import pytest
+
+from deadline.client import config
+from deadline.client.config.config_file import (
+    _normalize_path_for_config,
+    _normalize_path_from_config,
+)
+
+
+class TestNormalizePathForConfig:
+    """Tests for the _normalize_path_for_config helper (write direction)."""
+
+    def test_forward_slashes_unchanged(self):
+        assert _normalize_path_for_config("/usr/local/bin/monitor") == "/usr/local/bin/monitor"
+
+    @pytest.mark.skipif(os.name != "nt", reason="Backslash normalization only applies on Windows")
+    def test_backslashes_converted_on_windows(self):
+        assert _normalize_path_for_config("C:\\Users\\artist\\assets") == "C:/Users/artist/assets"
+
+    @pytest.mark.skipif(os.name != "nt", reason="Backslash normalization only applies on Windows")
+    def test_mixed_slashes_normalized_on_windows(self):
+        assert (
+            _normalize_path_for_config("C:\\Users/artist\\projects") == "C:/Users/artist/projects"
+        )
+
+    @pytest.mark.skipif(os.name == "nt", reason="Backslashes are path separators on Windows")
+    def test_backslashes_unchanged_on_posix(self):
+        """On POSIX, backslashes are valid filename characters and should not be modified."""
+        assert _normalize_path_for_config("path\\with\\backslashes") == "path\\with\\backslashes"
+
+    def test_empty_string(self):
+        assert _normalize_path_for_config("") == ""
+
+    @pytest.mark.skipif(os.name != "nt", reason="UNC paths only apply on Windows")
+    def test_unc_path(self):
+        assert _normalize_path_for_config("\\\\server\\share\\folder") == "//server/share/folder"
+
+
+class TestNormalizePathFromConfig:
+    """Tests for the _normalize_path_from_config helper (read direction)."""
+
+    @pytest.mark.skipif(os.name != "nt", reason="Only converts on Windows")
+    def test_forward_slashes_become_backslashes_on_windows(self):
+        assert _normalize_path_from_config("C:/Users/artist/assets") == "C:\\Users\\artist\\assets"
+
+    @pytest.mark.skipif(os.name == "nt", reason="No conversion on POSIX")
+    def test_forward_slashes_unchanged_on_posix(self):
+        assert _normalize_path_from_config("/mnt/shared/assets") == "/mnt/shared/assets"
+
+    def test_empty_string(self):
+        assert _normalize_path_from_config("") == ""
+
+
+class TestSetSettingPathNormalization:
+    """Tests that set_setting stores forward slashes and get_setting returns native paths."""
+
+    @pytest.mark.skipif(os.name != "nt", reason="Backslash normalization only applies on Windows")
+    def test_monitor_path_roundtrip(self, fresh_deadline_config):
+        """Backslash monitor path should roundtrip to native format on Windows."""
+        config.set_setting(
+            "deadline-cloud-monitor.path",
+            "C:\\Program Files\\DeadlineCloudMonitor\\monitor.exe",
+        )
+        assert (
+            config.get_setting("deadline-cloud-monitor.path")
+            == "C:\\Program Files\\DeadlineCloudMonitor\\monitor.exe"
+        )
+
+    @pytest.mark.skipif(os.name != "nt", reason="Backslash normalization only applies on Windows")
+    def test_job_history_dir_roundtrip(self, fresh_deadline_config):
+        """Backslash job_history_dir should roundtrip to native format on Windows."""
+        config.set_setting("settings.job_history_dir", "C:\\Users\\artist\\.deadline\\job_history")
+        assert (
+            config.get_setting("settings.job_history_dir")
+            == "C:\\Users\\artist\\.deadline\\job_history"
+        )
+
+    @pytest.mark.skipif(os.name != "nt", reason="Backslash normalization only applies on Windows")
+    def test_known_asset_paths_roundtrip(self, fresh_deadline_config):
+        """Backslash known_asset_paths should roundtrip to native format on Windows."""
+        paths = ";".join(["C:\\Users\\artist\\assets", "D:\\shared\\textures"])
+        config.set_setting("settings.known_asset_paths", paths)
+        result = config.get_setting("settings.known_asset_paths")
+        assert result.split(";") == ["C:\\Users\\artist\\assets", "D:\\shared\\textures"]
+
+    def test_known_asset_paths_forward_slashes_roundtrip(self, fresh_deadline_config):
+        """Forward-slash paths should roundtrip to native format."""
+        paths = os.pathsep.join(["/mnt/shared/assets", "/mnt/shared/textures"])
+        config.set_setting("settings.known_asset_paths", paths)
+        result = config.get_setting("settings.known_asset_paths")
+        result_paths = result.split(os.pathsep)
+        if os.name == "nt":
+            assert result_paths == ["\\mnt\\shared\\assets", "\\mnt\\shared\\textures"]
+        else:
+            assert result_paths == ["/mnt/shared/assets", "/mnt/shared/textures"]
+
+    def test_known_asset_paths_empty(self, fresh_deadline_config):
+        """Empty known_asset_paths should remain empty."""
+        config.set_setting("settings.known_asset_paths", "")
+        assert config.get_setting("settings.known_asset_paths") == ""
+
+    def test_non_path_setting_not_modified(self, fresh_deadline_config):
+        """Non-path settings should not have slashes modified."""
+        config.set_setting("defaults.aws_profile_name", "my\\profile")
+        assert config.get_setting("defaults.aws_profile_name") == "my\\profile"
+
+    def test_monitor_path_with_forward_slashes_roundtrip(self, fresh_deadline_config):
+        """Forward-slash monitor paths should roundtrip to native format."""
+        config.set_setting("deadline-cloud-monitor.path", "/usr/local/bin/DeadlineCloudMonitor")
+        result = config.get_setting("deadline-cloud-monitor.path")
+        if os.name == "nt":
+            assert result == "\\usr\\local\\bin\\DeadlineCloudMonitor"
+        else:
+            assert result == "/usr/local/bin/DeadlineCloudMonitor"
+
+
+class TestConfigFileStoredAsForwardSlashes:
+    """
+    Verify that the on-disk config file always contains forward slashes,
+    which is the whole point of this fix — preventing corruption by external tools.
+    """
+
+    @pytest.mark.skipif(os.name != "nt", reason="Backslash normalization only applies on Windows")
+    def test_known_paths_stored_as_forward_slashes(self, fresh_deadline_config):
+        """Config file on disk should contain forward slashes, not backslashes."""
+        config.set_setting(
+            "settings.known_asset_paths",
+            ";".join(["C:\\Users\\artist\\assets", "D:\\projects\\shared"]),
+        )
+
+        raw_config = ConfigParser()
+        raw_config.read(fresh_deadline_config, encoding="utf8")
+        raw_value = None
+        for section in raw_config.sections():
+            if raw_config.has_option(section, "known_asset_paths"):
+                raw_value = raw_config.get(section, "known_asset_paths")
+                break
+        assert raw_value is not None, "known_asset_paths not found in config file"
+        assert "\\" not in raw_value, f"Backslashes found in stored value: {raw_value}"
+        assert "C:/Users/artist/assets" in raw_value
+
+    @pytest.mark.skipif(os.name != "nt", reason="Backslash normalization only applies on Windows")
+    def test_monitor_path_stored_as_forward_slashes(self, fresh_deadline_config):
+        """Monitor path on disk should contain forward slashes."""
+        config.set_setting(
+            "deadline-cloud-monitor.path",
+            "C:\\Program Files\\AWS\\DeadlineCloudMonitor\\monitor.exe",
+        )
+
+        raw_config = ConfigParser()
+        raw_config.read(fresh_deadline_config, encoding="utf8")
+        raw_value = None
+        for section in raw_config.sections():
+            if raw_config.has_option(section, "path"):
+                raw_value = raw_config.get(section, "path")
+                break
+        assert raw_value is not None, "deadline-cloud-monitor.path not found in config file"
+        assert "\\" not in raw_value, f"Backslashes found in stored value: {raw_value}"
+        assert "C:/Program Files/AWS/DeadlineCloudMonitor/monitor.exe" == raw_value
+
+
+class TestDefaultPathNormalization:
+    """Verify that default values for path settings also get normalized."""
+
+    def test_job_history_dir_default_is_native(self, fresh_deadline_config):
+        """The default job_history_dir uses os.path.join which produces backslashes
+        on Windows. get_setting should normalize it to native format consistently."""
+        result = config.get_setting("settings.job_history_dir")
+        assert ".deadline" in result
+        assert "job_history" in result
+        if os.name == "nt":
+            # On Windows, the default should use backslashes
+            assert "\\" in result
+        else:
+            # On POSIX, the default should use forward slashes
+            assert "/" in result


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Logging in with Deadline Cloud monitor on Windows rewrites the ~/.deadline/config file with a different .ini library than Python. It treats '\\' in entries differently, and breaks the known paths.

### What was the solution? (How)

This change normalizes path configurations on Windows to write '/' instead of '\\' path separators, converting to/from normalized form in set_setting and get_setting.

### What is the impact of this change?

Correct behavior of known paths on Windows.

### How was this change tested?

Added unit tests, and confirmed the known paths were untouched after a Deadline Cloud monitor login by running `deadline config gui` before/after the login.

### Was this change documented?

N/A

### Does this PR introduce new dependencies?

No

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
