### PR TITLE
chore: Add macOS integration tests to release workflow

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -62,6 +62,20 @@ jobs:
       os: windows
       tag: ${{ needs.TagRelease.outputs.tag }}
 
+  MacOSIntegrationTests:
+    name: MacOS Integration Tests
+    needs: [TagRelease, UnitTests]
+    permissions:
+      id-token: write
+      contents: read
+    uses: aws-deadline/.github/.github/workflows/reusable_integration_test.yml@mainline
+    secrets: inherit
+    with:
+      repository: ${{ github.event.repository.name }}
+      environment: release
+      os: macos
+      tag: ${{ needs.TagRelease.outputs.tag }}
+
   PreRelease:
     needs: [TagRelease, LinuxIntegrationTests, WindowsIntegrationTests]
     uses: aws-deadline/.github/.github/workflows/reusable_prerelease.yml@mainline


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

macOS integration tests are currently performed manually for every release. Linux and Windows integration tests are already automated in the release workflow.

### What was the solution? (How)

Added a `MacOSIntegrationTests` job to `release_publish.yml` that runs in parallel with the existing Linux and Windows integration test jobs. 

### What is the impact of this change?

macOS integration tests will now run automatically during every release, matching the existing Linux and Windows pattern. Currently non-blocking — will be made a release gate after validation.

### How was this change tested?

The supporting infrastructure has been deployed and verified in Prod. The workflow uses the same reusable integration test workflow that Linux and Windows already use.

### Was this change documented?

N/A

### Does this PR introduce new dependencies?

No

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*