### PR TITLE
chore: drop manual release tests and schedule weekly bump

### DIFF
--- a/.github/workflows/dcm_integration_test_linux.yml
+++ b/.github/workflows/dcm_integration_test_linux.yml
@@ -3,6 +3,12 @@ name: DCM Integration Test (Linux)
 on:
   workflow_dispatch:
   workflow_call:
+    inputs:
+      tag:
+        description: Git ref (tag/branch/SHA) to test. Defaults to the triggering ref.
+        required: false
+        type: string
+        default: ''
 
 jobs:
   test:
@@ -30,6 +36,8 @@ jobs:
       MOZ_ACCESSIBILITY_ATK2: '1'
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag || github.ref }}
 
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/dcm_integration_test_macos.yml
+++ b/.github/workflows/dcm_integration_test_macos.yml
@@ -3,6 +3,12 @@ name: DCM Integration Test (macOS)
 on:
   workflow_dispatch:
   workflow_call:
+    inputs:
+      tag:
+        description: Git ref (tag/branch/SHA) to test. Defaults to the triggering ref.
+        required: false
+        type: string
+        default: ''
 
 jobs:
   test:
@@ -22,6 +28,8 @@ jobs:
       BROWSER_NAME: Safari
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag || github.ref }}
 
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/dcm_integration_test_windows.yml
+++ b/.github/workflows/dcm_integration_test_windows.yml
@@ -3,6 +3,12 @@ name: DCM Integration Test (Windows)
 on:
   workflow_dispatch:
   workflow_call:
+    inputs:
+      tag:
+        description: Git ref (tag/branch/SHA) to test. Defaults to the triggering ref.
+        required: false
+        type: string
+        default: ''
 
 jobs:
   test:
@@ -23,6 +29,8 @@ jobs:
       SCREENSHOT_DIR: ${{ github.workspace }}\screenshots
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag || github.ref }}
 
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/release_bump.yml
+++ b/.github/workflows/release_bump.yml
@@ -1,6 +1,9 @@
 name: "Release: Bump"
 
 on:
+  schedule:
+    # Every Monday at 14:00 UTC (~6/7am Pacific, ~9/10am Eastern).
+    - cron: "0 14 * * 1"
   workflow_dispatch:
     inputs:
       force_version_bump:

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -98,15 +98,8 @@ jobs:
       tag: ${{ needs.TagRelease.outputs.tag }}
       oses: "['Linux', 'Windows', 'MacOS']"
 
-  ManualTestGate:
-    needs: [TagRelease, BuildAndStageInstallers]
-    runs-on: ubuntu-latest
-    environment: release-gate
-    steps:
-      - run: echo "Manual testing approved for ${{ needs.TagRelease.outputs.tag }}"
-
   Release:
-    needs: [TagRelease, ManualTestGate]
+    needs: [TagRelease, BuildAndStageInstallers]
     uses: aws-deadline/.github/.github/workflows/reusable_release.yml@mainline
     secrets: inherit
     permissions:

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -76,8 +76,39 @@ jobs:
       os: macos
       tag: ${{ needs.TagRelease.outputs.tag }}
 
+  LinuxDCMIntegrationTest:
+    name: Linux DCM Integration Test
+    needs: [TagRelease, UnitTests]
+    uses: ./.github/workflows/dcm_integration_test_linux.yml
+    secrets: inherit
+    with:
+      tag: ${{ needs.TagRelease.outputs.tag }}
+
+  WindowsDCMIntegrationTest:
+    name: Windows DCM Integration Test
+    needs: [TagRelease, UnitTests]
+    uses: ./.github/workflows/dcm_integration_test_windows.yml
+    secrets: inherit
+    with:
+      tag: ${{ needs.TagRelease.outputs.tag }}
+
+  MacOSDCMIntegrationTest:
+    name: MacOS DCM Integration Test
+    needs: [TagRelease, UnitTests]
+    uses: ./.github/workflows/dcm_integration_test_macos.yml
+    secrets: inherit
+    with:
+      tag: ${{ needs.TagRelease.outputs.tag }}
+
   PreRelease:
-    needs: [TagRelease, LinuxIntegrationTests, WindowsIntegrationTests, MacOSIntegrationTests]
+    needs:
+      - TagRelease
+      - LinuxIntegrationTests
+      - WindowsIntegrationTests
+      - MacOSIntegrationTests
+      - LinuxDCMIntegrationTest
+      - WindowsDCMIntegrationTest
+      - MacOSDCMIntegrationTest
     uses: aws-deadline/.github/.github/workflows/reusable_prerelease.yml@mainline
     permissions:
       id-token: write

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -463,20 +463,3 @@ class MyCustomWidget(QWidget):
 Instead of runnning a deadline command as `deadline ...` run `pyinstrument -r html -m deadline ...`.
 
 This will profile the current `deadline` command and open the results in an interactive window.
