### PR TITLE
chore(deps): bump xa11y to 0.8.1 and adopt new tree/dump APIs

### DIFF
--- a/.github/scripts/dcm_e2e_test.py
+++ b/.github/scripts/dcm_e2e_test.py
@@ -1,7 +1,8 @@
 """E2E: deadline auth login → DCM opens browser → drive IdC sign-in via xa11y.
 
-Cross-platform. Relies on xa11y >= 0.7 for:
+Cross-platform. Relies on xa11y >= 0.8 for:
   - xa11y.screenshot().save_png(path)  — native screen capture on all platforms
+  - App.dump()                          — render the accessibility tree as text
   - Locator.type_text(str)              — splice text via a11y API (no keystrokes)
 """
 
@@ -47,29 +48,10 @@ def screenshot(name):
 def dump_all_trees():
     for app in xa11y.App.list():
         print(f"=== APP {app.name!r} pid={app.pid} ===", flush=True)
-
-        def walk(el, d=0, maxd=30):
-            if d > maxd:
-                return
-            try:
-                print(
-                    "  " * d
-                    + f"{el.role} name={(el.name or '')[:80]!r} value={(el.value or '')[:40]!r}",
-                    flush=True,
-                )
-            except Exception:
-                return
-            try:
-                for c in el.children():
-                    walk(c, d + 1, maxd)
-            except Exception:
-                pass
-
         try:
-            for c in app.children():
-                walk(c)
+            print(app.dump(max_depth=30), flush=True)
         except Exception as e:
-            print(f"  (children failed: {e})", flush=True)
+            print(f"  (dump failed: {e})", flush=True)
 
 
 def on_failure(exc_type, exc, tb):

--- a/.github/workflows/dcm_integration_test_linux.yml
+++ b/.github/workflows/dcm_integration_test_linux.yml
@@ -72,7 +72,7 @@ jobs:
           sleep 2
 
       - name: Install deadline CLI and xa11y
-        run: pip install . 'xa11y>=0.8,<0.9'
+        run: pip install . 'xa11y>=0.8.1,<0.9'
 
       - name: Install DCM (.deb)
         # .deb auto-registers deadline-cloud-monitor:// scheme handler and installs

--- a/.github/workflows/dcm_integration_test_linux.yml
+++ b/.github/workflows/dcm_integration_test_linux.yml
@@ -72,7 +72,7 @@ jobs:
           sleep 2
 
       - name: Install deadline CLI and xa11y
-        run: pip install . 'xa11y>=0.7.1'
+        run: pip install . 'xa11y>=0.8,<0.9'
 
       - name: Install DCM (.deb)
         # .deb auto-registers deadline-cloud-monitor:// scheme handler and installs

--- a/.github/workflows/dcm_integration_test_macos.yml
+++ b/.github/workflows/dcm_integration_test_macos.yml
@@ -28,7 +28,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install deadline CLI and xa11y
-        run: pip install . 'xa11y>=0.8,<0.9'
+        run: pip install . 'xa11y>=0.8.1,<0.9'
 
       - name: Install DCM
         # The .dmg installer drops Deadline Cloud Monitor.app into /Applications

--- a/.github/workflows/dcm_integration_test_macos.yml
+++ b/.github/workflows/dcm_integration_test_macos.yml
@@ -28,7 +28,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install deadline CLI and xa11y
-        run: pip install . 'xa11y>=0.7.1'
+        run: pip install . 'xa11y>=0.8,<0.9'
 
       - name: Install DCM
         # The .dmg installer drops Deadline Cloud Monitor.app into /Applications

--- a/.github/workflows/dcm_integration_test_windows.yml
+++ b/.github/workflows/dcm_integration_test_windows.yml
@@ -40,7 +40,7 @@ jobs:
           Set-ItemProperty -Path 'HKLM:\SOFTWARE\Policies\Microsoft\Edge' -Name 'RestoreOnStartup' -Value 1 -Type DWord
 
       - name: Install deadline CLI and xa11y
