### PR TITLE
feat: add beforeUI submission hook phase

### DIFF
--- a/docs/submission-hooks.md
+++ b/docs/submission-hooks.md
@@ -12,6 +12,11 @@ Place a `hooks.yaml` (or `hooks.json`) in your job bundle directory alongside `t
 
 ```yaml
 version: "1.0"
+preUI:
+  - command: python3
+    args: [prefill.py]
+    timeout: 10
+
 preSubmission:
   - command: python3
     args: [validate.py]
@@ -36,6 +41,58 @@ export DEADLINE_HOOKS_DIR=/studio/pipeline/hooks/maya
 Requires `settings.allow_environment_hooks` to be enabled. Both sources can be active simultaneously — environment hooks run first, then bundle hooks.
 
 ## Hook Types
+
+### Pre-UI Hooks
+
+Run **before** the submission dialog opens. Use these to:
+- Pre-populate job name, description, and priority
+- Set parameter defaults based on the current scene or pipeline context
+- Query a project management system for task metadata
+
+Pre-UI hooks **block the dialog from opening** if they fail (non-zero exit code or timeout).
+
+Output JSON to stdout to modify the initial dialog state:
+
+```python
+import json
+
+output = {
+    "name": "My Render - v042",
+    "description": "Submitted via pipeline",
+    "parameters": {
+        # Job template parameters
+        "SceneFile": "/resolved/path/to/scene.ma",
+        "OutputPath": "/shots/sh010/renders/",
+        # Shared job properties use the deadline: prefix
+        "deadline:priority": 75,
+        "deadline:maxFailedTasksCount": 5,
+        "deadline:maxRetriesPerTask": 3,
+        "deadline:maxWorkerCount": 10,
+        "deadline:targetTaskRunStatus": "READY",  # or "SUSPENDED"
+    }
+}
+print(json.dumps(output))
+```
+
+| Output field | Type | Description |
+|---|---|---|
+| `name` | string | Pre-fill the job name field |
+| `description` | string | Pre-fill the job description field |
+| `parameters` | object | Pre-fill parameter values by name (see below) |
+
+**Parameter keys** (inside `parameters`):
+
+Job template parameters use their name directly. Shared job properties use the `deadline:` prefix:
+
+| Key | Type | Description |
+|---|---|---|
+| `deadline:priority` | integer | Priority (0–100) |
+| `deadline:maxFailedTasksCount` | integer | Maximum failed tasks before the job fails |
+| `deadline:maxRetriesPerTask` | integer | Maximum retries per failed task |
+| `deadline:maxWorkerCount` | integer | Maximum concurrent workers |
+| `deadline:targetTaskRunStatus` | string | Initial task status: `"READY"` or `"SUSPENDED"` |
+
+> **Note:** CLI-supplied `--parameter` values take precedence over hook-supplied `parameters`.
 
 ### Pre-Submission Hooks
 
@@ -67,6 +124,11 @@ The `version` field is required and must be `"1.0"`.
 **YAML format:**
 ```yaml
 version: "1.0"
+preUI:
+  - command: python3
+    args: [scripts/prefill_from_shotgrid.py]
+    timeout: 10
+
 preSubmission:
   - command: python3
     args: [scripts/validate_assets.py]
@@ -320,10 +382,13 @@ This is useful for studios that want to enforce hooks across all submissions wit
 
 ### Confirmation Prompt
 
-When hooks are enabled, you'll be prompted to confirm before they run:
+When hooks are enabled, you'll be prompted to confirm before they run. Pre-UI hooks show a prompt before the dialog opens; pre- and post-submission hooks show a prompt when you click Submit.
 
 ```
 This job bundle contains submission hooks that will execute on your machine:
+
+  Pre-UI hooks:
+    [1] python3 prefill_from_shotgrid.py
 
   Pre-submission hooks:
     [1] python3 validate_assets.py

