### PR TITLE
docs: Add guidance not to update changelog in PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,7 @@ Use [conventional commits](https://www.conventionalcommits.org/):
 After completing any code changes:
 1. Always run `hatch run fmt` and `hatch run lint` to verify the changes are clean.
 2. If also committing, run the full checklist: fmt → lint → test → build → `git commit -s`.
+3. **Do not** update the changelog (`CHANGELOG.md`). The changelog is updated during the release process.
 
 ```bash
 hatch run fmt            # Auto-format code


### PR DESCRIPTION
The changelog is updated during the release process, not as part of individual PRs and i want to help AI Agents understand this.

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
