### PR TITLE
ci: run Code Quality on mainline pushes to seed shared cache

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -3,6 +3,9 @@ name: Code Quality
 on:
   pull_request:
     branches: [ mainline, release, feature_assets_cli, 'patch_*' , "feature_*"]
+  push:
+    # Run on mainline pushes to populate the Actions cache that PRs restore from.
+    branches: [ mainline ]
   workflow_call:
     inputs:
       branch:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
GitHub Actions scopes caches per ref. PR runs can restore caches from the default branch, but caches created on PR merge refs aren't shared across PRs. Since Code Quality only ran on pull_request, mainline had no cache and every new PR started cold.

### What was the solution? (How)
Adding a push trigger on mainline populates a shared cache that all new PRs can restore from on their first run.

### What is the impact of this change?
PRs can use the cache from mainline and will mostly get a cache hit for faster builds.

### How was this change tested?
n/a

### Was this change documented?
n/a

### Does this PR introduce new dependencies?
No

### Is this a breaking change?
No

### Does this change impact security?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
