### PR TITLE
chore(ui): add version information label to main submit dialog

### DIFF
--- a/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
@@ -19,6 +19,7 @@ from qtpy.QtWidgets import (  # pylint: disable=import-error; type: ignore
     QDialog,
     QDialogButtonBox,
     QFormLayout,
+    QLabel,
     QMessageBox,
     QPushButton,
     QScrollArea,
@@ -47,6 +48,7 @@ from ..widgets.host_requirements_tab import HostRequirementsWidget
 from . import DeadlineConfigDialog, DeadlineLoginDialog
 from ._types import JobBundlePurpose
 from ._help_dialog import _HelpDialog
+from ..dataclasses._environment_info import _EnvironmentInfo
 
 logger = logging.getLogger(__name__)
 
@@ -232,6 +234,8 @@ class SubmitJobToDeadlineDialog(QDialog):
 
         # Refresh the submit button enable state once queue parameter status changes
         self.shared_job_settings.valid_parameters.connect(self._set_submit_button_state)
+
+        self._build_version_info_label()
 
         self.button_box = QDialogButtonBox(Qt.Horizontal)
         self.settings_button = QPushButton(tr("Settings..."))
@@ -423,6 +427,59 @@ class SubmitJobToDeadlineDialog(QDialog):
                 "Error",
                 f"Failed to display Help dialog: {str(e)}",
             )
+
+    def _build_version_info_label(self):
+        """Build a compact version info label shown at the bottom of the submit dialog."""
+
+        def truncate(version):
+            return version[:10] + "..." if len(version) > 10 else version
+
+        display_parts = []
+        full_parts = []
+
+        # Get the deadline library version
+        try:
+            env_info = _EnvironmentInfo.collect()
+            deadline_version = env_info.deadline_dep_versions.get("deadline")
+            if deadline_version:
+                display_parts.append(f"deadline {truncate(deadline_version)}")
+                full_parts.append(f"deadline {deadline_version}")
+        except Exception as e:
+            logger.debug(f"Failed to collect environment info for version label: {e}")
+
+        # Add submitter package info
+        if (
+            self.submitter_info.submitter_package_name
+            and self.submitter_info.submitter_package_version
+        ):
+            pkg = self.submitter_info.submitter_package_name
+            ver = self.submitter_info.submitter_package_version
+            display_parts.append(f"{pkg} {truncate(ver)}")
+            full_parts.append(f"{pkg} {ver}")
+        elif self.submitter_info.submitter_package_version:
+            name = self.submitter_info.submitter_name
+            ver = self.submitter_info.submitter_package_version
+            display_parts.append(f"{name} {truncate(ver)}")
+            full_parts.append(f"{name} {ver}")
+
+        # Add host application info
+        if (
+            self.submitter_info.host_application_name
+            and self.submitter_info.host_application_version
+        ):
+            app = self.submitter_info.host_application_name
+            ver = self.submitter_info.host_application_version
+            display_parts.append(f"{app} {truncate(ver)}")
+            full_parts.append(f"{app} {ver}")
+
+        if display_parts:
+            display_text = "  |  ".join(display_parts)
+            full_text = "  |  ".join(full_parts)
+            self.version_info_label = QLabel(display_text)
+            self.version_info_label.setToolTip(full_text)
+            self.version_info_label.setStyleSheet("QLabel { color: gray; font-size: 11px; }")
+            self.version_info_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            self.lyt.addWidget(self.version_info_label)
 
     def _on_load_bundle(self):
         """Delegates to the job_settings widget's on_load_bundle method."""

