### PR TITLE
fix: bump boto3 version to support batch APIs for trace-schedule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
 # Applications that consume this library should be the ones that are more strictly
 # limiting dependencies if they want/need to.
 dependencies = [
-  "boto3 >= 1.42.29; python_version >= '3.9'",
+  "boto3 >= 1.42.89; python_version >= '3.9'",
   "boto3 >= 1.36.8; python_version < '3.9'",
   # Click 8.2 dropped python 3.8/3.9 support
   "click >= 8.1.7",


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

We recently added usage of batch apis to job-trace-schedule CLI #1117, but didn't bump the boto3 version that's required to use it. Released in version 1.42.89: https://github.com/boto/boto3/blob/develop/CHANGELOG.rst#L99

The command already guards against older versions of python, so nothing changes there.

### What was the solution? (How)

bump the version

### What is the impact of this change?

Working job-trace-schedule when you perform a `pip install` where you previously had an older boto3

### How was this change tested?

```
hatch run test
```

### Was this change documented?

N/A

### Does this PR introduce new dependencies?

N/A

### Is this a breaking change?

Maybe technically since whatever venv has to update and we don't know other deps restrictions? But we've been doing these as simple patch updates.

### Does this change impact security?

N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
