### PR TITLE
docs: revert manual CHANGELOG.md edits and document auto-generation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,15 @@ Use [conventional commits](https://www.conventionalcommits.org/):
 - `perf:` - Performance improvements
 - `feat!:` or `fix!:` - Breaking changes (Also include `BREAKING CHANGES:` section in message body)
 
+### CHANGELOG.md is auto-generated — do not edit it
+
+`CHANGELOG.md` is generated automatically from conventional commit messages
+during the release process. Do **not** add, remove, or rewrite entries in
+`CHANGELOG.md` as part of normal feature, fix, or refactor work — your commit
+message *is* the changelog entry. Only the release tooling (and humans
+preparing a release) should modify `CHANGELOG.md`. See
+[CHANGELOG_GUIDELINES.md](CHANGELOG_GUIDELINES.md) for entry formatting.
+
 ### Before Committing / Raising a PR
 
 After completing any code changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,12 +36,6 @@
 * Decoupled Job Attachments from the Client package — `deadline.job_attachments` no longer imports from `deadline.client` ([migration guide](https://github.com/aws-deadline/deadline-cloud/blob/mainline/docs/design/client-job-attachments-decoupling.md#migration-guide)) (#1076)
 
 ### Features
-* Add submission hooks support for job bundles (#986)
-  * Pre-submission and post-submission hooks can be configured via `hooks.yaml` or `hooks.json` in job bundles
-  * Pre-submission hooks run before hashing/uploading and can validate or modify the submission payload
-  * Post-submission hooks run after successful job creation for notifications and integrations
-  * Hooks receive job metadata via stdin (JSON) and environment variables (`DEADLINE_*`)
-  * Works with both `deadline bundle submit` (CLI) and `deadline bundle gui-submit` (GUI)
 * `deadline handle-web-url --install` and `--uninstall` now print a confirmation message on success (#1056) ([`6d0c5d9`](https://github.com/aws-deadline/deadline-cloud/commit/6d0c5d9dc167e8fd65721feb5cd6d318c7f38b44))
 
 ### Bug Fixes
@@ -64,6 +58,7 @@
 * Show checkboxes in multiselect combo boxes on macOS (#1052) ([`c4eb36b`](https://github.com/aws-deadline/deadline-cloud/commit/c4eb36b93c850330c0928afa00efb84cd3b1864f))
 * Accept hidden parameters with empty string defaults (#1032) ([`347adcc`](https://github.com/aws-deadline/deadline-cloud/commit/347adcce70e873792b62e554d70ab311f2d3ba09))
 * Fix load job bundle button not working (#1041) ([`eee187e`](https://github.com/aws-deadline/deadline-cloud/commit/eee187e7f763a1f52d7d09ee8980801e8c1841c6))
+
 
 ## 0.54.2 (2026-03-04)
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
CHANGELOG.md is generated from conventional commit messages during the release process, but a prior PR added entries directly. 

### What was the solution? (How)
Revert those manual edits and add a section to AGENTS.md instructing contributors (including AI agents) not to edit CHANGELOG.md as part of normal work.

### What is the impact of this change?
Fixed changelog - hopefully AIs understand they don't need to edit it

### How was this change tested?
ran formatters/linters

### Was this change documented?
NA

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [X ] This PR does not add any new dependencies.

### Is this a breaking change?
No

### Does this change impact security?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
