### PR TITLE
test(ui): cover 'Load a different job bundle' button flow

### DIFF
--- a/test/ui/conftest.py
+++ b/test/ui/conftest.py
@@ -103,6 +103,23 @@ class _QtPyPostImportPatcher:
             self._sigterm_pulse.start()
 
         _qw.QApplication.__init__ = _qa_init
+
+        # Stub QFileDialog.getExistingDirectory: when the test points
+        # DEADLINE_TEST_NEXT_BUNDLE_DIR_FILE at a file, return its contents
+        # (or "" for cancel — the call sites already handle that).
+        import os as _os
+
+        def _stub_get_existing_dir(*args, **kwargs):
+            ctl = _os.environ.get("DEADLINE_TEST_NEXT_BUNDLE_DIR_FILE")
+            if not ctl:
+                return ""
+            try:
+                with open(ctl) as _f:
+                    return _f.read().strip()
+            except OSError:
+                return ""
+
+        _qw.QFileDialog.getExistingDirectory = staticmethod(_stub_get_existing_dir)
         return None
 
 
@@ -176,6 +193,17 @@ def bundle_dir(tmp_path) -> str:
     d.mkdir()
     (d / "template.json").write_text(json.dumps(SAMPLE_TEMPLATE))
     return str(d)
+
+
+@pytest.fixture
+def bundle_picker_file(deadline_env, tmp_path) -> Path:
+    """Wire up the QFileDialog stub: tests write a bundle path to this file
+    and the next click on a "browse for directory" button reads it back."""
+    _backend, env = deadline_env
+    ctl = tmp_path / "next_bundle_dir.txt"
+    ctl.write_text("")
+    env["DEADLINE_TEST_NEXT_BUNDLE_DIR_FILE"] = str(ctl)
+    return ctl
 
 
 @pytest.fixture

--- a/test/ui/helpers.py
+++ b/test/ui/helpers.py
@@ -458,6 +458,36 @@ class SubmitterDialog(DeadlineApp):
         ok.wait_visible(timeout=EXPORT_TIMEOUT)
         ok.press()
 
+    def load_different_bundle(
+        self,
+        next_bundle_dir: str,
+        picker_file: str,
+        expected_name: str,
+        button_label: str = "Load Bundle",
+        timeout: float = FARM_RESOLVE_TIMEOUT,
+    ) -> None:
+        """Click the load-bundle button and wait for the dialog to refresh.
+
+        Writes *next_bundle_dir* to *picker_file* so the subprocess's stubbed
+        ``QFileDialog.getExistingDirectory`` returns it, then clicks
+        *button_label* and polls until the Name field shows *expected_name*.
+        """
+        with open(picker_file, "w") as f:
+            f.write(next_bundle_dir)
+        self.button(button_label).press()
+        deadline = time.monotonic() + timeout
+        last = ""
+        while time.monotonic() < deadline:
+            last = self.job_name
+            if last == expected_name:
+                return
+            time.sleep(0.25)
+        self.dump_tree()
+        raise AssertionError(
+            f"Job name did not refresh to {expected_name!r} within {timeout}s; "
+            f"last value was {last!r}"
+        )
+
     def submit_and_ok(self, timeout: float = SUBMIT_TIMEOUT) -> None:
         """Click Submit, wait for success, click Ok."""
         self.button("Submit").press()

--- a/test/ui/test_bundle_gui_submit.py
+++ b/test/ui/test_bundle_gui_submit.py
@@ -4,10 +4,11 @@
 
 from __future__ import annotations
 
+import copy
 import json
 import os
 
-from helpers import SubmitterDialog
+from helpers import SAMPLE_TEMPLATE, SubmitterDialog
 
 
 class TestSubmitterOpens:
@@ -37,6 +38,44 @@ class TestSubmitterOpens:
     def test_has_submit_and_export_buttons(self, gui_submit: SubmitterDialog):
         assert gui_submit.button("Submit").exists()
         assert gui_submit.button("Export bundle").exists()
+
+
+class TestLoadDifferentBundle:
+    """Covers the manual test 'Verify Load a different job bundle button in
+    GUI Submitter': open the submitter on bundle A with --browse, click the
+    load-bundle button, and confirm the dialog refreshes to bundle B's name.
+    """
+
+    def test_load_bundle_button_swaps_in_second_bundle(
+        self, bundle_dir, submitter_env, bundle_picker_file, tmp_path
+    ):
+        # Make a second bundle with a distinct template name so we can tell
+        # the dialog has refreshed by reading the visible Name field.
+        second = tmp_path / "second_bundle"
+        second.mkdir()
+        second_template = copy.deepcopy(SAMPLE_TEMPLATE)
+        second_template["name"] = "Second Bundle Job"
+        (second / "template.json").write_text(json.dumps(second_template))
+
+        with SubmitterDialog.open(
+            bundle_dir, env=submitter_env, extra_args=["--browse"]
+        ) as app:
+            app.wait_farm_resolved()
+            assert app.job_name == "Test Render Job"
+            assert app.button("Load Bundle").exists(), (
+                "Load-bundle button should be present when --browse is set"
+            )
+            app.load_different_bundle(
+                next_bundle_dir=str(second),
+                picker_file=str(bundle_picker_file),
+                expected_name="Second Bundle Job",
+            )
+
+    def test_load_bundle_button_hidden_without_browse_flag(
+        self, gui_submit: SubmitterDialog
+    ):
+        """Without --browse, browse_enabled is False and the button is not built."""
+        assert not gui_submit.button("Load Bundle").exists()
 
 
 class TestExportBundle:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We have a manual test case for the "Load another bundle" button.

### What was the solution? (How)
Automate it away.

### What is the impact of this change?
Removes a manual test case.

### How was this change tested?
PR actions

### Was this change documented?
n/a

### Does this PR introduce new dependencies?
No

### Is this a breaking change?
No

### Does this change impact security?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
