### PR TITLE
fix: environment hooks receive correct jobBundleDir and can modify te…

### DIFF
--- a/src/deadline/client/api/_submit_job_bundle.py
+++ b/src/deadline/client/api/_submit_job_bundle.py
@@ -721,6 +721,22 @@ def create_job_from_job_bundle(
         )
         hook_result = hook_manager.execute_pre_submission_hooks(hook_metadata, {})
 
+        # Apply template modifications from hooks via stdout output
+        if "template" in hook_result:
+            file_contents = hook_result["template"]
+            create_job_args["template"] = file_contents
+        else:
+            # Re-read template in case a hook modified it on disk
+            updated_contents, _ = read_yaml_or_json(job_bundle_dir, "template", required=True)
+            if updated_contents != file_contents:
+                file_contents = updated_contents
+                create_job_args["template"] = file_contents
+
+        # Apply priority modifications from hooks
+        if "priority" in hook_result:
+            priority = hook_result["priority"]
+            create_job_args["priority"] = priority
+
         # Merge any asset references from hooks into asset_references
         if "attachments" in hook_result and "assetReferences" in hook_result["attachments"]:
             hook_refs = hook_result["attachments"]["assetReferences"]

--- a/src/deadline/client/job_bundle/_hooks/_manager.py
+++ b/src/deadline/client/job_bundle/_hooks/_manager.py
@@ -77,9 +77,6 @@ class HookManager:
         if not self.hooks or not self.hooks.pre_submission:
             return payload
 
-        # Use original bundle dir for hooks to find files
-        metadata.job_bundle_dir = self._original_bundle_dir
-
         current_payload = payload
         for i, hook in enumerate(self.hooks.pre_submission):
             hook_name = f"{hook.command} {' '.join(hook.args)}".strip()

--- a/test/unit/deadline_client/job_bundle/test_hooks.py
+++ b/test/unit/deadline_client/job_bundle/test_hooks.py
@@ -924,3 +924,54 @@ class TestHookManager:
             )
             manager.execute_post_submission_hooks(metadata)
             assert os.path.exists(marker)
+
+    def test_pre_submission_hook_preserves_job_bundle_dir(self):
+        """Test that pre-submission hooks receive the metadata's job_bundle_dir, not the hooks dir."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create separate hooks dir and bundle dir
+            hooks_dir = os.path.join(tmpdir, "hooks")
+            bundle_dir = os.path.join(tmpdir, "bundle")
+            os.makedirs(hooks_dir)
+            os.makedirs(bundle_dir)
+
+            output_file = os.path.join(tmpdir, "output.txt")
+            escaped_output = output_file.replace("\\", "\\\\")
+
+            hooks_file = os.path.join(hooks_dir, "hooks.yaml")
+            with open(hooks_file, "w") as f:
+                yaml.dump(
+                    {
+                        "preSubmission": [
+                            {
+                                "command": sys.executable,
+                                "args": [
+                                    "-c",
+                                    f"import sys, json; d = json.load(sys.stdin); open('{escaped_output}', 'w').write(d['jobBundleDir'])",
+                                ],
+                            }
+                        ]
+                    },
+                    f,
+                )
+
+            # HookManager is created with hooks_dir (simulating environment hooks)
+            manager = HookManager(hooks_dir, lambda x: None)
+            manager.load_hooks()
+
+            # Metadata has the actual bundle dir
+            metadata = HookMetadata(
+                job_name="Test",
+                priority=50,
+                farm_id="farm-123",
+                queue_id="queue-456",
+                job_bundle_dir=bundle_dir,
+                parameters={},
+                submitter_name="Test",
+                asset_references={},
+                submission_payload={},
+            )
+            manager.execute_pre_submission_hooks(metadata, {})
+
+            with open(output_file) as f:
+                # Hook should receive the bundle_dir, not the hooks_dir
+                assert f.read() == bundle_dir


### PR DESCRIPTION
Summary

Three bugs in the submission hooks feature that prevent hooks from modifying the job template or priority:
**Bug 1:** jobBundleDir points to hooks directory for environment hooks

HookManager.execute_pre_submission_hooks() overwrites metadata.job_bundle_dir with self._original_bundle_dir. For environment hooks (DEADLINE_HOOKS_DIR), this resolves to the hooks directory rather than the actual job bundle directory where template.yaml lives.

Fix: Remove the override. The caller already sets the correct job_bundle_dir in the metadata.

**Bug 2:** Hook stdout output for template and priority is ignored

The hook result from execute_pre_submission_hooks only merges attachments.assetReferences back into the submission. Other output fields like template and priority (documented as modifiable) are silently dropped.

Fix: Apply template and priority from hook output to create_job_args.

**Bug 3:** Bundle hooks that modify template.yaml on disk have no effect

The job template is read from disk before hooks run. Bundle hooks that modify template.yaml directly (rather than outputting via stdout) have no effect since the stale file_contents is what gets submitted.

Fix: Re-read the template from disk after hooks complete (if no stdout template output was provided).

**Reproduction**

    Set DEADLINE_HOOKS_DIR=/path/to/hooks with a pre-submission hook that reads jobBundleDir
    Submit from Cinema 4D (or any DCC submitter)
    Hook receives the hooks directory path instead of the actual bundle directory
    Hook cannot find or modify template.yaml

**Testing**

    Added unit test test_pre_submission_hook_preserves_job_bundle_dir verifying the metadata's job_bundle_dir is preserved when HookManager directory differs
    All 57 existing hooks tests pass
    All 39 CLI bundle submit tests pass
    hatch run fmt and hatch run lint pass
    Verified end-to-end with Cinema 4D submitter setting taskRunTimeout via environment hook

### Was this change documented?

N/A

### Does this PR introduce new dependencies?

No

### Is this a breaking change?

No
### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
