### PR TITLE
fix(ci): grant id-token: write for release bump workflow

### DIFF
--- a/.github/workflows/release_bump.yml
+++ b/.github/workflows/release_bump.yml
@@ -21,6 +21,7 @@ jobs:
     name: Version Bump
     uses: aws-deadline/.github/.github/workflows/reusable_bump.yml@mainline
     permissions:
+      id-token: write
       contents: write
       pull-requests: write
     secrets: inherit


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Release workflow failed with new LLM-generated release notes.

### What was the solution? (How)
The reusable bump workflow now uses OIDC to assume an AWS role for Bedrock-generated release notes, which requires id-token: write. Propagate that permission from the caller so the nested job is allowed to request it.

### What is the impact of this change?
Fixes release workflow.

### How was this change tested?
n/a

### Was this change documented?
n/a

### Does this PR introduce new dependencies?
No

### Is this a breaking change?
No

### Does this change impact security?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
