### PR TITLE
feat(ui): add hover highlight to radio buttons

### DIFF
--- a/src/deadline/client/ui/widgets/__init__.py
+++ b/src/deadline/client/ui/widgets/__init__.py
@@ -20,6 +20,7 @@ __all__ = [
     "DeadlineCloudSettingsWidget",
     "SharedJobSettingsWidget",
     "SharedJobPropertiesWidget",
+    "HoverRadioButton",
     # Controller-based combo boxes
     "DeadlineFarmListComboBoxController",
     "DeadlineQueueListComboBoxController",
@@ -41,6 +42,7 @@ from .job_bundle_settings_tab import JobBundleSettingsWidget
 from .job_timeouts_widget import TimeoutEntryWidget, TimeoutTableWidget
 from .openjd_parameters_widget import OpenJDParametersWidget
 from .path_widgets import DirectoryPickerWidget, InputFilePickerWidget, OutputFilePickerWidget
+from .radio_button_widget import HoverRadioButton
 from .shared_job_settings_tab import (
     DeadlineCloudSettingsWidget,
     SharedJobSettingsWidget,

--- a/src/deadline/client/ui/widgets/host_requirements_tab.py
+++ b/src/deadline/client/ui/widgets/host_requirements_tab.py
@@ -35,13 +35,14 @@ from qtpy.QtWidgets import (  # type: ignore
     QListWidget,
     QListWidgetItem,
     QPushButton,
-    QRadioButton,
     QSizePolicy,
     QSpacerItem,
     QSpinBox,
     QVBoxLayout,
     QWidget,
 )
+
+from .radio_button_widget import HoverRadioButton
 
 from deadline.client.exceptions import NonValidInputError
 
@@ -201,11 +202,11 @@ class OverrideRequirementsWidget(QGroupBox):  # pylint: disable=too-few-public-m
 
     def _build_ui(self):
         # Use Fleet Default button
-        self.use_default_button = QRadioButton(tr("Run on all available worker hosts"))
+        self.use_default_button = HoverRadioButton(tr("Run on all available worker hosts"))
         self.use_default_button.setChecked(True)
 
         # Use customized settings button + tip
-        self.use_custom_button = QRadioButton(
+        self.use_custom_button = HoverRadioButton(
             tr("Run on worker hosts that meet the following requirements")
         )
         self.use_custom_button_tip = QHBoxLayout()
@@ -709,9 +710,9 @@ class CustomAttributeWidget(CustomCapabilityWidget):
         self.name_label = QLabel(tr("Attribute name"))
         self.name_label.setFixedWidth(LABEL_FIXED_WIDTH)
         self.value_label = QLabel(tr("Value(s)"))
-        self.all_of_button = QRadioButton(tr("All"))
+        self.all_of_button = HoverRadioButton(tr("All"))
         self.all_of_button.setChecked(True)
-        self.any_of_button = QRadioButton(tr("Any"))
+        self.any_of_button = HoverRadioButton(tr("Any"))
         self.name_line_edit = QLineEdit()
         self.name_line_edit.setFixedWidth(LABEL_FIXED_WIDTH)
         assert (100 - len(ATTRIBUTE_CAPABILITY_PREFIX)) > 0

--- a/src/deadline/client/ui/widgets/radio_button_widget.py
+++ b/src/deadline/client/ui/widgets/radio_button_widget.py
@@ -1,0 +1,31 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from __future__ import annotations
+
+from typing import Optional
+
+from qtpy.QtCore import Qt  # type: ignore
+from qtpy.QtWidgets import QRadioButton, QWidget  # type: ignore
+
+
+_HOVER_STYLE = """
+QRadioButton {
+    padding: 2px 4px;
+    border-radius: 3px;
+}
+QRadioButton:hover {
+    background-color: palette(midlight);
+}
+"""
+
+
+class HoverRadioButton(QRadioButton):
+    """
+    A QRadioButton with a subtle background highlight on hover
+    and a pointing-hand cursor.
+    """
+
+    def __init__(self, text: str = "", parent: Optional[QWidget] = None):
+        super().__init__(text, parent)
+        self.setCursor(Qt.PointingHandCursor)
+        self.setStyleSheet(_HOVER_STYLE)

--- a/src/deadline/client/ui/widgets/shared_job_settings_tab.py
+++ b/src/deadline/client/ui/widgets/shared_job_settings_tab.py
@@ -17,11 +17,12 @@ from qtpy.QtWidgets import (  # type: ignore
     QHBoxLayout,
     QLabel,
     QLineEdit,
-    QRadioButton,
     QSpinBox,
     QVBoxLayout,
     QWidget,
 )
+
+from .radio_button_widget import HoverRadioButton
 
 from ... import api
 from ...config import get_setting
@@ -268,8 +269,8 @@ class SharedJobPropertiesWidget(QGroupBox):  # pylint: disable=too-few-public-me
         self.max_worker_count_box_label.setToolTip(tr("Maximum worker count of job."))
         self.max_worker_count_box = QSpinBox()
         self.max_worker_count_box.setRange(1, 2147483647)
-        self.unlimited_max_worker_count = QRadioButton(tr("No max worker count"))
-        self.limited_max_worker_count = QRadioButton(tr("Set max worker count"))
+        self.unlimited_max_worker_count = HoverRadioButton(tr("No max worker count"))
+        self.limited_max_worker_count = HoverRadioButton(tr("Set max worker count"))
         self.limited_max_worker_count.toggled.connect(
             self.limited_max_worker_count_radio_button_toggled
         )


### PR DESCRIPTION
Fixes: *<insert link to GitHub issue here>*

### What was the problem/requirement? (What/Why)

Users identified that it can feel confusing that a radio item can be selected when clicking on the text instead of the button.

### What was the solution? (How)

Rather than making only the button clickable, make it obvious that clicking any where on the radio group (label or button) will select the item using a subtle highlight that will use the existing palette to accommodate dark mode or submitters that extend this base submitter.


https://github.com/user-attachments/assets/74f7745f-4cf7-4d65-b3b8-3a3107e112fd



### How was this change tested?
- Verified existing unit tests pass
- Verified xa11y tests pass
- Manually validated

### Was this change documented?

No, small style improvement. No new documentation needed.

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [✅] This PR does not add any new dependencies.

### Is this a breaking change?

Not a breaking change.

### Does this change impact security?

No change in our security posture.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