-
-# Manual Test Cases
-
-These are the manual test cases for the client software release cycle, covering Deadline CLI and job attachments across Linux, Windows, and macOS.
-
-## Deadline CLI Tests
-
-| Test Case | Test Steps | Notes |
-|---|---|---|
-| Pre-requisite: Uninstall any previous versions of the Deadline Cloud Submitter Installer | Update PATH if necessary. | |
-| Verify Deadline CLI can be successfully installed using the staged individual installer | Run the staged individual installer and verify that it can install. | |
-| Verify correct version of Deadline CLI is being tested | Verify correct version using `deadline --version` command. | |
-| Verify user can authenticate/login using DCM Profile: `deadline auth login` | In deadline config gui, you should see the profile name with a green checkmark beside it in the bottom left. | Would need to set using DCM profile first. |
-| Verify user can logout of DCM Profile: `deadline auth logout` | In deadline config gui, you should see the profile name with a red 'X' beside it in the bottom left. There should be a button to log in on the right. | |
-| Verify 'Load a different job bundle' button in GUI Submitter | Launch GUI Submitter using `deadline bundle gui-submit --browse`, select a job bundle. Verify correct defaults/details. Hit 'Load a different job bundle' button and select a second job bundle. Verify correct defaults/details for the second bundle. | Requires the native file browser, which cannot be driven from xa11y. |
-| Test Deadline Cloud release candidate against currently released DCC Submitter | A Blender manual install might be easiest. Build deadline-cloud from the release candidate branch and pip install it into the submitter dependencies instead of the latest in PyPi. | |
-

--- a/test/unit/deadline_client/ui/widgets/test_job_bundle_settings_tab.py
+++ b/test/unit/deadline_client/ui/widgets/test_job_bundle_settings_tab.py
@@ -1,0 +1,108 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+try:
+    from deadline.client.ui.dataclasses import JobBundleSettings
+    from deadline.client.ui.widgets.job_bundle_settings_tab import JobBundleSettingsWidget
+except ImportError:
+    pytest.importorskip("deadline.client.ui.widgets.job_bundle_settings_tab")
+
+
+MINIMAL_TEMPLATE = """
+specificationVersion: 'jobtemplate-2023-09'
+name: Second Bundle
+parameterDefinitions:
+- name: Greeting
+  type: STRING
+  default: hello
+steps:
+- name: NoOp
+  script:
+    actions:
+      onRun:
+        command: "echo hi"
+"""
+
+
+def _write_bundle(directory: str, template: str) -> None:
+    with open(os.path.join(directory, "template.yaml"), "w", encoding="utf8") as f:
+        f.write(template)
+
+
+@pytest.fixture
+def widget(qtbot, temp_job_bundle_dir):
+    _write_bundle(temp_job_bundle_dir, MINIMAL_TEMPLATE.replace("Second Bundle", "First Bundle"))
+    initial_settings = JobBundleSettings(
+        input_job_bundle_dir=temp_job_bundle_dir, name="First Bundle"
+    )
+    w = JobBundleSettingsWidget(initial_settings=initial_settings)
+    qtbot.addWidget(w)
+    return w
+
+
+def test_on_load_bundle_loads_new_bundle_and_refreshes_dialog(
+    widget, qtbot, fresh_deadline_config, tmp_path
+):
+    """Clicking 'Load a different job bundle' opens a file picker, loads the
+    chosen bundle, and pushes its settings into the parent dialog via refresh().
+    """
+    second_bundle = tmp_path / "second_bundle"
+    second_bundle.mkdir()
+    _write_bundle(str(second_bundle), MINIMAL_TEMPLATE)
+
+    parent_dialog = MagicMock()
+
+    with patch(
+        "deadline.client.ui.widgets.job_bundle_settings_tab.QFileDialog.getExistingDirectory",
+        return_value=str(second_bundle),
+    ), patch.object(widget, "window", return_value=parent_dialog):
+        widget.on_load_bundle()
+
+    assert widget.input_job_bundle_dir == str(second_bundle)
+    parent_dialog.refresh.assert_called_once()
+
+    kwargs = parent_dialog.refresh.call_args.kwargs
+    assert kwargs["load_new_bundle"] is True
+    assert kwargs["job_settings"].input_job_bundle_dir == str(second_bundle)
+    assert kwargs["job_settings"].name == "Second Bundle"
+
+
+def test_on_load_bundle_cancelled_dialog_is_noop(widget, qtbot):
+    """If the user cancels the file picker, nothing changes."""
+    original_dir = widget.input_job_bundle_dir
+    parent_dialog = MagicMock()
+
+    with patch(
+        "deadline.client.ui.widgets.job_bundle_settings_tab.QFileDialog.getExistingDirectory",
+        return_value="",
+    ), patch.object(widget, "window", return_value=parent_dialog):
+        widget.on_load_bundle()
+
+    assert widget.input_job_bundle_dir == original_dir
+    parent_dialog.refresh.assert_not_called()
+
+
+def test_on_load_bundle_invalid_bundle_shows_warning(
+    widget, qtbot, fresh_deadline_config, tmp_path
+):
+    """If the chosen directory isn't a valid bundle, show a warning and don't
+    refresh the parent dialog."""
+    bad_bundle = tmp_path / "not_a_bundle"
+    bad_bundle.mkdir()  # empty — no template.yaml
+
+    parent_dialog = MagicMock()
+
+    with patch(
+        "deadline.client.ui.widgets.job_bundle_settings_tab.QFileDialog.getExistingDirectory",
+        return_value=str(bad_bundle),
+    ), patch.object(widget, "window", return_value=parent_dialog), patch(
+        "deadline.client.ui.widgets.job_bundle_settings_tab.QMessageBox.warning"
+    ) as mock_warning:
+        widget.on_load_bundle()
+
+    mock_warning.assert_called_once()
+    parent_dialog.refresh.assert_not_called()


