### PR TITLE
ci: run DCM integ tests on mainline push, add combined status badge

### DIFF
--- a/.github/workflows/dcm_integration_test_linux.yml
+++ b/.github/workflows/dcm_integration_test_linux.yml
@@ -2,7 +2,7 @@ name: DCM Integration Test (Linux)
 
 on:
   workflow_dispatch:
-  pull_request:
+  workflow_call:
 
 jobs:
   test:

--- a/.github/workflows/dcm_integration_test_macos.yml
+++ b/.github/workflows/dcm_integration_test_macos.yml
@@ -2,7 +2,7 @@ name: DCM Integration Test (macOS)
 
 on:
   workflow_dispatch:
-  pull_request:
+  workflow_call:
 
 jobs:
   test:

--- a/.github/workflows/dcm_integration_test_windows.yml
+++ b/.github/workflows/dcm_integration_test_windows.yml
@@ -2,7 +2,7 @@ name: DCM Integration Test (Windows)
 
 on:
   workflow_dispatch:
-  pull_request:
+  workflow_call:
 
 jobs:
   test:

--- a/.github/workflows/dcm_integration_tests.yml
+++ b/.github/workflows/dcm_integration_tests.yml
@@ -1,0 +1,22 @@
+name: DCM Integration Tests
+
+# Fans out to the per-OS DCM integration tests so a single status check
+# (and a single README badge) reflects the combined Linux/macOS/Windows
+# result. The individual per-OS workflows can still be dispatched on
+# their own via workflow_dispatch for debugging.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [mainline]
+
+jobs:
+  linux:
+    uses: ./.github/workflows/dcm_integration_test_linux.yml
+    secrets: inherit
+  macos:
+    uses: ./.github/workflows/dcm_integration_test_macos.yml
+    secrets: inherit
+  windows:
+    uses: ./.github/workflows/dcm_integration_test_windows.yml
+    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 [![python](https://img.shields.io/pypi/pyversions/deadline.svg?style=flat)](https://pypi.python.org/pypi/deadline)
 [![license](https://img.shields.io/pypi/l/deadline.svg?style=flat)](https://github.com/aws-deadline/deadline/blob/mainline/LICENSE)
 
+[![DCM integ tests](https://github.com/aws-deadline/deadline-cloud/actions/workflows/dcm_integration_tests.yml/badge.svg?branch=mainline)](https://github.com/aws-deadline/deadline-cloud/actions/workflows/dcm_integration_tests.yml?query=branch%3Amainline)
+
 AWS Deadline Cloud client is a multi-purpose python library and command line tool for interacting with and submitting
 [Open Job Description (OpenJD)][openjd] jobs to [AWS Deadline Cloud][deadline-cloud].
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Turns out CI actions that run on PRs do not get secrets if they're from a fork (the normal case) as a security measure. As a result, DCM integ tests CI actions on PRs are failing.

### What was the solution? (How)
Move integ tests to post merge. Add a badge on the README to make the status easy to find.

### What is the impact of this change?
Fixes PR CI actions

### How was this change tested?
PR checks

### Was this change documented?
n/a

### Does this PR introduce new dependencies?
No

### Is this a breaking change?
No

### Does this change impact security?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
