### PR TITLE
chore: add manual test gate to release workflow

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -84,8 +84,15 @@ jobs:
       tag: ${{ needs.TagRelease.outputs.tag }}
       oses: "['Linux', 'Windows', 'MacOS']"
 
-  Release:
+  ManualTestGate:
     needs: [TagRelease, BuildAndStageInstallers]
+    runs-on: ubuntu-latest
+    environment: release-gate
+    steps:
+      - run: echo "Manual testing approved for ${{ needs.TagRelease.outputs.tag }}"
+
+  Release:
+    needs: [TagRelease, ManualTestGate]
     uses: aws-deadline/.github/.github/workflows/reusable_release.yml@mainline
     secrets: inherit
     permissions:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Releases require many manual approval clicks. Only one is actually required.

### What was the solution? (How)
Approvals are a property of job environments. So we'll:
1) add a new release-gate environment which requires an approval
2) remove approvals from the release environment which is used for many steps
3) add a manual approval step that uses the new release-gate environment (this PR) at the part of the release workflow that needs a manual approval

I will update the environments after this is approved and merged.

### What is the impact of this change?
Fewer clicks during releases

### How was this change tested?
n/a

### Was this change documented?
n/a

### Does this PR introduce new dependencies?
No

### Is this a breaking change?
No

### Does this change impact security?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
