### PR TITLE
chore: Gate release on macOS integration tests

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -77,7 +77,7 @@ jobs:
       tag: ${{ needs.TagRelease.outputs.tag }}
 
   PreRelease:
-    needs: [TagRelease, LinuxIntegrationTests, WindowsIntegrationTests]
+    needs: [TagRelease, LinuxIntegrationTests, WindowsIntegrationTests, MacOSIntegrationTests]
     uses: aws-deadline/.github/.github/workflows/reusable_prerelease.yml@mainline
     permissions:
       id-token: write


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

macOS integration tests were added as non-blocking in PR #1119. 

### What was the solution? (How)

Added `MacOSIntegrationTests` to the `PreRelease` dependencies so macOS test failures block releases, matching the existing Linux and Windows pattern.

### What is the impact of this change?

A macOS integration test failure will now block the release pipeline, ensuring macOS compatibility is verified before every release.

### How was this change tested?

macOS integration tests passed on a real release run before this gate was added.

### Was this change documented?

N/A

### Does this PR introduce new dependencies?

No

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*