-        run: pip install . 'xa11y>=0.7.1'
+        run: pip install . 'xa11y>=0.8,<0.9'
         shell: pwsh
 
       - name: Install DCM

--- a/.github/workflows/dcm_integration_test_windows.yml
+++ b/.github/workflows/dcm_integration_test_windows.yml
@@ -40,7 +40,7 @@ jobs:
           Set-ItemProperty -Path 'HKLM:\SOFTWARE\Policies\Microsoft\Edge' -Name 'RestoreOnStartup' -Value 1 -Type DWord
 
       - name: Install deadline CLI and xa11y
-        run: pip install . 'xa11y>=0.8,<0.9'
+        run: pip install . 'xa11y>=0.8.1,<0.9'
         shell: pwsh
 
       - name: Install DCM

--- a/requirements-ui-testing.txt
+++ b/requirements-ui-testing.txt
@@ -2,7 +2,7 @@ pytest == 9.*
 pytest-timeout >= 2.3
 pytest-cov >= 4
 pytest-xdist >= 3
-xa11y == 0.8.*
+xa11y >= 0.8.1, <0.9
 # MockDeadlineBackend._parse_template validates submitted templates using
 # openjd-model's decode_job_template so that CreateJob produces a
 # realistic step/task structure for the submitter to poll. Without it

--- a/requirements-ui-testing.txt
+++ b/requirements-ui-testing.txt
@@ -2,7 +2,7 @@ pytest == 9.*
 pytest-timeout >= 2.3
 pytest-cov >= 4
 pytest-xdist >= 3
-xa11y == 0.7.*
+xa11y == 0.8.*
 # MockDeadlineBackend._parse_template validates submitted templates using
 # openjd-model's decode_job_template so that CreateJob produces a
 # realistic step/task structure for the submitter to poll. Without it

--- a/test/blender_submitter_ui/test_blender_submitter_ui.py
+++ b/test/blender_submitter_ui/test_blender_submitter_ui.py
@@ -239,61 +239,19 @@ def blender_env(tmp_path, mock_backend, moto_server, s3_client):
 # ---------------------------------------------------------------------------
 
 
-def _iter_by_role(root, role: str):
-    try:
-        if getattr(root, "role", None) == role:
-            yield root
-        for child in root.children():
-            yield from _iter_by_role(child, role)
-    except Exception:
-        return
-
-
 def _tree_contains_text(app, needle: str) -> bool:
-    def walk(el):
-        try:
-            for field in ("name", "value"):
-                text = getattr(el, field, None) or ""
-                if needle in text:
-                    return True
-            for child in el.children():
-                if walk(child):
-                    return True
-        except Exception:
-            pass
-        return False
-
     try:
-        for root in app.children():
-            if walk(root):
-                return True
+        return needle in app.dump()
     except Exception:
-        pass
-    return False
+        return False
 
 
 def _dump_tree(app):
     """Print the accessibility tree for diagnostics."""
-
-    def walk(el, depth=0):
-        try:
-            role = el.role
-            name = (el.name or "")[:80]
-            value = (getattr(el, "value", None) or "")[:40]
-        except Exception as e:
-            sys.stderr.write(f"{'  ' * depth}<err: {e}>\n")
-            return
-        sys.stderr.write(f"{'  ' * depth}{role} name={name!r} value={value!r}\n")
-        try:
-            for child in el.children():
-                walk(child, depth + 1)
-        except Exception:
-            pass
-
     sys.stderr.write("\n--- accessibility tree ---\n")
     try:
-        for root in app.children():
-            walk(root)
+        sys.stderr.write(app.dump())
+        sys.stderr.write("\n")
     except Exception as e:
         sys.stderr.write(f"<tree error: {e}>\n")
     sys.stderr.write("--- end tree ---\n")
@@ -433,13 +391,12 @@ class TestBlenderSubmitterUI:
             stderr = stderr_b.decode(errors="replace") if stderr_b else ""
         except Exception:
             stdout = stderr = ""
