### PR TITLE
fix: restore deadline auth login after STS-to-ListFarms switch

### DIFF
--- a/src/deadline/client/api/__init__.py
+++ b/src/deadline/client/api/__init__.py
@@ -32,6 +32,7 @@ __all__ = [
     "check_authentication_status",
     "check_deadline_api_available",
     "get_credentials_source",
+    "get_user_and_identity_store_id",
     "precache_clients",
     "list_farms",
     "list_queues",
@@ -74,7 +75,7 @@ __all__ = [
 import encodings.idna  # noqa # pylint: disable=unused-import
 from configparser import ConfigParser
 from logging import getLogger
-from typing import Any, Dict, Optional
+from typing import Optional
 
 
 # Telemetry must be imported before Submit Job Bundle to avoid circular dependencies.
@@ -157,17 +158,11 @@ def check_deadline_api_available(config: Optional[ConfigParser] = None) -> bool:
     """
     import logging
 
-    from ._session import _modified_logging_level
+    from ._session import _list_farms_for_auth_probe, _modified_logging_level
 
     with _modified_logging_level(logging.getLogger("botocore.credentials"), logging.ERROR):
         try:
-            list_farm_params: Dict[str, Any] = {"maxResults": 1}
-            user_id, _ = get_user_and_identity_store_id(config=config)
-            if user_id:
-                list_farm_params["principalId"] = str(user_id)
-
-            deadline = get_boto3_client("deadline", config=config)
-            deadline.list_farms(**list_farm_params)
+            _list_farms_for_auth_probe(config=config)
             return True
         except Exception:
             logger.exception("Error invoking ListFarms")

--- a/src/deadline/client/api/_list_apis.py
+++ b/src/deadline/client/api/_list_apis.py
@@ -7,6 +7,14 @@ from ._session import (
 from .. import api
 
 
+def _apply_principal_id_filter(kwargs, config=None):
+    """Injects ``principalId`` into *kwargs* when the active profile has a DCM user_id."""
+    if "principalId" not in kwargs:
+        user_id, _ = get_user_and_identity_store_id(config=config)
+        if user_id:
+            kwargs["principalId"] = user_id
+
+
 def _call_paginated_deadline_list_api(list_api, list_property_name, **kwargs):
     """
     Calls a deadline:List* API repeatedly to concatenate all pages.
@@ -39,11 +47,7 @@ def list_farms(config=None, **kwargs):
 
     [deadline:ListFarms]: https://docs.aws.amazon.com/deadline-cloud/latest/APIReference/API_ListFarms.html
     """
-    if "principalId" not in kwargs:
-        user_id, _ = get_user_and_identity_store_id(config=config)
-        if user_id:
-            kwargs["principalId"] = user_id
-
+    _apply_principal_id_filter(kwargs, config=config)
     deadline = get_boto3_client("deadline", config=config)
     return _call_paginated_deadline_list_api(deadline.list_farms, "farms", **kwargs)
 
@@ -57,11 +61,7 @@ def list_queues(config=None, **kwargs):
 
     [deadline:ListQueues]: https://docs.aws.amazon.com/deadline-cloud/latest/APIReference/API_ListQueues.html
     """
-    if "principalId" not in kwargs:
-        user_id, _ = get_user_and_identity_store_id(config=config)
-        if user_id:
-            kwargs["principalId"] = user_id
-
+    _apply_principal_id_filter(kwargs, config=config)
     deadline = get_boto3_client("deadline", config=config)
     return _call_paginated_deadline_list_api(deadline.list_queues, "queues", **kwargs)
 
@@ -75,11 +75,7 @@ def list_jobs(config=None, **kwargs):
 
     [deadline:ListJobs]: https://docs.aws.amazon.com/deadline-cloud/latest/APIReference/API_ListJobs.html
     """
-    if "principalId" not in kwargs:
-        user_id, _ = get_user_and_identity_store_id(config=config)
-        if user_id:
-            kwargs["principalId"] = user_id
-
+    _apply_principal_id_filter(kwargs, config=config)
     deadline = get_boto3_client("deadline", config=config)
     return _call_paginated_deadline_list_api(deadline.list_jobs, "jobs", **kwargs)
 
@@ -93,11 +89,7 @@ def list_fleets(config=None, **kwargs):
 
     [deadline:ListFleets]: https://docs.aws.amazon.com/deadline-cloud/latest/APIReference/API_ListFleets.html
     """
-    if "principalId" not in kwargs:
-        user_id, _ = get_user_and_identity_store_id(config=config)
-        if user_id:
-            kwargs["principalId"] = user_id
-
+    _apply_principal_id_filter(kwargs, config=config)
     deadline = get_boto3_client("deadline", config=config)
     return _call_paginated_deadline_list_api(deadline.list_fleets, "fleets", **kwargs)
 

--- a/src/deadline/client/api/_loginout.py
+++ b/src/deadline/client/api/_loginout.py
@@ -64,7 +64,12 @@ def _login_deadline_cloud_monitor(
     # And wait for the user to complete login
     while True:
         # Deadline Cloud monitor is a GUI app that will keep on running
-        # So we sit here and test that profile for validity until it works
+        # So we sit here and test that profile for validity until it works.
+        # Force-refresh the session each iteration so the next probe picks up
+        # profile keys DCM writes (user_id, identity_store_id, monitor_id) as
+        # login completes — the GUI does the same on file-watch events in
+        # DeadlineAuthenticationStatus.files_changed, but CLI has no watcher.
+        _session.get_boto3_session(force_refresh=True, config=config)
         if check_authentication_status(config) == AwsAuthenticationStatus.AUTHENTICATED:
             return f"Deadline Cloud monitor profile: {profile_name}"
         if on_cancellation_check:

--- a/src/deadline/client/api/_session.py
+++ b/src/deadline/client/api/_session.py
@@ -297,10 +297,10 @@ def _list_farms_for_auth_probe(config: Optional[ConfigParser] = None) -> None:
     Raises whatever exception the underlying boto3 call raises; callers are
     responsible for exception handling.
     """
+    from ._list_apis import _apply_principal_id_filter
+
     list_farm_params: dict = {"maxResults": 1}
-    user_id, _ = get_user_and_identity_store_id(config=config)
-    if user_id:
-        list_farm_params["principalId"] = str(user_id)
+    _apply_principal_id_filter(list_farm_params, config=config)
     get_boto3_client("deadline", config=config).list_farms(**list_farm_params)
 
 

--- a/src/deadline/client/api/_session.py
+++ b/src/deadline/client/api/_session.py
@@ -283,6 +283,27 @@ def _modified_logging_level(logger, level):
         logger.setLevel(old_level)
 
 
+def _list_farms_for_auth_probe(config: Optional[ConfigParser] = None) -> None:
+    """
+    Makes a minimal ``deadline:ListFarms`` call used as an auth/reachability
+    probe by :func:`check_authentication_status` and
+    :func:`check_deadline_api_available`.
+
+    For Deadline Cloud monitor profiles, injects ``principalId`` so the call
+    is scoped to the caller's IdC user (matching the :func:`api.list_farms`
+    wrapper). Without it, IdC-issued sessions get denied by the service and
+    the auth-login poll loop never resolves to AUTHENTICATED.
+
+    Raises whatever exception the underlying boto3 call raises; callers are
+    responsible for exception handling.
+    """
+    list_farm_params: dict = {"maxResults": 1}
+    user_id, _ = get_user_and_identity_store_id(config=config)
+    if user_id:
+        list_farm_params["principalId"] = str(user_id)
+    get_boto3_client("deadline", config=config).list_farms(**list_farm_params)
+
+
 def check_authentication_status(
     config: Optional[ConfigParser] = None,
 ) -> AwsAuthenticationStatus:
@@ -303,7 +324,7 @@ def check_authentication_status(
 
     with _modified_logging_level(logging.getLogger("botocore.credentials"), logging.ERROR):
         try:
-            get_boto3_client("deadline", config=config).list_farms(maxResults=1)
+            _list_farms_for_auth_probe(config=config)
             return AwsAuthenticationStatus.AUTHENTICATED
         except Exception:
             # We assume that the presence of a Deadline Cloud monitor profile

--- a/test/unit/deadline_client/api/test_api_session.py
+++ b/test/unit/deadline_client/api/test_api_session.py
@@ -74,7 +74,7 @@ def test_get_boto3_session_caching_behavior(fresh_deadline_config):
 def test_get_check_authentication_status_authenticated(fresh_deadline_config):
     """Confirm that check_authentication_status returns AUTHENTICATED (non-DCM profile)."""
     with patch.object(api._session, "get_boto3_client") as boto3_client_mock, patch.object(
-        api._session, "get_user_and_identity_store_id", return_value=(None, None)
+        api._list_apis, "get_user_and_identity_store_id", return_value=(None, None)
     ):
         config.set_setting("defaults.aws_profile_name", "SomeRandomProfileName")
         boto3_client_mock.return_value.list_farms.return_value = {"farms": []}
@@ -92,7 +92,7 @@ def test_get_check_authentication_status_authenticated_injects_principal_id(
     caller's user membership (avoids AccessDenied that would otherwise leave
     the auth-login poll loop stuck in NEEDS_LOGIN)."""
     with patch.object(api._session, "get_boto3_client") as boto3_client_mock, patch.object(
-        api._session,
+        api._list_apis,
         "get_user_and_identity_store_id",
         return_value=("user-1234", "d-abcdef0123"),
     ):
@@ -108,7 +108,7 @@ def test_get_check_authentication_status_authenticated_injects_principal_id(
 def test_get_check_authentication_status_configuration_error(fresh_deadline_config):
     """Confirm that check_authentication_status returns CONFIGURATION_ERROR"""
     with patch.object(api._session, "get_boto3_client") as boto3_client_mock, patch.object(
-        api._session, "get_user_and_identity_store_id", return_value=(None, None)
+        api._list_apis, "get_user_and_identity_store_id", return_value=(None, None)
     ):
         config.set_setting("defaults.aws_profile_name", "SomeRandomProfileName")
         boto3_client_mock.return_value.list_farms.side_effect = Exception("some uncaught exception")
@@ -157,7 +157,7 @@ def test_check_deadline_api_available(fresh_deadline_config):
 def test_check_deadline_api_available_injects_principal_id(fresh_deadline_config):
     """For DCM profiles, check_deadline_api_available must pass principalId."""
     with patch.object(api._session, "get_boto3_client") as boto3_client_mock, patch.object(
-        api._session,
+        api._list_apis,
         "get_user_and_identity_store_id",
         return_value=("user-1234", "d-abcdef0123"),
     ):

--- a/test/unit/deadline_client/api/test_api_session.py
+++ b/test/unit/deadline_client/api/test_api_session.py
@@ -72,18 +72,44 @@ def test_get_boto3_session_caching_behavior(fresh_deadline_config):
 
 
 def test_get_check_authentication_status_authenticated(fresh_deadline_config):
-    """Confirm that check_authentication_status returns AUTHENTICATED"""
-    with patch.object(api._session, "get_boto3_client") as boto3_client_mock:
+    """Confirm that check_authentication_status returns AUTHENTICATED (non-DCM profile)."""
+    with patch.object(api._session, "get_boto3_client") as boto3_client_mock, patch.object(
+        api._session, "get_user_and_identity_store_id", return_value=(None, None)
+    ):
         config.set_setting("defaults.aws_profile_name", "SomeRandomProfileName")
         boto3_client_mock.return_value.list_farms.return_value = {"farms": []}
 
         assert api.check_authentication_status() == api.AwsAuthenticationStatus.AUTHENTICATED
+        # Without a DCM-provided user_id, principalId must not be injected.
         boto3_client_mock.return_value.list_farms.assert_called_once_with(maxResults=1)
+
+
+def test_get_check_authentication_status_authenticated_injects_principal_id(
+    fresh_deadline_config,
+):
+    """For Deadline Cloud monitor profiles, check_authentication_status must pass
+    the IdC user id as principalId so the ListFarms probe is scoped to the
+    caller's user membership (avoids AccessDenied that would otherwise leave
+    the auth-login poll loop stuck in NEEDS_LOGIN)."""
+    with patch.object(api._session, "get_boto3_client") as boto3_client_mock, patch.object(
+        api._session,
+        "get_user_and_identity_store_id",
+        return_value=("user-1234", "d-abcdef0123"),
+    ):
+        config.set_setting("defaults.aws_profile_name", "dcm-profile")
+        boto3_client_mock.return_value.list_farms.return_value = {"farms": []}
+
+        assert api.check_authentication_status() == api.AwsAuthenticationStatus.AUTHENTICATED
+        boto3_client_mock.return_value.list_farms.assert_called_once_with(
+            maxResults=1, principalId="user-1234"
+        )
 
 
 def test_get_check_authentication_status_configuration_error(fresh_deadline_config):
     """Confirm that check_authentication_status returns CONFIGURATION_ERROR"""
-    with patch.object(api._session, "get_boto3_client") as boto3_client_mock:
+    with patch.object(api._session, "get_boto3_client") as boto3_client_mock, patch.object(
+        api._session, "get_user_and_identity_store_id", return_value=(None, None)
+    ):
         config.set_setting("defaults.aws_profile_name", "SomeRandomProfileName")
         boto3_client_mock.return_value.list_farms.side_effect = Exception("some uncaught exception")
 
@@ -117,27 +143,46 @@ def test_get_queue_user_boto3_session_no_profile(fresh_deadline_config):
 
 
 def test_check_deadline_api_available(fresh_deadline_config):
-    with patch.object(api._session, "get_boto3_session") as session_mock:
-        session_mock().client("deadline").list_farms.return_value = {"farms": []}
+    with patch.object(api._session, "get_boto3_client") as boto3_client_mock, patch.object(
+        api._session, "get_user_and_identity_store_id", return_value=(None, None)
+    ):
+        boto3_client_mock.return_value.list_farms.return_value = {"farms": []}
 
         # Call the function under test
         result = api.check_deadline_api_available()
 
         assert result is True
         # It should have called list_farms to check the API
-        session_mock().client("deadline").list_farms.assert_called_once_with(maxResults=1)
+        boto3_client_mock.return_value.list_farms.assert_called_once_with(maxResults=1)
+
+
+def test_check_deadline_api_available_injects_principal_id(fresh_deadline_config):
+    """For DCM profiles, check_deadline_api_available must pass principalId."""
+    with patch.object(api._session, "get_boto3_client") as boto3_client_mock, patch.object(
+        api._session,
+        "get_user_and_identity_store_id",
+        return_value=("user-1234", "d-abcdef0123"),
+    ):
+        boto3_client_mock.return_value.list_farms.return_value = {"farms": []}
+
+        assert api.check_deadline_api_available() is True
+        boto3_client_mock.return_value.list_farms.assert_called_once_with(
+            maxResults=1, principalId="user-1234"
+        )
 
 
 def test_check_deadline_api_available_fails(fresh_deadline_config):
-    with patch.object(api._session, "get_boto3_session") as session_mock:
-        session_mock().client("deadline").list_farms.side_effect = Exception()
+    with patch.object(api._session, "get_boto3_client") as boto3_client_mock, patch.object(
+        api._session, "get_user_and_identity_store_id", return_value=(None, None)
+    ):
+        boto3_client_mock.return_value.list_farms.side_effect = Exception()
 
         # Call the function under test
         result = api.check_deadline_api_available()
 
         assert result is False
         # It should have called list_farms with to check the API
-        session_mock().client("deadline").list_farms.assert_called_once_with(maxResults=1)
+        boto3_client_mock.return_value.list_farms.assert_called_once_with(maxResults=1)
 
 
 def test_get_session_client_caching():

--- a/test/unit/deadline_client/cli/test_cli_auth.py
+++ b/test/unit/deadline_client/cli/test_cli_auth.py
@@ -160,9 +160,7 @@ def test_cli_auth_status_json(fresh_deadline_config):
         api, "get_boto3_session", new=session_mock
     ), patch.object(
         api, "check_authentication_status", return_value=api.AwsAuthenticationStatus.AUTHENTICATED
-    ), patch.object(
-        api, "check_deadline_api_available", return_value=False
-    ):
+    ), patch.object(api, "check_deadline_api_available", return_value=False):
         # The profile name
         session_mock().profile_name = profile_name
         # This configuration includes the IdC profile


### PR DESCRIPTION
## Summary

`check_authentication_status` (introduced in #1147) broke `deadline auth login` against Deadline Cloud monitor profiles. The DCM integration tests (`dcm_integration_test_{linux,macos,windows}.yml`) have hung for 180s on every run since then; the same hang is observable for any human running `deadline auth login` against an IdC profile.

Two bugs, both fixed here. Either one alone is insufficient.

## Bug 1: ListFarms probe was missing `principalId`

`check_authentication_status` called `deadline:ListFarms(maxResults=1)` without injecting `principalId` from the DCM profile's `user_id`. For IdC-issued sessions the service rejects the un-scoped call with AccessDenied, so `_login_deadline_cloud_monitor`'s polling loop never sees `AUTHENTICATED`.

The sibling `check_deadline_api_available` and the `api.list_farms` wrapper already inject `principalId`; this change makes both probes share that logic.

**Fix:** Extract a private `_list_farms_for_auth_probe()` helper in `_session.py` and have both `check_authentication_status` and `check_deadline_api_available` call it. Single source of truth for the principalId-injection policy.

## Bug 2: stale profile-map cache in the poll loop

After fixing bug 1, `deadline auth login` still hung — even though a separate `deadline auth status` process reported `AUTHENTICATED` / `api_availability: true`.

Root cause: `get_user_and_identity_store_id` goes through botocore's `get_scoped_config()`, which caches the parsed profile map on first read. The polling loop in `_login_deadline_cloud_monitor` probes every 0.5s. The first probe runs BEFORE DCM has written `user_id`/`identity_store_id`/the real `monitor_id` to `~/.aws/config`, so botocore caches the pre-login profile. Subsequent probes (even after DCM finishes writing) see the same cached profile → `user_id` is still `None` → ListFarms is called without `principalId` → AccessDenied → NEEDS_LOGIN forever.

This is specific to long-running processes like `deadline auth login`; fresh invocations (`deadline auth status`, `deadline farm list`) create a new session and load the profile once, so they don't hit this.

**Fix:** Invalidate the boto3 session cache each iteration of the poll loop in `_login_deadline_cloud_monitor` so each probe reads the current on-disk profile.

## Testing

- `hatch run test test/unit/` → 2085 passed, 21 skipped.
- `hatch run typing`, `ruff check` → clean.
- DCM integration tests dispatched against this branch: **all three platforms pass** (run [25170595534](https://github.com/aws-deadline/deadline-cloud/actions/runs/25170595534)):
  - linux: 1m 52s (was hanging at 4m 45s before)
  - macos: 1m 54s (was hanging at 5m)
  - windows: 2m 10s (was hanging at 5m 18s)
- manually running the auth flow locally with DCM creds 

Timings match the pre-regression baseline from 2026-04-28.

## Known pre-existing API surface

The check-api-changes job flags `deadline.client.api.Any` and `deadline.client.api.Dict` as removed. These were incidental re-exports of `typing.Any`/`typing.Dict` that leaked into the public namespace via a top-level `from typing import Any, Dict, Optional`. The inline usage was removed as part of refactoring `check_deadline_api_available` to call the shared helper; they are not legitimate Deadline APIs, so I left them removed.

## Follow-up

`check_authentication_status` (3-way enum) and `check_deadline_api_available` (bool) now share the same probe but still exist as separate public helpers with different return types and failure semantics. Consolidating them would touch the public surface (`deadline auth status` CLI, GUI status widget) and is tracked in #1152.

## Signed-off-by

All commits include `Signed-off-by` per repository policy.