--- a/test/unit/deadline_client/ui/dialogs/test_submit_job_dialog_version_label.py
+++ b/test/unit/deadline_client/ui/dialogs/test_submit_job_dialog_version_label.py
@@ -1,0 +1,272 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Tests for the version info label in SubmitJobToDeadlineDialog.
+
+These tests verify that the compact version label is built correctly
+with various combinations of submitter info and environment data,
+including version truncation and tooltip behavior.
+"""
+
+import pytest
+from unittest.mock import Mock, MagicMock, patch, PropertyMock
+from configparser import ConfigParser
+
+from deadline.client.dataclasses.submitter_info import SubmitterInfo
+
+try:
+    from qtpy.QtCore import Qt  # type: ignore
+    from qtpy.QtWidgets import QWidget
+    from deadline.client.ui.dataclasses import JobBundleSettings
+    from deadline.client.job_bundle.submission import AssetReferences
+    from deadline.client.ui.dialogs.submit_job_to_deadline_dialog import (
+        SubmitJobToDeadlineDialog,
+    )
+    from deadline.client.ui.dataclasses._environment_info import _EnvironmentInfo
+except ImportError:
+    pytest.importorskip("deadline.client.ui.dialogs.submit_job_to_deadline_dialog")
+
+
+class MockJobSettingsWidget(QWidget):
+    """A mock job settings widget that is a real QWidget."""
+
+    def __init__(self, initial_settings=None, parent=None):
+        super().__init__(parent)
+        self.initial_settings = initial_settings
+        self.parameter_changed = MagicMock()
+        self.parameter_changed.connect = MagicMock()
+
+    def update_settings(self, settings):
+        pass
+
+
+@pytest.fixture
+def mock_auth_status():
+    """Create a mock DeadlineAuthenticationStatus that prevents API calls."""
+    mock_instance = MagicMock()
+    type(mock_instance).api_availability = PropertyMock(return_value=None)
+    type(mock_instance).creds_source = PropertyMock(return_value=None)
+    type(mock_instance).auth_status = PropertyMock(return_value=None)
+    mock_instance.config = ConfigParser()
+    mock_instance.api_availability_changed = MagicMock()
+    mock_instance.api_availability_changed.connect = MagicMock()
+    mock_instance.creds_source_changed = MagicMock()
+    mock_instance.creds_source_changed.connect = MagicMock()
+    mock_instance.auth_status_changed = MagicMock()
+    mock_instance.auth_status_changed.connect = MagicMock()
+    return mock_instance
+
+
+def _create_dialog(qtbot, mock_auth_status, submitter_info=None, deadline_version="1.2.3"):
+    """Helper to create a SubmitJobToDeadlineDialog with mocked dependencies."""
+    import deadline.client.ui.deadline_authentication_status as auth_module
+
+    auth_module._deadline_authentication_status = mock_auth_status
+
+    env_info = Mock(spec=_EnvironmentInfo)
+    env_info.deadline_dep_versions = {"deadline": deadline_version}
+
+    with patch(
+        "deadline.client.ui.widgets.deadline_authentication_status_widget.DeadlineAuthenticationStatus.getInstance",
+        return_value=mock_auth_status,
+    ), patch(
+        "deadline.client.ui.dialogs.submit_job_to_deadline_dialog.DeadlineAuthenticationStatus.getInstance",
+        return_value=mock_auth_status,
+    ), patch(
+        "deadline.client.ui.dialogs.submit_job_to_deadline_dialog._EnvironmentInfo.collect",
+        return_value=env_info,
+    ):
+        settings = JobBundleSettings()
+
+        dialog = SubmitJobToDeadlineDialog(
+            job_setup_widget_type=MockJobSettingsWidget,
+            initial_job_settings=settings,
+            initial_shared_parameter_values={},
+            auto_detected_attachments=AssetReferences(),
+            attachments=AssetReferences(),
+            on_create_job_bundle_callback=MagicMock(),
+            submitter_info=submitter_info,
+        )
+        qtbot.addWidget(dialog)
+        return dialog
+
+
+class TestVersionInfoLabel:
+    """Test cases for the version info label in SubmitJobToDeadlineDialog."""
+
+    def test_version_label_shows_deadline_version(self, qtbot, mock_auth_status):
+        """Test that the version label displays the deadline library version."""
+        submitter_info = SubmitterInfo(submitter_name="TestApp")
+        dialog = _create_dialog(qtbot, mock_auth_status, submitter_info=submitter_info)
+
+        assert hasattr(dialog, "version_info_label")
+        assert "deadline 1.2.3" in dialog.version_info_label.text()
+
+    def test_version_label_shows_submitter_package_info(self, qtbot, mock_auth_status):
+        """Test that the version label displays submitter package name and version."""
+        submitter_info = SubmitterInfo(
+            submitter_name="Blender",
+            submitter_package_name="deadline-cloud-for-blender",
+            submitter_package_version="0.6.3",
+        )
+        dialog = _create_dialog(qtbot, mock_auth_status, submitter_info=submitter_info)
+
+        label_text = dialog.version_info_label.text()
+        assert "deadline-cloud-for-blender 0.6.3" in label_text
+
+    def test_version_label_shows_host_application_info(self, qtbot, mock_auth_status):
+        """Test that the version label displays host application name and version."""
+        submitter_info = SubmitterInfo(
+            submitter_name="Blender",
+            submitter_package_name="deadline-cloud-for-blender",
+            submitter_package_version="0.6.3",
+            host_application_name="Blender",
+            host_application_version="4.5.21",
+        )
+        dialog = _create_dialog(qtbot, mock_auth_status, submitter_info=submitter_info)
+
+        label_text = dialog.version_info_label.text()
+        assert "Blender 4.5.21" in label_text
+
+    def test_version_label_shows_all_parts_with_separator(self, qtbot, mock_auth_status):
+        """Test that all version parts are joined with pipe separators."""
+        submitter_info = SubmitterInfo(
+            submitter_name="Blender",
+            submitter_package_name="deadline-cloud-for-blender",
+            submitter_package_version="0.6.3",
+            host_application_name="Blender",
+            host_application_version="4.5.21",
+        )
+        dialog = _create_dialog(qtbot, mock_auth_status, submitter_info=submitter_info)
+
+        label_text = dialog.version_info_label.text()
+        assert "deadline 1.2.3" in label_text
+        assert "deadline-cloud-for-blender 0.6.3" in label_text
+        assert "Blender 4.5.21" in label_text
+        assert "|" in label_text
+
+    def test_version_label_falls_back_to_submitter_name_when_no_package_name(
+        self, qtbot, mock_auth_status
+    ):
+        """Test that submitter_name is used when package_name is not provided."""
+        submitter_info = SubmitterInfo(
+            submitter_name="CustomApp",
+            submitter_package_version="2.0.0",
+        )
+        dialog = _create_dialog(qtbot, mock_auth_status, submitter_info=submitter_info)
+
+        label_text = dialog.version_info_label.text()
+        assert "CustomApp 2.0.0" in label_text
+
+    def test_version_label_omits_host_app_when_not_provided(self, qtbot, mock_auth_status):
+        """Test that host application info is omitted when not available."""
+        submitter_info = SubmitterInfo(
+            submitter_name="CLI",
+            submitter_package_name="deadline-cloud-cli",
+            submitter_package_version="1.0.0",
+        )
+        dialog = _create_dialog(qtbot, mock_auth_status, submitter_info=submitter_info)
+
+        label_text = dialog.version_info_label.text()
+        assert "deadline 1.2.3" in label_text
+        assert "deadline-cloud-cli 1.0.0" in label_text
+        assert label_text.count("|") == 1
+
+    def test_version_label_truncates_long_versions(self, qtbot, mock_auth_status):
+        """Test that long dev version strings are truncated with ellipsis."""
+        submitter_info = SubmitterInfo(
+            submitter_name="Blender",
+            submitter_package_name="deadline-cloud-for-blender",
+            submitter_package_version="0.57.0.post6+a9f1944194",
+        )
+        dialog = _create_dialog(
+            qtbot,
+            mock_auth_status,
+            submitter_info=submitter_info,
+            deadline_version="1.2.3.post2+abc123",
+        )
+
+        label_text = dialog.version_info_label.text()
+        # Full dev versions should NOT appear in the display
+        assert "0.57.0.post6+a9f1944194" not in label_text
+        assert "1.2.3.post2+abc123" not in label_text
+        # Should contain ellipsis for truncated versions
+        assert "..." in label_text
+
+    def test_version_label_tooltip_shows_full_versions(self, qtbot, mock_auth_status):
+        """Test that the tooltip shows full untruncated version strings."""
+        submitter_info = SubmitterInfo(
+            submitter_name="Blender",
+            submitter_package_name="deadline-cloud-for-blender",
+            submitter_package_version="0.57.0.post6+a9f1944194",
+        )
+        dialog = _create_dialog(
+            qtbot,
+            mock_auth_status,
+            submitter_info=submitter_info,
+            deadline_version="1.2.3.post2+abc123",
+        )
+
+        tooltip = dialog.version_info_label.toolTip()
+        assert "1.2.3.post2+abc123" in tooltip
+        assert "0.57.0.post6+a9f1944194" in tooltip
+
+    def test_version_label_short_versions_not_truncated(self, qtbot, mock_auth_status):
+        """Test that normal release versions are not truncated."""
+        submitter_info = SubmitterInfo(
+            submitter_name="Blender",
+            submitter_package_name="deadline-cloud-for-blender",
+            submitter_package_version="0.6.3",
+        )
+        dialog = _create_dialog(qtbot, mock_auth_status, submitter_info=submitter_info)
+
+        label_text = dialog.version_info_label.text()
+        assert "deadline-cloud-for-blender 0.6.3" in label_text
+        assert "..." not in label_text
+
+    def test_version_label_handles_environment_info_failure(self, qtbot, mock_auth_status):
+        """Test that the label still works when _EnvironmentInfo.collect() fails."""
+        import deadline.client.ui.deadline_authentication_status as auth_module
+
+        auth_module._deadline_authentication_status = mock_auth_status
+
+        submitter_info = SubmitterInfo(
+            submitter_name="Blender",
+            submitter_package_name="deadline-cloud-for-blender",
+            submitter_package_version="0.6.3",
+        )
+
+        with patch(
+            "deadline.client.ui.widgets.deadline_authentication_status_widget.DeadlineAuthenticationStatus.getInstance",
+            return_value=mock_auth_status,
+        ), patch(
+            "deadline.client.ui.dialogs.submit_job_to_deadline_dialog.DeadlineAuthenticationStatus.getInstance",
+            return_value=mock_auth_status,
+        ), patch(
+            "deadline.client.ui.dialogs.submit_job_to_deadline_dialog._EnvironmentInfo.collect",
+            side_effect=RuntimeError("collection failed"),
+        ):
+            settings = JobBundleSettings()
+
+            dialog = SubmitJobToDeadlineDialog(
+                job_setup_widget_type=MockJobSettingsWidget,
+                initial_job_settings=settings,
+                initial_shared_parameter_values={},
+                auto_detected_attachments=AssetReferences(),
+                attachments=AssetReferences(),
+                on_create_job_bundle_callback=MagicMock(),
+                submitter_info=submitter_info,
+            )
+            qtbot.addWidget(dialog)
+
+        assert hasattr(dialog, "version_info_label")
+        label_text = dialog.version_info_label.text()
+        assert "deadline-cloud-for-blender 0.6.3" in label_text
+
+    def test_version_label_is_center_aligned(self, qtbot, mock_auth_status):
+        """Test that the version label is center-aligned."""
+        submitter_info = SubmitterInfo(submitter_name="TestApp")
+        dialog = _create_dialog(qtbot, mock_auth_status, submitter_info=submitter_info)
+
+        assert hasattr(dialog, "version_info_label")
+        assert dialog.version_info_label.alignment() == Qt.AlignmentFlag.AlignCenter


### PR DESCRIPTION
Related to: https://github.com/aws-deadline/deadline-cloud-for-3ds-max/issues/222

### What was the problem/requirement? (What/Why)
The submitter versions are currently available but are hidden away in the Help menu

### What was the solution? (How)
Add a label to the submitter dialog with a summary of the versions of submitter installed 
- deadline-cloud
- Submitter
- DCC

It clips the version numbers to 10 chars (probably we won't go more than `99.123.123` for any version of our software) in the label while the tooltip has the full version string

### What is the impact of this change?
There's a label with the above versions in the main submit dialog

### How was this change tested?

- Added a unit test
- Installed it to local Blender submitter and verify label and tooltip look nice

<img width="907" height="420" alt="image" src="https://github.com/user-attachments/assets/0aa339f7-b850-4cb7-9b96-c70e2b89cd08" />


### Was this change documented?

No

### Does this PR introduce new dependencies?

No

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