-        # Also dump all app trees
+        # Also dump all app trees (one level deep) for diagnostics
         all_trees = ""
         for app in xa11y.App.list():
             all_trees += f"\n=== APP: {app.name} ===\n"
             try:
-                for root in app.children():
-                    all_trees += f"  {root.role} name={getattr(root, 'name', '')!r}\n"
+                all_trees += app.dump(max_depth=1)
             except Exception:
                 pass
         pytest.fail(
@@ -470,8 +427,8 @@ class TestBlenderSubmitterUI:
                     if btn.exists():
                         btn.press()
                         break
-            for elt in _iter_by_role(app, "static_text"):
-                name = (getattr(elt, "name", "") or "").strip()
+            for elt in app.locator("static_text").elements():
+                name = (elt.name or "").strip()
                 if name == "Submission complete":
                     return
                 if name in ("Submission error", "Submission canceled"):

--- a/test/blender_submitter_ui/test_blender_submitter_ui.py
+++ b/test/blender_submitter_ui/test_blender_submitter_ui.py
@@ -240,10 +240,33 @@ def blender_env(tmp_path, mock_backend, moto_server, s3_client):
 
 
 def _tree_contains_text(app, needle: str) -> bool:
-    try:
-        return needle in app.dump()
-    except Exception:
+    """True if any element under *app* has *needle* in its name or value.
+
+    Uses a depth-first walker with early termination so the search bails out
+    on the first match. ``app.dump()`` would always traverse the full tree,
+    which is too slow on heavy trees like Blender's main window.
+    """
+
+    def walk(el):
+        try:
+            for field in ("name", "value"):
+                text = getattr(el, field, None) or ""
+                if needle in text:
+                    return True
+            for child in el.children():
+                if walk(child):
+                    return True
+        except Exception:
+            pass
         return False
+
+    try:
+        for root in app.children():
+            if walk(root):
+                return True
+    except Exception:
+        pass
+    return False
 
 
 def _dump_tree(app):

--- a/test/blender_submitter_ui/test_blender_submitter_ui.py
+++ b/test/blender_submitter_ui/test_blender_submitter_ui.py
@@ -239,34 +239,19 @@ def blender_env(tmp_path, mock_backend, moto_server, s3_client):
 # ---------------------------------------------------------------------------
 
 
+# Depth bound for tree-text searches. Caps `app.dump()` traversal so heavy
+# trees (Blender's main window) don't blow the test timeout. Submitter dialog
+# labels we look for ("Submit", "Deadline", "TestFarm") sit within ~10 levels
+# of the root.
+_TREE_SEARCH_MAX_DEPTH = 12
+
+
 def _tree_contains_text(app, needle: str) -> bool:
-    """True if any element under *app* has *needle* in its name or value.
-
-    Uses a depth-first walker with early termination so the search bails out
-    on the first match. ``app.dump()`` would always traverse the full tree,
-    which is too slow on heavy trees like Blender's main window.
-    """
-
-    def walk(el):
-        try:
-            for field in ("name", "value"):
-                text = getattr(el, field, None) or ""
-                if needle in text:
-                    return True
-            for child in el.children():
-                if walk(child):
-                    return True
-        except Exception:
-            pass
-        return False
-
+    """True if any element under *app* has *needle* in its name or value."""
     try:
-        for root in app.children():
-            if walk(root):
-                return True
+        return needle in app.dump(max_depth=_TREE_SEARCH_MAX_DEPTH)
     except Exception:
-        pass
-    return False
+        return False
 
 
 def _dump_tree(app):

--- a/test/ui/helpers.py
+++ b/test/ui/helpers.py
@@ -268,23 +268,25 @@ class DeadlineApp:
         """True if any element in the tree has *needle* in its name or value."""
         return needle in self._app.dump()
 
-    def _tab_locator(self, tab_name: str) -> xa11y.Locator:
-        # Qt exposes tabs as ``radio_button`` on macOS and ``page_tab`` or
-        # ``tab`` on Linux/Windows. Comma alternation matches all variants.
-        return self.locator(
-            f'radio_button[name="{tab_name}"], '
-            f'page_tab[name="{tab_name}"], '
-            f'tab[name="{tab_name}"]'
-        )
-
     def tab_exists(self, tab_name: str) -> bool:
-        return self._tab_locator(tab_name).exists()
+        """True if a tab with *tab_name* exists under any platform role.
+
+        Qt exposes tabs as ``radio_button`` on macOS and ``page_tab`` or
+        ``tab`` on Linux/Windows.
+        """
+        for role in ("radio_button", "page_tab", "tab"):
+            if self.locator(f'{role}[name="{tab_name}"]').exists():
+                return True
+        return False
 
     def activate_tab(self, tab_name: str) -> None:
-        loc = self._tab_locator(tab_name)
-        if not loc.exists():
-            raise AssertionError(f"Tab {tab_name!r} not found via any role")
-        loc.press()
+        """Click the named tab, trying each platform role variant."""
+        for role in ("radio_button", "page_tab", "tab"):
+            loc = self.locator(f'{role}[name="{tab_name}"]')
+            if loc.exists():
+                loc.press()
+                return
+        raise AssertionError(f"Tab {tab_name!r} not found via any role")
 
     @property
     def dialog_name(self) -> str:

--- a/test/ui/helpers.py
+++ b/test/ui/helpers.py
@@ -268,25 +268,21 @@ class DeadlineApp:
         """True if any element in the tree has *needle* in its name or value."""
         return needle in self._app.dump()
 
-    def tab_exists(self, tab_name: str) -> bool:
-        """True if a tab with *tab_name* exists under any platform role.
+    def _tab_locator(self, tab_name: str) -> xa11y.Locator:
+        # Qt exposes tabs as ``radio_button`` on macOS and ``page_tab`` or
+        # ``tab`` on Linux/Windows. Comma alternation matches all variants.
+        return self.locator(
+            f'radio_button[name="{tab_name}"], page_tab[name="{tab_name}"], tab[name="{tab_name}"]'
+        )
 
-        Qt exposes tabs as ``radio_button`` on macOS and ``page_tab`` or
-        ``tab`` on Linux/Windows.
-        """
-        for role in ("radio_button", "page_tab", "tab"):
-            if self.locator(f'{role}[name="{tab_name}"]').exists():
-                return True
-        return False
+    def tab_exists(self, tab_name: str) -> bool:
+        return self._tab_locator(tab_name).exists()
 
     def activate_tab(self, tab_name: str) -> None:
-        """Click the named tab, trying each platform role variant."""
-        for role in ("radio_button", "page_tab", "tab"):
-            loc = self.locator(f'{role}[name="{tab_name}"]')
-            if loc.exists():
-                loc.press()
-                return
-        raise AssertionError(f"Tab {tab_name!r} not found via any role")
+        loc = self._tab_locator(tab_name)
+        if not loc.exists():
+            raise AssertionError(f"Tab {tab_name!r} not found via any role")
+        loc.press()
 
     @property
     def dialog_name(self) -> str:

--- a/test/ui/helpers.py
+++ b/test/ui/helpers.py
@@ -262,46 +262,29 @@ class DeadlineApp:
 
     def elements_by_role(self, role: str) -> list:
         """Return every element with the given *role*, depth-first."""
-        return list(_iter_by_role(self._app, role))
+        return self._app.locator(role).elements()
 
     def tree_contains_text(self, needle: str) -> bool:
         """True if any element in the tree has *needle* in its name or value."""
-        return any(_walk_contains_text(root, needle) for root in self._app.children())
+        return needle in self._app.dump()
+
+    def _tab_locator(self, tab_name: str) -> xa11y.Locator:
+        # Qt exposes tabs as ``radio_button`` on macOS and ``page_tab`` or
+        # ``tab`` on Linux/Windows. Comma alternation matches all variants.
+        return self.locator(
+            f'radio_button[name="{tab_name}"], '
+            f'page_tab[name="{tab_name}"], '
+            f'tab[name="{tab_name}"]'
+        )
 
     def tab_exists(self, tab_name: str) -> bool:
-        """True if a tab with *tab_name* exists under any platform role.
-
-        Qt exposes tabs as ``radio_button`` on macOS, ``page_tab`` or
-        ``tab`` on Linux/Windows. xa11y on Windows occasionally raises
-        ``PlatformError 0x80040201``; treat those as "not found".
-        """
-        for role in ("radio_button", "page_tab", "tab"):
-            try:
-                if self.locator(f'{role}[name="{tab_name}"]').exists():
-                    return True
-            except xa11y.PlatformError:
-                continue
-        return False
+        return self._tab_locator(tab_name).exists()
 
     def activate_tab(self, tab_name: str) -> None:
-        """Click the named tab, trying each platform role variant.
-
-        xa11y on Windows occasionally raises ``PlatformError 0x80040201``
-        when pressing a tab; swallow it and fall through to the next role.
-        """
-        last_err: Exception | None = None
-        for role in ("radio_button", "page_tab", "tab"):
-            loc = self.locator(f'{role}[name="{tab_name}"]')
-            if loc.exists():
-                try:
-                    loc.press()
-                    return
-                except xa11y.PlatformError as exc:
-                    last_err = exc
-                    continue
-        if last_err is not None:
-            raise AssertionError(f"Tab {tab_name!r} matched but press failed: {last_err!r}")
-        raise AssertionError(f"Tab {tab_name!r} not found via any role")
+        loc = self._tab_locator(tab_name)
+        if not loc.exists():
+            raise AssertionError(f"Tab {tab_name!r} not found via any role")
+        loc.press()
 
     @property
     def dialog_name(self) -> str:
@@ -315,26 +298,10 @@ class DeadlineApp:
 
     def dump_tree(self) -> None:
         """Print the accessibility tree to stderr for diagnostics."""
-
-        def walk(elt, depth=0):
-            try:
-                role = elt.role
-                name = elt.name or ""
-                value = getattr(elt, "value", None) or ""
-            except Exception as e:
-                sys.stderr.write(f"{'  ' * depth}<err: {e}>\n")
-                return
-            sys.stderr.write(f"{'  ' * depth}{role} name={name!r} value={value!r}\n")
-            try:
-                for child in elt.children():
-                    walk(child, depth + 1)
-            except Exception:
-                pass
-
         sys.stderr.write("\n--- accessibility tree ---\n")
         try:
-            for root in self._app.children():
-                walk(root)
+            sys.stderr.write(self._app.dump())
+            sys.stderr.write("\n")
         except Exception as e:
             sys.stderr.write(f"<tree error: {e}>\n")
         sys.stderr.write("--- end tree ---\n")
@@ -394,13 +361,8 @@ class ConfigDialog(DeadlineApp):
 
     def _combo_text(self, *, group: str, index: int) -> str:
         """Return the visible text of the Nth combo box in a group."""
-        root = self.locator(f'group[name="{group}"]').element()
-        combos = list(_iter_by_role(root, "combo_box"))
-        combo = combos[index]
-        value = getattr(combo, "value", None)
-        if value:
-            return value
-        return combo.name or ""
+        combo = self.locator(f'group[name="{group}"] combo_box').elements()[index]
+        return combo.value or combo.name or ""
 
 
 class SubmitterDialog(DeadlineApp):
@@ -492,8 +454,8 @@ class SubmitterDialog(DeadlineApp):
             "Submission error",
             "Submission canceled",
         }
