### PR TITLE
test: add DCM integration test workflows (Linux, macOS, Windows)

### DIFF
--- a/.github/scripts/dcm_e2e_test.py
+++ b/.github/scripts/dcm_e2e_test.py
@@ -1,0 +1,194 @@
+"""E2E: deadline auth login → DCM opens browser → drive IdC sign-in via xa11y.
+
+Cross-platform. Relies on xa11y >= 0.7 for:
+  - xa11y.screenshot().save_png(path)  — native screen capture on all platforms
+  - Locator.type_text(str)              — splice text via a11y API (no keystrokes)
+"""
+import os
+import platform
+import subprocess
+import sys
+import time
+
+import xa11y
+
+sys.stdout.reconfigure(line_buffering=True)
+
+IS_LINUX = platform.system() == "Linux"
+
+USERNAME = os.environ["MONITOR_USERNAME"]
+PASSWORD = os.environ["MONITOR_PASSWORD"]
+
+# Browser xa11y app name and Open-Link button label vary per platform.
+BROWSER_NAME = os.environ.get("BROWSER_NAME", "Firefox")
+OPEN_LINK_LABELS = os.environ.get("OPEN_LINK_LABELS", "Open Link,Open link,Open").split(",")
+
+SCREENSHOT_DIR = os.environ.get("SCREENSHOT_DIR", "/tmp")
+
+
+def run(cmd, check=True, timeout=180):
+    print(f"$ {' '.join(cmd)}", flush=True)
+    r = subprocess.run(cmd, text=True, capture_output=True, timeout=timeout)
+    print(r.stdout, r.stderr, flush=True)
+    if check and r.returncode:
+        fail(f"failed: {cmd}")
+    return r
+
+
+def screenshot(name):
+    path = os.path.join(SCREENSHOT_DIR, f"{name}.png")
+    try:
+        xa11y.screenshot().save_png(path)
+    except Exception as e:
+        print(f"screenshot({name}) failed: {e}", flush=True)
+
+
+def dump_all_trees():
+    for app in xa11y.App.list():
+        print(f"=== APP {app.name!r} pid={app.pid} ===", flush=True)
+
+        def walk(el, d=0, maxd=30):
+            if d > maxd:
+                return
+            try:
+                print("  " * d + f"{el.role} name={(el.name or '')[:80]!r} value={(el.value or '')[:40]!r}",
+                      flush=True)
+            except Exception:
+                return
+            try:
+                for c in el.children():
+                    walk(c, d + 1, maxd)
+            except Exception:
+                pass
+
+        try:
+            for c in app.children():
+                walk(c)
+        except Exception as e:
+            print(f"  (children failed: {e})", flush=True)
+
+
+def on_failure(exc_type, exc, tb):
+    ts = int(time.time())
+    print(f"\n=== FAILURE {exc_type.__name__}: {exc} ===", flush=True)
+    try:
+        screenshot(f"failure_{ts}")
+        dump_all_trees()
+    except Exception as e:
+        print(f"diagnostic failed: {e}", flush=True)
+    sys.__excepthook__(exc_type, exc, tb)
+
+
+sys.excepthook = on_failure
+
+
+def fail(msg):
+    raise RuntimeError(msg)
+
+
+def browser():
+    """Find the browser app. BROWSER_NAME is a substring; first matching app wins."""
+    end = time.time() + 90
+    while time.time() < end:
+        for app in xa11y.App.list():
+            if BROWSER_NAME.lower() in (app.name or "").lower():
+                return app
+        time.sleep(1)
+    fail(f"browser {BROWSER_NAME!r} not found; apps: {[a.name for a in xa11y.App.list()]}")
+
+
+def click_open_link(br):
+    """Click the browser's 'Open this link in Deadline Cloud monitor?' dialog."""
+    for label in OPEN_LINK_LABELS:
+        try:
+            br.locator(f"button[name='{label}']").press()
+            print(f"pressed button[name='{label}']", flush=True)
+            return True
+        except Exception:
+            pass
+    # Linux Firefox fallback: auto-redirect page with a 'here' link. Locator.press
+    # invokes the link's a11y action, which triggers the browser's scheme-open UI.
+    if IS_LINUX:
+        try:
+            br.locator("link[name='here']").press()
+            print("pressed link[name='here']", flush=True)
+            return True
+        except Exception:
+            pass
+    return False
+
+
+def _type_into(locator, text):
+    """Type text into a focused field. Locator.type_text() uses the a11y splice
+    API, which doesn't work on browser web-content fields on macOS/Linux (only
+    on native widgets). InputSim.type_text() synthesises real keystrokes
+    through the OS, which works everywhere as long as the field has focus."""
+    locator.focus()
+    time.sleep(0.3)
+    xa11y.input_sim().type_text(text)
+
+
+def sign_in():
+    br = browser()
+    # Dismiss any first-run welcome screens (Edge has several layered ones)
+    for _ in range(6):
+        dismissed = False
+        for label in ("Start without your data", "Confirm and continue",
+                      "Confirm and start browsing", "Skip", "Not now",
+                      "Continue without this data", "Continue without Microsoft data"):
+            try:
+                btn = br.locator(f"button[name='{label}']")
+                btn.wait_visible(timeout=1)
+                btn.press()
+                print(f"dismissed welcome: {label}", flush=True)
+                dismissed = True
+                time.sleep(1)
+                break
+            except Exception:
+                pass
+        if not dismissed:
+            break
+    user = br.locator("text_field[name='Username']")
+    user.wait_visible(timeout=120)
+    _type_into(user, USERNAME)
+    br.locator("button[name='Next']").press()
+    pw = br.locator("text_field[name='Password']")
+    pw.wait_visible(timeout=60)
+    _type_into(pw, PASSWORD)
+    br.locator("button[name='Sign in']").press()
+    # Optional IdC 'Allow' consent screen
+    try:
+        br.locator("button[name='Allow']").wait_visible(timeout=10)
+        br.locator("button[name='Allow']").press()
+    except xa11y.TimeoutError:
+        pass
+    # Wait for Open-Link dialog (Linux Firefox). On macOS Safari + some browsers,
+    # the deadline-cloud-monitor:// scheme is auto-dispatched without prompt.
+    end = time.time() + 60
+    while time.time() < end:
+        if click_open_link(br):
+            return
+        time.sleep(1)
+    print("No Open Link dialog appeared (browser may have auto-dispatched the scheme)", flush=True)
+
+
+def main():
+    cli = subprocess.Popen(["deadline", "auth", "login"])
+    print(f"auth login pid={cli.pid}", flush=True)
+    try:
+        time.sleep(10)
+        sign_in()
+        cli.wait(timeout=180)
+        if cli.returncode:
+            fail(f"auth login failed: {cli.returncode}")
+    finally:
+        if cli.poll() is None:
+            cli.kill()
+
+    run(["deadline", "auth", "status"])
+    run(["deadline", "farm", "list"])
+    print("SUCCESS")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/dcm_integration_test_linux.yml
+++ b/.github/workflows/dcm_integration_test_linux.yml
@@ -1,0 +1,101 @@
+name: DCM Integration Test (Linux)
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  test:
+    name: DCM E2E Test (Linux)
+    # Ubuntu 22.04 is the newest ubuntu runner that still has libwebkit2gtk-4.0-37,
+    # which the DCM .deb depends on (Tauri v1 runtime).
+    runs-on: ubuntu-22.04
+    environment: integ
+    timeout-minutes: 20
+    env:
+      MONITOR_SUBDOMAIN: ${{ secrets.MONITOR_SUBDOMAIN }}
+      MONITOR_REGION: ${{ secrets.MONITOR_REGION }}
+      MONITOR_USERNAME: ${{ secrets.MONITOR_USERNAME }}
+      MONITOR_PASSWORD: ${{ secrets.MONITOR_PASSWORD }}
+      MONITOR_ID: monitor-00000000000000000000000000000000
+      DISPLAY: ':99'
+      # Force GTK/Firefox to use the AT-SPI accessibility backend so xa11y can
+      # read the browser's DOM tree. Without these, Firefox doesn't expose web
+      # content to AT-SPI and xa11y sees only the chrome (tabs, buttons, etc.).
+      GTK_MODULES: gail:atk-bridge
+      GTK_A11Y: atk
+      GNOME_ACCESSIBILITY: '1'
+      ACCESSIBILITY_ENABLED: '1'
+      MOZ_ENABLE_WAYLAND: '0'
+      MOZ_ACCESSIBILITY_ATK2: '1'
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xvfb dbus-x11 at-spi2-core \
+            libayatana-appindicator3-1 libwebkit2gtk-4.0-37 desktop-file-utils
+
+      - name: Install Firefox
+        # Ubuntu 22.04+ ships Firefox as a snap transitional package which
+        # doesn't work without snapd. Install the Mozilla tarball directly and
+        # register it as the default http/https handler so DCM's xdg-open works.
+        run: |
+          curl -sL 'https://download.mozilla.org/?product=firefox-latest-ssl&os=linux64&lang=en-US' -o /tmp/ff.tar.xz
+          sudo tar -xJf /tmp/ff.tar.xz -C /opt
+          sudo ln -sf /opt/firefox/firefox /usr/local/bin/firefox
+          mkdir -p ~/.local/share/applications
+          cat > ~/.local/share/applications/firefox.desktop <<'EOF'
+          [Desktop Entry]
+          Type=Application
+          Name=Firefox
+          Exec=/opt/firefox/firefox %u
+          MimeType=x-scheme-handler/http;x-scheme-handler/https;
+          Terminal=false
+          EOF
+          update-desktop-database ~/.local/share/applications
+          xdg-mime default firefox.desktop x-scheme-handler/http
+          xdg-mime default firefox.desktop x-scheme-handler/https
+
+      - name: Start Xvfb + session bus + AT-SPI
+        run: |
+          Xvfb :99 -screen 0 1920x1080x24 &
+          sleep 1
+          eval "$(dbus-launch --sh-syntax)"
+          echo "DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS" >> $GITHUB_ENV
+          /usr/libexec/at-spi-bus-launcher --launch-immediately &
+          sleep 2
+
+      - name: Install deadline CLI and xa11y
+        run: pip install . 'xa11y>=0.7.1'
+
+      - name: Install DCM (.deb)
+        # .deb auto-registers deadline-cloud-monitor:// scheme handler and installs
+        # the binary to /usr/bin, so no symlinks or manual xdg-mime calls are needed.
+        run: |
+          DEB=$(curl -s https://downloads.deadlinecloud.amazonaws.com/manifest.json | python -c "import sys,json; print(json.load(sys.stdin)['latest']['linux_deb'])")
+          curl -sL "$DEB" -o /tmp/dcm.deb
+          sudo apt-get install -y /tmp/dcm.deb
+
+      - name: Create DCM profile
+        run: |
+          deadline-cloud-monitor create-profile --profile dcm-test \
+            --monitor-id "$MONITOR_ID" \
+            --monitor-url "https://${MONITOR_SUBDOMAIN}.${MONITOR_REGION}.deadlinecloud.amazonaws.com" \
+            --enable-auto-login --set-as-deadline-default
+
+      - name: Run E2E test
+        run: python .github/scripts/dcm_e2e_test.py
+
+      - name: Upload screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: screenshots-linux
+          path: /tmp/*.png
+          if-no-files-found: ignore

--- a/.github/workflows/dcm_integration_test_macos.yml
+++ b/.github/workflows/dcm_integration_test_macos.yml
@@ -1,0 +1,64 @@
+name: DCM Integration Test (macOS)
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  test:
+    name: DCM E2E Test (macOS)
+    runs-on: macos-latest
+    environment: integ
+    timeout-minutes: 20
+    env:
+      MONITOR_SUBDOMAIN: ${{ secrets.MONITOR_SUBDOMAIN }}
+      MONITOR_REGION: ${{ secrets.MONITOR_REGION }}
+      MONITOR_USERNAME: ${{ secrets.MONITOR_USERNAME }}
+      MONITOR_PASSWORD: ${{ secrets.MONITOR_PASSWORD }}
+      MONITOR_ID: monitor-00000000000000000000000000000000
+      # Drive Safari (the default browser on the macOS runner). The IdC sign-in
+      # form labels match Firefox's, and Safari auto-dispatches the
+      # deadline-cloud-monitor:// URL scheme without an "Open Link" prompt.
+      BROWSER_NAME: Safari
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install deadline CLI and xa11y
+        run: pip install . 'xa11y>=0.7.1'
+
+      - name: Install DCM
+        # The .dmg installer drops Deadline Cloud Monitor.app into /Applications
+        # and registers the deadline-cloud-monitor:// URL scheme via the app's
+        # Info.plist. We add the app bundle's MacOS dir to PATH so the deadline
+        # CLI can find the binary by name.
+        run: |
+          DMG=$(curl -s https://downloads.deadlinecloud.amazonaws.com/manifest.json \
+            | python -c "import sys,json,urllib.parse as u; print(u.quote(json.load(sys.stdin)['latest']['mac_aarch64'], safe=':/'))")
+          curl -sL "$DMG" -o /tmp/dcm.dmg
+          hdiutil attach /tmp/dcm.dmg -nobrowse -quiet
+          cp -R "/Volumes/Deadline Cloud Monitor/Deadline Cloud Monitor.app" /Applications/
+          hdiutil detach "/Volumes/Deadline Cloud Monitor" -quiet
+          echo "/Applications/Deadline Cloud Monitor.app/Contents/MacOS" >> $GITHUB_PATH
+
+      - name: Create DCM profile
+        run: |
+          "/Applications/Deadline Cloud Monitor.app/Contents/MacOS/Deadline Cloud Monitor" \
+            create-profile --profile dcm-test \
+            --monitor-id "$MONITOR_ID" \
+            --monitor-url "https://${MONITOR_SUBDOMAIN}.${MONITOR_REGION}.deadlinecloud.amazonaws.com" \
+            --enable-auto-login --set-as-deadline-default
+
+      - name: Run E2E test
+        run: python .github/scripts/dcm_e2e_test.py
+
+      - name: Upload screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: screenshots-macos
+          path: /tmp/*.png
+          if-no-files-found: ignore

--- a/.github/workflows/dcm_integration_test_windows.yml
+++ b/.github/workflows/dcm_integration_test_windows.yml
@@ -1,0 +1,83 @@
+name: DCM Integration Test (Windows)
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  test:
+    name: DCM E2E Test (Windows)
+    runs-on: windows-latest
+    environment: integ
+    timeout-minutes: 20
+    env:
+      MONITOR_SUBDOMAIN: ${{ secrets.MONITOR_SUBDOMAIN }}
+      MONITOR_REGION: ${{ secrets.MONITOR_REGION }}
+      MONITOR_USERNAME: ${{ secrets.MONITOR_USERNAME }}
+      MONITOR_PASSWORD: ${{ secrets.MONITOR_PASSWORD }}
+      MONITOR_ID: monitor-00000000000000000000000000000000
+      # Drive Edge (the default browser on the Windows runner). The IdC sign-in
+      # form labels match Firefox's; Edge auto-dispatches deadline-cloud-monitor:// .
+      BROWSER_NAME: Edge
+      OPEN_LINK_LABELS: "Open,Open Link,Open link,Yes"
+      SCREENSHOT_DIR: ${{ github.workspace }}\screenshots
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Disable Edge first-run experience
+        # Without these policies, Edge shows 3+ layered welcome screens on first
+        # launch that cover the IdC sign-in page and have no obvious dismiss.
+        shell: pwsh
+        run: |
+          New-Item -Path 'HKLM:\SOFTWARE\Policies\Microsoft\Edge' -Force | Out-Null
+          Set-ItemProperty -Path 'HKLM:\SOFTWARE\Policies\Microsoft\Edge' -Name 'HideFirstRunExperience' -Value 1 -Type DWord
+          Set-ItemProperty -Path 'HKLM:\SOFTWARE\Policies\Microsoft\Edge' -Name 'BrowserSignin' -Value 0 -Type DWord
+          Set-ItemProperty -Path 'HKLM:\SOFTWARE\Policies\Microsoft\Edge' -Name 'SyncDisabled' -Value 1 -Type DWord
+          Set-ItemProperty -Path 'HKLM:\SOFTWARE\Policies\Microsoft\Edge' -Name 'RestoreOnStartup' -Value 1 -Type DWord
+
+      - name: Install deadline CLI and xa11y
+        run: pip install . 'xa11y>=0.7.1'
+        shell: pwsh
+
+      - name: Install DCM
+        # The NSIS installer (/S = silent) installs DCM and registers the
+        # deadline-cloud-monitor:// URL scheme via the Windows registry. We just
+        # need to put the install dir on PATH so the deadline CLI can find the
+        # binary (DCM's create-profile will write its absolute path to
+        # ~/.deadline/config automatically).
+        shell: pwsh
+        run: |
+          $EXE = (Invoke-RestMethod https://downloads.deadlinecloud.amazonaws.com/manifest.json).latest.windows_x64
+          Invoke-WebRequest $EXE -OutFile dcm-setup.exe
+          Start-Process -Wait -FilePath .\dcm-setup.exe -ArgumentList '/S'
+          Start-Sleep -Seconds 5
+          "$env:LOCALAPPDATA\DeadlineCloudMonitor" | Out-File $env:GITHUB_PATH -Append
+
+      - name: Create DCM profile
+        shell: pwsh
+        run: |
+          & "$env:LOCALAPPDATA\DeadlineCloudMonitor\DeadlineCloudMonitor.exe" `
+            create-profile --profile dcm-test `
+            --monitor-id $env:MONITOR_ID `
+            --monitor-url "https://$env:MONITOR_SUBDOMAIN.$env:MONITOR_REGION.deadlinecloud.amazonaws.com" `
+            --enable-auto-login --set-as-deadline-default
+
+      - name: Prepare screenshot dir
+        shell: pwsh
+        run: New-Item -ItemType Directory -Force -Path $env:SCREENSHOT_DIR
+
+      - name: Run E2E test
+        shell: pwsh
+        run: python .github/scripts/dcm_e2e_test.py
+
+      - name: Upload screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: screenshots-windows
+          path: ${{ env.SCREENSHOT_DIR }}\*.png
+          if-no-files-found: ignore


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We want to automated DCM + Deadline client integ tests.

### What was the solution? (How)
Add them. New tests download DCM and then use the Deadline CLI to authenticate and call `deadline farm list`. Tests run on PR.

### What is the impact of this change?
Less manual testing

### How was this change tested?
...

### Was this change documented?
n/a

### Does this PR introduce new dependencies?
No

### Is this a breaking change?
No

### Does this change impact security?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
