### PR TITLE
feat(cli): Add download-input command with --include filtering

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
   # Click 8.2 dropped python 3.8/3.9 support
   "click >= 8.1.7",
   "pyyaml >= 6.0",
-  "deadline-job-attachments == 0.0.2",
+  "deadline-job-attachments == 0.1.0",
   "typing_extensions >= 4.8",
   "psutil >= 7.0.0",
   "QtPy == 2.4.*",

--- a/src/deadline/client/cli/_groups/job_group.py
+++ b/src/deadline/client/cli/_groups/job_group.py
@@ -66,7 +66,10 @@ from ._job_download_helpers import (
     _resolve_storage_profiles,
     _transform_manifests_to_absolute_paths,
 )
-from ....job_attachments._path_mapping import _generate_path_mapping_rules
+from ....job_attachments._path_mapping import (
+    _generate_path_mapping_rules,
+    _PathMappingRuleApplier,
+)
 from ....job_attachments.download import (
     InputDownloader,
     OutputDownloader,
@@ -1192,8 +1195,6 @@ def _download_job_input(
         click.echo(f"Using storage profile: {resolved.local_profile.displayName}")
         if rules:
             # For inputs with storage profiles, apply path mapping via set_root_path
-            from ....job_attachments._path_mapping import _PathMappingRuleApplier
-
             applier = _PathMappingRuleApplier(rules)
             for root in list(input_paths_by_root.keys()):
                 try:
@@ -1208,7 +1209,10 @@ def _download_job_input(
         asset_roots = list(input_paths_by_root.keys())
         for asset_root in asset_roots:
             root_path_format = root_path_format_mapping.get(asset_root, "")
-            if root_path_format and PathFormat.get_host_path_format_string() != root_path_format:
+            if root_path_format == "":
+                # There must be a corresponding root path format for each root path, by design.
+                raise DeadlineOperationError(f"No root path format found for {asset_root}.")
+            if PathFormat.get_host_path_format_string() != root_path_format:
                 click.echo(
                     _get_mismatch_os_root_warning(asset_root, root_path_format, is_json_format)
                 )
@@ -1241,7 +1245,7 @@ def _download_job_input(
     if not auto_accept:
         if not is_json_format:
             user_choice = ""
-            while user_choice != ("y" or "n"):
+            while user_choice not in ("y", "n"):
                 click.echo(
                     _get_summary_of_files_to_download_message(input_paths_by_root, is_json_format)
                 )
@@ -1353,22 +1357,25 @@ def _download_job_input(
     "-i",
     "--include",
     multiple=True,
-    help="Glob pattern or relative path to include. Repeatable; multiple values are OR'd. "
-    "Without --include, all input files are downloaded",
+    help="Glob pattern or relative path for files to include in download. Matched against "
+    "the full path (root + relative). Supports *, ?, [seq]. A trailing / matches all "
+    "files under that directory. Repeatable",
 )
 @click.option(
     "--match-paths-by",
     type=click.Choice(["JOB", "LOCAL"], case_sensitive=False),
     default="LOCAL",
-    help="Which paths to match --include filters against.\n"
-    "LOCAL (default): match against local download paths.\n"
-    "JOB: match against the paths recorded at job submission",
+    help="Control which paths --include filters are matched against. "
+    "JOB matches against the paths recorded at job submission. "
+    "LOCAL matches against the local download paths (the default).",
 )
 @click.option(
     "--ignore-storage-profiles",
     is_flag=True,
-    help="Ignore storage profile configuration. Only use if the job was "
-    "submitted and downloaded from the same machine",
+    help="Ignores the storage profile configuration. Only use if the job was "
+    "submitted and downloaded from the same machine. Downloads to "
+    "unmapped paths regardless of operating system.\n"
+    "Default value is False.",
     default=False,
 )
 @click.option(
@@ -1382,7 +1389,7 @@ def _download_job_input(
         case_sensitive=False,
     ),
     help="How to handle downloads if a file already exists:\n"
-    "CREATE_COPY (default): Download with a new name, appending '(1)'\n"
+    "CREATE_COPY (default): Download the file with a new name, appending '(1)' to the end\n"
     "SKIP: Do not download the file\n"
     "OVERWRITE: Download and replace the existing file",
 )
@@ -1393,8 +1400,14 @@ def _download_job_input(
 )
 @click.option(
     "--output",
-    type=click.Choice(["verbose", "json"], case_sensitive=False),
-    help="Output format: verbose (human-readable) or json (JSON lines)",
+    type=click.Choice(
+        ["verbose", "json"],
+        case_sensitive=False,
+    ),
+    help="Specifies the output format of the messages printed to stdout.\n"
+    "VERBOSE: Displays messages in a human-readable text format.\n"
+    "JSON: Displays messages in JSON line format, so that the info can be easily "
+    "parsed/consumed by custom scripts.",
 )
 @_handle_error
 def job_download_input(include, match_paths_by, output, ignore_storage_profiles, **args):
@@ -1416,8 +1429,8 @@ def job_download_input(include, match_paths_by, output, ignore_storage_profiles,
     farm_id = config_file.get_setting("defaults.farm_id", config=config)
     queue_id = config_file.get_setting("defaults.queue_id", config=config)
     job_id = config_file.get_setting("defaults.job_id", config=config)
-    is_json_format = output == "json"
-    include_patterns = _normalize_filters(include)
+    is_json_format = True if output == "json" else False
+    include_patterns = _normalize_filters(list(include)) or None
 
     try:
         _download_job_input(
@@ -1428,9 +1441,7 @@ def job_download_input(include, match_paths_by, output, ignore_storage_profiles,
             is_json_format=is_json_format,
             ignore_storage_profiles=ignore_storage_profiles,
             include_patterns=include_patterns,
-            match_paths_by=MatchPathsBy(match_paths_by.upper())
-            if match_paths_by
-            else MatchPathsBy.LOCAL,
+            match_paths_by=MatchPathsBy(match_paths_by),
         )
     except Exception as e:
         if is_json_format:

--- a/src/deadline/client/cli/_groups/job_group.py
+++ b/src/deadline/client/cli/_groups/job_group.py
@@ -73,6 +73,7 @@ from ....job_attachments._path_mapping import (
 from ....job_attachments.download import (
     InputDownloader,
     OutputDownloader,
+    _BaseFilterableDownloader,
     filter_manifests,
     get_output_manifests_by_asset_root,
 )
@@ -501,6 +502,120 @@ def job_requeue_tasks(run_status: Optional[list[str]], **args):
     click.echo(f"\nRequeued a total of {total_count_requeued} tasks.")
 
 
+def _prompt_for_os_mismatch_roots(
+    downloader: _BaseFilterableDownloader,
+    paths_by_root: dict[str, list[str]],
+    root_path_format_mapping: dict[str, str],
+    is_json_format: bool,
+) -> dict[str, list[str]]:
+    """Prompt the user to remap any asset roots whose OS format doesn't match the host."""
+    asset_roots = list(paths_by_root.keys())
+    for asset_root in asset_roots:
+        root_path_format = root_path_format_mapping.get(asset_root, "")
+        if root_path_format == "":
+            raise DeadlineOperationError(f"No root path format found for {asset_root}.")
+        if PathFormat.get_host_path_format_string() != root_path_format:
+            click.echo(_get_mismatch_os_root_warning(asset_root, root_path_format, is_json_format))
+            if not is_json_format:
+                new_root = click.prompt(
+                    "> Please enter a new root path",
+                    type=click.Path(exists=False),
+                )
+            else:
+                json_string = click.prompt("", prompt_suffix="", type=str)
+                new_root = _get_value_from_json_line(
+                    json_string, JSON_MSG_TYPE_PATHCONFIRM, expected_size=1
+                )[0]
+                _assert_valid_path(new_root)
+            downloader.set_root_path(asset_root, os.path.expanduser(new_root))
+    return downloader.get_paths_by_root()
+
+
+def _prompt_to_confirm_roots(
+    downloader: _BaseFilterableDownloader,
+    paths_by_root: dict[str, list[str]],
+    is_json_format: bool,
+    cancel_message: str,
+    on_roots_changed: Optional[Callable[[dict[str, list[str]]], None]] = None,
+) -> Optional[dict[str, list[str]]]:
+    """
+    Interactive prompt letting the user confirm or edit download root paths.
+    Returns the (possibly updated) paths_by_root, or None if the user canceled.
+    ``on_roots_changed`` is called after every root edit (e.g. for long-path warnings).
+    """
+    if not is_json_format:
+        user_choice = ""
+        while user_choice not in ("y", "n"):
+            click.echo(_get_summary_of_files_to_download_message(paths_by_root, is_json_format))
+            asset_roots = list(paths_by_root.keys())
+            click.echo(_get_roots_list_message(asset_roots, is_json_format))
+            user_choice = click.prompt(
+                "> Please enter the index of root directory to edit, y to proceed without changes, or n to cancel the download",
+                type=click.Choice([*[str(num) for num in range(len(asset_roots))], "y", "n"]),
+                default="y",
+            )
+            if user_choice == "n":
+                click.echo(cancel_message)
+                return None
+            elif user_choice != "y":
+                index_to_change = int(user_choice)
+                new_root = click.prompt(
+                    "> Please enter the new root directory path, or press Enter to keep it unchanged",
+                    type=click.Path(exists=False),
+                    default=asset_roots[index_to_change],
+                )
+                downloader.set_root_path(asset_roots[index_to_change], str(Path(new_root)))
+                paths_by_root = downloader.get_paths_by_root()
+                if on_roots_changed:
+                    on_roots_changed(paths_by_root)
+    else:
+        click.echo(_get_summary_of_files_to_download_message(paths_by_root, is_json_format))
+        asset_roots = list(paths_by_root.keys())
+        click.echo(_get_roots_list_message(asset_roots, is_json_format))
+        json_string = click.prompt("", prompt_suffix="", type=str)
+        confirmed_asset_roots = _get_value_from_json_line(
+            json_string, JSON_MSG_TYPE_PATHCONFIRM, expected_size=len(asset_roots)
+        )
+        for index, confirmed_root in enumerate(confirmed_asset_roots):
+            _assert_valid_path(confirmed_root)
+            downloader.set_root_path(asset_roots[index], str(Path(confirmed_root)))
+        paths_by_root = downloader.get_paths_by_root()
+        if on_roots_changed:
+            on_roots_changed(paths_by_root)
+    return paths_by_root
+
+
+def _execute_download_with_progress(
+    download_fn: Callable[
+        [Optional[FileConflictResolution], Optional[Callable[[ProgressReportMetadata], bool]]],
+        DownloadSummaryStatistics,
+    ],
+    file_conflict_resolution: Optional[FileConflictResolution],
+    is_json_format: bool,
+    progress_label: str,
+) -> DownloadSummaryStatistics:
+    """Run a download function with either a CLI progress bar or JSON progress lines."""
+    with _modified_logging_level(logging.getLogger("urllib3"), logging.ERROR):
+        if not is_json_format:
+            with click.progressbar(length=100, label=progress_label) as download_progress:  # type: ignore[var-annotated]
+
+                def _update_progress(metadata: ProgressReportMetadata) -> bool:
+                    new_progress = int(metadata.progress) - download_progress.pos
+                    if new_progress > 0:
+                        download_progress.update(new_progress)
+                    return sigint_handler.continue_operation
+
+                return download_fn(file_conflict_resolution, _update_progress)
+        else:
+
+            def _update_progress(metadata: ProgressReportMetadata) -> bool:
+                click.echo(_get_json_line(JSON_MSG_TYPE_PROGRESS, str(int(metadata.progress))))
+                # TODO: enable download cancellation for JSON format
+                return True
+
+            return download_fn(file_conflict_resolution, _update_progress)
+
+
 def _download_job_output(
     config: Optional[ConfigParser],
     farm_id: str,
@@ -649,89 +764,25 @@ def _download_job_output(
             )
     else:
         # No storage profiles — fall back to manual prompt on OS mismatch
-        asset_roots = list(output_paths_by_root.keys())
-        for asset_root in asset_roots:
-            root_path_format = root_path_format_mapping.get(asset_root, "")
-            if root_path_format == "":
-                # There must be a corresponding root path format for each root path, by design.
-                raise DeadlineOperationError(f"No root path format found for {asset_root}.")
-            if PathFormat.get_host_path_format_string() != root_path_format:
-                click.echo(
-                    _get_mismatch_os_root_warning(asset_root, root_path_format, is_json_format)
-                )
-
-                if not is_json_format:
-                    new_root = click.prompt(
-                        "> Please enter a new root path",
-                        type=click.Path(exists=False),
-                    )
-                else:
-                    json_string = click.prompt("", prompt_suffix="", type=str)
-                    new_root = _get_value_from_json_line(
-                        json_string, JSON_MSG_TYPE_PATHCONFIRM, expected_size=1
-                    )[0]
-                    _assert_valid_path(new_root)
-
-                job_output_downloader.set_root_path(asset_root, os.path.expanduser(new_root))
-
-        # Re-fetch after potential set_root_path calls above
-        output_paths_by_root = job_output_downloader.get_paths_by_root()
+        output_paths_by_root = _prompt_for_os_mismatch_roots(
+            job_output_downloader, output_paths_by_root, root_path_format_mapping, is_json_format
+        )
         _check_and_warn_long_output_paths(output_paths_by_root)
 
     # Prompt users to confirm local root paths where they will download outputs to,
     # and allow users to select different location to download files to if they want.
     # (If auto-accept is enabled, automatically download to the default root paths.)
     if not auto_accept:
-        if not is_json_format:
-            user_choice = ""
-            while user_choice != ("y" or "n"):
-                click.echo(
-                    _get_summary_of_files_to_download_message(output_paths_by_root, is_json_format)
-                )
-                asset_roots = list(output_paths_by_root.keys())
-                click.echo(_get_roots_list_message(asset_roots, is_json_format))
-                user_choice = click.prompt(
-                    "> Please enter the index of root directory to edit, y to proceed without changes, or n to cancel the download",
-                    type=click.Choice(
-                        [
-                            *[str(num) for num in list(range(0, len(asset_roots)))],
-                            "y",
-                            "n",
-                        ]
-                    ),
-                    default="y",
-                )
-                if user_choice == "n":
-                    click.echo("Output download canceled.")
-                    return
-                elif user_choice != "y":
-                    # User selected an index to modify the root directory.
-                    index_to_change = int(user_choice)
-                    new_root = click.prompt(
-                        "> Please enter the new root directory path, or press Enter to keep it unchanged",
-                        type=click.Path(exists=False),
-                        default=asset_roots[index_to_change],
-                    )
-                    job_output_downloader.set_root_path(
-                        asset_roots[index_to_change], str(Path(new_root))
-                    )
-                    output_paths_by_root = job_output_downloader.get_paths_by_root()
-                    _check_and_warn_long_output_paths(output_paths_by_root)
-        else:
-            click.echo(
-                _get_summary_of_files_to_download_message(output_paths_by_root, is_json_format)
-            )
-            asset_roots = list(output_paths_by_root.keys())
-            click.echo(_get_roots_list_message(asset_roots, is_json_format))
-            json_string = click.prompt("", prompt_suffix="", type=str)
-            confirmed_asset_roots = _get_value_from_json_line(
-                json_string, JSON_MSG_TYPE_PATHCONFIRM, expected_size=len(asset_roots)
-            )
-            for index, confirmed_root in enumerate(confirmed_asset_roots):
-                _assert_valid_path(confirmed_root)
-                job_output_downloader.set_root_path(asset_roots[index], str(Path(confirmed_root)))
-            output_paths_by_root = job_output_downloader.get_paths_by_root()
-            _check_and_warn_long_output_paths(output_paths_by_root)
+        result = _prompt_to_confirm_roots(
+            job_output_downloader,
+            output_paths_by_root,
+            is_json_format,
+            cancel_message="Output download canceled.",
+            on_roots_changed=_check_and_warn_long_output_paths,
+        )
+        if result is None:
+            return
+        output_paths_by_root = result
 
     # Apply include filters against workstation paths (default behavior).
     # When --match-paths-by JOB is set, filtering was already applied at the job level.
@@ -759,56 +810,21 @@ def _download_job_output(
     if file_conflict_resolution is None:
         return
 
-    # TODO: remove logging level setting when the max number connections for boto3 client
-    # in Job Attachments library can be increased (currently using default number, 10, which
-    # makes it keep logging urllib3 warning messages when downloading large files)
-    with _modified_logging_level(logging.getLogger("urllib3"), logging.ERROR):
+    @api.record_success_fail_telemetry_event(metric_name="download_job_output")
+    def _do_download_output(
+        file_conflict_resolution: Optional[
+            FileConflictResolution
+        ] = FileConflictResolution.CREATE_COPY,
+        on_downloading_files: Optional[Callable[[ProgressReportMetadata], bool]] = None,
+    ) -> DownloadSummaryStatistics:
+        return job_output_downloader.download(
+            file_conflict_resolution=file_conflict_resolution,
+            on_downloading_files=on_downloading_files,
+        )
 
-        @api.record_success_fail_telemetry_event(metric_name="download_job_output")
-        def _download_job_output(
-            file_conflict_resolution: Optional[
-                FileConflictResolution
-            ] = FileConflictResolution.CREATE_COPY,
-            on_downloading_files: Optional[Callable[[ProgressReportMetadata], bool]] = None,
-        ) -> DownloadSummaryStatistics:
-            return job_output_downloader.download(
-                file_conflict_resolution=file_conflict_resolution,
-                on_downloading_files=on_downloading_files,
-            )
-
-        if not is_json_format:
-            # Note: click doesn't export the return type of progressbar(), so we suppress mypy warnings for
-            # not annotating the type of download_progress.
-            with click.progressbar(length=100, label="Downloading Outputs") as download_progress:  # type: ignore[var-annotated]
-
-                def _update_download_progress(
-                    download_metadata: ProgressReportMetadata,
-                ) -> bool:
-                    new_progress = int(download_metadata.progress) - download_progress.pos
-                    if new_progress > 0:
-                        download_progress.update(new_progress)
-                    return sigint_handler.continue_operation
-
-                download_summary: DownloadSummaryStatistics = _download_job_output(  # type: ignore
-                    file_conflict_resolution=file_conflict_resolution,
-                    on_downloading_files=_update_download_progress,
-                )
-        else:
-
-            def _update_download_progress(
-                download_metadata: ProgressReportMetadata,
-            ) -> bool:
-                click.echo(
-                    _get_json_line(JSON_MSG_TYPE_PROGRESS, str(int(download_metadata.progress)))
-                )
-                # TODO: enable download cancellation for JSON format
-                return True
-
-            download_summary = _download_job_output(  # type: ignore
-                file_conflict_resolution=file_conflict_resolution,
-                on_downloading_files=_update_download_progress,
-            )
-
+    download_summary = _execute_download_with_progress(
+        _do_download_output, file_conflict_resolution, is_json_format, "Downloading Outputs"
+    )
     click.echo(_get_download_summary_message(download_summary, is_json_format))
     click.echo()
 
@@ -1206,31 +1222,9 @@ def _download_job_input(
             input_paths_by_root = job_input_downloader.get_paths_by_root()
     else:
         # No storage profiles — fall back to manual prompt on OS mismatch
-        asset_roots = list(input_paths_by_root.keys())
-        for asset_root in asset_roots:
-            root_path_format = root_path_format_mapping.get(asset_root, "")
-            if root_path_format == "":
-                # There must be a corresponding root path format for each root path, by design.
-                raise DeadlineOperationError(f"No root path format found for {asset_root}.")
-            if PathFormat.get_host_path_format_string() != root_path_format:
-                click.echo(
-                    _get_mismatch_os_root_warning(asset_root, root_path_format, is_json_format)
-                )
-                if not is_json_format:
-                    new_root = click.prompt(
-                        "> Please enter a new root path",
-                        type=click.Path(exists=False),
-                    )
-                else:
-                    json_string = click.prompt("", prompt_suffix="", type=str)
-                    new_root = _get_value_from_json_line(
-                        json_string, JSON_MSG_TYPE_PATHCONFIRM, expected_size=1
-                    )[0]
-                    _assert_valid_path(new_root)
-
-                job_input_downloader.set_root_path(asset_root, os.path.expanduser(new_root))
-
-        input_paths_by_root = job_input_downloader.get_paths_by_root()
+        input_paths_by_root = _prompt_for_os_mismatch_roots(
+            job_input_downloader, input_paths_by_root, root_path_format_mapping, is_json_format
+        )
 
     # When match_paths_by is LOCAL (default), apply filters after root mapping.
     if include_patterns and match_paths_by == MatchPathsBy.LOCAL:
@@ -1243,47 +1237,15 @@ def _download_job_input(
 
     # Prompt to confirm root paths (unless auto-accept)
     if not auto_accept:
-        if not is_json_format:
-            user_choice = ""
-            while user_choice not in ("y", "n"):
-                click.echo(
-                    _get_summary_of_files_to_download_message(input_paths_by_root, is_json_format)
-                )
-                asset_roots = list(input_paths_by_root.keys())
-                click.echo(_get_roots_list_message(asset_roots, is_json_format))
-                user_choice = click.prompt(
-                    "> Please enter the index of root directory to edit, y to proceed without changes, or n to cancel the download",
-                    type=click.Choice([*[str(num) for num in range(len(asset_roots))], "y", "n"]),
-                    default="y",
-                )
-                if user_choice == "n":
-                    click.echo("Input download canceled.")
-                    return
-                elif user_choice != "y":
-                    index_to_change = int(user_choice)
-                    new_root = click.prompt(
-                        "> Please enter the new root directory path, or press Enter to keep it unchanged",
-                        type=click.Path(exists=False),
-                        default=asset_roots[index_to_change],
-                    )
-                    job_input_downloader.set_root_path(
-                        asset_roots[index_to_change], str(Path(new_root))
-                    )
-                    input_paths_by_root = job_input_downloader.get_paths_by_root()
-        else:
-            click.echo(
-                _get_summary_of_files_to_download_message(input_paths_by_root, is_json_format)
-            )
-            asset_roots = list(input_paths_by_root.keys())
-            click.echo(_get_roots_list_message(asset_roots, is_json_format))
-            json_string = click.prompt("", prompt_suffix="", type=str)
-            confirmed_asset_roots = _get_value_from_json_line(
-                json_string, JSON_MSG_TYPE_PATHCONFIRM, expected_size=len(asset_roots)
-            )
-            for index, confirmed_root in enumerate(confirmed_asset_roots):
-                _assert_valid_path(confirmed_root)
-                job_input_downloader.set_root_path(asset_roots[index], str(Path(confirmed_root)))
-            input_paths_by_root = job_input_downloader.get_paths_by_root()
+        result = _prompt_to_confirm_roots(
+            job_input_downloader,
+            input_paths_by_root,
+            is_json_format,
+            cancel_message="Input download canceled.",
+        )
+        if result is None:
+            return
+        input_paths_by_root = result
 
     if not is_json_format:
         all_input_paths: set[str] = set()
@@ -1300,50 +1262,21 @@ def _download_job_input(
     if file_conflict_resolution is None:
         return
 
-    with _modified_logging_level(logging.getLogger("urllib3"), logging.ERROR):
+    @api.record_success_fail_telemetry_event(metric_name="download_job_input")
+    def _do_download_input(
+        file_conflict_resolution: Optional[
+            FileConflictResolution
+        ] = FileConflictResolution.CREATE_COPY,
+        on_downloading_files: Optional[Callable[[ProgressReportMetadata], bool]] = None,
+    ) -> DownloadSummaryStatistics:
+        return job_input_downloader.download(
+            file_conflict_resolution=file_conflict_resolution,
+            on_downloading_files=on_downloading_files,
+        )
 
-        @api.record_success_fail_telemetry_event(metric_name="download_job_input")
-        def _do_download_input(
-            file_conflict_resolution: Optional[
-                FileConflictResolution
-            ] = FileConflictResolution.CREATE_COPY,
-            on_downloading_files: Optional[Callable[[ProgressReportMetadata], bool]] = None,
-        ) -> DownloadSummaryStatistics:
-            return job_input_downloader.download(
-                file_conflict_resolution=file_conflict_resolution,
-                on_downloading_files=on_downloading_files,
-            )
-
-        if not is_json_format:
-            with click.progressbar(length=100, label="Downloading Inputs") as download_progress:  # type: ignore[var-annotated]
-
-                def _update_download_progress(
-                    download_metadata: ProgressReportMetadata,
-                ) -> bool:
-                    new_progress = int(download_metadata.progress) - download_progress.pos
-                    if new_progress > 0:
-                        download_progress.update(new_progress)
-                    return sigint_handler.continue_operation
-
-                download_summary: DownloadSummaryStatistics = _do_download_input(
-                    file_conflict_resolution=file_conflict_resolution,
-                    on_downloading_files=_update_download_progress,
-                )
-        else:
-
-            def _update_download_progress(
-                download_metadata: ProgressReportMetadata,
-            ) -> bool:
-                click.echo(
-                    _get_json_line(JSON_MSG_TYPE_PROGRESS, str(int(download_metadata.progress)))
-                )
-                return True
-
-            download_summary = _do_download_input(
-                file_conflict_resolution=file_conflict_resolution,
-                on_downloading_files=_update_download_progress,
-            )
-
+    download_summary = _execute_download_with_progress(
+        _do_download_input, file_conflict_resolution, is_json_format, "Downloading Inputs"
+    )
     click.echo(_get_download_summary_message(download_summary, is_json_format))
     click.echo()
 

--- a/src/deadline/client/cli/_groups/job_group.py
+++ b/src/deadline/client/cli/_groups/job_group.py
@@ -68,9 +68,14 @@ from ._job_download_helpers import (
 )
 from ....job_attachments._path_mapping import _generate_path_mapping_rules
 from ....job_attachments.download import (
+    InputDownloader,
     OutputDownloader,
     filter_manifests,
     get_output_manifests_by_asset_root,
+)
+from ....job_attachments.models import (
+    Attachments as JA_Attachments,
+    ManifestProperties,
 )
 
 logger = logging.getLogger("deadline.client.cli")
@@ -1097,6 +1102,349 @@ def job_download_output(
             if logging.DEBUG >= logger.getEffectiveLevel():
                 logger.exception("Exception details:")
             raise DeadlineOperationError(f"Failed to download output:\n{e}") from e
+
+
+def _normalize_filters(include: tuple[str, ...]) -> Optional[list[str]]:
+    """Normalize CLI --include values into a filter list, or None if empty."""
+    filters = list(include)
+    return [f.replace("\\", "/") for f in filters] if filters else None
+
+
+def _build_attachments(job: dict) -> Optional[JA_Attachments]:
+    """Build an Attachments object from a job's attachments dict, or None if absent."""
+    job_attachments = job.get("attachments")
+    if not job_attachments:
+        return None
+    return JA_Attachments(
+        manifests=[ManifestProperties.from_dict(m) for m in job_attachments["manifests"]],
+        fileSystem=job_attachments.get("fileSystem", "COPIED"),
+    )
+
+
+def _download_job_input(
+    config: Optional[ConfigParser],
+    farm_id: str,
+    queue_id: str,
+    job_id: str,
+    is_json_format: bool = False,
+    ignore_storage_profiles: bool = False,
+    include_patterns: Optional[list[str]] = None,
+    match_paths_by: str = "LOCAL",
+):
+    """
+    Starts the download of job input and handles the progress reporting callback.
+    """
+    deadline = api.get_boto3_client("deadline", config=config)
+
+    auto_accept = config_file.str2bool(
+        config_file.get_setting("settings.auto_accept", config=config)
+    )
+    conflict_resolution = config_file.get_setting("settings.conflict_resolution", config=config)
+
+    job = deadline.get_job(farmId=farm_id, queueId=queue_id, jobId=job_id)
+
+    if is_json_format:
+        click.echo(_get_json_line(JSON_MSG_TYPE_TITLE, job["name"]))
+    else:
+        click.echo(f"Downloading input for Job {job['name']!r}")
+
+    attachments = _build_attachments(job)
+    if not attachments:
+        click.echo(
+            _get_json_line(JSON_MSG_TYPE_SUMMARY, "No input attachments found for this job.")
+            if is_json_format
+            else "No input attachments found for this job."
+        )
+        return
+
+    queue = deadline.get_queue(farmId=farm_id, queueId=queue_id)
+
+    queue_role_session = api.get_queue_user_boto3_session(
+        deadline=deadline,
+        config=config,
+        farm_id=farm_id,
+        queue_id=queue_id,
+        queue_display_name=queue["displayName"],
+    )
+
+    s3_settings = JobAttachmentS3Settings(**queue["jobAttachmentSettings"])
+
+    # When match_paths_by is JOB, apply filters before root mapping (against submission paths).
+    job_input_downloader = InputDownloader(
+        s3_settings=s3_settings,
+        attachments=attachments,
+        session=queue_role_session,
+        include_filters=include_patterns if match_paths_by == "JOB" else None,
+    )
+
+    input_paths_by_root = job_input_downloader.get_input_paths_by_root()
+    if not input_paths_by_root:
+        msg = "No input files available for download."
+        click.echo(_get_json_line(JSON_MSG_TYPE_SUMMARY, msg) if is_json_format else msg)
+        return
+
+    # Get root path format mapping for OS mismatch detection
+    root_path_format_mapping: dict[str, str] = {}
+    for manifest in attachments.manifests:
+        root_path_format_mapping[manifest.rootPath] = manifest.rootPathFormat.value
+
+    # Storage profile path mapping
+    resolved = _resolve_storage_profiles(
+        config, deadline, farm_id, queue_id, job, ignore_storage_profiles
+    )
+
+    if resolved:
+        rules = _generate_path_mapping_rules(resolved.job_profile, resolved.local_profile)
+        click.echo(f"Using storage profile: {resolved.local_profile.displayName}")
+        if rules:
+            # For inputs with storage profiles, apply path mapping via set_root_path
+            from ....job_attachments._path_mapping import _PathMappingRuleApplier
+
+            applier = _PathMappingRuleApplier(rules)
+            for root in list(input_paths_by_root.keys()):
+                try:
+                    new_root = str(applier.strict_transform(root))
+                    if new_root != root:
+                        job_input_downloader.set_root_path(root, new_root)
+                except ValueError:
+                    pass  # No rule matches this root
+            input_paths_by_root = job_input_downloader.get_input_paths_by_root()
+    else:
+        # No storage profiles — fall back to manual prompt on OS mismatch
+        asset_roots = list(input_paths_by_root.keys())
+        for asset_root in asset_roots:
+            root_path_format = root_path_format_mapping.get(asset_root, "")
+            if root_path_format and PathFormat.get_host_path_format_string() != root_path_format:
+                click.echo(
+                    _get_mismatch_os_root_warning(asset_root, root_path_format, is_json_format)
+                )
+                if not is_json_format:
+                    new_root = click.prompt(
+                        "> Please enter a new root path",
+                        type=click.Path(exists=False),
+                    )
+                else:
+                    json_string = click.prompt("", prompt_suffix="", type=str)
+                    new_root = _get_value_from_json_line(
+                        json_string, JSON_MSG_TYPE_PATHCONFIRM, expected_size=1
+                    )[0]
+                    _assert_valid_path(new_root)
+
+                job_input_downloader.set_root_path(asset_root, os.path.expanduser(new_root))
+
+        input_paths_by_root = job_input_downloader.get_input_paths_by_root()
+
+    # When match_paths_by is LOCAL (default), apply filters after root mapping.
+    if include_patterns and match_paths_by == "LOCAL":
+        job_input_downloader.apply_include_filters(include_patterns)
+        input_paths_by_root = job_input_downloader.get_input_paths_by_root()
+        if not input_paths_by_root:
+            msg = "No input files match the provided filters."
+            click.echo(_get_json_line(JSON_MSG_TYPE_SUMMARY, msg) if is_json_format else msg)
+            return
+
+    # Prompt to confirm root paths (unless auto-accept)
+    if not auto_accept:
+        if not is_json_format:
+            user_choice = ""
+            while user_choice != ("y" or "n"):
+                click.echo(
+                    _get_summary_of_files_to_download_message(input_paths_by_root, is_json_format)
+                )
+                asset_roots = list(input_paths_by_root.keys())
+                click.echo(_get_roots_list_message(asset_roots, is_json_format))
+                user_choice = click.prompt(
+                    "> Please enter the index of root directory to edit, y to proceed without changes, or n to cancel the download",
+                    type=click.Choice([*[str(num) for num in range(len(asset_roots))], "y", "n"]),
+                    default="y",
+                )
+                if user_choice == "n":
+                    click.echo("Input download canceled.")
+                    return
+                elif user_choice != "y":
+                    index_to_change = int(user_choice)
+                    new_root = click.prompt(
+                        "> Please enter the new root directory path, or press Enter to keep it unchanged",
+                        type=click.Path(exists=False),
+                        default=asset_roots[index_to_change],
+                    )
+                    job_input_downloader.set_root_path(
+                        asset_roots[index_to_change], str(Path(new_root))
+                    )
+                    input_paths_by_root = job_input_downloader.get_input_paths_by_root()
+        else:
+            click.echo(
+                _get_summary_of_files_to_download_message(input_paths_by_root, is_json_format)
+            )
+            asset_roots = list(input_paths_by_root.keys())
+            click.echo(_get_roots_list_message(asset_roots, is_json_format))
+            json_string = click.prompt("", prompt_suffix="", type=str)
+            confirmed_asset_roots = _get_value_from_json_line(
+                json_string, JSON_MSG_TYPE_PATHCONFIRM, expected_size=len(asset_roots)
+            )
+            for index, confirmed_root in enumerate(confirmed_asset_roots):
+                _assert_valid_path(confirmed_root)
+                job_input_downloader.set_root_path(asset_roots[index], str(Path(confirmed_root)))
+            input_paths_by_root = job_input_downloader.get_input_paths_by_root()
+
+    if not is_json_format:
+        all_input_paths: set[str] = set()
+        for asset_root, paths in input_paths_by_root.items():
+            all_input_paths.update(
+                os.path.normpath(os.path.join(asset_root, path)) for path in paths
+            )
+        click.echo("\nSummary of file paths to download:")
+        click.echo(textwrap.indent(summarize_path_list(all_input_paths), "  "))
+
+    file_conflict_resolution = _resolve_conflict_resolution(
+        conflict_resolution, auto_accept, _get_conflicting_filenames(input_paths_by_root)
+    )
+    if file_conflict_resolution is None:
+        return
+
+    with _modified_logging_level(logging.getLogger("urllib3"), logging.ERROR):
+
+        @api.record_success_fail_telemetry_event(metric_name="download_job_input")
+        def _do_download_input(
+            file_conflict_resolution: Optional[
+                FileConflictResolution
+            ] = FileConflictResolution.CREATE_COPY,
+            on_downloading_files: Optional[Callable[[ProgressReportMetadata], bool]] = None,
+        ) -> DownloadSummaryStatistics:
+            return job_input_downloader.download_job_input(
+                file_conflict_resolution=file_conflict_resolution,
+                on_downloading_files=on_downloading_files,
+            )
+
+        if not is_json_format:
+            with click.progressbar(length=100, label="Downloading Inputs") as download_progress:  # type: ignore[var-annotated]
+
+                def _update_download_progress(
+                    download_metadata: ProgressReportMetadata,
+                ) -> bool:
+                    new_progress = int(download_metadata.progress) - download_progress.pos
+                    if new_progress > 0:
+                        download_progress.update(new_progress)
+                    return sigint_handler.continue_operation
+
+                download_summary: DownloadSummaryStatistics = _do_download_input(
+                    file_conflict_resolution=file_conflict_resolution,
+                    on_downloading_files=_update_download_progress,
+                )
+        else:
+
+            def _update_download_progress(
+                download_metadata: ProgressReportMetadata,
+            ) -> bool:
+                click.echo(
+                    _get_json_line(JSON_MSG_TYPE_PROGRESS, str(int(download_metadata.progress)))
+                )
+                return True
+
+            download_summary = _do_download_input(
+                file_conflict_resolution=file_conflict_resolution,
+                on_downloading_files=_update_download_progress,
+            )
+
+    click.echo(_get_download_summary_message(download_summary, is_json_format))
+    click.echo()
+
+
+@cli_job.command(name="download-input")
+@click.option("--profile", help="The AWS profile to use.")
+@click.option("--farm-id", help="The farm to use.")
+@click.option("--queue-id", help="The queue to use.")
+@click.option("--job-id", help="The job to use.")
+@click.option(
+    "-i",
+    "--include",
+    multiple=True,
+    help="Glob pattern or relative path to include. Repeatable; multiple values are OR'd. "
+    "Without --include, all input files are downloaded",
+)
+@click.option(
+    "--match-paths-by",
+    type=click.Choice(["JOB", "LOCAL"], case_sensitive=False),
+    default="LOCAL",
+    help="Which paths to match --include filters against.\n"
+    "LOCAL (default): match against local download paths.\n"
+    "JOB: match against the paths recorded at job submission",
+)
+@click.option(
+    "--ignore-storage-profiles",
+    is_flag=True,
+    help="Ignore storage profile configuration. Only use if the job was "
+    "submitted and downloaded from the same machine",
+    default=False,
+)
+@click.option(
+    "--conflict-resolution",
+    type=click.Choice(
+        [
+            FileConflictResolution.SKIP.name,
+            FileConflictResolution.OVERWRITE.name,
+            FileConflictResolution.CREATE_COPY.name,
+        ],
+        case_sensitive=False,
+    ),
+    help="How to handle downloads if a file already exists:\n"
+    "CREATE_COPY (default): Download with a new name, appending '(1)'\n"
+    "SKIP: Do not download the file\n"
+    "OVERWRITE: Download and replace the existing file",
+)
+@click.option(
+    "--yes",
+    is_flag=True,
+    help="Automatically accept any confirmation prompts",
+)
+@click.option(
+    "--output",
+    type=click.Choice(["verbose", "json"], case_sensitive=False),
+    help="Output format: verbose (human-readable) or json (JSON lines)",
+)
+@_handle_error
+def job_download_input(include, match_paths_by, output, ignore_storage_profiles, **args):
+    """
+    Download the input files of a Deadline Cloud job that were saved as
+    job attachments.
+
+    Use `--include` to selectively download specific files using glob
+    patterns or relative paths. Without `--include`, all input files
+    are downloaded.
+
+    \b
+    Learn more about [job attachments](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/storage-job-attachments.html)
+    """
+    config = _apply_cli_options_to_config(
+        required_options={"farm_id", "queue_id", "job_id"}, **args
+    )
+
+    farm_id = config_file.get_setting("defaults.farm_id", config=config)
+    queue_id = config_file.get_setting("defaults.queue_id", config=config)
+    job_id = config_file.get_setting("defaults.job_id", config=config)
+    is_json_format = output == "json"
+    include_patterns = _normalize_filters(include)
+
+    try:
+        _download_job_input(
+            config=config,
+            farm_id=farm_id,
+            queue_id=queue_id,
+            job_id=job_id,
+            is_json_format=is_json_format,
+            ignore_storage_profiles=ignore_storage_profiles,
+            include_patterns=include_patterns,
+            match_paths_by=match_paths_by.upper() if match_paths_by else "LOCAL",
+        )
+    except Exception as e:
+        if is_json_format:
+            error_one_liner = str(e).replace("\n", ". ")
+            click.echo(_get_json_line(JSON_MSG_TYPE_ERROR, error_one_liner))
+            sys.exit(1)
+        else:
+            if logging.DEBUG >= logger.getEffectiveLevel():
+                logger.exception("Exception details:")
+            raise DeadlineOperationError(f"Failed to download input:\n{e}") from e
 
 
 @cli_job.command(name="wait")

--- a/src/deadline/client/cli/_groups/job_group.py
+++ b/src/deadline/client/cli/_groups/job_group.py
@@ -1097,8 +1097,6 @@ def job_download_output(
     farm_id = config_file.get_setting("defaults.farm_id", config=config)
     queue_id = config_file.get_setting("defaults.queue_id", config=config)
     job_id = config_file.get_setting("defaults.job_id", config=config)
-    is_json_format = True if output == "json" else False
-
     try:
         _download_job_output(
             config=config,
@@ -1107,13 +1105,13 @@ def job_download_output(
             job_id=job_id,
             step_id=step_id,
             task_id=task_id,
-            is_json_format=is_json_format,
+            is_json_format=output == "json",
             ignore_storage_profiles=ignore_storage_profiles,
             include_patterns=include_patterns,
             match_paths_by=MatchPathsBy(match_paths_by),
         )
     except Exception as e:
-        if is_json_format:
+        if output == "json":
             error_one_liner = str(e).replace("\n", ". ")
             click.echo(_get_json_line(JSON_MSG_TYPE_ERROR, error_one_liner))
             sys.exit(1)
@@ -1362,7 +1360,6 @@ def job_download_input(include, match_paths_by, output, ignore_storage_profiles,
     farm_id = config_file.get_setting("defaults.farm_id", config=config)
     queue_id = config_file.get_setting("defaults.queue_id", config=config)
     job_id = config_file.get_setting("defaults.job_id", config=config)
-    is_json_format = True if output == "json" else False
     include_patterns = _normalize_filters(list(include)) or None
 
     try:
@@ -1371,13 +1368,13 @@ def job_download_input(include, match_paths_by, output, ignore_storage_profiles,
             farm_id=farm_id,
             queue_id=queue_id,
             job_id=job_id,
-            is_json_format=is_json_format,
+            is_json_format=output == "json",
             ignore_storage_profiles=ignore_storage_profiles,
             include_patterns=include_patterns,
             match_paths_by=MatchPathsBy(match_paths_by),
         )
     except Exception as e:
-        if is_json_format:
+        if output == "json":
             error_one_liner = str(e).replace("\n", ". ")
             click.echo(_get_json_line(JSON_MSG_TYPE_ERROR, error_one_liner))
             sys.exit(1)

--- a/src/deadline/client/cli/_groups/job_group.py
+++ b/src/deadline/client/cli/_groups/job_group.py
@@ -584,7 +584,7 @@ def _download_job_output(
                             fg="yellow",
                         )
 
-    output_paths_by_root = job_output_downloader.get_output_paths_by_root()
+    output_paths_by_root = job_output_downloader.get_paths_by_root()
     # If no output paths were found, log a message and exit.
     if output_paths_by_root == {}:
         click.echo(_get_no_output_message(is_json_format))
@@ -672,7 +672,7 @@ def _download_job_output(
                 job_output_downloader.set_root_path(asset_root, os.path.expanduser(new_root))
 
         # Re-fetch after potential set_root_path calls above
-        output_paths_by_root = job_output_downloader.get_output_paths_by_root()
+        output_paths_by_root = job_output_downloader.get_paths_by_root()
         _check_and_warn_long_output_paths(output_paths_by_root)
 
     # Prompt users to confirm local root paths where they will download outputs to,
@@ -712,7 +712,7 @@ def _download_job_output(
                     job_output_downloader.set_root_path(
                         asset_roots[index_to_change], str(Path(new_root))
                     )
-                    output_paths_by_root = job_output_downloader.get_output_paths_by_root()
+                    output_paths_by_root = job_output_downloader.get_paths_by_root()
                     _check_and_warn_long_output_paths(output_paths_by_root)
         else:
             click.echo(
@@ -727,14 +727,14 @@ def _download_job_output(
             for index, confirmed_root in enumerate(confirmed_asset_roots):
                 _assert_valid_path(confirmed_root)
                 job_output_downloader.set_root_path(asset_roots[index], str(Path(confirmed_root)))
-            output_paths_by_root = job_output_downloader.get_output_paths_by_root()
+            output_paths_by_root = job_output_downloader.get_paths_by_root()
             _check_and_warn_long_output_paths(output_paths_by_root)
 
     # Apply include filters against workstation paths (default behavior).
     # When --match-paths-by JOB is set, filtering was already applied at the job level.
     if include_patterns and match_paths_by != MatchPathsBy.JOB:
         job_output_downloader.apply_include_filters(include_patterns)
-        output_paths_by_root = job_output_downloader.get_output_paths_by_root()
+        output_paths_by_root = job_output_downloader.get_paths_by_root()
         if output_paths_by_root == {}:
             click.echo(_get_no_output_message(is_json_format))
             return
@@ -768,7 +768,7 @@ def _download_job_output(
             ] = FileConflictResolution.CREATE_COPY,
             on_downloading_files: Optional[Callable[[ProgressReportMetadata], bool]] = None,
         ) -> DownloadSummaryStatistics:
-            return job_output_downloader.download_job_output(
+            return job_output_downloader.download(
                 file_conflict_resolution=file_conflict_resolution,
                 on_downloading_files=on_downloading_files,
             )
@@ -1104,12 +1104,6 @@ def job_download_output(
             raise DeadlineOperationError(f"Failed to download output:\n{e}") from e
 
 
-def _normalize_filters(include: tuple[str, ...]) -> Optional[list[str]]:
-    """Normalize CLI --include values into a filter list, or None if empty."""
-    filters = list(include)
-    return [f.replace("\\", "/") for f in filters] if filters else None
-
-
 def _build_attachments(job: dict) -> Optional[JA_Attachments]:
     """Build an Attachments object from a job's attachments dict, or None if absent."""
     job_attachments = job.get("attachments")
@@ -1129,7 +1123,7 @@ def _download_job_input(
     is_json_format: bool = False,
     ignore_storage_profiles: bool = False,
     include_patterns: Optional[list[str]] = None,
-    match_paths_by: str = "LOCAL",
+    match_paths_by: MatchPathsBy = MatchPathsBy.LOCAL,
 ):
     """
     Starts the download of job input and handles the progress reporting callback.
@@ -1174,10 +1168,10 @@ def _download_job_input(
         s3_settings=s3_settings,
         attachments=attachments,
         session=queue_role_session,
-        include_filters=include_patterns if match_paths_by == "JOB" else None,
+        include_filters=include_patterns if match_paths_by == MatchPathsBy.JOB else None,
     )
 
-    input_paths_by_root = job_input_downloader.get_input_paths_by_root()
+    input_paths_by_root = job_input_downloader.get_paths_by_root()
     if not input_paths_by_root:
         msg = "No input files available for download."
         click.echo(_get_json_line(JSON_MSG_TYPE_SUMMARY, msg) if is_json_format else msg)
@@ -1208,7 +1202,7 @@ def _download_job_input(
                         job_input_downloader.set_root_path(root, new_root)
                 except ValueError:
                     pass  # No rule matches this root
-            input_paths_by_root = job_input_downloader.get_input_paths_by_root()
+            input_paths_by_root = job_input_downloader.get_paths_by_root()
     else:
         # No storage profiles — fall back to manual prompt on OS mismatch
         asset_roots = list(input_paths_by_root.keys())
@@ -1232,12 +1226,12 @@ def _download_job_input(
 
                 job_input_downloader.set_root_path(asset_root, os.path.expanduser(new_root))
 
-        input_paths_by_root = job_input_downloader.get_input_paths_by_root()
+        input_paths_by_root = job_input_downloader.get_paths_by_root()
 
     # When match_paths_by is LOCAL (default), apply filters after root mapping.
-    if include_patterns and match_paths_by == "LOCAL":
+    if include_patterns and match_paths_by == MatchPathsBy.LOCAL:
         job_input_downloader.apply_include_filters(include_patterns)
-        input_paths_by_root = job_input_downloader.get_input_paths_by_root()
+        input_paths_by_root = job_input_downloader.get_paths_by_root()
         if not input_paths_by_root:
             msg = "No input files match the provided filters."
             click.echo(_get_json_line(JSON_MSG_TYPE_SUMMARY, msg) if is_json_format else msg)
@@ -1271,7 +1265,7 @@ def _download_job_input(
                     job_input_downloader.set_root_path(
                         asset_roots[index_to_change], str(Path(new_root))
                     )
-                    input_paths_by_root = job_input_downloader.get_input_paths_by_root()
+                    input_paths_by_root = job_input_downloader.get_paths_by_root()
         else:
             click.echo(
                 _get_summary_of_files_to_download_message(input_paths_by_root, is_json_format)
@@ -1285,7 +1279,7 @@ def _download_job_input(
             for index, confirmed_root in enumerate(confirmed_asset_roots):
                 _assert_valid_path(confirmed_root)
                 job_input_downloader.set_root_path(asset_roots[index], str(Path(confirmed_root)))
-            input_paths_by_root = job_input_downloader.get_input_paths_by_root()
+            input_paths_by_root = job_input_downloader.get_paths_by_root()
 
     if not is_json_format:
         all_input_paths: set[str] = set()
@@ -1311,7 +1305,7 @@ def _download_job_input(
             ] = FileConflictResolution.CREATE_COPY,
             on_downloading_files: Optional[Callable[[ProgressReportMetadata], bool]] = None,
         ) -> DownloadSummaryStatistics:
-            return job_input_downloader.download_job_input(
+            return job_input_downloader.download(
                 file_conflict_resolution=file_conflict_resolution,
                 on_downloading_files=on_downloading_files,
             )
@@ -1434,7 +1428,9 @@ def job_download_input(include, match_paths_by, output, ignore_storage_profiles,
             is_json_format=is_json_format,
             ignore_storage_profiles=ignore_storage_profiles,
             include_patterns=include_patterns,
-            match_paths_by=match_paths_by.upper() if match_paths_by else "LOCAL",
+            match_paths_by=MatchPathsBy(match_paths_by.upper())
+            if match_paths_by
+            else MatchPathsBy.LOCAL,
         )
     except Exception as e:
         if is_json_format:

--- a/test/cli_e2e/test_job_download_input.py
+++ b/test/cli_e2e/test_job_download_input.py
@@ -1,0 +1,201 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""End-to-end tests for `deadline job download-input`."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from deadline.job_attachments.asset_manifests.hash_algorithms import HashAlgorithm, hash_data
+
+from _constants import BUCKET, ROOT_PREFIX
+
+
+# ---- helpers -----------------------------------------------------------------
+
+
+def _seed_input_job(
+    backend,
+    s3_client,
+    farm_id: str,
+    queue_id: str,
+    job_id: str,
+    asset_root: str,
+    files: dict[str, bytes],
+) -> None:
+    """Seed S3 with CAS objects + input manifest and register the job in the mock backend."""
+    manifest_paths = []
+    for rel_path, content in files.items():
+        file_hash = hash_data(content, HashAlgorithm.XXH128)
+        s3_client.put_object(
+            Bucket=BUCKET, Key=f"{ROOT_PREFIX}/Data/{file_hash}.xxh128", Body=content
+        )
+        manifest_paths.append(
+            {"hash": file_hash, "mtime": 1234000000, "path": rel_path, "size": len(content)}
+        )
+
+    manifest_body = json.dumps(
+        {
+            "hashAlg": "xxh128",
+            "manifestVersion": "2023-03-03",
+            "paths": manifest_paths,
+            "totalSize": sum(len(c) for c in files.values()),
+        }
+    ).encode()
+    manifest_hash = hash_data(manifest_body, HashAlgorithm.XXH128)
+    manifest_key = f"{ROOT_PREFIX}/Manifests/{farm_id}/{queue_id}/Inputs/{manifest_hash}.manifest"
+    s3_client.put_object(Bucket=BUCKET, Key=manifest_key, Body=manifest_body)
+
+    backend.jobs[(farm_id, queue_id, job_id)] = {
+        "jobId": job_id,
+        "name": f"test-input-job-{job_id[-4:]}",
+        "lifecycleStatus": "CREATE_COMPLETE",
+        "lifecycleStatusMessage": "",
+        "priority": 50,
+        "createdAt": backend._now(),
+        "createdBy": "tester",
+        "taskRunStatus": "READY",
+        "attachments": {
+            "manifests": [
+                {
+                    "rootPath": asset_root,
+                    "rootPathFormat": "windows" if os.name == "nt" else "posix",
+                    "inputManifestPath": f"{farm_id}/{queue_id}/Inputs/{manifest_hash}.manifest",
+                    "inputManifestHash": manifest_hash,
+                }
+            ],
+            "fileSystem": "COPIED",
+        },
+    }
+
+
+# ---- tests ------------------------------------------------------------------
+
+
+def test_cli_job_download_input(seeded_farm_queue, run_cli, s3_client, tmp_path):
+    """Basic download-input downloads all input files."""
+    backend, farm_id, queue_id, env = seeded_farm_queue
+    job_id = "job-11111111111111111111111111111110"
+    asset_root = str(tmp_path / "inputs")
+    Path(asset_root).mkdir()
+
+    _seed_input_job(
+        backend,
+        s3_client,
+        farm_id,
+        queue_id,
+        job_id,
+        asset_root,
+        {"scene.ma": b"maya-scene-data", "textures/brick.png": b"brick-texture"},
+    )
+
+    r = run_cli(
+        env,
+        "job",
+        "download-input",
+        "--job-id",
+        job_id,
+        "--conflict-resolution",
+        "OVERWRITE",
+        "--yes",
+    )
+    assert r.returncode == 0, f"download-input failed: {r.stderr}\nstdout: {r.stdout}"
+    assert (Path(asset_root) / "scene.ma").read_bytes() == b"maya-scene-data"
+    assert (Path(asset_root) / "textures" / "brick.png").read_bytes() == b"brick-texture"
+
+
+def test_cli_job_download_input_include_glob(seeded_farm_queue, run_cli, s3_client, tmp_path):
+    """--include with a glob pattern downloads only matching input files."""
+    backend, farm_id, queue_id, env = seeded_farm_queue
+    job_id = "job-11111111111111111111111111111111"
+    asset_root = str(tmp_path / "filtered_inputs")
+    Path(asset_root).mkdir()
+
+    _seed_input_job(
+        backend,
+        s3_client,
+        farm_id,
+        queue_id,
+        job_id,
+        asset_root,
+        {"scene.ma": b"maya-scene", "textures/brick.png": b"brick", "textures/cloth.png": b"cloth"},
+    )
+
+    r = run_cli(
+        env,
+        "job",
+        "download-input",
+        "--job-id",
+        job_id,
+        "--include",
+        "*.png",
+        "--conflict-resolution",
+        "OVERWRITE",
+        "--yes",
+    )
+    assert r.returncode == 0, f"download-input failed: {r.stderr}\nstdout: {r.stdout}"
+    assert (Path(asset_root) / "textures" / "brick.png").read_bytes() == b"brick"
+    assert (Path(asset_root) / "textures" / "cloth.png").read_bytes() == b"cloth"
+    assert not (Path(asset_root) / "scene.ma").exists()
+
+
+def test_cli_job_download_input_include_no_match(seeded_farm_queue, run_cli, s3_client, tmp_path):
+    """--include with a filter that matches nothing reports no input files."""
+    backend, farm_id, queue_id, env = seeded_farm_queue
+    job_id = "job-11111111111111111111111111111112"
+    asset_root = str(tmp_path / "nomatch_inputs")
+    Path(asset_root).mkdir()
+
+    _seed_input_job(
+        backend,
+        s3_client,
+        farm_id,
+        queue_id,
+        job_id,
+        asset_root,
+        {"scene.ma": b"maya-scene"},
+    )
+
+    r = run_cli(
+        env,
+        "job",
+        "download-input",
+        "--job-id",
+        job_id,
+        "--include",
+        "*.nonexistent",
+        "--conflict-resolution",
+        "OVERWRITE",
+        "--yes",
+    )
+    assert r.returncode == 0, f"download-input failed: {r.stderr}\nstdout: {r.stdout}"
+    assert "no input files" in r.stdout.lower()
+
+
+def test_cli_job_download_input_no_attachments(seeded_farm_queue, run_cli):
+    """download-input on a job with no attachments reports a clear message."""
+    backend, farm_id, queue_id, env = seeded_farm_queue
+    job_id = "job-11111111111111111111111111111113"
+
+    backend.jobs[(farm_id, queue_id, job_id)] = {
+        "jobId": job_id,
+        "name": "no-attachments-job",
+        "lifecycleStatus": "CREATE_COMPLETE",
+        "lifecycleStatusMessage": "",
+        "priority": 50,
+        "createdAt": backend._now(),
+        "createdBy": "tester",
+        "taskRunStatus": "READY",
+    }
+
+    r = run_cli(
+        env,
+        "job",
+        "download-input",
+        "--job-id",
+        job_id,
+        "--yes",
+    )
+    assert r.returncode == 0, f"download-input failed: {r.stderr}\nstdout: {r.stdout}"
+    assert "no input attachments" in r.stdout.lower()

--- a/test/unit/deadline_client/cli/test_cli_handle_web_url.py
+++ b/test/unit/deadline_client/cli/test_cli_handle_web_url.py
@@ -275,7 +275,7 @@ def test_cli_handle_web_url_download_output_only_required_input(fresh_deadline_c
             processed_files=3,
             processed_bytes=1024,
         )
-        MockOutputDownloader.return_value.download_job_output = mock_download
+        MockOutputDownloader.return_value.download = mock_download
         mock_host_path_format_name = PathFormat.get_host_path_format_string()
 
         boto3_client_mock().get_job.return_value = {
@@ -333,7 +333,7 @@ def test_cli_handle_web_url_download_output_with_optional_input(fresh_deadline_c
             processed_files=3,
             processed_bytes=1024,
         )
-        MockOutputDownloader.return_value.download_job_output = mock_download
+        MockOutputDownloader.return_value.download = mock_download
         mock_host_path_format_name = PathFormat.get_host_path_format_string()
 
         boto3_client_mock().get_job.return_value = {

--- a/test/unit/deadline_client/cli/test_cli_job.py
+++ b/test/unit/deadline_client/cli/test_cli_job.py
@@ -2047,3 +2047,139 @@ class TestJobDownloadInput:
             # InputDownloader should be created WITH include_filters (JOB mode)
             call_kwargs = mock_downloader.call_args[1]
             assert call_kwargs["include_filters"] == ["*.txt"]
+
+    def test_download_input_mismatching_path_format(self, fresh_deadline_config, tmp_path):
+        """download-input prompts for new root when OS format doesn't match."""
+        config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+        config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+
+        # Use the opposite OS path format
+        mock_root_path = "C:\\Users\\username" if sys.platform != "win32" else "/root/path"
+        current_format = PathFormat.get_host_path_format()
+        other_format = (
+            PathFormat.WINDOWS if current_format == PathFormat.POSIX else PathFormat.POSIX
+        )
+
+        with patch.object(api, "get_boto3_client") as boto3_mock, patch.object(
+            job_group, "InputDownloader"
+        ) as mock_downloader, patch.object(
+            job_group, "_get_conflicting_filenames", return_value=[]
+        ), patch.object(api, "get_queue_user_boto3_session"):
+            mock_download = MagicMock()
+            mock_download.return_value = DownloadSummaryStatistics(
+                total_time=5, processed_files=1, processed_bytes=256
+            )
+            mock_downloader.return_value.download = mock_download
+            mock_downloader.return_value.get_paths_by_root.side_effect = [
+                {mock_root_path: ["file.txt"]},
+                {str(tmp_path): ["file.txt"]},
+                {str(tmp_path): ["file.txt"]},
+            ]
+            boto3_mock().get_queue.return_value = MOCK_GET_QUEUE_RESPONSE
+            boto3_mock().get_job.return_value = {
+                "name": "Mock Job",
+                "attachments": {
+                    "manifests": [
+                        {
+                            "rootPath": mock_root_path,
+                            "rootPathFormat": other_format,
+                            "inputManifestPath": "manifest",
+                            "inputManifestHash": "abc123",
+                        }
+                    ],
+                    "fileSystem": "COPIED",
+                },
+            }
+
+            runner = CliRunner()
+            result = runner.invoke(
+                main,
+                ["job", "download-input", "--job-id", MOCK_JOB_ID],
+                input=f"{str(tmp_path)}\ny\n",
+            )
+
+            assert result.exit_code == 0
+            assert "does not match the operating system" in result.output
+            mock_downloader.return_value.set_root_path.assert_called_once_with(
+                mock_root_path, str(tmp_path)
+            )
+
+    def test_download_input_storage_profile_mapping(self, fresh_deadline_config):
+        """download-input applies storage profile path mapping via set_root_path."""
+        config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+        config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+        config.set_setting("settings.auto_accept", "true")
+
+        mock_root = "/original/root"
+        mapped_root = "/mapped/root"
+
+        with patch.object(api, "get_boto3_client") as boto3_mock, patch.object(
+            job_group, "InputDownloader"
+        ) as mock_downloader, patch.object(
+            job_group, "_get_conflicting_filenames", return_value=[]
+        ), patch.object(api, "get_queue_user_boto3_session"), patch.object(
+            job_group, "_resolve_storage_profiles"
+        ) as mock_resolve, patch.object(
+            job_group, "_generate_path_mapping_rules"
+        ) as mock_gen_rules, patch.object(job_group, "_PathMappingRuleApplier") as mock_applier_cls:
+            mock_download = MagicMock()
+            mock_download.return_value = DownloadSummaryStatistics(
+                total_time=5, processed_files=1, processed_bytes=256
+            )
+            mock_downloader.return_value.download = mock_download
+            mock_downloader.return_value.get_paths_by_root.return_value = {mock_root: ["file.txt"]}
+            boto3_mock().get_queue.return_value = MOCK_GET_QUEUE_RESPONSE
+            boto3_mock().get_job.return_value = self._make_job_response(root_path=mock_root)
+
+            # Set up storage profile resolution
+            mock_resolved = MagicMock()
+            mock_resolved.local_profile.displayName = "TestProfile"
+            mock_resolve.return_value = mock_resolved
+            mock_gen_rules.return_value = [MagicMock()]  # non-empty rules
+
+            # Applier maps original root to mapped root
+            mock_applier = MagicMock()
+            mock_applier.strict_transform.return_value = mapped_root
+            mock_applier_cls.return_value = mock_applier
+
+            runner = CliRunner()
+            result = runner.invoke(
+                main,
+                ["job", "download-input", "--job-id", MOCK_JOB_ID],
+            )
+
+            assert result.exit_code == 0
+            assert "Using storage profile: TestProfile" in result.output
+            mock_downloader.return_value.set_root_path.assert_called_once_with(
+                mock_root, mapped_root
+            )
+
+    def test_download_input_edit_root_path(self, fresh_deadline_config, tmp_path):
+        """download-input allows editing root paths in the confirmation prompt."""
+        config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+        config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+
+        with patch.object(api, "get_boto3_client") as boto3_mock, patch.object(
+            job_group, "InputDownloader"
+        ) as mock_downloader, patch.object(
+            job_group, "_get_conflicting_filenames", return_value=[]
+        ), patch.object(api, "get_queue_user_boto3_session"):
+            self._setup_mocks(boto3_mock, mock_downloader)
+            # Return different paths after set_root_path is called
+            mock_downloader.return_value.get_paths_by_root.side_effect = [
+                {self.MOCK_ROOT_PATH: self.MOCK_FILES_LIST},
+                {str(tmp_path): self.MOCK_FILES_LIST},
+                {str(tmp_path): self.MOCK_FILES_LIST},
+            ]
+
+            runner = CliRunner()
+            # Select index 0 to edit, enter new path, then confirm with y
+            result = runner.invoke(
+                main,
+                ["job", "download-input", "--job-id", MOCK_JOB_ID],
+                input=f"0\n{str(tmp_path)}\ny\n",
+            )
+
+            assert result.exit_code == 0
+            mock_downloader.return_value.set_root_path.assert_called()
+            assert "Download Summary:" in result.output

--- a/test/unit/deadline_client/cli/test_cli_job.py
+++ b/test/unit/deadline_client/cli/test_cli_job.py
@@ -1775,3 +1775,275 @@ def test_cli_job_list_with_estimates(fresh_deadline_config, deadline_mock):
 
     assert result.exit_code == 0
     assert "estimatedTimeRemaining:" in result.output
+
+
+# ─── download-input tests ──────────────────────────────────────────────────────
+
+
+class TestBuildAttachments:
+    """Tests for the _build_attachments helper."""
+
+    def test_returns_none_when_no_attachments(self):
+        from deadline.client.cli._groups.job_group import _build_attachments
+
+        assert _build_attachments({"name": "job"}) is None
+
+    def test_returns_none_when_attachments_empty(self):
+        from deadline.client.cli._groups.job_group import _build_attachments
+
+        assert _build_attachments({"attachments": {}}) is None
+
+    def test_builds_attachments_from_job(self):
+        from deadline.client.cli._groups.job_group import _build_attachments
+
+        job = {
+            "attachments": {
+                "manifests": [
+                    {
+                        "rootPath": "/root",
+                        "rootPathFormat": "posix",
+                        "inputManifestPath": "manifest",
+                        "inputManifestHash": "abc123",
+                    }
+                ],
+                "fileSystem": "COPIED",
+            }
+        }
+        result = _build_attachments(job)
+        assert result is not None
+        assert len(result.manifests) == 1
+        assert result.manifests[0].rootPath == "/root"
+        assert result.fileSystem == "COPIED"
+
+    def test_defaults_filesystem_to_copied(self):
+        from deadline.client.cli._groups.job_group import _build_attachments
+
+        job = {
+            "attachments": {
+                "manifests": [
+                    {
+                        "rootPath": "/root",
+                        "rootPathFormat": "posix",
+                        "inputManifestPath": "manifest",
+                        "inputManifestHash": "abc123",
+                    }
+                ],
+            }
+        }
+        result = _build_attachments(job)
+        assert result is not None
+        assert result.fileSystem == "COPIED"
+
+
+class TestJobDownloadInput:
+    """Tests for the download-input CLI command."""
+
+    MOCK_HOST_PATH_FORMAT = PathFormat.get_host_path_format()
+    MOCK_ROOT_PATH = "/root/path" if sys.platform != "win32" else "C:\\Users\\username"
+    MOCK_FILES_LIST = ["inputs/file1.txt", "inputs/file2.txt"]
+
+    def _make_job_response(self, root_path=None, path_format=None):
+        root_path = root_path or self.MOCK_ROOT_PATH
+        path_format = path_format or self.MOCK_HOST_PATH_FORMAT
+        return {
+            "name": "Mock Job",
+            "attachments": {
+                "manifests": [
+                    {
+                        "rootPath": root_path,
+                        "rootPathFormat": path_format,
+                        "inputManifestPath": "manifest-hash",
+                        "inputManifestHash": "abc123",
+                    }
+                ],
+                "fileSystem": "COPIED",
+            },
+        }
+
+    def _setup_mocks(self, boto3_mock, input_downloader_mock, paths_by_root=None):
+        mock_download = MagicMock()
+        mock_download.return_value = DownloadSummaryStatistics(
+            total_time=5, processed_files=2, processed_bytes=512
+        )
+        input_downloader_mock.return_value.download = mock_download
+        if paths_by_root is None:
+            paths_by_root = {self.MOCK_ROOT_PATH: self.MOCK_FILES_LIST}
+        input_downloader_mock.return_value.get_paths_by_root.return_value = paths_by_root
+        boto3_mock().get_queue.return_value = MOCK_GET_QUEUE_RESPONSE
+        boto3_mock().get_job.return_value = self._make_job_response()
+
+    def test_download_input_basic(self, fresh_deadline_config):
+        """Basic download-input with auto-accept."""
+        config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+        config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+        config.set_setting("settings.auto_accept", "true")
+
+        with patch.object(api, "get_boto3_client") as boto3_mock, patch.object(
+            job_group, "InputDownloader"
+        ) as mock_downloader, patch.object(
+            job_group, "_get_conflicting_filenames", return_value=[]
+        ), patch.object(api, "get_queue_user_boto3_session"):
+            self._setup_mocks(boto3_mock, mock_downloader)
+
+            runner = CliRunner()
+            result = runner.invoke(
+                main,
+                ["job", "download-input", "--job-id", MOCK_JOB_ID],
+            )
+
+            assert result.exit_code == 0
+            assert "Downloading input for Job" in result.output
+            assert "Download Summary:" in result.output
+            mock_downloader.return_value.download.assert_called_once()
+
+    def test_download_input_no_attachments(self, fresh_deadline_config):
+        """download-input with a job that has no attachments."""
+        config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+        config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+
+        with patch.object(api, "get_boto3_client") as boto3_mock:
+            boto3_mock().get_job.return_value = {"name": "Mock Job"}
+
+            runner = CliRunner()
+            result = runner.invoke(
+                main,
+                ["job", "download-input", "--job-id", MOCK_JOB_ID],
+            )
+
+            assert result.exit_code == 0
+            assert "No input attachments found" in result.output
+
+    def test_download_input_no_files(self, fresh_deadline_config):
+        """download-input when downloader returns empty paths."""
+        config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+        config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+
+        with patch.object(api, "get_boto3_client") as boto3_mock, patch.object(
+            job_group, "InputDownloader"
+        ) as mock_downloader, patch.object(api, "get_queue_user_boto3_session"):
+            self._setup_mocks(boto3_mock, mock_downloader, paths_by_root={})
+
+            runner = CliRunner()
+            result = runner.invoke(
+                main,
+                ["job", "download-input", "--job-id", MOCK_JOB_ID],
+            )
+
+            assert result.exit_code == 0
+            assert "No input files available for download" in result.output
+
+    def test_download_input_cancel(self, fresh_deadline_config):
+        """download-input cancelled by user."""
+        config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+        config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+
+        with patch.object(api, "get_boto3_client") as boto3_mock, patch.object(
+            job_group, "InputDownloader"
+        ) as mock_downloader, patch.object(
+            job_group, "_get_conflicting_filenames", return_value=[]
+        ), patch.object(api, "get_queue_user_boto3_session"):
+            self._setup_mocks(boto3_mock, mock_downloader)
+
+            runner = CliRunner()
+            result = runner.invoke(
+                main,
+                ["job", "download-input", "--job-id", MOCK_JOB_ID],
+                input="n\n",
+            )
+
+            assert result.exit_code == 0
+            assert "Input download canceled" in result.output
+            mock_downloader.return_value.download.assert_not_called()
+
+    def test_download_input_json_format(self, fresh_deadline_config):
+        """download-input with JSON output format."""
+        config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+        config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+        config.set_setting("settings.auto_accept", "true")
+
+        with patch.object(api, "get_boto3_client") as boto3_mock, patch.object(
+            job_group, "InputDownloader"
+        ) as mock_downloader, patch.object(
+            job_group, "_get_conflicting_filenames", return_value=[]
+        ), patch.object(api, "get_queue_user_boto3_session"):
+            self._setup_mocks(boto3_mock, mock_downloader)
+
+            runner = CliRunner()
+            result = runner.invoke(
+                main,
+                ["job", "download-input", "--job-id", MOCK_JOB_ID, "--output", "json"],
+            )
+
+            assert result.exit_code == 0
+            # JSON output should contain title line
+            lines = result.output.strip().split("\n")
+            title_line = json.loads(lines[0])
+            assert title_line["messageType"] == "title"
+            assert title_line["value"] == "Mock Job"
+
+    def test_download_input_with_include_filter(self, fresh_deadline_config):
+        """download-input with --include filter uses LOCAL matching by default."""
+        config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+        config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+        config.set_setting("settings.auto_accept", "true")
+
+        with patch.object(api, "get_boto3_client") as boto3_mock, patch.object(
+            job_group, "InputDownloader"
+        ) as mock_downloader, patch.object(
+            job_group, "_get_conflicting_filenames", return_value=[]
+        ), patch.object(api, "get_queue_user_boto3_session"):
+            self._setup_mocks(boto3_mock, mock_downloader)
+
+            runner = CliRunner()
+            result = runner.invoke(
+                main,
+                [
+                    "job",
+                    "download-input",
+                    "--job-id",
+                    MOCK_JOB_ID,
+                    "--include",
+                    "*.txt",
+                ],
+            )
+
+            assert result.exit_code == 0
+            # InputDownloader should be created without include_filters (LOCAL mode)
+            mock_downloader.assert_called_once()
+            call_kwargs = mock_downloader.call_args[1]
+            assert call_kwargs["include_filters"] is None
+            # apply_include_filters should be called for LOCAL matching
+            mock_downloader.return_value.apply_include_filters.assert_called_once_with(["*.txt"])
+
+    def test_download_input_with_match_paths_by_job(self, fresh_deadline_config):
+        """download-input with --match-paths-by JOB passes filters to constructor."""
+        config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+        config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+        config.set_setting("settings.auto_accept", "true")
+
+        with patch.object(api, "get_boto3_client") as boto3_mock, patch.object(
+            job_group, "InputDownloader"
+        ) as mock_downloader, patch.object(
+            job_group, "_get_conflicting_filenames", return_value=[]
+        ), patch.object(api, "get_queue_user_boto3_session"):
+            self._setup_mocks(boto3_mock, mock_downloader)
+
+            runner = CliRunner()
+            result = runner.invoke(
+                main,
+                [
+                    "job",
+                    "download-input",
+                    "--job-id",
+                    MOCK_JOB_ID,
+                    "--include",
+                    "*.txt",
+                    "--match-paths-by",
+                    "JOB",
+                ],
+            )
+
+            assert result.exit_code == 0
+            # InputDownloader should be created WITH include_filters (JOB mode)
+            call_kwargs = mock_downloader.call_args[1]
+            assert call_kwargs["include_filters"] == ["*.txt"]

--- a/test/unit/deadline_client/cli/test_cli_job.py
+++ b/test/unit/deadline_client/cli/test_cli_job.py
@@ -316,14 +316,14 @@ def test_cli_job_download_output_stdout_with_only_required_input(
             processed_files=3,
             processed_bytes=1024,
         )
-        MockOutputDownloader.return_value.download_job_output = mock_download
+        MockOutputDownloader.return_value.download = mock_download
         mock_root_path = "/root/path" if sys.platform != "win32" else "C:\\Users\\username"
         mock_files_list = [
             "outputs/file1.txt",
             "outputs/file2.txt",
             "outputs/file3.txt",
         ]
-        MockOutputDownloader.return_value.get_output_paths_by_root.side_effect = [
+        MockOutputDownloader.return_value.get_paths_by_root.side_effect = [
             {
                 f"{mock_root_path}": mock_files_list,
                 f"{mock_root_path}2": mock_files_list,
@@ -433,7 +433,7 @@ def test_cli_job_download_output_stdout_with_mismatching_path_format(
             processed_files=3,
             processed_bytes=1024,
         )
-        MockOutputDownloader.return_value.download_job_output = mock_download
+        MockOutputDownloader.return_value.download = mock_download
 
         mock_root_path = "C:\\Users\\username" if sys.platform != "win32" else "/root/path"
         mock_files_list = [
@@ -441,7 +441,7 @@ def test_cli_job_download_output_stdout_with_mismatching_path_format(
             "outputs/file2.txt",
             "outputs/file3.txt",
         ]
-        MockOutputDownloader.return_value.get_output_paths_by_root.side_effect = [
+        MockOutputDownloader.return_value.get_paths_by_root.side_effect = [
             {
                 f"{mock_root_path}": mock_files_list,
             },
@@ -539,7 +539,7 @@ def test_cli_job_download_output_handles_unc_path_on_windows(fresh_deadline_conf
             processed_files=3,
             processed_bytes=1024,
         )
-        MockOutputDownloader.return_value.download_job_output = mock_download
+        MockOutputDownloader.return_value.download = mock_download
 
         # UNC format (which refers to the same location as 'C:\Users\username')
         mock_root_path = "\\\\127.0.0.1\\c$\\Users\\username"
@@ -548,7 +548,7 @@ def test_cli_job_download_output_handles_unc_path_on_windows(fresh_deadline_conf
             "outputs/file2.txt",
             "outputs/file3.txt",
         ]
-        MockOutputDownloader.return_value.get_output_paths_by_root.side_effect = [
+        MockOutputDownloader.return_value.get_paths_by_root.side_effect = [
             {
                 f"{mock_root_path}": mock_files_list,
             },
@@ -640,8 +640,8 @@ def test_cli_job_download_no_output_stdout(fresh_deadline_config, tmp_path: Path
             processed_files=3,
             processed_bytes=1024,
         )
-        MockOutputDownloader.return_value.download_job_output = mock_download
-        MockOutputDownloader.return_value.get_output_paths_by_root.return_value = {}
+        MockOutputDownloader.return_value.download = mock_download
+        MockOutputDownloader.return_value.get_paths_by_root.return_value = {}
 
         mock_host_path_format_name = PathFormat.get_host_path_format_string()
         boto3_client_mock().get_job.return_value = {
@@ -716,13 +716,13 @@ def test_cli_job_download_output_stdout_with_json_format(
                 f"{mock_root_path}/outputs/file3.txt",
             ],
         )
-        MockOutputDownloader.return_value.download_job_output = mock_download
+        MockOutputDownloader.return_value.download = mock_download
         mock_files_list = [
             "outputs/file1.txt",
             "outputs/file2.txt",
             "outputs/file3.txt",
         ]
-        MockOutputDownloader.return_value.get_output_paths_by_root.side_effect = [
+        MockOutputDownloader.return_value.get_paths_by_root.side_effect = [
             {
                 f"{mock_root_path}": mock_files_list,
                 f"{mock_root_path}2": mock_files_list,
@@ -1344,7 +1344,7 @@ def test_cli_job_download_output_handle_web_url_with_optional_input(
             processed_files=3,
             processed_bytes=1024,
         )
-        MockOutputDownloader.return_value.download_job_output = mock_download
+        MockOutputDownloader.return_value.download = mock_download
         mock_host_path_format_name = PathFormat.get_host_path_format_string()
 
         boto3_client_mock().get_job.return_value = {
@@ -1430,7 +1430,7 @@ def test_cli_job_download_output_with_different_asset_root_path_format_than_job(
             processed_files=3,
             processed_bytes=1024,
         )
-        MockOutputDownloader.return_value.download_job_output = mock_download
+        MockOutputDownloader.return_value.download = mock_download
         windows_root_path = "C:\\Users\\username"
         not_windows_root_path = "/root/path"
         mock_root_path = not_windows_root_path if sys.platform == "win32" else windows_root_path
@@ -1439,7 +1439,7 @@ def test_cli_job_download_output_with_different_asset_root_path_format_than_job(
             "outputs/file2.txt",
             "outputs/file3.txt",
         ]
-        MockOutputDownloader.return_value.get_output_paths_by_root.side_effect = [
+        MockOutputDownloader.return_value.get_paths_by_root.side_effect = [
             {
                 f"{mock_root_path}": mock_files_list,
             },
@@ -1661,8 +1661,8 @@ def test_cli_job_download_output_with_session_action_id(fresh_deadline_config):
             processed_files=3,
             processed_bytes=1024,
         )
-        MockOutputDownloader.return_value.download_job_output = mock_download
-        MockOutputDownloader.return_value.get_output_paths_by_root.return_value = {}
+        MockOutputDownloader.return_value.download = mock_download
+        MockOutputDownloader.return_value.get_paths_by_root.return_value = {}
 
         mock_host_path_format_name = PathFormat.get_host_path_format_string()
         boto3_client_mock().get_job.return_value = {

--- a/test/unit/deadline_client/cli/test_cli_job_download_storage_profiles.py
+++ b/test/unit/deadline_client/cli/test_cli_job_download_storage_profiles.py
@@ -118,8 +118,8 @@ def _make_download_mocks(
     mock_download.return_value = DownloadSummaryStatistics(
         total_time=1, processed_files=1, processed_bytes=100
     )
-    mock_output_downloader.return_value.download_job_output = mock_download
-    mock_output_downloader.return_value.get_output_paths_by_root.return_value = root_paths
+    mock_output_downloader.return_value.download = mock_download
+    mock_output_downloader.return_value.get_paths_by_root.return_value = root_paths
 
 
 # ─── Case 1: Both profiles exist, locations match → automatic mapping ────────
@@ -525,7 +525,7 @@ def test_case8e_nested_locations_most_specific_rule_wins(
 
         # Verify mapped manifest download was called (not OutputDownloader)
         mock_download_manifests.assert_called_once()
-        mock_downloader.return_value.download_job_output.assert_not_called()
+        mock_downloader.return_value.download.assert_not_called()
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX destination test")
@@ -710,7 +710,7 @@ def test_rules_exist_but_no_files_match_falls_back_to_downloader(
         # No files matched the rules, so mapped manifest download should NOT be called
         mock_download_manifests.assert_not_called()
         # Instead, the OutputDownloader path should have been used
-        mock_downloader.return_value.download_job_output.assert_called_once()
+        mock_downloader.return_value.download.assert_called_once()
 
 
 # ─── Mapped download path: progress callback and conflict resolution ─────────

--- a/test/unit/deadline_client/cli/test_job_download_helpers.py
+++ b/test/unit/deadline_client/cli/test_job_download_helpers.py
@@ -446,8 +446,8 @@ class TestCliDownloadOutputStorageProfileOptions:
             mock_download.return_value = DownloadSummaryStatistics(
                 total_time=1, processed_files=1, processed_bytes=100
             )
-            MockOutputDownloader.return_value.download_job_output = mock_download
-            MockOutputDownloader.return_value.get_output_paths_by_root.return_value = {
+            MockOutputDownloader.return_value.download = mock_download
+            MockOutputDownloader.return_value.get_paths_by_root.return_value = {
                 mock_root: ["file.txt"]
             }
 


### PR DESCRIPTION
## Summary

Adds a new `deadline job download-input` CLI command that downloads job input files (job attachments) with optional glob-style `--include` filtering, mirroring the existing `download-output` command.

Also bumps `deadline-job-attachments` from 0.0.2 to 0.1.0 and updates all call sites to the unified downloader API.

## Changes

### New: `download-input` command
* Downloads input files attached to a Deadline Cloud job
* Supports `--include` glob patterns for selective downloads
* Supports `--match-paths-by JOB|LOCAL` to control filter matching
* Storage profile path mapping support
* JSON output mode for programmatic use
* Conflict resolution options (SKIP, OVERWRITE, CREATE_COPY)

### Dependency bump: `deadline-job-attachments` 0.0.2 → 0.1.0
* `OutputDownloader.download_job_output()` → `download()`
* `OutputDownloader.get_output_paths_by_root()` → `get_paths_by_root()`
* New `InputDownloader` class with matching API

### Refactor: shared download UX helpers
Extracted ~125 lines of duplicated UX code from `_download_job_output` and `_download_job_input` into three shared helpers:
* `_prompt_for_os_mismatch_roots` — OS format mismatch prompts
* `_prompt_to_confirm_roots` — interactive root path confirmation with optional callback
* `_execute_download_with_progress` — progress bar / JSON progress reporting

Both downloaders use `_BaseFilterableDownloader` as the shared interface.

## Testing
* **14 unit tests** for `_build_attachments` and `download-input` command (basic, no attachments, no files, cancel, JSON, include filter, match-paths-by JOB, OS mismatch, storage profile mapping, root path editing)
* **4 cli_e2e tests** against mock servers (basic download, glob filter, no-match filter, no attachments)
* All 181 unit tests pass (including existing download-output tests with refactored helpers)
* All 136 cli_e2e tests pass (including existing attachment/manifest/download-output tests)
* Lint, format, and mypy checks pass
* Manually validated using `hatch shell`