--- a/examples/hooks/pre_ui_priority.py
+++ b/examples/hooks/pre_ui_priority.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Pre-UI hook: set job priority based on deadline proximity.
+
+Place this script alongside a hooks.yaml in your job bundle:
+
+    hooks.yaml
+    ----------
+    version: "1.0"
+    preUI:
+      - command: python3
+        args: [pre_ui_priority.py]
+        timeout: 5
+
+The hook reads the current date and sets priority 90 if a deadline is
+approaching (within 2 days), otherwise 50. It also pre-fills the job name
+with a datestamp so artists can see when the job was submitted.
+"""
+
+import json
+import sys
+from datetime import date
+
+TODAY = date.today()
+DEADLINE = date(TODAY.year, TODAY.month, 28)  # example: end-of-month deadline
+DAYS_REMAINING = (DEADLINE - TODAY).days
+
+if DAYS_REMAINING <= 2:
+    priority = 90
+    name_suffix = " [URGENT]"
+elif DAYS_REMAINING <= 7:
+    priority = 70
+    name_suffix = " [due soon]"
+else:
+    priority = 50
+    name_suffix = ""
+
+metadata = json.load(sys.stdin)
+job_name = metadata.get("jobName", "Job")
+
+output = {
+    "name": f"{job_name}{name_suffix} ({TODAY.isoformat()})",
+    "parameters": {
+        "deadline:priority": priority,
+    },
+}
+
+json.dump(output, sys.stdout)

--- a/src/deadline/client/job_bundle/_hooks/__init__.py
+++ b/src/deadline/client/job_bundle/_hooks/__init__.py
@@ -4,6 +4,7 @@
 
 from ._manager import HookManager, _generate_hooks_confirmation_message
 from ._models import HookConfiguration, HookDefinition, HookMetadata, HookResult
+from ._validator import validate_pre_ui_output
 
 __all__ = [
     "HookManager",
@@ -12,4 +13,5 @@ __all__ = [
     "HookMetadata",
     "HookResult",
     "_generate_hooks_confirmation_message",
+    "validate_pre_ui_output",
 ]

--- a/src/deadline/client/job_bundle/_hooks/_manager.py
+++ b/src/deadline/client/job_bundle/_hooks/_manager.py
@@ -15,6 +15,7 @@ from ._executor import HookExecutor as _HookExecutor
 from ._merger import merge_payload as _merge_payload
 from ._models import HookConfiguration as _HookConfiguration
 from ._models import HookMetadata as _HookMetadata
+from ._validator import validate_pre_ui_output as _validate_pre_ui_output
 from ._validator import validate_configuration as _validate_configuration
 from ._validator import validate_modified_payload as _validate_modified_payload
 
@@ -24,6 +25,13 @@ _logger = _logging.getLogger(__name__)
 def _generate_hooks_confirmation_message(hooks: _HookConfiguration, bundle_dir: str) -> str:
     """Generate a confirmation message listing hooks that will execute."""
     lines = ["This job bundle contains submission hooks that will execute on your machine:\n"]
+
+    if hooks.pre_ui:
+        lines.append("  Pre-UI hooks:")
+        for i, hook in enumerate(hooks.pre_ui):
+            cmd = f"{hook.command} {' '.join(hook.args)}".strip()
+            lines.append(f"    [{i + 1}] {cmd}")
+        lines.append("")
 
     if hooks.pre_submission:
         lines.append("  Pre-submission hooks:")
@@ -67,6 +75,63 @@ class HookManager:
         _validate_configuration(config_data)
         self.hooks = _HookConfiguration.from_dict(config_data)
         return self.hooks
+
+    def execute_pre_ui_hooks(
+        self,
+        metadata: _HookMetadata,
+    ) -> _Dict[str, _Any]:
+        """Execute all pre-UI hooks and return merged initial parameter overrides.
+
+        Runs before the submission dialog opens. Hooks may output JSON to pre-populate
+        dialog fields: parameters, priority, farmId, queueId, name, description.
+        Failures block the dialog from opening.
+        """
+        if not self.hooks or not self.hooks.pre_ui:
+            return {}
+
+        metadata.job_bundle_dir = self._original_bundle_dir
+
+        merged: _Dict[str, _Any] = {}
+        for i, hook in enumerate(self.hooks.pre_ui):
+            hook_name = f"{hook.command} {' '.join(hook.args)}".strip()
+            self.print_callback(f"Running pre-UI hook [{i + 1}]: {hook_name}")
+
+            result = self._executor.execute(hook, metadata, "pre-UI", i + 1)
+
+            if result.timed_out:
+                self._report_failure(hook, result, i + 1, "pre-UI")
+                raise _DeadlineOperationError(
+                    f"Pre-UI hook [{i + 1}] timed out after {hook.timeout}s: {hook_name}"
+                )
+
+            if not result.is_success():
+                self._report_failure(hook, result, i + 1, "pre-UI")
+                raise _DeadlineOperationError(
+                    f"Pre-UI hook [{i + 1}] failed with exit code {result.exit_code}: {hook_name}"
+                )
+
+            if result.stdout.strip():
+                try:
+                    output = _json.loads(result.stdout)
+                    _validate_pre_ui_output(output, hook_name)
+                    # Later hooks override earlier ones for scalar fields; parameters are merged.
+                    params = merged.pop("parameters", {})
+                    params.update(output.pop("parameters", {}))
+                    merged.update(output)
+                    if params:
+                        merged["parameters"] = params
+                    _logger.debug(f"Pre-UI hook [{i + 1}] modified initial settings")
+                except _json.JSONDecodeError as e:
+                    raise _DeadlineOperationError(
+                        f"Pre-UI hook [{i + 1}] produced invalid JSON: {e}"
+                    )
+
+            if result.stderr:
+                _logger.warning(f"Pre-UI hook [{i + 1}] stderr: {result.stderr}")
+
+            _logger.debug(f"Pre-UI hook [{i + 1}] completed in {result.execution_time:.2f}s")
+
+        return merged
 
     def execute_pre_submission_hooks(
         self,

--- a/src/deadline/client/job_bundle/_hooks/_models.py
+++ b/src/deadline/client/job_bundle/_hooks/_models.py
@@ -33,6 +33,7 @@ class HookConfiguration:
     """Complete hook configuration from hooks.yaml/json."""
 
     version: str
+    pre_ui: _List[HookDefinition]
     pre_submission: _List[HookDefinition]
     post_submission: _List[HookDefinition]
 
@@ -40,6 +41,7 @@ class HookConfiguration:
     def from_dict(cls, data: _Dict[str, _Any]) -> HookConfiguration:
         return cls(
             version=data.get("version", "1.0"),
+            pre_ui=[HookDefinition.from_dict(h) for h in data.get("preUI", [])],
             pre_submission=[HookDefinition.from_dict(h) for h in data.get("preSubmission", [])],
             post_submission=[HookDefinition.from_dict(h) for h in data.get("postSubmission", [])],
         )

--- a/src/deadline/client/job_bundle/_hooks/_validator.py
+++ b/src/deadline/client/job_bundle/_hooks/_validator.py
@@ -39,7 +39,7 @@ def validate_configuration(config: _Dict[str, _Any]) -> None:
             f"Unsupported hooks version '{version}'. Supported: {', '.join(sorted(_SUPPORTED_VERSIONS))}"
         )
 
-    for key in ("preSubmission", "postSubmission"):
+    for key in ("preUI", "preSubmission", "postSubmission"):
         if key in config and not isinstance(config[key], list):
             raise _DeadlineOperationError(f"Hook configuration '{key}' must be a list")
 
@@ -69,3 +69,28 @@ def validate_modified_payload(payload: _Dict[str, _Any], hook_name: str) -> None
             raise _DeadlineOperationError(f"Hook '{hook_name}' 'attachments' must be an object")
         if "assetReferences" in attachments:
             _validate_asset_references(attachments["assetReferences"], hook_name)
+
+
+_PRE_UI_ALLOWED_KEYS = {"parameters", "name", "description"}
+
+
+def validate_pre_ui_output(output: _Dict[str, _Any], hook_name: str) -> None:
+    """Validate that a pre-UI hook output contains only recognised fields."""
+    if not isinstance(output, dict):
+        raise _DeadlineOperationError(f"Hook '{hook_name}' output must be a JSON object")
+
+    unknown = set(output.keys()) - _PRE_UI_ALLOWED_KEYS
+    if unknown:
+        raise _DeadlineOperationError(
+            f"Hook '{hook_name}' output contains unrecognised fields: {', '.join(sorted(unknown))}. "
+            f"Allowed fields: {', '.join(sorted(_PRE_UI_ALLOWED_KEYS))}"
+        )
+
+    if "parameters" in output and not isinstance(output["parameters"], dict):
+        raise _DeadlineOperationError(
+            f"Hook '{hook_name}' 'parameters' must be an object mapping parameter names to values"
+        )
+
+    for str_field in ("name", "description"):
+        if str_field in output and not isinstance(output[str_field], str):
+            raise _DeadlineOperationError(f"Hook '{hook_name}' '{str_field}' must be a string")

--- a/src/deadline/client/ui/job_bundle_submitter.py
+++ b/src/deadline/client/ui/job_bundle_submitter.py
@@ -16,7 +16,15 @@ from qtpy.QtWidgets import (  # pylint: disable=import-error; type: ignore
     QWidget,
 )
 
+from ..config import config_file as _config_file
+from ..config.config_file import get_setting as _get_setting
+from ..exceptions import DeadlineOperationCanceled as _DeadlineOperationCanceled
 from ..exceptions import DeadlineOperationError
+from ..job_bundle._hooks import (
+    HookManager as _HookManager,
+    HookMetadata as _HookMetadata,
+    _generate_hooks_confirmation_message,
+)
 from ..job_bundle.loader import (
     parse_yaml_or_json_content,
     read_yaml_or_json,
@@ -42,6 +50,30 @@ from ..job_bundle.submission import AssetReferences
 from ..api._session import session_context
 
 logger = getLogger(__name__)
+
+
+def _make_pre_ui_metadata(initial_settings: Any, job_bundle_dir: str) -> _HookMetadata:
+    """Build minimal HookMetadata for the pre-UI phase."""
+    farm_id = _get_setting("defaults.farm_id") or ""
+    queue_id = _get_setting("defaults.queue_id") or ""
+    storage_profile_id = _get_setting("settings.storage_profile_id") or None
+    parameters = {
+        p["name"]: p.get("value", p.get("default"))
+        for p in getattr(initial_settings, "parameters", [])
+        if "value" in p or "default" in p
+    }
+    return _HookMetadata(
+        job_name=getattr(initial_settings, "name", ""),
+        priority=50,
+        farm_id=farm_id,
+        queue_id=queue_id,
+        job_bundle_dir=job_bundle_dir,
+        parameters=parameters,
+        submitter_name=getattr(initial_settings, "submitter_name", "JobBundle"),
+        asset_references={},
+        submission_payload={},
+        storage_profile_id=storage_profile_id,
+    )
 
 
 def _validate_job_parameters_against_definitions(
@@ -281,6 +313,35 @@ def show_job_bundle_submitter(
     initial_settings.parameters = read_job_bundle_parameters(input_job_bundle_dir)
     initial_settings.browse_enabled = browse
 
+    # Run pre-UI hooks to allow studios to pre-populate dialog fields.
+    pre_ui_output: dict[str, Any] = {}
+    allow_env_hooks = _config_file.str2bool(_get_setting("settings.allow_environment_hooks"))
+    allow_bundle_hooks = _config_file.str2bool(_get_setting("settings.allow_bundle_hooks"))
+    hook_manager = _HookManager(input_job_bundle_dir, logger.info)
+    hooks = hook_manager.load_hooks()
+    if hooks and hooks.pre_ui and not allow_bundle_hooks and not allow_env_hooks:
+        logger.warning(
+            "Note: Job bundle contains preUI hooks but bundle hooks are disabled.\n"
+            "Enable with: deadline config set settings.allow_bundle_hooks true"
+        )
+    if (allow_env_hooks or allow_bundle_hooks) and hooks and hooks.pre_ui:
+        if not _config_file.str2bool(_get_setting("settings.auto_accept")):
+            confirmation_msg = (
+                _generate_hooks_confirmation_message(hooks, input_job_bundle_dir)
+                + "Do you want to run these hooks?"
+            )
+            reply = QMessageBox.question(
+                parent,
+                tr("Job Submission Confirmation"),
+                confirmation_msg,
+                QMessageBox.Yes | QMessageBox.No,
+                QMessageBox.No,
+            )
+            if reply != QMessageBox.Yes:
+                raise _DeadlineOperationCanceled("Job submission canceled (user declined hooks).")
+        hook_metadata = _make_pre_ui_metadata(initial_settings, input_job_bundle_dir)
+        pre_ui_output = hook_manager.execute_pre_ui_hooks(hook_metadata)
+
     initial_shared_parameter_values = {}
 
     job_parameters_dict = {param["name"]: param for param in (job_parameters or [])}
@@ -308,6 +369,27 @@ def show_job_bundle_submitter(
     # Put the job_parameter values that weren't for the template in the shared parameter values
     for parameter in job_parameters_dict.values():
         initial_shared_parameter_values[parameter["name"]] = parameter["value"]
+
+    # Merge pre-UI hook output. CLI-supplied parameters take precedence over hook values.
+    if pre_ui_output:
+        hook_params = pre_ui_output.get("parameters", {})
+        template_param_names = {p["name"] for p in initial_settings.parameters}
+        for param_name, param_value in hook_params.items():
+            if param_name in (job_parameters_dict or {}):
+                continue
+            if param_name in template_param_names:
+                # Job template parameter — update initial_settings.parameters in-place
+                for p in initial_settings.parameters:
+                    if p["name"] == param_name:
+                        p["value"] = param_value
+                        break
+            else:
+                # Shared job property (deadline: keys, queue parameters, etc.)
+                initial_shared_parameter_values[param_name] = param_value
+        if "name" in pre_ui_output:
+            initial_settings.name = pre_ui_output["name"]
+        if "description" in pre_ui_output:
+            initial_settings.description = pre_ui_output["description"]
 
     submitter_dialog = SubmitJobToDeadlineDialog(
         job_setup_widget_type=JobBundleSettingsWidget,

--- a/test/unit/deadline_client/job_bundle/test_hooks.py
+++ b/test/unit/deadline_client/job_bundle/test_hooks.py
@@ -22,6 +22,7 @@ from deadline.client.job_bundle._hooks import (
 )
 from deadline.client.job_bundle._hooks._merger import merge_asset_references, merge_payload
 from deadline.client.job_bundle._hooks._validator import (
+    validate_pre_ui_output,
     validate_configuration,
     validate_modified_payload,
 )
@@ -60,6 +61,7 @@ class TestHookConfiguration:
     def test_from_dict_empty(self):
         """Test parsing empty configuration."""
         config = HookConfiguration.from_dict({})
+        assert config.pre_ui == []
         assert config.pre_submission == []
         assert config.post_submission == []
         assert config.version == "1.0"
@@ -842,10 +844,13 @@ class TestHookManager:
 
         hooks = HookConfiguration(
             version="1.0",
+            pre_ui=[HookDefinition(command="python", args=["prefill.py"])],
             pre_submission=[HookDefinition(command="python", args=["validate.py"])],
             post_submission=[HookDefinition(command="bash", args=["notify.sh"])],
         )
         message = _generate_hooks_confirmation_message(hooks, "/path/to/bundle")
+        assert "Pre-UI hooks:" in message
+        assert "python prefill.py" in message
         assert "Pre-submission hooks:" in message
         assert "python validate.py" in message
         assert "Post-submission hooks:" in message
@@ -924,3 +929,284 @@ class TestHookManager:
             )
             manager.execute_post_submission_hooks(metadata)
             assert os.path.exists(marker)
+
+
+class TestValidateBeforeUIOutput:
+    """Tests for pre-UI hook output validation."""
+
+    def test_valid_empty(self):
+        validate_pre_ui_output({}, "hook")
+
+    def test_valid_all_fields(self):
+        validate_pre_ui_output(
+            {
+                "name": "My Job",
+                "description": "desc",
+                "parameters": {"deadline:priority": 75, "k": "v"},
+            },
+            "hook",
+        )
+
+    def test_invalid_not_dict(self):
+        with pytest.raises(DeadlineOperationError, match="must be a JSON object"):
+            validate_pre_ui_output("string", "hook")  # type: ignore[arg-type]
+
+    def test_invalid_unknown_field(self):
+        with pytest.raises(DeadlineOperationError, match="unrecognised fields"):
+            validate_pre_ui_output({"farmId": "farm-123"}, "hook")
+
+    def test_invalid_parameters_not_dict(self):
+        with pytest.raises(DeadlineOperationError, match="'parameters' must be an object"):
+            validate_pre_ui_output({"parameters": ["list"]}, "hook")
+
+    def test_invalid_unknown_field_priority(self):
+        with pytest.raises(DeadlineOperationError, match="unrecognised fields"):
+            validate_pre_ui_output({"priority": 75}, "hook")
+
+    def test_invalid_name_not_string(self):
+        with pytest.raises(DeadlineOperationError, match="'name' must be a string"):
+            validate_pre_ui_output({"name": 123}, "hook")
+
+    def test_invalid_description_not_string(self):
+        with pytest.raises(DeadlineOperationError, match="'description' must be a string"):
+            validate_pre_ui_output({"description": []}, "hook")
+
+
+class TestHookConfigurationBeforeUI:
+    """Tests for preUI in HookConfiguration."""
+
+    def test_from_dict_pre_ui(self):
+        data = {"preUI": [{"command": "prefill.py"}]}
+        config = HookConfiguration.from_dict(data)
+        assert len(config.pre_ui) == 1
+        assert config.pre_ui[0].command == "prefill.py"
+
+    def test_from_dict_all_phases(self):
+        data = {
+            "preUI": [{"command": "prefill.py"}],
+            "preSubmission": [{"command": "validate.py"}],
+            "postSubmission": [{"command": "notify.py"}],
+        }
+        config = HookConfiguration.from_dict(data)
+        assert len(config.pre_ui) == 1
+        assert len(config.pre_submission) == 1
+        assert len(config.post_submission) == 1
+
+
+class TestValidateConfigurationBeforeUI:
+    """Tests for preUI phase in validate_configuration."""
+
+    def test_valid_pre_ui(self):
+        validate_configuration({"preUI": [{"command": "prefill.py"}]})
+
+    def test_invalid_pre_ui_not_list(self):
+        with pytest.raises(DeadlineOperationError, match="must be a list"):
+            validate_configuration({"preUI": "not a list"})
+
+    def test_invalid_pre_ui_hook_missing_command(self):
+        with pytest.raises(DeadlineOperationError, match="missing required 'command'"):
+            validate_configuration({"preUI": [{"args": []}]})
+
+
+class TestExecuteBeforeUIHooks:
+    """Tests for HookManager.execute_pre_ui_hooks."""
+
+    def _make_metadata(self, tmpdir: str) -> HookMetadata:
+        return HookMetadata(
+            job_name="Test",
+            priority=50,
+            farm_id="farm-123",
+            queue_id="queue-456",
+            job_bundle_dir=tmpdir,
+            parameters={},
+            submitter_name="Test",
+            asset_references={},
+            submission_payload={},
+        )
+
+    def test_no_pre_ui_hooks_returns_empty(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            hooks_file = os.path.join(tmpdir, "hooks.yaml")
+            with open(hooks_file, "w") as f:
+                yaml.dump(
+                    {"preSubmission": [{"command": sys.executable, "args": ["-c", "pass"]}]}, f
+                )
+            manager = HookManager(tmpdir, lambda x: None)
+            manager.load_hooks()
+            result = manager.execute_pre_ui_hooks(self._make_metadata(tmpdir))
+            assert result == {}
+
+    def test_returns_merged_output(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            hooks_file = os.path.join(tmpdir, "hooks.yaml")
+            output = {
+                "name": "Prefilled Job",
+                "parameters": {"deadline:priority": 80, "Foo": "bar"},
+            }
+            with open(hooks_file, "w") as f:
+                yaml.dump(
+                    {
+                        "preUI": [
+                            {
+                                "command": sys.executable,
+                                "args": ["-c", f"import json; print(json.dumps({output!r}))"],
+                            }
+                        ]
+                    },
+                    f,
+                )
+            manager = HookManager(tmpdir, lambda x: None)
+            manager.load_hooks()
+            result = manager.execute_pre_ui_hooks(self._make_metadata(tmpdir))
+            assert result["name"] == "Prefilled Job"
+            assert result["parameters"] == {"deadline:priority": 80, "Foo": "bar"}
+
+    def test_later_hook_overrides_scalar(self):
+        """Later hooks override earlier hooks for scalar fields like name."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            hooks_file = os.path.join(tmpdir, "hooks.yaml")
+            with open(hooks_file, "w") as f:
+                yaml.dump(
+                    {
+                        "preUI": [
+                            {
+                                "command": sys.executable,
+                                "args": ["-c", 'import json; print(json.dumps({"name": "first"}))'],
+                            },
+                            {
+                                "command": sys.executable,
+                                "args": [
+                                    "-c",
+                                    'import json; print(json.dumps({"name": "second"}))',
+                                ],
+                            },
+                        ]
+                    },
+                    f,
+                )
+            manager = HookManager(tmpdir, lambda x: None)
+            manager.load_hooks()
+            result = manager.execute_pre_ui_hooks(self._make_metadata(tmpdir))
+            assert result["name"] == "second"
+
+    def test_parameters_merged_across_hooks(self):
+        """Parameters from multiple hooks are merged (not replaced)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            hooks_file = os.path.join(tmpdir, "hooks.yaml")
+            with open(hooks_file, "w") as f:
+                yaml.dump(
+                    {
+                        "preUI": [
+                            {
+                                "command": sys.executable,
+                                "args": [
+                                    "-c",
+                                    'import json; print(json.dumps({"parameters": {"A": "1"}}))',
+                                ],
+                            },
+                            {
+                                "command": sys.executable,
+                                "args": [
+                                    "-c",
+                                    'import json; print(json.dumps({"parameters": {"B": "2"}}))',
+                                ],
+                            },
+                        ]
+                    },
+                    f,
+                )
+            manager = HookManager(tmpdir, lambda x: None)
+            manager.load_hooks()
+            result = manager.execute_pre_ui_hooks(self._make_metadata(tmpdir))
+            assert result["parameters"] == {"A": "1", "B": "2"}
+
+    def test_failure_blocks(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            hooks_file = os.path.join(tmpdir, "hooks.yaml")
+            with open(hooks_file, "w") as f:
+                yaml.dump({"preUI": [{"command": sys.executable, "args": ["-c", "exit(1)"]}]}, f)
+            manager = HookManager(tmpdir, lambda x: None)
+            manager.load_hooks()
+            with pytest.raises(DeadlineOperationError, match="failed with exit code 1"):
+                manager.execute_pre_ui_hooks(self._make_metadata(tmpdir))
+
+    def test_timeout_blocks(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            hooks_file = os.path.join(tmpdir, "hooks.yaml")
+            with open(hooks_file, "w") as f:
+                yaml.dump(
+                    {
+                        "preUI": [
+                            {
+                                "command": sys.executable,
+                                "args": ["-c", "import time; time.sleep(10)"],
+                                "timeout": 1,
+                            }
+                        ]
+                    },
+                    f,
+                )
+            manager = HookManager(tmpdir, lambda x: None)
+            manager.load_hooks()
+            with pytest.raises(DeadlineOperationError, match="timed out"):
+                manager.execute_pre_ui_hooks(self._make_metadata(tmpdir))
+
+    def test_invalid_json_output_raises(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            hooks_file = os.path.join(tmpdir, "hooks.yaml")
+            with open(hooks_file, "w") as f:
+                yaml.dump(
+                    {"preUI": [{"command": sys.executable, "args": ["-c", "print('not json')"]}]},
+                    f,
+                )
+            manager = HookManager(tmpdir, lambda x: None)
+            manager.load_hooks()
+            with pytest.raises(DeadlineOperationError, match="invalid JSON"):
+                manager.execute_pre_ui_hooks(self._make_metadata(tmpdir))
+
+    def test_no_output_returns_empty(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            hooks_file = os.path.join(tmpdir, "hooks.yaml")
+            with open(hooks_file, "w") as f:
+                yaml.dump({"preUI": [{"command": sys.executable, "args": ["-c", "pass"]}]}, f)
+            manager = HookManager(tmpdir, lambda x: None)
+            manager.load_hooks()
+            result = manager.execute_pre_ui_hooks(self._make_metadata(tmpdir))
+            assert result == {}
+
+    def test_deadline_prefix_params_go_to_shared_values(self):
+        """deadline: params land in initial_shared_parameter_values, not initial_settings."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            hooks_file = os.path.join(tmpdir, "hooks.yaml")
+            with open(hooks_file, "w") as f:
+                yaml.dump(
+                    {
+                        "preUI": [
+                            {
+                                "command": sys.executable,
+                                "args": [
+                                    "-c",
+                                    'import json; print(json.dumps({"parameters": {"deadline:priority": 80}}))',
+                                ],
+                            }
+                        ]
+                    },
+                    f,
+                )
+            manager = HookManager(tmpdir, lambda x: None)
+            manager.load_hooks()
+            result = manager.execute_pre_ui_hooks(self._make_metadata(tmpdir))
+            assert result["parameters"]["deadline:priority"] == 80
+
+    def test_confirmation_message_includes_pre_ui(self):
+        from deadline.client.job_bundle._hooks import _generate_hooks_confirmation_message
+
+        hooks = HookConfiguration(
+            version="1.0",
+            pre_ui=[HookDefinition(command="python", args=["prefill.py"])],
+            pre_submission=[],
+            post_submission=[],
+        )
+        message = _generate_hooks_confirmation_message(hooks, "/bundle")
+        assert "Pre-UI hooks:" in message
+        assert "python prefill.py" in message