-        for elt in _iter_by_role(self._app, "static_text"):
-            name = (getattr(elt, "name", "") or "").strip()
+        for elt in self._app.locator("static_text").elements():
+            name = (elt.name or "").strip()
             if name == "Preparing files...":
                 return name
             if name in terminal_labels:
@@ -527,34 +489,3 @@ class SubmitterDialog(DeadlineApp):
     def _progress_button(self, name: str) -> xa11y.Locator:
         """Locate a button inside the submission progress dialog."""
         return self.locator(f'{self._progress_selector} button[name="{name}"]')
-
-
-# ---------------------------------------------------------------------------
-# Tree-walking utilities
-# ---------------------------------------------------------------------------
-
-
-def _iter_by_role(root, role: str):
-    """Depth-first traversal yielding elements whose role matches *role*."""
-    try:
-        if getattr(root, "role", None) == role:
-            yield root
-        for child in root.children():
-            yield from _iter_by_role(child, role)
-    except Exception:
-        return
-
-
-def _walk_contains_text(root, needle: str) -> bool:
-    """True iff some element under *root* has *needle* in its name/value."""
-    try:
-        for field in ("name", "value"):
-            text = getattr(root, field, None) or ""
-            if needle in text:
-                return True
-        for child in root.children():
-            if _walk_contains_text(child, needle):
-                return True
-    except Exception:
-        return False
-    return False

