### PR TITLE
fix: Use OVERWRITE mode when syncing dependency job attachments

### DIFF
--- a/src/deadline/job_attachments/asset_sync.py
+++ b/src/deadline/job_attachments/asset_sync.py
@@ -54,6 +54,7 @@ from .exceptions import (
 from .vfs import VFSProcessManager
 from .models import (
     Attachments,
+    FileConflictResolution as _FileConflictResolution,
     JobAttachmentsFileSystem,
     JobAttachmentS3Settings,
     ManifestProperties,
@@ -301,6 +302,7 @@ class AssetSync:
         fs_permission_settings: Optional[FileSystemPermissionSettings] = None,
         merged_manifests_by_root: dict[str, BaseAssetManifest] = dict(),
         on_downloading_files: Optional[Callable[[ProgressReportMetadata], bool]] = None,
+        conflict_resolution: _FileConflictResolution = _FileConflictResolution.CREATE_COPY,
     ) -> SummaryStatistics:
         """
         Args:
@@ -331,6 +333,7 @@ class AssetSync:
                 session=self.session,
                 on_downloading_files=on_downloading_files,
                 logger=self.logger,
+                conflict_resolution=conflict_resolution,
             ).convert_to_summary_statistics()
         except JobAttachmentsS3ClientError as exc:
             if exc.status_code == 404:
@@ -495,13 +498,16 @@ class AssetSync:
                 on_mount_complete=on_vfs_mount_complete,
             )
         else:
-            # Copied Download flow
+            # Copied Download flow — always use OVERWRITE since the worker downloads
+            # into a fresh session directory. CREATE_COPY would create duplicate files
+            # with "(1)" suffixes when step dependency outputs overlap with inputs.
             summary_statistics = self.copied_download(
                 s3_settings=s3_settings,
                 session_dir=session_dir,
                 fs_permission_settings=fs_permission_settings,
                 merged_manifests_by_root=merged_manifests_by_root,
                 on_downloading_files=on_downloading_files,
+                conflict_resolution=_FileConflictResolution.OVERWRITE,
             )
 
         self._record_attachment_mtimes(merged_manifests_by_root)

--- a/test/unit/deadline_job_attachments/test_asset_sync.py
+++ b/test/unit/deadline_job_attachments/test_asset_sync.py
@@ -28,6 +28,7 @@ from deadline.job_attachments.exceptions import (
 )
 from deadline.job_attachments.models import (
     Attachments,
+    FileConflictResolution,
     Job,
     JobAttachmentsFileSystem,
     JobAttachmentS3Settings,
@@ -1256,6 +1257,55 @@ class TestAssetSync:
             ("default_job_attachment_s3_settings"),
         ],
     )
+    def test_step_dependency_download_uses_overwrite_conflict_resolution(
+        self,
+        tmp_path: Path,
+        default_queue: Queue,
+        default_job: Job,
+        s3_settings_fixture_name: str,
+        test_manifest_one: dict,
+        request: pytest.FixtureRequest,
+    ):
+        """Downloads should always use OVERWRITE conflict resolution since the worker
+        downloads into a fresh session directory."""
+        # GIVEN
+        s3_settings: JobAttachmentS3Settings = request.getfixturevalue(s3_settings_fixture_name)
+        default_queue.jobAttachmentSettings = s3_settings
+        dest_dir = "assetroot-27bggh78dd2b568ab123"
+        test_manifest = decode_manifest(json.dumps(test_manifest_one))
+        assert default_job.attachments
+
+        # WHEN — no step dependencies
+        with patch(
+            f"{deadline.__package__}.job_attachments.asset_sync.get_manifest_from_s3",
+            return_value=test_manifest,
+        ), patch(
+            f"{deadline.__package__}.job_attachments.asset_sync.download_files_from_manifests",
+            side_effect=[DownloadSummaryStatistics()],
+        ) as mock_download, patch(
+            f"{deadline.__package__}.job_attachments.asset_sync._get_unique_dest_dir_name",
+            side_effect=[dest_dir],
+        ), patch.object(Path, "stat", MagicMock(st_mtime_ns=1234512345123451)):
+            self.default_asset_sync.attachment_sync_inputs(
+                s3_settings,
+                default_job.attachments,
+                default_queue.queueId,
+                default_job.jobId,
+                tmp_path,
+                on_downloading_files=MagicMock(return_value=True),
+            )
+
+            # THEN — should always use OVERWRITE
+            mock_download.assert_called_once()
+            call_kwargs = mock_download.call_args
+            assert call_kwargs.kwargs.get("conflict_resolution") == FileConflictResolution.OVERWRITE
+
+    @pytest.mark.parametrize(
+        ("s3_settings_fixture_name"),
+        [
+            ("default_job_attachment_s3_settings"),
+        ],
+    )
     def test_attachment_sync_inputs_with_step_dependencies_same_root_vfs_on_posix(
         self,
         tmp_path: Path,
@@ -1567,6 +1617,7 @@ class TestAssetSync:
                 session=ANY,
                 on_downloading_files=mock_on_downloading_files,
                 logger=getLogger("deadline.job_attachments"),
+                conflict_resolution=FileConflictResolution.OVERWRITE,
             )
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

I ran into failures on Windows when running the worker agent e2e tests per the deadline-test-fixtures setup. Job attachments was producing files with (1) instead of ovewriting them.

It was defaulting to COPY mode, which creates new filenames with (1) and similar suffixes. This is the wrong behavior when syncing job attachments within the worker agent.

### What was the solution? (How)

Change the asset sync code being used to overwrite instead of copying to alternate filenames.

### What is the impact of this change?

Correct behavior of job attachments on workers.

### How was this change tested?

Wrote a unit test for the change.

### Was this change documented?

N/A

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
