### PR TITLE
feat: support conflict resolution in job download output path mapped cases

### DIFF
--- a/src/deadline/client/cli/_groups/_job_download_helpers.py
+++ b/src/deadline/client/cli/_groups/_job_download_helpers.py
@@ -179,12 +179,55 @@ def _transform_manifests_to_absolute_paths(
     return result
 
 
+def _resolve_conflict_resolution(
+    conflict_resolution_setting: str,
+    auto_accept: bool,
+    conflicting_filenames: list[str],
+) -> Optional[FileConflictResolution]:
+    """Determine file conflict resolution, prompting the user if needed.
+
+    Shared logic for both the mapped-manifest and OutputDownloader download paths.
+
+    Args:
+        conflict_resolution_setting: raw config setting string (e.g. "CREATE_COPY", "NOT_SELECTED").
+        auto_accept: whether to skip interactive prompts (--yes flag).
+        conflicting_filenames: list of absolute paths that already exist locally.
+
+    Returns:
+        FileConflictResolution to use, or None if the user canceled.
+    """
+    if conflict_resolution_setting != FileConflictResolution.NOT_SELECTED.name:
+        return FileConflictResolution[conflict_resolution_setting]
+
+    if auto_accept:
+        return FileConflictResolution.CREATE_COPY
+
+    if not conflicting_filenames:
+        return FileConflictResolution.CREATE_COPY
+
+    # Lazy import to avoid circular dependency
+    from .job_group import _get_conflict_resolution_selection_message
+
+    click.echo(_get_conflict_resolution_selection_message(conflicting_filenames))
+    user_choice = click.prompt(
+        "> Please enter your choice (1, 2, 3, or n to cancel the download)",
+        type=click.Choice(["1", "2", "3", "n"]),
+        default="3",
+    )
+    if user_choice == "n":
+        click.echo("Output download canceled.")
+        return None
+
+    return FileConflictResolution(int(user_choice))
+
+
 def _download_mapped_manifests(
     mapped_manifests: dict[str, Any],
     queue: dict[str, Any],
     queue_role_session: Any,
     conflict_resolution_setting: str,
     is_json_format: bool,
+    auto_accept: bool = False,
 ) -> Any:
     """Download output files using path-mapped manifests with progress reporting.
 
@@ -199,16 +242,25 @@ def _download_mapped_manifests(
         queue_role_session: boto3 session with queue role credentials for S3 access.
         conflict_resolution_setting: the raw config setting string for conflict resolution.
         is_json_format: whether to emit JSON progress lines instead of a click progressbar.
+        auto_accept: whether to skip interactive prompts (--yes flag).
 
     Returns:
-        DownloadSummaryStatistics from the download.
+        DownloadSummaryStatistics from the download, or None if canceled.
     """
-    # Determine conflict resolution: use config setting if specified, otherwise CREATE_COPY.
-    # No interactive prompt on the mapped path — the user opted into automatic mapping.
-    if conflict_resolution_setting != FileConflictResolution.NOT_SELECTED.name:
-        file_conflict_resolution = FileConflictResolution[conflict_resolution_setting]
-    else:
-        file_conflict_resolution = FileConflictResolution.CREATE_COPY
+    from pathlib import Path as _Path
+
+    # Check for conflicting files at the mapped destinations
+    conflicting_filenames: list[str] = []
+    for manifest in mapped_manifests.values():
+        for manifest_path in manifest.paths:
+            if _Path(manifest_path.path).is_file():
+                conflicting_filenames.append(manifest_path.path)
+
+    file_conflict_resolution = _resolve_conflict_resolution(
+        conflict_resolution_setting, auto_accept, conflicting_filenames
+    )
+    if file_conflict_resolution is None:
+        return None
 
     s3_settings = JobAttachmentS3Settings(**queue["jobAttachmentSettings"])
     sigint_handler = SigIntHandler()

--- a/src/deadline/client/cli/_groups/job_group.py
+++ b/src/deadline/client/cli/_groups/job_group.py
@@ -60,6 +60,7 @@ from ._job_helpers import (
 from ._job_download_helpers import (
     JSON_MSG_TYPE_PROGRESS,
     _download_mapped_manifests,
+    _resolve_conflict_resolution,
     _resolve_storage_profiles,
     _transform_manifests_to_absolute_paths,
 )
@@ -612,7 +613,10 @@ def _download_job_output(
                     queue_role_session=queue_role_session,
                     conflict_resolution_setting=conflict_resolution,
                     is_json_format=is_json_format,
+                    auto_accept=auto_accept,
                 )
+                if download_summary is None:
+                    return
                 click.echo(_get_download_summary_message(download_summary, is_json_format))
                 click.echo()
                 return
@@ -719,29 +723,12 @@ def _download_job_output(
         click.echo("\nSummary of file paths to download:")
         click.echo(textwrap.indent(summarize_path_list(all_output_paths), "  "))
 
-    # If the conflict resolution option was not specified, auto-accept is false, and
-    # if there are any conflicting files in local, prompt users to select a resolution method.
-    # (skip, overwrite, or make a copy.)
-    if conflict_resolution != FileConflictResolution.NOT_SELECTED.name:
-        file_conflict_resolution = FileConflictResolution[conflict_resolution]
-    elif auto_accept:
-        file_conflict_resolution = FileConflictResolution.CREATE_COPY
-    else:
-        file_conflict_resolution = FileConflictResolution.CREATE_COPY
-        conflicting_filenames = _get_conflicting_filenames(output_paths_by_root)
-        if conflicting_filenames:
-            click.echo(_get_conflict_resolution_selection_message(conflicting_filenames))
-            user_choice = click.prompt(
-                "> Please enter your choice (1, 2, 3, or n to cancel the download)",
-                type=click.Choice(["1", "2", "3", "n"]),
-                default="3",
-            )
-            if user_choice == "n":
-                click.echo("Output download canceled.")
-                return
-            else:
-                resolution_choice_int = int(user_choice)
-                file_conflict_resolution = FileConflictResolution(resolution_choice_int)
+    # Resolve conflict resolution — shared logic for both mapped and unmapped paths
+    file_conflict_resolution = _resolve_conflict_resolution(
+        conflict_resolution, auto_accept, _get_conflicting_filenames(output_paths_by_root)
+    )
+    if file_conflict_resolution is None:
+        return
 
     # TODO: remove logging level setting when the max number connections for boto3 client
     # in Job Attachments library can be increased (currently using default number, 10, which

--- a/test/unit/deadline_client/cli/test_job_download_helpers.py
+++ b/test/unit/deadline_client/cli/test_job_download_helpers.py
@@ -20,6 +20,7 @@ from deadline.client.cli import main
 from deadline.client.cli._groups import job_group
 from deadline.client.cli._groups._job_download_helpers import (
     ResolvedStorageProfiles,
+    _resolve_conflict_resolution,
     _resolve_storage_profiles,
     _transform_manifests_to_absolute_paths,
 )
@@ -366,6 +367,60 @@ MOCK_GET_QUEUE_RESPONSE = {
         "rootPrefix": "AWS Deadline Cloud",
     },
 }
+
+
+# ─── _resolve_conflict_resolution ────────────────────────────────────────────
+
+
+class TestResolveConflictResolution:
+    def test_config_setting_takes_priority(self) -> None:
+        """When conflict_resolution is set in config, use it directly without prompting."""
+        result = _resolve_conflict_resolution("SKIP", auto_accept=False, conflicting_filenames=[])
+        from deadline.job_attachments.models import FileConflictResolution
+
+        assert result == FileConflictResolution.SKIP
+
+    def test_auto_accept_defaults_to_create_copy(self) -> None:
+        """When auto_accept is True, default to CREATE_COPY without prompting."""
+        result = _resolve_conflict_resolution(
+            "NOT_SELECTED", auto_accept=True, conflicting_filenames=["/some/file.txt"]
+        )
+        from deadline.job_attachments.models import FileConflictResolution
+
+        assert result == FileConflictResolution.CREATE_COPY
+
+    def test_no_conflicts_defaults_to_create_copy(self) -> None:
+        """When there are no conflicting files, default to CREATE_COPY."""
+        result = _resolve_conflict_resolution(
+            "NOT_SELECTED", auto_accept=False, conflicting_filenames=[]
+        )
+        from deadline.job_attachments.models import FileConflictResolution
+
+        assert result == FileConflictResolution.CREATE_COPY
+
+    @patch("deadline.client.cli._groups._job_download_helpers.click")
+    def test_user_cancels_returns_none(self, mock_click: MagicMock) -> None:
+        """When user enters 'n', return None to signal cancellation."""
+        mock_click.prompt.return_value = "n"
+        mock_click.echo = MagicMock()
+        mock_click.Choice = MagicMock()
+        result = _resolve_conflict_resolution(
+            "NOT_SELECTED", auto_accept=False, conflicting_filenames=["/existing/file.txt"]
+        )
+        assert result is None
+
+    @patch("deadline.client.cli._groups._job_download_helpers.click")
+    def test_user_selects_overwrite(self, mock_click: MagicMock) -> None:
+        """When user enters '2' (overwrite), return OVERWRITE."""
+        mock_click.prompt.return_value = "2"
+        mock_click.echo = MagicMock()
+        mock_click.Choice = MagicMock()
+        result = _resolve_conflict_resolution(
+            "NOT_SELECTED", auto_accept=False, conflicting_filenames=["/existing/file.txt"]
+        )
+        from deadline.job_attachments.models import FileConflictResolution
+
+        assert result == FileConflictResolution.OVERWRITE
 
 
 class TestCliDownloadOutputStorageProfileOptions:


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud/issues/829

Fixes: https://github.com/aws-deadline/deadline-cloud/pull/1029#discussion_r3113550910

### What was the problem/requirement? (What/Why)

The mapped-manifest download path (used when storage profiles resolve path mapping rules) silently defaulted to `CREATE_COPY` for file conflicts without offering the user the same skip/overwrite/copy prompt that the existing OutputDownloader path provides. This inconsistency meant users on the automatic mapping path had no way to choose how to handle existing files at the destination.

### What was the solution? (How)

Extracted the conflict resolution logic into a shared `_resolve_conflict_resolution()` function in `_job_download_helpers.py`. Both the mapped-manifest path and the existing OutputDownloader path now call this same function, which:

1. Uses the config setting if `settings.conflict_resolution` is set
2. Defaults to `CREATE_COPY` if `--yes` (auto_accept) is passed
3. Otherwise checks for conflicting files and prompts the user with skip/overwrite/copy/cancel options

### What is the impact of this change?

Both download code paths now have identical conflict resolution behavior. Users re-downloading to a destination with existing files will see the same interactive prompt regardless of whether storage profile mapping is active.

### How was this change tested?

- 5 new unit tests in `test_job_download_helpers.py` for `_resolve_conflict_resolution` (config priority, auto_accept default, no conflicts, user cancel, user overwrite)
- All existing unit tests pass (53 relevant tests, 2559 total)
- 9/9 e2e tests pass against live AWS resources

- [x] Have you run the unit tests?
- [x] Have you run the integration tests?
- [ ] Have you made changes to the `download` or `asset_sync` modules? No.

### Was this change documented?

- Docstring added to `_resolve_conflict_resolution()`

### Does this PR introduce new dependencies?

*   [x] This PR does not add any new dependencies.

### Is this a breaking change?

No. The OutputDownloader path behavior is unchanged — same logic, just moved to a shared function. The mapped-manifest path gains the conflict prompt it was previously missing.

### Does this change impact security?

No. Only affects user-facing prompt logic for file conflict resolution.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*

