### PR TITLE
chore: ensure patch branches also get code scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "mainline", "feature_*" ]
+    branches: [ "mainline", "feature_*", "patch_*" ]
   pull_request:
-    branches: [ "mainline", "feature_*" ]
+    branches: [ "mainline", "feature_*", "patch_*" ]
   schedule:
     - cron: '0 8 * * MON'
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

When trying to do a patch release, code scanning was blocking merges.

### What was the solution? (How)

enable code scanning on patch branches

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