### PR DESCRIPTION
Adds a new beforeUI hook phase that runs before the job submission dialog opens, allowing studios to pre-populate dialog fields such as job name, description, and parameters (including deadline: prefixed shared job properties) from pipeline context.

Hook output schema:
  name        - pre-fill job name
  description - pre-fill job description
  parameters  - pre-fill parameters by name; use deadline: prefix for
                shared job properties (priority, maxFailedTasksCount,
                maxRetriesPerTask, maxWorkerCount, targetTaskRunStatus)

beforeUI hooks are gated by the existing allow_bundle_hooks / allow_environment_hooks settings and show a confirmation prompt unless auto_accept is enabled.

### What was the problem/requirement? (What/Why)

When using the gui submitter there's use cases to adjust fields automatically for users before the UI is displayed, especially use cases with system defined hooks where certain things like priority, naming, or other best practices can be dynamically set as starting defaults when the UI is launched.

### What was the solution? (How)
Adds a new beforeUI hook phase that runs before the job submission dialog opens

### What is the impact of this change?


### How was this change tested?

Locally tested a few different parameters and scenarios.

- Have you run the unit tests? Yes!
- Have you run the integration tests? No.

### Was this change documented?
Yes

### Does this PR introduce new dependencies?
No

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [*] This PR does not add any new dependencies.

### Is this a breaking change?

No

### Does this change impact security?

It's adding additional script execution so there's potentially some impact. It's reusing the same basic appraoch as the existing hooks feature though so in practice should be minimal impact.


----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