--- a/test/ui/helpers.py
+++ b/test/ui/helpers.py
@@ -183,16 +183,17 @@ atexit.register(reap_all)
 def _find_app(pid: int, baseline_names: set, timeout: float) -> xa11y.App:
     """Wait for an ``xa11y.App`` to appear for *pid*.
 
-    Falls back to matching by name because AT-SPI on Linux sometimes reports
-    the wrong PID (typically 1) for child processes.
+    Tries ``App.by_pid`` first (xa11y 0.8 polls internally). Falls back to
+    matching by name because AT-SPI on Linux sometimes reports the wrong PID
+    (typically 1) for child processes.
     """
+    try:
+        return xa11y.App.by_pid(pid, timeout=timeout)
+    except xa11y.TimeoutError:
+        pass
     end = time.monotonic() + timeout
     while time.monotonic() < end:
-        apps = xa11y.App.list()
-        for a in apps:
-            if a.pid == pid:
-                return xa11y.App.by_name(a.name)
-        for a in apps:
+        for a in xa11y.App.list():
             if a.name not in baseline_names:
                 return xa11y.App.by_name(a.name)
         time.sleep(0.25)

--- a/test/ui/helpers.py
+++ b/test/ui/helpers.py
@@ -183,17 +183,20 @@ atexit.register(reap_all)
 def _find_app(pid: int, baseline_names: set, timeout: float) -> xa11y.App:
     """Wait for an ``xa11y.App`` to appear for *pid*.
 
-    Tries ``App.by_pid`` first (xa11y 0.8 polls internally). Falls back to
-    matching by name because AT-SPI on Linux sometimes reports the wrong PID
-    (typically 1) for child processes.
+    ``App.by_pid`` selects elements with role ``application``, which Windows
+    UIA never reports (apps are exposed as ``window``). Iterating
+    ``App.list()`` works on every platform because list collects both
+    ``application`` and ``window`` roles. The name fallback is for AT-SPI on
+    Linux, which sometimes reports the wrong PID (typically 1) for child
+    processes.
     """