### PR DESCRIPTION
Fixes: *N/A — internal cleanup, no GitHub issue.*

### What was the problem/requirement? (What/Why)

The `# Manual Test Cases` table in `DEVELOPMENT.md` and the `ManualTestGate` job in `release_publish.yml` were holdovers from before the project had broad UI/CLI/installer automation. They no longer add signal — every row in the table is now covered by automated tests, so the gate just requires a human to click "approve" on every release with no actual manual verification happening behind it.

Separately, the version bump that kicks off a release was workflow-dispatch only, so the release cadence depended on someone remembering to click it.

### What was the solution? (How)

1. **Removed the `# Manual Test Cases` section from `DEVELOPMENT.md`.** Each row maps to existing automation:

    | Manual case | Replaced by |
    |---|---|
    | Uninstall previous, install via staged installer | `test/installer/test_installer.py` |
    | `deadline --version` | `test/installer/test_installer.py:93-98` |
    | `deadline auth login` (DCM profile) | `.github/scripts/dcm_e2e_test.py` (Linux/macOS/Windows DCM E2E) |
    | `deadline auth logout` (DCM profile) | `test/cli_e2e/test_auth.py`, `test/unit/deadline_client/cli/test_cli_auth.py` |
    | 'Load a different job bundle' button in GUI Submitter | **new** `test/unit/deadline_client/ui/widgets/test_job_bundle_settings_tab.py` (this PR) |
    | Release candidate vs DCC submitter | `.github/workflows/blender_submitter_ui_test.yml` |

2. **Removed the `ManualTestGate` job from `.github/workflows/release_publish.yml`.** The `Release` job now depends directly on `BuildAndStageInstallers`. The `release-gate` GitHub environment is no longer referenced.

3. **Added a weekly schedule to `.github/workflows/release_bump.yml`:** cron `0 14 * * 1` (Mondays at 14:00 UTC). Existing `workflow_dispatch` with `force_version_bump` is preserved.

4. **Added pytest-qt coverage for the 'Load a different job bundle' flow.** Mocks `QFileDialog.getExistingDirectory` and exercises the real `JobBundleSettingsWidget.on_load_bundle()` against an on-disk bundle. Verifies happy path (refresh called with `load_new_bundle=True` and the loaded bundle's settings), cancel (no-op), and invalid bundle (`QMessageBox.warning` shown, no refresh).

### What is the impact of this change?

- **Releases auto-cut weekly** instead of waiting on human button-clicks.
- **Releases publish without a manual gate** — they still depend on Linux/Windows/macOS integration tests, unit tests, and installer build/stage, so the test signal that mattered is preserved.
- **The 'Load a different job bundle' flow has non-Squish coverage** for the first time, so the regression risk doesn't depend on the Squish suite running.

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- [x] Have you run the unit tests? Yes — `hatch run test test/unit/deadline_client/ui/widgets/test_job_bundle_settings_tab.py` passes 3/3.
- [x] Have you run the integration tests? Not run locally; this PR doesn't touch integration test code paths. CI will exercise them.

### Was this change documented?

- [x] Are relevant docstrings in the code base updated? New test file has docstrings explaining each scenario.
- [x] Has the README.md been updated? Not needed — no CLI argument or user-facing API changes. `DEVELOPMENT.md` is updated to remove the obsolete manual-test section.

### Does this PR introduce new dependencies?

- [x] This PR does not add any new dependencies.

### Is this a breaking change?

No. No public API, CLI argument, or file-format change. The release workflow change is internal to the project's CI.

### Does this change impact security?

No. The dropped `ManualTestGate` was a workflow-level human-approval gate, not a security control. The new schedule trigger runs the same `reusable_bump.yml` workflow that `workflow_dispatch` already runs, with the same permissions.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*