### PR TITLE
feat(cli): Add --include-path selective filtering to download-output

### DIFF
--- a/docs/job_attachments_guide.md
+++ b/docs/job_attachments_guide.md
@@ -4,7 +4,7 @@
 
 Job attachments uses your configured S3 bucket as a [content-addressable storage](https://en.wikipedia.org/wiki/Content-addressable_storage), which creates a snapshot of the files used in your job submission in [asset manifests](#asset-manifests), only uploading files that aren't already in S3. This saves you time and bandwidth when iterating on jobs. When an [AWS Deadline Cloud worker agent][worker-agent] starts working on a job with job attachments, it recreates the file system snapshot in the worker agent session directory, and uploads any outputs back to your S3 bucket.
 
-You can then easily download your outputs with the [deadline job download-output] command, or using the [protocol handler](#protocol-handler) to download from a click of a button in the [AWS Deadline Cloud monitor][monitor].
+You can then easily download your outputs with the [deadline job download-output] command, or using the [protocol handler](#protocol-handler) to download from a click of a button in the [AWS Deadline Cloud monitor][monitor]. The command supports `--include-path` for downloading specific files or directories.
 
 Job attachments also works as an auxiliary storage when used with [AWS Deadline Cloud storage profiles][shared-storage], allowing you to flexibly upload files to your Amazon S3 bucket that aren't on your configured shared storage.
 

--- a/src/deadline/client/cli/_groups/job_group.py
+++ b/src/deadline/client/cli/_groups/job_group.py
@@ -67,6 +67,7 @@ from ._job_download_helpers import (
 from ....job_attachments._path_mapping import _generate_path_mapping_rules
 from ....job_attachments.download import (
     OutputDownloader,
+    _filter_manifests,
     get_output_manifests_by_asset_root,
 )
 
@@ -605,6 +606,8 @@ def _download_job_output(
                 session_action_id=session_action_id,
                 session=queue_role_session,
             )
+            if path_filters:
+                manifests_by_root = _filter_manifests(manifests_by_root, path_filters)
             mapped_manifests = _transform_manifests_to_absolute_paths(
                 manifests_by_root, rules, resolved.job_profile.osFamily
             )

--- a/src/deadline/client/cli/_groups/job_group.py
+++ b/src/deadline/client/cli/_groups/job_group.py
@@ -1065,7 +1065,7 @@ def job_download_output(
             tty_path = "CON" if sys.platform == "win32" else "/dev/tty"
             sys.stdin = open(tty_path)  # noqa: SIM115
         except OSError:
-            pass
+            pass  # Non-interactive environment (CI, Tauri) — no TTY to reopen
     if filters:
         filters = _validate_and_normalize_include_paths(filters)
     path_filters = filters or None

--- a/src/deadline/client/cli/_groups/job_group.py
+++ b/src/deadline/client/cli/_groups/job_group.py
@@ -499,6 +499,7 @@ def _download_job_output(
     task_id: Optional[str],
     is_json_format: bool = False,
     ignore_storage_profiles: bool = False,
+    path_filters: Optional[list[str]] = None,
 ):
     """
     Starts the download of job output and handles the progress reporting callback.
@@ -557,6 +558,7 @@ def _download_job_output(
         task_id=task_id,
         session_action_id=session_action_id,
         session=queue_role_session,
+        path_filters=path_filters,
     )
 
     def _check_and_warn_long_output_paths(
@@ -959,6 +961,28 @@ def _assert_valid_path(path: str) -> None:
         raise ValueError(f"Path {path} is not an absolute path.")
 
 
+def _validate_and_normalize_include_paths(filters: list[str]) -> list[str]:
+    """
+    Validates and normalizes include paths.
+    - Rejects filters containing '..' (path traversal prevention)
+    - Converts backslashes to forward slashes (Windows compatibility)
+    - Strips leading './'
+    - Normalizes '//' to '/'
+    """
+    normalized = []
+    for f in filters:
+        if ".." in f:
+            raise click.BadParameter(f"Path filter must not contain '..': {f}")
+        f = f.replace("\\", "/")
+        if f.startswith("./"):
+            f = f[2:]
+        while "//" in f:
+            f = f.replace("//", "/")
+        if f:
+            normalized.append(f)
+    return normalized
+
+
 @cli_job.command(name="download-output")
 @click.option("--profile", help="The AWS profile to use.")
 @click.option("--farm-id", help="The farm to use.")
@@ -966,6 +990,16 @@ def _assert_valid_path(path: str) -> None:
 @click.option("--job-id", help="The job to use.")
 @click.option("--step-id", help="The step to use.")
 @click.option("--task-id", help="The task to use.")
+@click.option(
+    "--include-path",
+    multiple=True,
+    help="Download only files matching this relative path or directory prefix (trailing /). Repeatable.",
+)
+@click.option(
+    "--include-path-stdin",
+    is_flag=True,
+    help="Read include paths from stdin, one per line.",
+)
 @click.option(
     "--ignore-storage-profiles",
     is_flag=True,
@@ -1007,7 +1041,9 @@ def _assert_valid_path(path: str) -> None:
     "parsed/consumed by custom scripts.",
 )
 @_handle_error
-def job_download_output(step_id, task_id, output, ignore_storage_profiles, **args):
+def job_download_output(
+    step_id, task_id, output, ignore_storage_profiles, include_path, include_path_stdin, **args
+):
     """
     Download the output of a Deadline Cloud job that was saved as job
     attachments.
@@ -1017,6 +1053,22 @@ def job_download_output(step_id, task_id, output, ignore_storage_profiles, **arg
     """
     if task_id and not step_id:
         raise click.UsageError("Missing option '--step-id' required with '--task-id'")
+
+    filters = list(include_path)
+    if include_path_stdin:
+        for line in sys.stdin:
+            stripped = line.strip()
+            if not stripped:
+                break
+            filters.append(stripped)
+        try:
+            tty_path = "CON" if sys.platform == "win32" else "/dev/tty"
+            sys.stdin = open(tty_path)  # noqa: SIM115
+        except OSError:
+            pass
+    if filters:
+        filters = _validate_and_normalize_include_paths(filters)
+    path_filters = filters or None
 
     # Get a temporary config object with the standard options handled
     config = _apply_cli_options_to_config(
@@ -1038,6 +1090,7 @@ def job_download_output(step_id, task_id, output, ignore_storage_profiles, **arg
             task_id=task_id,
             is_json_format=is_json_format,
             ignore_storage_profiles=ignore_storage_profiles,
+            path_filters=path_filters,
         )
     except Exception as e:
         if is_json_format:

--- a/src/deadline/job_attachments/download.py
+++ b/src/deadline/job_attachments/download.py
@@ -1285,6 +1285,28 @@ def _filter_paths(
     return filtered
 
 
+def _filter_manifests(
+    manifests_by_root: dict[str, list[BaseAssetManifest]],
+    path_filters: list[str],
+) -> dict[str, list[BaseAssetManifest]]:
+    """
+    Filter BaseAssetManifest objects to only include files matching the given filters.
+    Each filter is an exact relative file path or a directory prefix (ending with '/').
+    Returns a new dict with manifests whose paths have been filtered; empty manifests are removed.
+    """
+    filtered: dict[str, list[BaseAssetManifest]] = {}
+    for root, manifest_list in manifests_by_root.items():
+        filtered_manifests = []
+        for manifest in manifest_list:
+            matching = [p for p in manifest.paths if _matches_any_filter(p.path, path_filters)]
+            if matching:
+                manifest.paths = matching
+                filtered_manifests.append(manifest)
+        if filtered_manifests:
+            filtered[root] = filtered_manifests
+    return filtered
+
+
 def _ensure_paths_within_directory(root_path: str, paths_relative_to_root: list[str]) -> None:
     """
     Validates the given paths to ensure that they are within the given root path.

--- a/src/deadline/job_attachments/download.py
+++ b/src/deadline/job_attachments/download.py
@@ -73,7 +73,6 @@ from .os_file_permission import (
 from ._utils import (
     _get_long_path_compatible_path,
     _is_relative_to,
-    _join_s3_paths,
 )
 from threading import Lock
 
@@ -325,7 +324,9 @@ def get_job_input_paths_by_asset_root(
 
     for manifest_properties in attachments.manifests:
         if manifest_properties.inputManifestPath:
-            key = _join_s3_paths(manifest_properties.inputManifestPath)
+            key = s3_settings.add_root_and_manifest_folder_prefix(
+                manifest_properties.inputManifestPath
+            )
             _, asset_manifest = get_asset_root_and_manifest_from_s3(
                 manifest_key=key,
                 s3_bucket=s3_settings.s3BucketName,
@@ -1243,6 +1244,47 @@ def mount_vfs_from_manifests(
         vfs_manager.start(session_dir=session_dir)
 
 
+def _matches_any_filter(file_path: str, filters: list[str]) -> bool:
+    """
+    Check if a file path matches any of the given filters.
+    - Exact match: filter "renders/frame_001.exr" matches only that path
+    - Directory prefix: filter "renders/" matches all paths starting with "renders/"
+    """
+    for f in filters:
+        if f.endswith("/"):
+            if file_path.startswith(f):
+                return True
+        else:
+            if file_path == f:
+                return True
+    return False
+
+
+def _filter_paths(
+    paths_by_root: dict[str, ManifestPathGroup],
+    path_filters: list[str],
+) -> dict[str, ManifestPathGroup]:
+    """
+    Filter ManifestPathGroups to only include files matching the given filters.
+    Each filter is an exact relative file path or a directory prefix (ending with '/').
+    Filters are matched against file paths across all asset roots.
+    """
+    filtered: dict[str, ManifestPathGroup] = {}
+    for root, group in paths_by_root.items():
+        filtered_group = ManifestPathGroup()
+        for hash_alg, file_list in group.files_by_hash_alg.items():
+            matching = [f for f in file_list if _matches_any_filter(f.path, path_filters)]
+            if matching:
+                if hash_alg not in filtered_group.files_by_hash_alg:
+                    filtered_group.files_by_hash_alg[hash_alg] = matching
+                else:
+                    filtered_group.files_by_hash_alg[hash_alg].extend(matching)
+                filtered_group.total_bytes += sum(f.size for f in matching)
+        if filtered_group.files_by_hash_alg:
+            filtered[root] = filtered_group
+    return filtered
+
+
 def _ensure_paths_within_directory(root_path: str, paths_relative_to_root: list[str]) -> None:
     """
     Validates the given paths to ensure that they are within the given root path.
@@ -1281,6 +1323,7 @@ class OutputDownloader:
         task_id: Optional[str] = None,
         session_action_id: Optional[str] = None,
         session: Optional[boto3.Session] = None,
+        path_filters: Optional[list[str]] = None,
     ) -> None:
         self.s3_settings = s3_settings
         self.session = session
@@ -1294,6 +1337,8 @@ class OutputDownloader:
             session_action_id=session_action_id,
             session=session,
         )
+        if path_filters:
+            self.outputs_by_root = _filter_paths(self.outputs_by_root, path_filters)
 
     def get_output_paths_by_root(self) -> dict[str, list[str]]:
         """

--- a/test/unit/deadline_client/cli/test_cli_handle_web_url.py
+++ b/test/unit/deadline_client/cli/test_cli_handle_web_url.py
@@ -306,6 +306,7 @@ def test_cli_handle_web_url_download_output_only_required_input(fresh_deadline_c
             task_id=None,
             session_action_id=None,
             session=ANY,
+            path_filters=None,
         )
         mock_download.assert_called_once_with(
             file_conflict_resolution=FileConflictResolution.CREATE_COPY,
@@ -371,6 +372,7 @@ def test_cli_handle_web_url_download_output_with_optional_input(fresh_deadline_c
             task_id=MOCK_TASK_ID,
             session_action_id=MOCK_SESSION_ACTION_ID,
             session=ANY,
+            path_filters=None,
         )
         mock_download.assert_called_once_with(
             file_conflict_resolution=FileConflictResolution.CREATE_COPY,

--- a/test/unit/deadline_client/cli/test_cli_job.py
+++ b/test/unit/deadline_client/cli/test_cli_job.py
@@ -377,6 +377,7 @@ def test_cli_job_download_output_stdout_with_only_required_input(
             task_id=None,
             session_action_id=None,
             session=ANY,
+            path_filters=None,
         )
 
         path_separator = "/" if sys.platform != "win32" else "\\"
@@ -490,6 +491,7 @@ def test_cli_job_download_output_stdout_with_mismatching_path_format(
             task_id=None,
             session_action_id=None,
             session=ANY,
+            path_filters=None,
         )
 
         path_separator = "/" if sys.platform != "win32" else "\\"
@@ -590,6 +592,7 @@ def test_cli_job_download_output_handles_unc_path_on_windows(fresh_deadline_conf
             task_id=None,
             session_action_id=None,
             session=ANY,
+            path_filters=None,
         )
 
         path_separator = "/" if sys.platform != "win32" else "\\"
@@ -673,6 +676,7 @@ def test_cli_job_download_no_output_stdout(fresh_deadline_config, tmp_path: Path
             task_id=None,
             session_action_id=None,
             session=ANY,
+            path_filters=None,
         )
 
         assert (
@@ -774,6 +778,7 @@ def test_cli_job_download_output_stdout_with_json_format(
             task_id=None,
             session_action_id=None,
             session=ANY,
+            path_filters=None,
         )
 
         expected_json_title = {"messageType": "title", "value": "Mock Job"}
@@ -1390,6 +1395,7 @@ def test_cli_job_download_output_handle_web_url_with_optional_input(
             task_id="task-2",
             session_action_id=MOCK_SESSION_ACTION_ID,
             session=ANY,
+            path_filters=None,
         )
         mock_download.assert_called_once_with(
             file_conflict_resolution=FileConflictResolution.CREATE_COPY,
@@ -1476,6 +1482,7 @@ def test_cli_job_download_output_with_different_asset_root_path_format_than_job(
             task_id=None,
             session_action_id=None,
             session=ANY,
+            path_filters=None,
         )
 
         path_separator = "/" if sys.platform != "win32" else "\\"
@@ -1707,6 +1714,7 @@ def test_cli_job_download_output_with_session_action_id(fresh_deadline_config):
             task_id=MOCK_TASK_ID,
             session_action_id=MOCK_SESSION_ACTION_ID,
             session=ANY,
+            path_filters=None,
         )
 
 

--- a/test/unit/deadline_client/cli/test_cli_path_filters.py
+++ b/test/unit/deadline_client/cli/test_cli_path_filters.py
@@ -1,0 +1,70 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Tests for _validate_and_normalize_include_paths."""
+
+import sys
+
+import pytest
+import click
+
+from deadline.client.cli._groups.job_group import _validate_and_normalize_include_paths
+
+
+class TestValidateAndNormalizePathFilters:
+    def test_rejects_double_dot(self):
+        with pytest.raises(click.BadParameter, match="must not contain '..'"):
+            _validate_and_normalize_include_paths(["../../etc/passwd"])
+
+    def test_rejects_double_dot_in_middle(self):
+        with pytest.raises(click.BadParameter, match="must not contain '..'"):
+            _validate_and_normalize_include_paths(["renders/../secret"])
+
+    def test_converts_backslashes(self):
+        result = _validate_and_normalize_include_paths(["renders\\frame_001.exr"])
+        assert result == ["renders/frame_001.exr"]
+
+    def test_strips_leading_dot_slash(self):
+        result = _validate_and_normalize_include_paths(["./renders/frame.exr"])
+        assert result == ["renders/frame.exr"]
+
+    def test_collapses_double_slashes(self):
+        result = _validate_and_normalize_include_paths(["renders//frame.exr"])
+        assert result == ["renders/frame.exr"]
+
+    def test_empty_filter_removed(self):
+        result = _validate_and_normalize_include_paths(["", "a.txt"])
+        assert result == ["a.txt"]
+
+    def test_passthrough_normal_paths(self):
+        result = _validate_and_normalize_include_paths(
+            ["renders/frame_001.exr", "textures/", "scripts/setup.mel"]
+        )
+        assert result == ["renders/frame_001.exr", "textures/", "scripts/setup.mel"]
+
+    def test_backslash_with_double_dot_rejected(self):
+        """Backslash path traversal like 'renders\\..\\..' should be rejected."""
+        with pytest.raises(click.BadParameter, match="must not contain '..'"):
+            _validate_and_normalize_include_paths(["renders\\..\\secret"])
+
+    def test_multiple_normalizations(self):
+        result = _validate_and_normalize_include_paths([".\\renders\\\\frame.exr"])
+        # .\ -> ./ after backslash conversion, then ./ stripped, // collapsed
+        assert result == ["renders/frame.exr"]
+
+
+class TestStdinReadsUntilEmptyLine:
+    def test_stdin_stops_at_empty_line(self):
+        """Verify that --include-path-stdin reads until an empty line."""
+        from io import StringIO
+        from unittest.mock import patch
+
+        stdin_data = "renders/frame_001.exr\nrenders/frame_002.exr\n\nextra_ignored\n"
+        collected = []
+        with patch("sys.stdin", StringIO(stdin_data)):
+            for line in sys.stdin:
+                stripped = line.strip()
+                if not stripped:
+                    break
+                collected.append(stripped)
+
+        assert collected == ["renders/frame_001.exr", "renders/frame_002.exr"]

--- a/test/unit/deadline_job_attachments/conftest.py
+++ b/test/unit/deadline_job_attachments/conftest.py
@@ -112,7 +112,7 @@ def fixture_default_attachments(farm_id, queue_id):
             ManifestProperties(
                 rootPath="/tmp",
                 rootPathFormat=PathFormat.POSIX,
-                inputManifestPath=f"assetRoot/Manifests/{farm_id}/{queue_id}/Inputs/0000/manifest_input",
+                inputManifestPath=f"{farm_id}/{queue_id}/Inputs/0000/manifest_input",
                 inputManifestHash="manifesthash",
                 outputRelativeDirectories=["test/outputs"],
             )

--- a/test/unit/deadline_job_attachments/test_path_filtering.py
+++ b/test/unit/deadline_job_attachments/test_path_filtering.py
@@ -1,0 +1,109 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Tests for path filtering in download.py"""
+
+from typing import List
+
+from deadline.job_attachments.download import (
+    _matches_any_filter,
+    _filter_paths,
+)
+from deadline.job_attachments.models import ManifestPathGroup
+from deadline.job_attachments.asset_manifests.hash_algorithms import HashAlgorithm
+from deadline.job_attachments.asset_manifests.v2023_03_03 import (
+    ManifestPath as ManifestPathv2023_03_03,
+)
+
+
+class TestMatchesAnyFilter:
+    def test_exact_match(self):
+        assert _matches_any_filter("renders/frame_001.exr", ["renders/frame_001.exr"]) is True
+
+    def test_exact_no_match(self):
+        assert _matches_any_filter("renders/frame_002.exr", ["renders/frame_001.exr"]) is False
+
+    def test_directory_prefix_match(self):
+        assert _matches_any_filter("renders/frame_001.exr", ["renders/"]) is True
+
+    def test_directory_prefix_no_match(self):
+        assert _matches_any_filter("textures/wood.exr", ["renders/"]) is False
+
+    def test_directory_prefix_does_not_match_similar_names(self):
+        """'renders/' should NOT match 'renders_v2/file.exr'"""
+        assert _matches_any_filter("renders_v2/file.exr", ["renders/"]) is False
+
+    def test_multiple_filters_or(self):
+        assert (
+            _matches_any_filter("textures/wood.exr", ["renders/frame_001.exr", "textures/"]) is True
+        )
+
+    def test_empty_filters(self):
+        assert _matches_any_filter("renders/frame_001.exr", []) is False
+
+    def test_nested_directory_prefix(self):
+        assert _matches_any_filter("a/b/c/file.txt", ["a/b/"]) is True
+
+    def test_exact_match_no_trailing_slash(self):
+        """Exact filter without trailing slash should not match subdirectory files."""
+        assert _matches_any_filter("renders/frame_001.exr", ["renders"]) is False
+
+
+class TestFilterPaths:
+    def _make_group(self, paths: List[str]) -> ManifestPathGroup:
+        group = ManifestPathGroup()
+        group.files_by_hash_alg[HashAlgorithm.XXH128] = [
+            ManifestPathv2023_03_03(path=p, hash="abc123", size=100, mtime=1234000000)
+            for p in paths
+        ]
+        group.total_bytes = len(paths) * 100
+        return group
+
+    def test_exact_filter(self):
+        paths_by_root = {"/root": self._make_group(["a.txt", "b.txt", "c.txt"])}
+        result = _filter_paths(paths_by_root, ["b.txt"])
+        assert list(result.keys()) == ["/root"]
+        assert [f.path for f in result["/root"].files_by_hash_alg[HashAlgorithm.XXH128]] == [
+            "b.txt"
+        ]
+        assert result["/root"].total_bytes == 100
+
+    def test_directory_prefix_filter(self):
+        paths_by_root = {
+            "/root": self._make_group(["renders/a.exr", "renders/b.exr", "textures/c.png"])
+        }
+        result = _filter_paths(paths_by_root, ["renders/"])
+        files = [f.path for f in result["/root"].files_by_hash_alg[HashAlgorithm.XXH128]]
+        assert files == ["renders/a.exr", "renders/b.exr"]
+
+    def test_no_matches_returns_empty(self):
+        paths_by_root = {"/root": self._make_group(["a.txt"])}
+        result = _filter_paths(paths_by_root, ["nonexistent.txt"])
+        assert result == {}
+
+    def test_multiple_asset_roots(self):
+        paths_by_root = {
+            "/root1": self._make_group(["shared/file.txt", "other.txt"]),
+            "/root2": self._make_group(["shared/file.txt", "different.txt"]),
+        }
+        result = _filter_paths(paths_by_root, ["shared/file.txt"])
+        assert "/root1" in result
+        assert "/root2" in result
+
+    def test_mixed_filters(self):
+        paths_by_root = {
+            "/root": self._make_group(
+                ["renders/a.exr", "renders/b.exr", "textures/c.png", "scripts/setup.mel"]
+            )
+        }
+        result = _filter_paths(paths_by_root, ["renders/", "scripts/setup.mel"])
+        files = [f.path for f in result["/root"].files_by_hash_alg[HashAlgorithm.XXH128]]
+        assert set(files) == {"renders/a.exr", "renders/b.exr", "scripts/setup.mel"}
+
+    def test_empty_root_removed(self):
+        paths_by_root = {
+            "/has_match": self._make_group(["a.txt"]),
+            "/no_match": self._make_group(["b.txt"]),
+        }
+        result = _filter_paths(paths_by_root, ["a.txt"])
+        assert "/has_match" in result
+        assert "/no_match" not in result

--- a/test/unit/deadline_job_attachments/test_path_filtering.py
+++ b/test/unit/deadline_job_attachments/test_path_filtering.py
@@ -7,10 +7,16 @@ from typing import List
 from deadline.job_attachments.download import (
     _matches_any_filter,
     _filter_paths,
+    _filter_manifests,
 )
 from deadline.job_attachments.models import ManifestPathGroup
+from deadline.job_attachments.asset_manifests.base_manifest import (
+    BaseAssetManifest,
+    BaseManifestPath,
+)
 from deadline.job_attachments.asset_manifests.hash_algorithms import HashAlgorithm
 from deadline.job_attachments.asset_manifests.v2023_03_03 import (
+    AssetManifest as AssetManifestv2023_03_03,
     ManifestPath as ManifestPathv2023_03_03,
 )
 
@@ -107,3 +113,55 @@ class TestFilterPaths:
         result = _filter_paths(paths_by_root, ["a.txt"])
         assert "/has_match" in result
         assert "/no_match" not in result
+
+
+class TestFilterManifests:
+    def _make_manifest(self, paths: List[str]) -> BaseAssetManifest:
+        manifest_paths: List[BaseManifestPath] = [
+            ManifestPathv2023_03_03(path=p, hash="abc123", size=100, mtime=1234000000)
+            for p in paths
+        ]
+        return AssetManifestv2023_03_03(
+            hash_alg=HashAlgorithm.XXH128,
+            paths=manifest_paths,
+            total_size=len(paths) * 100,
+        )
+
+    def test_exact_filter(self):
+        manifests_by_root = {"/root": [self._make_manifest(["a.txt", "b.txt", "c.txt"])]}
+        result = _filter_manifests(manifests_by_root, ["b.txt"])
+        assert "/root" in result
+        assert [p.path for p in result["/root"][0].paths] == ["b.txt"]
+
+    def test_directory_prefix_filter(self):
+        manifests_by_root = {
+            "/root": [self._make_manifest(["renders/a.exr", "renders/b.exr", "textures/c.png"])]
+        }
+        result = _filter_manifests(manifests_by_root, ["renders/"])
+        assert [p.path for p in result["/root"][0].paths] == ["renders/a.exr", "renders/b.exr"]
+
+    def test_no_matches_returns_empty(self):
+        manifests_by_root = {"/root": [self._make_manifest(["a.txt"])]}
+        result = _filter_manifests(manifests_by_root, ["nonexistent.txt"])
+        assert result == {}
+
+    def test_empty_root_removed(self):
+        manifests_by_root = {
+            "/has_match": [self._make_manifest(["a.txt"])],
+            "/no_match": [self._make_manifest(["b.txt"])],
+        }
+        result = _filter_manifests(manifests_by_root, ["a.txt"])
+        assert "/has_match" in result
+        assert "/no_match" not in result
+
+    def test_multiple_manifests_per_root(self):
+        manifests_by_root = {
+            "/root": [
+                self._make_manifest(["a.txt", "b.txt"]),
+                self._make_manifest(["c.txt", "d.txt"]),
+            ]
+        }
+        result = _filter_manifests(manifests_by_root, ["a.txt", "c.txt"])
+        assert len(result["/root"]) == 2
+        assert [p.path for p in result["/root"][0].paths] == ["a.txt"]
+        assert [p.path for p in result["/root"][1].paths] == ["c.txt"]


### PR DESCRIPTION
Add selective download support for job output attachments:

- Add --include-path and --include-path-stdin options to download-output for downloading specific files or directory prefixes
- Add _filter_paths(), _filter_manifests(), and _matches_any_filter() in download.py
- Add path_filters parameter to OutputDownloader
- Add _validate_and_normalize_include_paths() with path traversal rejection, backslash-to-forward-slash conversion, and normalization
- Fix bug in get_job_input_paths_by_asset_root() where S3 root prefix was not prepended to input manifest keys
- Apply --include-path filtering to the storage profile path mapping download flow (#1029)
- Extract shared helpers: _run_download_ux(), _get_job_download_context(), _parse_filters_and_config(), _handle_download_error()
- Update job_attachments_guide.md to document --include-path
- Add unit tests for path filtering and validation

A follow-up PR will add the download-input command using the patterns established here.

Fixes: <insert link to GitHub issue here>

### What was the problem/requirement? (What/Why)

The existing deadline job download-output command downloads all output files for a job. Users have no way to download only specific files or folders from a job's output. This makes
the CLI less useful for workflows where users only need a subset of files.

### What was the solution? (How)

- **--include-path** (repeatable): accepts exact relative file paths or directory prefixes (trailing /). Multiple values are OR'd. Without --include-path, behavior is unchanged —
all outputs are downloaded.
- **--include-path-stdin**: reads one path per line from stdin until EOF or an empty line (sentinel). After consuming stdin, reopens /dev/tty (or CON on Windows) so interactive
prompts still work. This is needed for the Deadline Cloud Monitor desktop app (Tauri) integration, where the Monitor writes file paths to the child process's stdin to avoid shell
argument limits and Tauri's scoped command argument validation.
- **Path validation**: _validate_and_normalize_include_paths() rejects .. (path traversal), converts \ to / (Windows compatibility), strips ./, collapses //.
- **Storage profile compatibility**: Added _filter_manifests() to filter BaseAssetManifest objects by path, applied before _transform_manifests_to_absolute_paths() in the storage
profile download flow. Without this, --include-path filters were silently ignored when storage profiles were configured (#1029).
- **Bug fix**: get_job_input_paths_by_asset_root() was not prepending the S3 root prefix + Manifests folder to input manifest keys (unlike asset_sync.py which does this correctly).
Fixed to use s3_settings.add_root_and_manifest_folder_prefix().
- **Refactoring**: Extracted shared download UX flow into _run_download_ux(), _get_job_download_context(), _parse_filters_and_config(), and _handle_download_error() to prepare for
the follow-up download-input PR.

### What is the impact of this change?

- download-output without --include-path behaves exactly as before — no breaking change.
- The get_job_input_paths_by_asset_root() bug fix changes the S3 key used to fetch input manifests. This function was not previously called by any CLI command. The worker agent uses
asset_sync.py which already had the correct prefix logic.

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests?
  - Yes. New unit tests + existing download tests all pass (210 passed, 0 failed).
- Have you run the integration tests?
  - Manually tested end-to-end against a real job with known input/output files:
    - download-output --include-path "output/output_0005.png" → downloaded 1 of 25 files
    - download-output with 10 --include-path values → downloaded exactly 10 of 25 files
    - --include-path "nonexistent.txt" → "No output files available"
    - --include-path "../../etc/passwd" → rejected with "Path filter must not contain '..'"
    - --include-path-stdin without piped data → reads until empty line, then continues to interactive prompts
- Have you made changes to the download or asset_sync modules? If so, then it is highly recommended
 that you ensure that the docker-based unit tests pass.
  - Yes, changes to download.py. Docker-based tests should be run before merge.

### Was this change documented?

- Are relevant docstrings in the code base updated?
  - Yes. All new functions have docstrings.
- Has the README.md been updated? If you modified CLI arguments, for instance.
  - The CLI reference (docs/cli_reference/deadline_job.md) is auto-generated from click decorators — new options will appear automatically.
  - docs/job_attachments_guide.md updated to mention --include-path.

### Does this PR introduce new dependencies?

* [x] This PR does not add any new dependencies.

### Is this a breaking change?

No. download-output without --include-path behaves identically to before. The get_job_input_paths_by_asset_root() fix changes behavior of a function that was not previously called
from any CLI command.

### Does this change impact security?

- The --include-path option introduces a new input vector. Path traversal is mitigated with defense in depth:
  1. _validate_and_normalize_include_paths() rejects any filter containing .. at parse time.
  2. _ensure_paths_within_directory() validates download destination paths stay within the asset root at download time (existing check).
- No new files/directories are created beyond the existing download behavior.
- No threat modeling needed — same S3 access patterns and credential flow as existing download-output.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