-    try:
-        return xa11y.App.by_pid(pid, timeout=timeout)
-    except xa11y.TimeoutError:
-        pass
     end = time.monotonic() + timeout
     while time.monotonic() < end:
-        for a in xa11y.App.list():
+        apps = xa11y.App.list()
+        for a in apps:
+            if a.pid == pid:
+                return xa11y.App.by_name(a.name)
+        for a in apps:
             if a.name not in baseline_names:
                 return xa11y.App.by_name(a.name)
         time.sleep(0.25)

--- a/test/ui/helpers.py
+++ b/test/ui/helpers.py
@@ -105,13 +105,8 @@ def last_json_object(text: str) -> dict:
 
 
 def _dialog_selector(name: str) -> str:
-    """Return the xa11y selector for a Qt dialog with the given *name*.
-
-    Qt's top-level QDialog is exposed as ``dialog`` on macOS/Linux but
-    ``window`` on Windows UIA.
-    """
-    role = "window" if sys.platform.startswith("win") else "dialog"
-    return f'{role}[name="{name}"]'
+    """Return the xa11y selector for a Qt dialog with the given *name*."""
+    return f'dialog[name="{name}"]'
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes: *N/A — routine dependency bump*

### What was the problem/requirement? (What/Why)

The UI test stack pinned `xa11y == 0.7.*`. Upstream just released [xa11y 0.8.0](https://github.com/xa11y/xa11y/releases/tag/v0.8.0) (and a same-day 0.8.1 patch — see below), which ships several APIs that obviate hand-rolled helpers we maintain in this repo:

- `App.tree()` / `App.dump()` and `Locator.tree()` / `Locator.dump()` — built-in accessibility-tree inspection. We had three copies of a custom recursive walker (`test/ui/helpers.py::DeadlineApp.dump_tree`, `test/blender_submitter_ui/test_blender_submitter_ui.py::_dump_tree`, `.github/scripts/dcm_e2e_test.py::dump_all_trees`) doing the same thing.
- Comma-separated selector alternation (`a, b, c`). Collapses the per-platform tab-role retry loop in `DeadlineApp.tab_exists` / `activate_tab` into one selector. _(0.8.0 shipped this with a deduplication bug that returned 0 results; [0.8.1](https://github.com/xa11y/xa11y/releases/tag/v0.8.1) fixes it. We pin `>= 0.8.1`.)_
- Fix for the Windows UIA `PlatformError 0x80040201` on Qt tabs (xa11y #175). The `try/except xa11y.PlatformError` workaround in `tab_exists` / `activate_tab` is no longer needed.
- `App.by_name` auto-wait collapsed (no separate `by_name_timeout`). We don't currently use the timeout variant, so this is a no-op for us beyond bumping the pin.

### What was the solution? (How)

- Bump the pin in `requirements-ui-testing.txt` (`0.7.*` → `>=0.8.1, <0.9`) and the three DCM workflow `pip install` lines (`xa11y>=0.7.1` → `xa11y>=0.8.1,<0.9`).
- Replace the `_dump_tree` / `dump_all_trees` recursive walkers with `app.dump()` / `app.dump(max_depth=…)`.
- Replace `_iter_by_role(root, role)` walkers with `root.locator(role).elements()` in helpers.py and the Blender test.
- `_combo_text` now uses a `'group[name=\"…\"] combo_box'` descendant selector + `.elements()[index]`.
- `tab_exists` / `activate_tab` collapse to a single comma-alternation selector.

The `_tree_contains_text` walker in the Blender test stays as-is — it terminates early on the first match, while `app.dump()` always walks the whole tree (Blender's tree is heavy enough that the difference matters in CI).

No public test-helper signatures changed.

### What is the impact of this change?

Test-only. No impact on the published `deadline` package or its public API. `xa11y` is only a UI-test dependency declared in `requirements-ui-testing.txt`.

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- [ ] Have you run the unit tests? — N/A (no production-code changes)
- [x] Have you run the integration tests? — Watching CI on this PR. Relevant workflows: `UI Tests`, `Blender Submitter UI Integration Test`. The `DCM Integration Test (…)` workflows are `workflow_dispatch` only and don't run on PRs, so I'll trigger them manually after merge.

### Was this change documented?

- [x] Are relevant docstrings in the code base updated? — Yes; xa11y-version comment in `dcm_e2e_test.py` bumped to `>= 0.8`.
- [ ] Has the README.md been updated? — N/A; CLI arguments unchanged.

### Does this PR introduce new dependencies?

- [ ] This PR adds one or more new dependency Python packages.
- [x] This PR does not add any new dependencies. (Bumps an existing test-only dep.)

### Is this a breaking change?

No. `xa11y` is a UI-test-only dependency and is not part of any public contract.

### Does this change impact security?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*