### PR TITLE
chore: use centralized build-python-version for PublishToPyPI

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -121,7 +121,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: ${{ needs.TagRelease.outputs.build-python-version }}
       - name: Install dependencies
         run: |
           pip install --upgrade hatch


### PR DESCRIPTION
## Summary

Use the `build-python-version` output from the shared `TagRelease` workflow instead of a hardcoded Python version in the `PublishToPyPI` job.

## Motivation

`hatchling` 1.29.0 dropped Python 3.9 support (requires `>=3.10`), breaking `PublishToPyPI` in repos still using `python-version: '3.9'`. By referencing a centralized output from [aws-deadline/.github#74](https://github.com/aws-deadline/.github/pull/74), all repos stay in sync when build tool requirements change.

## Depends on

- [aws-deadline/.github#74](https://github.com/aws-deadline/.github/pull/74) (adds `build-python-version` output to `reusable_tag_release.yml`)