### PR TITLE
feat: add preGUI submission hook phase

### DIFF
--- a/docs/submission-hooks.md
+++ b/docs/submission-hooks.md
@@ -12,7 +12,7 @@ Place a `hooks.yaml` (or `hooks.json`) in your job bundle directory alongside `t
 
 ```yaml
 version: "1.0"
-preUI:
+preGUI:
   - command: python3
     args: [prefill.py]
     timeout: 10
@@ -42,14 +42,14 @@ Requires `settings.allow_environment_hooks` to be enabled. Both sources can be a
 
 ## Hook Types
 
-### Pre-UI Hooks
+### Pre-GUI Hooks
 
 Run **before** the submission dialog opens. Use these to:
 - Pre-populate job name, description, and priority
 - Set parameter defaults based on the current scene or pipeline context
 - Query a project management system for task metadata
 
-Pre-UI hooks **block the dialog from opening** if they fail (non-zero exit code or timeout).
+Pre-GUI hooks **block the dialog from opening** if they fail (non-zero exit code or timeout).
 
 Output JSON to stdout to modify the initial dialog state:
 
@@ -124,7 +124,7 @@ The `version` field is required and must be `"1.0"`.
 **YAML format:**
 ```yaml
 version: "1.0"
-preUI:
+preGUI:
   - command: python3
     args: [scripts/prefill_from_shotgrid.py]
     timeout: 10
@@ -382,12 +382,12 @@ This is useful for studios that want to enforce hooks across all submissions wit
 
 ### Confirmation Prompt
 
-When hooks are enabled, you'll be prompted to confirm before they run. Pre-UI hooks show a prompt before the dialog opens; pre- and post-submission hooks show a prompt when you click Submit.
+When hooks are enabled, you'll be prompted to confirm before they run. Pre-GUI hooks show a prompt before the dialog opens; pre- and post-submission hooks show a prompt when you click Submit.
 
 ```
 This job bundle contains submission hooks that will execute on your machine:
 
-  Pre-UI hooks:
+  Pre-GUI hooks:
     [1] python3 prefill_from_shotgrid.py
 
   Pre-submission hooks:

--- a/docs/submission-hooks.md
+++ b/docs/submission-hooks.md
@@ -12,6 +12,11 @@ Place a `hooks.yaml` (or `hooks.json`) in your job bundle directory alongside `t
 
 ```yaml
 version: "1.0"
+preUI:
+  - command: python3
+    args: [prefill.py]
+    timeout: 10
+
 preSubmission:
   - command: python3
     args: [validate.py]
@@ -36,6 +41,58 @@ export DEADLINE_HOOKS_DIR=/studio/pipeline/hooks/maya
 Requires `settings.allow_environment_hooks` to be enabled. Both sources can be active simultaneously — environment hooks run first, then bundle hooks.
 
 ## Hook Types
+
+### Pre-UI Hooks
+
+Run **before** the submission dialog opens. Use these to:
+- Pre-populate job name, description, and priority
+- Set parameter defaults based on the current scene or pipeline context
+- Query a project management system for task metadata
+
+Pre-UI hooks **block the dialog from opening** if they fail (non-zero exit code or timeout).
+
+Output JSON to stdout to modify the initial dialog state:
+
+```python
+import json
+
+output = {
+    "name": "My Render - v042",
+    "description": "Submitted via pipeline",
+    "parameters": {
+        # Job template parameters
+        "SceneFile": "/resolved/path/to/scene.ma",
+        "OutputPath": "/shots/sh010/renders/",
+        # Shared job properties use the deadline: prefix
+        "deadline:priority": 75,
+        "deadline:maxFailedTasksCount": 5,
+        "deadline:maxRetriesPerTask": 3,
+        "deadline:maxWorkerCount": 10,
+        "deadline:targetTaskRunStatus": "READY",  # or "SUSPENDED"
+    }
+}
+print(json.dumps(output))
+```
+
+| Output field | Type | Description |
+|---|---|---|
+| `name` | string | Pre-fill the job name field |
+| `description` | string | Pre-fill the job description field |
+| `parameters` | object | Pre-fill parameter values by name (see below) |
+
+**Parameter keys** (inside `parameters`):
+
+Job template parameters use their name directly. Shared job properties use the `deadline:` prefix:
+
+| Key | Type | Description |
+|---|---|---|
+| `deadline:priority` | integer | Priority (0–100) |
+| `deadline:maxFailedTasksCount` | integer | Maximum failed tasks before the job fails |
+| `deadline:maxRetriesPerTask` | integer | Maximum retries per failed task |
+| `deadline:maxWorkerCount` | integer | Maximum concurrent workers |
+| `deadline:targetTaskRunStatus` | string | Initial task status: `"READY"` or `"SUSPENDED"` |
+
+> **Note:** CLI-supplied `--parameter` values take precedence over hook-supplied `parameters`.
 
 ### Pre-Submission Hooks
 
@@ -67,6 +124,11 @@ The `version` field is required and must be `"1.0"`.
 **YAML format:**
 ```yaml
 version: "1.0"
+preUI:
+  - command: python3
+    args: [scripts/prefill_from_shotgrid.py]
+    timeout: 10
+
 preSubmission:
   - command: python3
     args: [scripts/validate_assets.py]
@@ -320,10 +382,13 @@ This is useful for studios that want to enforce hooks across all submissions wit
 
 ### Confirmation Prompt
 
-When hooks are enabled, you'll be prompted to confirm before they run:
+When hooks are enabled, you'll be prompted to confirm before they run. Pre-UI hooks show a prompt before the dialog opens; pre- and post-submission hooks show a prompt when you click Submit.
 
 ```
 This job bundle contains submission hooks that will execute on your machine:
+
+  Pre-UI hooks:
+    [1] python3 prefill_from_shotgrid.py
 
   Pre-submission hooks:
     [1] python3 validate_assets.py

--- a/examples/hooks/pre_gui_priority.py
+++ b/examples/hooks/pre_gui_priority.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
-"""Pre-UI hook: set job priority based on deadline proximity.
+"""Pre-GUI hook: set job priority based on deadline proximity.
 
 Place this script alongside a hooks.yaml in your job bundle:
 
     hooks.yaml
     ----------
     version: "1.0"
-    preUI:
+    preGUI:
       - command: python3
-        args: [pre_ui_priority.py]
+        args: [pre_gui_priority.py]
         timeout: 5
 
 The hook reads the current date and sets priority 90 if a deadline is

--- a/examples/hooks/pre_ui_priority.py
+++ b/examples/hooks/pre_ui_priority.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Pre-UI hook: set job priority based on deadline proximity.
+
+Place this script alongside a hooks.yaml in your job bundle:
+
+    hooks.yaml
+    ----------
+    version: "1.0"
+    preUI:
+      - command: python3
+        args: [pre_ui_priority.py]
+        timeout: 5
+
+The hook reads the current date and sets priority 90 if a deadline is
+approaching (within 2 days), otherwise 50. It also pre-fills the job name
+with a datestamp so artists can see when the job was submitted.
+"""
+
+import json
+import sys
+from datetime import date
+
+TODAY = date.today()
+DEADLINE = date(TODAY.year, TODAY.month, 28)  # example: end-of-month deadline
+DAYS_REMAINING = (DEADLINE - TODAY).days
+
+if DAYS_REMAINING <= 2:
+    priority = 90
+    name_suffix = " [URGENT]"
+elif DAYS_REMAINING <= 7:
+    priority = 70
+    name_suffix = " [due soon]"
+else:
+    priority = 50
+    name_suffix = ""
+
+metadata = json.load(sys.stdin)
+job_name = metadata.get("jobName", "Job")
+
+output = {
+    "name": f"{job_name}{name_suffix} ({TODAY.isoformat()})",
+    "parameters": {
+        "deadline:priority": priority,
+    },
+}
+
+json.dump(output, sys.stdout)

--- a/src/deadline/client/job_bundle/_hooks/__init__.py
+++ b/src/deadline/client/job_bundle/_hooks/__init__.py
@@ -4,7 +4,7 @@
 
 from ._manager import HookManager, _generate_hooks_confirmation_message
 from ._models import HookConfiguration, HookDefinition, HookMetadata, HookResult
-from ._validator import validate_pre_ui_output
+from ._validator import validate_pre_gui_output
 
 __all__ = [
     "HookManager",
@@ -13,5 +13,5 @@ __all__ = [
     "HookMetadata",
     "HookResult",
     "_generate_hooks_confirmation_message",
-    "validate_pre_ui_output",
+    "validate_pre_gui_output",
 ]

--- a/src/deadline/client/job_bundle/_hooks/__init__.py
+++ b/src/deadline/client/job_bundle/_hooks/__init__.py
@@ -4,6 +4,7 @@
 
 from ._manager import HookManager, _generate_hooks_confirmation_message
 from ._models import HookConfiguration, HookDefinition, HookMetadata, HookResult
+from ._validator import validate_pre_ui_output
 
 __all__ = [
     "HookManager",
@@ -12,4 +13,5 @@ __all__ = [
     "HookMetadata",
     "HookResult",
     "_generate_hooks_confirmation_message",
+    "validate_pre_ui_output",
 ]

--- a/src/deadline/client/job_bundle/_hooks/_manager.py
+++ b/src/deadline/client/job_bundle/_hooks/_manager.py
@@ -15,7 +15,7 @@ from ._executor import HookExecutor as _HookExecutor
 from ._merger import merge_payload as _merge_payload
 from ._models import HookConfiguration as _HookConfiguration
 from ._models import HookMetadata as _HookMetadata
-from ._validator import validate_pre_ui_output as _validate_pre_ui_output
+from ._validator import validate_pre_gui_output as _validate_pre_gui_output
 from ._validator import validate_configuration as _validate_configuration
 from ._validator import validate_modified_payload as _validate_modified_payload
 
@@ -26,9 +26,9 @@ def _generate_hooks_confirmation_message(hooks: _HookConfiguration, bundle_dir: 
     """Generate a confirmation message listing hooks that will execute."""
     lines = ["This job bundle contains submission hooks that will execute on your machine:\n"]
 
-    if hooks.pre_ui:
-        lines.append("  Pre-UI hooks:")
-        for i, hook in enumerate(hooks.pre_ui):
+    if hooks.pre_gui:
+        lines.append("  Pre-GUI hooks:")
+        for i, hook in enumerate(hooks.pre_gui):
             cmd = f"{hook.command} {' '.join(hook.args)}".strip()
             lines.append(f"    [{i + 1}] {cmd}")
         lines.append("")
@@ -76,60 +76,60 @@ class HookManager:
         self.hooks = _HookConfiguration.from_dict(config_data)
         return self.hooks
 
-    def execute_pre_ui_hooks(
+    def execute_pre_gui_hooks(
         self,
         metadata: _HookMetadata,
     ) -> _Dict[str, _Any]:
-        """Execute all pre-UI hooks and return merged initial parameter overrides.
+        """Execute all pre-GUI hooks and return merged initial parameter overrides.
 
         Runs before the submission dialog opens. Hooks may output JSON to pre-populate
         dialog fields: parameters, priority, farmId, queueId, name, description.
         Failures block the dialog from opening.
         """
-        if not self.hooks or not self.hooks.pre_ui:
+        if not self.hooks or not self.hooks.pre_gui:
             return {}
 
         metadata.job_bundle_dir = self._original_bundle_dir
 
         merged: _Dict[str, _Any] = {}
-        for i, hook in enumerate(self.hooks.pre_ui):
+        for i, hook in enumerate(self.hooks.pre_gui):
             hook_name = f"{hook.command} {' '.join(hook.args)}".strip()
-            self.print_callback(f"Running pre-UI hook [{i + 1}]: {hook_name}")
+            self.print_callback(f"Running pre-GUI hook [{i + 1}]: {hook_name}")
 
-            result = self._executor.execute(hook, metadata, "pre-UI", i + 1)
+            result = self._executor.execute(hook, metadata, "pre-GUI", i + 1)
 
             if result.timed_out:
-                self._report_failure(hook, result, i + 1, "pre-UI")
+                self._report_failure(hook, result, i + 1, "pre-GUI")
                 raise _DeadlineOperationError(
-                    f"Pre-UI hook [{i + 1}] timed out after {hook.timeout}s: {hook_name}"
+                    f"Pre-GUI hook [{i + 1}] timed out after {hook.timeout}s: {hook_name}"
                 )
 
             if not result.is_success():
-                self._report_failure(hook, result, i + 1, "pre-UI")
+                self._report_failure(hook, result, i + 1, "pre-GUI")
                 raise _DeadlineOperationError(
-                    f"Pre-UI hook [{i + 1}] failed with exit code {result.exit_code}: {hook_name}"
+                    f"Pre-GUI hook [{i + 1}] failed with exit code {result.exit_code}: {hook_name}"
                 )
 
             if result.stdout.strip():
                 try:
                     output = _json.loads(result.stdout)
-                    _validate_pre_ui_output(output, hook_name)
+                    _validate_pre_gui_output(output, hook_name)
                     # Later hooks override earlier ones for scalar fields; parameters are merged.
                     params = merged.pop("parameters", {})
                     params.update(output.pop("parameters", {}))
                     merged.update(output)
                     if params:
                         merged["parameters"] = params
-                    _logger.debug(f"Pre-UI hook [{i + 1}] modified initial settings")
+                    _logger.debug(f"Pre-GUI hook [{i + 1}] modified initial settings")
                 except _json.JSONDecodeError as e:
                     raise _DeadlineOperationError(
-                        f"Pre-UI hook [{i + 1}] produced invalid JSON: {e}"
+                        f"Pre-GUI hook [{i + 1}] produced invalid JSON: {e}"
                     )
 
             if result.stderr:
-                _logger.warning(f"Pre-UI hook [{i + 1}] stderr: {result.stderr}")
+                _logger.warning(f"Pre-GUI hook [{i + 1}] stderr: {result.stderr}")
 
-            _logger.debug(f"Pre-UI hook [{i + 1}] completed in {result.execution_time:.2f}s")
+            _logger.debug(f"Pre-GUI hook [{i + 1}] completed in {result.execution_time:.2f}s")
 
         return merged
 

--- a/src/deadline/client/job_bundle/_hooks/_manager.py
+++ b/src/deadline/client/job_bundle/_hooks/_manager.py
@@ -15,6 +15,7 @@ from ._executor import HookExecutor as _HookExecutor
 from ._merger import merge_payload as _merge_payload
 from ._models import HookConfiguration as _HookConfiguration
 from ._models import HookMetadata as _HookMetadata
+from ._validator import validate_pre_ui_output as _validate_pre_ui_output
 from ._validator import validate_configuration as _validate_configuration
 from ._validator import validate_modified_payload as _validate_modified_payload
 
@@ -24,6 +25,13 @@ _logger = _logging.getLogger(__name__)
 def _generate_hooks_confirmation_message(hooks: _HookConfiguration, bundle_dir: str) -> str:
     """Generate a confirmation message listing hooks that will execute."""
     lines = ["This job bundle contains submission hooks that will execute on your machine:\n"]
+
+    if hooks.pre_ui:
+        lines.append("  Pre-UI hooks:")
+        for i, hook in enumerate(hooks.pre_ui):
+            cmd = f"{hook.command} {' '.join(hook.args)}".strip()
+            lines.append(f"    [{i + 1}] {cmd}")
+        lines.append("")
 
     if hooks.pre_submission:
         lines.append("  Pre-submission hooks:")
@@ -67,6 +75,63 @@ class HookManager:
         _validate_configuration(config_data)
         self.hooks = _HookConfiguration.from_dict(config_data)
         return self.hooks
+
+    def execute_pre_ui_hooks(
+        self,
+        metadata: _HookMetadata,
+    ) -> _Dict[str, _Any]:
+        """Execute all pre-UI hooks and return merged initial parameter overrides.
+
+        Runs before the submission dialog opens. Hooks may output JSON to pre-populate
+        dialog fields: parameters, priority, farmId, queueId, name, description.
+        Failures block the dialog from opening.
+        """
+        if not self.hooks or not self.hooks.pre_ui:
+            return {}
+
+        metadata.job_bundle_dir = self._original_bundle_dir
+
+        merged: _Dict[str, _Any] = {}
+        for i, hook in enumerate(self.hooks.pre_ui):
+            hook_name = f"{hook.command} {' '.join(hook.args)}".strip()
+            self.print_callback(f"Running pre-UI hook [{i + 1}]: {hook_name}")
+
+            result = self._executor.execute(hook, metadata, "pre-UI", i + 1)
+
+            if result.timed_out:
+                self._report_failure(hook, result, i + 1, "pre-UI")
+                raise _DeadlineOperationError(
+                    f"Pre-UI hook [{i + 1}] timed out after {hook.timeout}s: {hook_name}"
+                )
+
+            if not result.is_success():
+                self._report_failure(hook, result, i + 1, "pre-UI")
+                raise _DeadlineOperationError(
+                    f"Pre-UI hook [{i + 1}] failed with exit code {result.exit_code}: {hook_name}"
+                )
+
+            if result.stdout.strip():
+                try:
+                    output = _json.loads(result.stdout)
+                    _validate_pre_ui_output(output, hook_name)
+                    # Later hooks override earlier ones for scalar fields; parameters are merged.
+                    params = merged.pop("parameters", {})
+                    params.update(output.pop("parameters", {}))
+                    merged.update(output)
+                    if params:
+                        merged["parameters"] = params
+                    _logger.debug(f"Pre-UI hook [{i + 1}] modified initial settings")
+                except _json.JSONDecodeError as e:
+                    raise _DeadlineOperationError(
+                        f"Pre-UI hook [{i + 1}] produced invalid JSON: {e}"
+                    )
+
+            if result.stderr:
+                _logger.warning(f"Pre-UI hook [{i + 1}] stderr: {result.stderr}")
+
+            _logger.debug(f"Pre-UI hook [{i + 1}] completed in {result.execution_time:.2f}s")
+
+        return merged
 
     def execute_pre_submission_hooks(
         self,

--- a/src/deadline/client/job_bundle/_hooks/_models.py
+++ b/src/deadline/client/job_bundle/_hooks/_models.py
@@ -33,6 +33,7 @@ class HookConfiguration:
     """Complete hook configuration from hooks.yaml/json."""
 
     version: str
+    pre_ui: _List[HookDefinition]
     pre_submission: _List[HookDefinition]
     post_submission: _List[HookDefinition]
 
@@ -40,6 +41,7 @@ class HookConfiguration:
     def from_dict(cls, data: _Dict[str, _Any]) -> HookConfiguration:
         return cls(
             version=data.get("version", "1.0"),
+            pre_ui=[HookDefinition.from_dict(h) for h in data.get("preUI", [])],
             pre_submission=[HookDefinition.from_dict(h) for h in data.get("preSubmission", [])],
             post_submission=[HookDefinition.from_dict(h) for h in data.get("postSubmission", [])],
         )

--- a/src/deadline/client/job_bundle/_hooks/_models.py
+++ b/src/deadline/client/job_bundle/_hooks/_models.py
@@ -33,7 +33,7 @@ class HookConfiguration:
     """Complete hook configuration from hooks.yaml/json."""
 
     version: str
-    pre_ui: _List[HookDefinition]
+    pre_gui: _List[HookDefinition]
     pre_submission: _List[HookDefinition]
     post_submission: _List[HookDefinition]
 
@@ -41,7 +41,7 @@ class HookConfiguration:
     def from_dict(cls, data: _Dict[str, _Any]) -> HookConfiguration:
         return cls(
             version=data.get("version", "1.0"),
-            pre_ui=[HookDefinition.from_dict(h) for h in data.get("preUI", [])],
+            pre_gui=[HookDefinition.from_dict(h) for h in data.get("preGUI", [])],
             pre_submission=[HookDefinition.from_dict(h) for h in data.get("preSubmission", [])],
             post_submission=[HookDefinition.from_dict(h) for h in data.get("postSubmission", [])],
         )

--- a/src/deadline/client/job_bundle/_hooks/_validator.py
+++ b/src/deadline/client/job_bundle/_hooks/_validator.py
@@ -39,7 +39,7 @@ def validate_configuration(config: _Dict[str, _Any]) -> None:
             f"Unsupported hooks version '{version}'. Supported: {', '.join(sorted(_SUPPORTED_VERSIONS))}"
         )
 
-    for key in ("preSubmission", "postSubmission"):
+    for key in ("preUI", "preSubmission", "postSubmission"):
         if key in config and not isinstance(config[key], list):
             raise _DeadlineOperationError(f"Hook configuration '{key}' must be a list")
 
@@ -69,3 +69,28 @@ def validate_modified_payload(payload: _Dict[str, _Any], hook_name: str) -> None
             raise _DeadlineOperationError(f"Hook '{hook_name}' 'attachments' must be an object")
         if "assetReferences" in attachments:
             _validate_asset_references(attachments["assetReferences"], hook_name)
+
+
+_PRE_UI_ALLOWED_KEYS = {"parameters", "name", "description"}
+
+
+def validate_pre_ui_output(output: _Dict[str, _Any], hook_name: str) -> None:
+    """Validate that a pre-UI hook output contains only recognised fields."""
+    if not isinstance(output, dict):
+        raise _DeadlineOperationError(f"Hook '{hook_name}' output must be a JSON object")
+
+    unknown = set(output.keys()) - _PRE_UI_ALLOWED_KEYS
+    if unknown:
+        raise _DeadlineOperationError(
+            f"Hook '{hook_name}' output contains unrecognised fields: {', '.join(sorted(unknown))}. "
+            f"Allowed fields: {', '.join(sorted(_PRE_UI_ALLOWED_KEYS))}"
+        )
+
+    if "parameters" in output and not isinstance(output["parameters"], dict):
+        raise _DeadlineOperationError(
+            f"Hook '{hook_name}' 'parameters' must be an object mapping parameter names to values"
+        )
+
+    for str_field in ("name", "description"):
+        if str_field in output and not isinstance(output[str_field], str):
+            raise _DeadlineOperationError(f"Hook '{hook_name}' '{str_field}' must be a string")

--- a/src/deadline/client/job_bundle/_hooks/_validator.py
+++ b/src/deadline/client/job_bundle/_hooks/_validator.py
@@ -39,7 +39,7 @@ def validate_configuration(config: _Dict[str, _Any]) -> None:
             f"Unsupported hooks version '{version}'. Supported: {', '.join(sorted(_SUPPORTED_VERSIONS))}"
         )
 
-    for key in ("preUI", "preSubmission", "postSubmission"):
+    for key in ("preGUI", "preSubmission", "postSubmission"):
         if key in config and not isinstance(config[key], list):
             raise _DeadlineOperationError(f"Hook configuration '{key}' must be a list")
 
@@ -71,19 +71,19 @@ def validate_modified_payload(payload: _Dict[str, _Any], hook_name: str) -> None
             _validate_asset_references(attachments["assetReferences"], hook_name)
 
 
-_PRE_UI_ALLOWED_KEYS = {"parameters", "name", "description"}
+_PRE_GUI_ALLOWED_KEYS = {"parameters", "name", "description"}
 
 
-def validate_pre_ui_output(output: _Dict[str, _Any], hook_name: str) -> None:
-    """Validate that a pre-UI hook output contains only recognised fields."""
+def validate_pre_gui_output(output: _Dict[str, _Any], hook_name: str) -> None:
+    """Validate that a pre-GUI hook output contains only recognised fields."""
     if not isinstance(output, dict):
         raise _DeadlineOperationError(f"Hook '{hook_name}' output must be a JSON object")
 
-    unknown = set(output.keys()) - _PRE_UI_ALLOWED_KEYS
+    unknown = set(output.keys()) - _PRE_GUI_ALLOWED_KEYS
     if unknown:
         raise _DeadlineOperationError(
             f"Hook '{hook_name}' output contains unrecognised fields: {', '.join(sorted(unknown))}. "
-            f"Allowed fields: {', '.join(sorted(_PRE_UI_ALLOWED_KEYS))}"
+            f"Allowed fields: {', '.join(sorted(_PRE_GUI_ALLOWED_KEYS))}"
         )
 
     if "parameters" in output and not isinstance(output["parameters"], dict):

--- a/src/deadline/client/ui/job_bundle_submitter.py
+++ b/src/deadline/client/ui/job_bundle_submitter.py
@@ -16,7 +16,15 @@ from qtpy.QtWidgets import (  # pylint: disable=import-error; type: ignore
     QWidget,
 )
 
+from ..config import config_file as _config_file
+from ..config.config_file import get_setting as _get_setting
+from ..exceptions import DeadlineOperationCanceled as _DeadlineOperationCanceled
 from ..exceptions import DeadlineOperationError
+from ..job_bundle._hooks import (
+    HookManager as _HookManager,
+    HookMetadata as _HookMetadata,
+    _generate_hooks_confirmation_message,
+)
 from ..job_bundle.loader import (
     parse_yaml_or_json_content,
     read_yaml_or_json,
@@ -42,6 +50,30 @@ from ..job_bundle.submission import AssetReferences
 from ..api._session import session_context
 
 logger = getLogger(__name__)
+
+
+def _make_pre_ui_metadata(initial_settings: Any, job_bundle_dir: str) -> _HookMetadata:
+    """Build minimal HookMetadata for the pre-UI phase."""
+    farm_id = _get_setting("defaults.farm_id") or ""
+    queue_id = _get_setting("defaults.queue_id") or ""
+    storage_profile_id = _get_setting("settings.storage_profile_id") or None
+    parameters = {
+        p["name"]: p.get("value", p.get("default"))
+        for p in getattr(initial_settings, "parameters", [])
+        if "value" in p or "default" in p
+    }
+    return _HookMetadata(
+        job_name=getattr(initial_settings, "name", ""),
+        priority=50,
+        farm_id=farm_id,
+        queue_id=queue_id,
+        job_bundle_dir=job_bundle_dir,
+        parameters=parameters,
+        submitter_name=getattr(initial_settings, "submitter_name", "JobBundle"),
+        asset_references={},
+        submission_payload={},
+        storage_profile_id=storage_profile_id,
+    )
 
 
 def _validate_job_parameters_against_definitions(
@@ -281,6 +313,35 @@ def show_job_bundle_submitter(
     initial_settings.parameters = read_job_bundle_parameters(input_job_bundle_dir)
     initial_settings.browse_enabled = browse
 
+    # Run pre-UI hooks to allow studios to pre-populate dialog fields.
+    pre_ui_output: dict[str, Any] = {}
+    allow_env_hooks = _config_file.str2bool(_get_setting("settings.allow_environment_hooks"))
+    allow_bundle_hooks = _config_file.str2bool(_get_setting("settings.allow_bundle_hooks"))
+    hook_manager = _HookManager(input_job_bundle_dir, logger.info)
+    hooks = hook_manager.load_hooks()
+    if hooks and hooks.pre_ui and not allow_bundle_hooks and not allow_env_hooks:
+        logger.warning(
+            "Note: Job bundle contains preUI hooks but bundle hooks are disabled.\n"
+            "Enable with: deadline config set settings.allow_bundle_hooks true"
+        )
+    if (allow_env_hooks or allow_bundle_hooks) and hooks and hooks.pre_ui:
+        if not _config_file.str2bool(_get_setting("settings.auto_accept")):
+            confirmation_msg = (
+                _generate_hooks_confirmation_message(hooks, input_job_bundle_dir)
+                + "Do you want to run these hooks?"
+            )
+            reply = QMessageBox.question(
+                parent,
+                tr("Job Submission Confirmation"),
+                confirmation_msg,
+                QMessageBox.Yes | QMessageBox.No,
+                QMessageBox.No,
+            )
+            if reply != QMessageBox.Yes:
+                raise _DeadlineOperationCanceled("Job submission canceled (user declined hooks).")
+        hook_metadata = _make_pre_ui_metadata(initial_settings, input_job_bundle_dir)
+        pre_ui_output = hook_manager.execute_pre_ui_hooks(hook_metadata)
+
     initial_shared_parameter_values = {}
 
     job_parameters_dict = {param["name"]: param for param in (job_parameters or [])}
@@ -308,6 +369,27 @@ def show_job_bundle_submitter(
     # Put the job_parameter values that weren't for the template in the shared parameter values
     for parameter in job_parameters_dict.values():
         initial_shared_parameter_values[parameter["name"]] = parameter["value"]
+
+    # Merge pre-UI hook output. CLI-supplied parameters take precedence over hook values.
+    if pre_ui_output:
+        hook_params = pre_ui_output.get("parameters", {})
+        template_param_names = {p["name"] for p in initial_settings.parameters}
+        for param_name, param_value in hook_params.items():
+            if param_name in (job_parameters_dict or {}):
+                continue
+            if param_name in template_param_names:
+                # Job template parameter — update initial_settings.parameters in-place
+                for p in initial_settings.parameters:
+                    if p["name"] == param_name:
+                        p["value"] = param_value
+                        break
+            else:
+                # Shared job property (deadline: keys, queue parameters, etc.)
+                initial_shared_parameter_values[param_name] = param_value
+        if "name" in pre_ui_output:
+            initial_settings.name = pre_ui_output["name"]
+        if "description" in pre_ui_output:
+            initial_settings.description = pre_ui_output["description"]
 
     submitter_dialog = SubmitJobToDeadlineDialog(
         job_setup_widget_type=JobBundleSettingsWidget,

--- a/src/deadline/client/ui/job_bundle_submitter.py
+++ b/src/deadline/client/ui/job_bundle_submitter.py
@@ -52,8 +52,8 @@ from ..api._session import session_context
 logger = getLogger(__name__)
 
 
-def _make_pre_ui_metadata(initial_settings: Any, job_bundle_dir: str) -> _HookMetadata:
-    """Build minimal HookMetadata for the pre-UI phase."""
+def _make_pre_gui_metadata(initial_settings: Any, job_bundle_dir: str) -> _HookMetadata:
+    """Build minimal HookMetadata for the pre-GUI phase."""
     farm_id = _get_setting("defaults.farm_id") or ""
     queue_id = _get_setting("defaults.queue_id") or ""
     storage_profile_id = _get_setting("settings.storage_profile_id") or None
@@ -313,18 +313,18 @@ def show_job_bundle_submitter(
     initial_settings.parameters = read_job_bundle_parameters(input_job_bundle_dir)
     initial_settings.browse_enabled = browse
 
-    # Run pre-UI hooks to allow studios to pre-populate dialog fields.
-    pre_ui_output: dict[str, Any] = {}
+    # Run pre-GUI hooks to allow studios to pre-populate dialog fields.
+    pre_gui_output: dict[str, Any] = {}
     allow_env_hooks = _config_file.str2bool(_get_setting("settings.allow_environment_hooks"))
     allow_bundle_hooks = _config_file.str2bool(_get_setting("settings.allow_bundle_hooks"))
     hook_manager = _HookManager(input_job_bundle_dir, logger.info)
     hooks = hook_manager.load_hooks()
-    if hooks and hooks.pre_ui and not allow_bundle_hooks and not allow_env_hooks:
+    if hooks and hooks.pre_gui and not allow_bundle_hooks and not allow_env_hooks:
         logger.warning(
-            "Note: Job bundle contains preUI hooks but bundle hooks are disabled.\n"
+            "Note: Job bundle contains preGUI hooks but bundle hooks are disabled.\n"
             "Enable with: deadline config set settings.allow_bundle_hooks true"
         )
-    if (allow_env_hooks or allow_bundle_hooks) and hooks and hooks.pre_ui:
+    if (allow_env_hooks or allow_bundle_hooks) and hooks and hooks.pre_gui:
         if not _config_file.str2bool(_get_setting("settings.auto_accept")):
             confirmation_msg = (
                 _generate_hooks_confirmation_message(hooks, input_job_bundle_dir)
@@ -339,8 +339,8 @@ def show_job_bundle_submitter(
             )
             if reply != QMessageBox.Yes:
                 raise _DeadlineOperationCanceled("Job submission canceled (user declined hooks).")
-        hook_metadata = _make_pre_ui_metadata(initial_settings, input_job_bundle_dir)
-        pre_ui_output = hook_manager.execute_pre_ui_hooks(hook_metadata)
+        hook_metadata = _make_pre_gui_metadata(initial_settings, input_job_bundle_dir)
+        pre_gui_output = hook_manager.execute_pre_gui_hooks(hook_metadata)
 
     initial_shared_parameter_values = {}
 
@@ -370,9 +370,9 @@ def show_job_bundle_submitter(
     for parameter in job_parameters_dict.values():
         initial_shared_parameter_values[parameter["name"]] = parameter["value"]
 
-    # Merge pre-UI hook output. CLI-supplied parameters take precedence over hook values.
-    if pre_ui_output:
-        hook_params = pre_ui_output.get("parameters", {})
+    # Merge pre-GUI hook output. CLI-supplied parameters take precedence over hook values.
+    if pre_gui_output:
+        hook_params = pre_gui_output.get("parameters", {})
         template_param_names = {p["name"] for p in initial_settings.parameters}
         for param_name, param_value in hook_params.items():
             if param_name in (job_parameters_dict or {}):
@@ -386,10 +386,10 @@ def show_job_bundle_submitter(
             else:
                 # Shared job property (deadline: keys, queue parameters, etc.)
                 initial_shared_parameter_values[param_name] = param_value
-        if "name" in pre_ui_output:
-            initial_settings.name = pre_ui_output["name"]
-        if "description" in pre_ui_output:
-            initial_settings.description = pre_ui_output["description"]
+        if "name" in pre_gui_output:
+            initial_settings.name = pre_gui_output["name"]
+        if "description" in pre_gui_output:
+            initial_settings.description = pre_gui_output["description"]
 
     submitter_dialog = SubmitJobToDeadlineDialog(
         job_setup_widget_type=JobBundleSettingsWidget,

--- a/test/unit/deadline_client/job_bundle/test_hooks.py
+++ b/test/unit/deadline_client/job_bundle/test_hooks.py
@@ -22,7 +22,7 @@ from deadline.client.job_bundle._hooks import (
 )
 from deadline.client.job_bundle._hooks._merger import merge_asset_references, merge_payload
 from deadline.client.job_bundle._hooks._validator import (
-    validate_pre_ui_output,
+    validate_pre_gui_output,
     validate_configuration,
     validate_modified_payload,
 )
@@ -61,7 +61,7 @@ class TestHookConfiguration:
     def test_from_dict_empty(self):
         """Test parsing empty configuration."""
         config = HookConfiguration.from_dict({})
-        assert config.pre_ui == []
+        assert config.pre_gui == []
         assert config.pre_submission == []
         assert config.post_submission == []
         assert config.version == "1.0"
@@ -844,12 +844,12 @@ class TestHookManager:
 
         hooks = HookConfiguration(
             version="1.0",
-            pre_ui=[HookDefinition(command="python", args=["prefill.py"])],
+            pre_gui=[HookDefinition(command="python", args=["prefill.py"])],
             pre_submission=[HookDefinition(command="python", args=["validate.py"])],
             post_submission=[HookDefinition(command="bash", args=["notify.sh"])],
         )
         message = _generate_hooks_confirmation_message(hooks, "/path/to/bundle")
-        assert "Pre-UI hooks:" in message
+        assert "Pre-GUI hooks:" in message
         assert "python prefill.py" in message
         assert "Pre-submission hooks:" in message
         assert "python validate.py" in message
@@ -982,14 +982,14 @@ class TestHookManager:
                 assert f.read() == bundle_dir
 
 
-class TestValidateBeforeUIOutput:
-    """Tests for pre-UI hook output validation."""
+class TestValidateBeforeGUIOutput:
+    """Tests for pre-GUI hook output validation."""
 
     def test_valid_empty(self):
-        validate_pre_ui_output({}, "hook")
+        validate_pre_gui_output({}, "hook")
 
     def test_valid_all_fields(self):
-        validate_pre_ui_output(
+        validate_pre_gui_output(
             {
                 "name": "My Job",
                 "description": "desc",
@@ -1000,67 +1000,67 @@ class TestValidateBeforeUIOutput:
 
     def test_invalid_not_dict(self):
         with pytest.raises(DeadlineOperationError, match="must be a JSON object"):
-            validate_pre_ui_output("string", "hook")  # type: ignore[arg-type]
+            validate_pre_gui_output("string", "hook")  # type: ignore[arg-type]
 
     def test_invalid_unknown_field(self):
         with pytest.raises(DeadlineOperationError, match="unrecognised fields"):
-            validate_pre_ui_output({"farmId": "farm-123"}, "hook")
+            validate_pre_gui_output({"farmId": "farm-123"}, "hook")
 
     def test_invalid_parameters_not_dict(self):
         with pytest.raises(DeadlineOperationError, match="'parameters' must be an object"):
-            validate_pre_ui_output({"parameters": ["list"]}, "hook")
+            validate_pre_gui_output({"parameters": ["list"]}, "hook")
 
     def test_invalid_unknown_field_priority(self):
         with pytest.raises(DeadlineOperationError, match="unrecognised fields"):
-            validate_pre_ui_output({"priority": 75}, "hook")
+            validate_pre_gui_output({"priority": 75}, "hook")
 
     def test_invalid_name_not_string(self):
         with pytest.raises(DeadlineOperationError, match="'name' must be a string"):
-            validate_pre_ui_output({"name": 123}, "hook")
+            validate_pre_gui_output({"name": 123}, "hook")
 
     def test_invalid_description_not_string(self):
         with pytest.raises(DeadlineOperationError, match="'description' must be a string"):
-            validate_pre_ui_output({"description": []}, "hook")
+            validate_pre_gui_output({"description": []}, "hook")
 
 
-class TestHookConfigurationBeforeUI:
-    """Tests for preUI in HookConfiguration."""
+class TestHookConfigurationBeforeGUI:
+    """Tests for preGUI in HookConfiguration."""
 
-    def test_from_dict_pre_ui(self):
-        data = {"preUI": [{"command": "prefill.py"}]}
+    def test_from_dict_pre_gui(self):
+        data = {"preGUI": [{"command": "prefill.py"}]}
         config = HookConfiguration.from_dict(data)
-        assert len(config.pre_ui) == 1
-        assert config.pre_ui[0].command == "prefill.py"
+        assert len(config.pre_gui) == 1
+        assert config.pre_gui[0].command == "prefill.py"
 
     def test_from_dict_all_phases(self):
         data = {
-            "preUI": [{"command": "prefill.py"}],
+            "preGUI": [{"command": "prefill.py"}],
             "preSubmission": [{"command": "validate.py"}],
             "postSubmission": [{"command": "notify.py"}],
         }
         config = HookConfiguration.from_dict(data)
-        assert len(config.pre_ui) == 1
+        assert len(config.pre_gui) == 1
         assert len(config.pre_submission) == 1
         assert len(config.post_submission) == 1
 
 
-class TestValidateConfigurationBeforeUI:
-    """Tests for preUI phase in validate_configuration."""
+class TestValidateConfigurationBeforeGUI:
+    """Tests for preGUI phase in validate_configuration."""
 
-    def test_valid_pre_ui(self):
-        validate_configuration({"preUI": [{"command": "prefill.py"}]})
+    def test_valid_pre_gui(self):
+        validate_configuration({"preGUI": [{"command": "prefill.py"}]})
 
-    def test_invalid_pre_ui_not_list(self):
+    def test_invalid_pre_gui_not_list(self):
         with pytest.raises(DeadlineOperationError, match="must be a list"):
-            validate_configuration({"preUI": "not a list"})
+            validate_configuration({"preGUI": "not a list"})
 
-    def test_invalid_pre_ui_hook_missing_command(self):
+    def test_invalid_pre_gui_hook_missing_command(self):
         with pytest.raises(DeadlineOperationError, match="missing required 'command'"):
-            validate_configuration({"preUI": [{"args": []}]})
+            validate_configuration({"preGUI": [{"args": []}]})
 
 
-class TestExecuteBeforeUIHooks:
-    """Tests for HookManager.execute_pre_ui_hooks."""
+class TestExecuteBeforeGUIHooks:
+    """Tests for HookManager.execute_pre_gui_hooks."""
 
     def _make_metadata(self, tmpdir: str) -> HookMetadata:
         return HookMetadata(
@@ -1075,7 +1075,7 @@ class TestExecuteBeforeUIHooks:
             submission_payload={},
         )
 
-    def test_no_pre_ui_hooks_returns_empty(self):
+    def test_no_pre_gui_hooks_returns_empty(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             hooks_file = os.path.join(tmpdir, "hooks.yaml")
             with open(hooks_file, "w") as f:
@@ -1084,7 +1084,7 @@ class TestExecuteBeforeUIHooks:
                 )
             manager = HookManager(tmpdir, lambda x: None)
             manager.load_hooks()
-            result = manager.execute_pre_ui_hooks(self._make_metadata(tmpdir))
+            result = manager.execute_pre_gui_hooks(self._make_metadata(tmpdir))
             assert result == {}
 
     def test_returns_merged_output(self):
@@ -1097,7 +1097,7 @@ class TestExecuteBeforeUIHooks:
             with open(hooks_file, "w") as f:
                 yaml.dump(
                     {
-                        "preUI": [
+                        "preGUI": [
                             {
                                 "command": sys.executable,
                                 "args": ["-c", f"import json; print(json.dumps({output!r}))"],
@@ -1108,7 +1108,7 @@ class TestExecuteBeforeUIHooks:
                 )
             manager = HookManager(tmpdir, lambda x: None)
             manager.load_hooks()
-            result = manager.execute_pre_ui_hooks(self._make_metadata(tmpdir))
+            result = manager.execute_pre_gui_hooks(self._make_metadata(tmpdir))
             assert result["name"] == "Prefilled Job"
             assert result["parameters"] == {"deadline:priority": 80, "Foo": "bar"}
 
@@ -1119,7 +1119,7 @@ class TestExecuteBeforeUIHooks:
             with open(hooks_file, "w") as f:
                 yaml.dump(
                     {
-                        "preUI": [
+                        "preGUI": [
                             {
                                 "command": sys.executable,
                                 "args": ["-c", 'import json; print(json.dumps({"name": "first"}))'],
@@ -1137,7 +1137,7 @@ class TestExecuteBeforeUIHooks:
                 )
             manager = HookManager(tmpdir, lambda x: None)
             manager.load_hooks()
-            result = manager.execute_pre_ui_hooks(self._make_metadata(tmpdir))
+            result = manager.execute_pre_gui_hooks(self._make_metadata(tmpdir))
             assert result["name"] == "second"
 
     def test_parameters_merged_across_hooks(self):
@@ -1147,7 +1147,7 @@ class TestExecuteBeforeUIHooks:
             with open(hooks_file, "w") as f:
                 yaml.dump(
                     {
-                        "preUI": [
+                        "preGUI": [
                             {
                                 "command": sys.executable,
                                 "args": [
@@ -1168,18 +1168,18 @@ class TestExecuteBeforeUIHooks:
                 )
             manager = HookManager(tmpdir, lambda x: None)
             manager.load_hooks()
-            result = manager.execute_pre_ui_hooks(self._make_metadata(tmpdir))
+            result = manager.execute_pre_gui_hooks(self._make_metadata(tmpdir))
             assert result["parameters"] == {"A": "1", "B": "2"}
 
     def test_failure_blocks(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             hooks_file = os.path.join(tmpdir, "hooks.yaml")
             with open(hooks_file, "w") as f:
-                yaml.dump({"preUI": [{"command": sys.executable, "args": ["-c", "exit(1)"]}]}, f)
+                yaml.dump({"preGUI": [{"command": sys.executable, "args": ["-c", "exit(1)"]}]}, f)
             manager = HookManager(tmpdir, lambda x: None)
             manager.load_hooks()
             with pytest.raises(DeadlineOperationError, match="failed with exit code 1"):
-                manager.execute_pre_ui_hooks(self._make_metadata(tmpdir))
+                manager.execute_pre_gui_hooks(self._make_metadata(tmpdir))
 
     def test_timeout_blocks(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -1187,7 +1187,7 @@ class TestExecuteBeforeUIHooks:
             with open(hooks_file, "w") as f:
                 yaml.dump(
                     {
-                        "preUI": [
+                        "preGUI": [
                             {
                                 "command": sys.executable,
                                 "args": ["-c", "import time; time.sleep(10)"],
@@ -1200,29 +1200,29 @@ class TestExecuteBeforeUIHooks:
             manager = HookManager(tmpdir, lambda x: None)
             manager.load_hooks()
             with pytest.raises(DeadlineOperationError, match="timed out"):
-                manager.execute_pre_ui_hooks(self._make_metadata(tmpdir))
+                manager.execute_pre_gui_hooks(self._make_metadata(tmpdir))
 
     def test_invalid_json_output_raises(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             hooks_file = os.path.join(tmpdir, "hooks.yaml")
             with open(hooks_file, "w") as f:
                 yaml.dump(
-                    {"preUI": [{"command": sys.executable, "args": ["-c", "print('not json')"]}]},
+                    {"preGUI": [{"command": sys.executable, "args": ["-c", "print('not json')"]}]},
                     f,
                 )
             manager = HookManager(tmpdir, lambda x: None)
             manager.load_hooks()
             with pytest.raises(DeadlineOperationError, match="invalid JSON"):
-                manager.execute_pre_ui_hooks(self._make_metadata(tmpdir))
+                manager.execute_pre_gui_hooks(self._make_metadata(tmpdir))
 
     def test_no_output_returns_empty(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             hooks_file = os.path.join(tmpdir, "hooks.yaml")
             with open(hooks_file, "w") as f:
-                yaml.dump({"preUI": [{"command": sys.executable, "args": ["-c", "pass"]}]}, f)
+                yaml.dump({"preGUI": [{"command": sys.executable, "args": ["-c", "pass"]}]}, f)
             manager = HookManager(tmpdir, lambda x: None)
             manager.load_hooks()
-            result = manager.execute_pre_ui_hooks(self._make_metadata(tmpdir))
+            result = manager.execute_pre_gui_hooks(self._make_metadata(tmpdir))
             assert result == {}
 
     def test_deadline_prefix_params_go_to_shared_values(self):
@@ -1232,7 +1232,7 @@ class TestExecuteBeforeUIHooks:
             with open(hooks_file, "w") as f:
                 yaml.dump(
                     {
-                        "preUI": [
+                        "preGUI": [
                             {
                                 "command": sys.executable,
                                 "args": [
@@ -1246,18 +1246,18 @@ class TestExecuteBeforeUIHooks:
                 )
             manager = HookManager(tmpdir, lambda x: None)
             manager.load_hooks()
-            result = manager.execute_pre_ui_hooks(self._make_metadata(tmpdir))
+            result = manager.execute_pre_gui_hooks(self._make_metadata(tmpdir))
             assert result["parameters"]["deadline:priority"] == 80
 
-    def test_confirmation_message_includes_pre_ui(self):
+    def test_confirmation_message_includes_pre_gui(self):
         from deadline.client.job_bundle._hooks import _generate_hooks_confirmation_message
 
         hooks = HookConfiguration(
             version="1.0",
-            pre_ui=[HookDefinition(command="python", args=["prefill.py"])],
+            pre_gui=[HookDefinition(command="python", args=["prefill.py"])],
             pre_submission=[],
             post_submission=[],
         )
         message = _generate_hooks_confirmation_message(hooks, "/bundle")
-        assert "Pre-UI hooks:" in message
+        assert "Pre-GUI hooks:" in message
         assert "python prefill.py" in message

--- a/test/unit/deadline_client/job_bundle/test_hooks.py
+++ b/test/unit/deadline_client/job_bundle/test_hooks.py
@@ -22,6 +22,7 @@ from deadline.client.job_bundle._hooks import (
 )
 from deadline.client.job_bundle._hooks._merger import merge_asset_references, merge_payload
 from deadline.client.job_bundle._hooks._validator import (
+    validate_pre_ui_output,
     validate_configuration,
     validate_modified_payload,
 )
@@ -60,6 +61,7 @@ class TestHookConfiguration:
     def test_from_dict_empty(self):
         """Test parsing empty configuration."""
         config = HookConfiguration.from_dict({})
+        assert config.pre_ui == []
         assert config.pre_submission == []
         assert config.post_submission == []
         assert config.version == "1.0"
@@ -842,10 +844,13 @@ class TestHookManager:
 
         hooks = HookConfiguration(
             version="1.0",
+            pre_ui=[HookDefinition(command="python", args=["prefill.py"])],
             pre_submission=[HookDefinition(command="python", args=["validate.py"])],
             post_submission=[HookDefinition(command="bash", args=["notify.sh"])],
         )
         message = _generate_hooks_confirmation_message(hooks, "/path/to/bundle")
+        assert "Pre-UI hooks:" in message
+        assert "python prefill.py" in message
         assert "Pre-submission hooks:" in message
         assert "python validate.py" in message
         assert "Post-submission hooks:" in message
@@ -975,3 +980,284 @@ class TestHookManager:
             with open(output_file) as f:
                 # Hook should receive the bundle_dir, not the hooks_dir
                 assert f.read() == bundle_dir
+
+
+class TestValidateBeforeUIOutput:
+    """Tests for pre-UI hook output validation."""
+
+    def test_valid_empty(self):
+        validate_pre_ui_output({}, "hook")
+
+    def test_valid_all_fields(self):
+        validate_pre_ui_output(
+            {
+                "name": "My Job",
+                "description": "desc",
+                "parameters": {"deadline:priority": 75, "k": "v"},
+            },
+            "hook",
+        )
+
+    def test_invalid_not_dict(self):
+        with pytest.raises(DeadlineOperationError, match="must be a JSON object"):
+            validate_pre_ui_output("string", "hook")  # type: ignore[arg-type]
+
+    def test_invalid_unknown_field(self):
+        with pytest.raises(DeadlineOperationError, match="unrecognised fields"):
+            validate_pre_ui_output({"farmId": "farm-123"}, "hook")
+
+    def test_invalid_parameters_not_dict(self):
+        with pytest.raises(DeadlineOperationError, match="'parameters' must be an object"):
+            validate_pre_ui_output({"parameters": ["list"]}, "hook")
+
+    def test_invalid_unknown_field_priority(self):
+        with pytest.raises(DeadlineOperationError, match="unrecognised fields"):
+            validate_pre_ui_output({"priority": 75}, "hook")
+
+    def test_invalid_name_not_string(self):
+        with pytest.raises(DeadlineOperationError, match="'name' must be a string"):
+            validate_pre_ui_output({"name": 123}, "hook")
+
+    def test_invalid_description_not_string(self):
+        with pytest.raises(DeadlineOperationError, match="'description' must be a string"):
+            validate_pre_ui_output({"description": []}, "hook")
+
+
+class TestHookConfigurationBeforeUI:
+    """Tests for preUI in HookConfiguration."""
+
+    def test_from_dict_pre_ui(self):
+        data = {"preUI": [{"command": "prefill.py"}]}
+        config = HookConfiguration.from_dict(data)
+        assert len(config.pre_ui) == 1
+        assert config.pre_ui[0].command == "prefill.py"
+
+    def test_from_dict_all_phases(self):
+        data = {
+            "preUI": [{"command": "prefill.py"}],
+            "preSubmission": [{"command": "validate.py"}],
+            "postSubmission": [{"command": "notify.py"}],
+        }
+        config = HookConfiguration.from_dict(data)
+        assert len(config.pre_ui) == 1
+        assert len(config.pre_submission) == 1
+        assert len(config.post_submission) == 1
+
+
+class TestValidateConfigurationBeforeUI:
+    """Tests for preUI phase in validate_configuration."""
+
+    def test_valid_pre_ui(self):
+        validate_configuration({"preUI": [{"command": "prefill.py"}]})
+
+    def test_invalid_pre_ui_not_list(self):
+        with pytest.raises(DeadlineOperationError, match="must be a list"):
+            validate_configuration({"preUI": "not a list"})
+
+    def test_invalid_pre_ui_hook_missing_command(self):
+        with pytest.raises(DeadlineOperationError, match="missing required 'command'"):
+            validate_configuration({"preUI": [{"args": []}]})
+
+
+class TestExecuteBeforeUIHooks:
+    """Tests for HookManager.execute_pre_ui_hooks."""
+
+    def _make_metadata(self, tmpdir: str) -> HookMetadata:
+        return HookMetadata(
+            job_name="Test",
+            priority=50,
+            farm_id="farm-123",
+            queue_id="queue-456",
+            job_bundle_dir=tmpdir,
+            parameters={},
+            submitter_name="Test",
+            asset_references={},
+            submission_payload={},
+        )
+
+    def test_no_pre_ui_hooks_returns_empty(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            hooks_file = os.path.join(tmpdir, "hooks.yaml")
+            with open(hooks_file, "w") as f:
+                yaml.dump(
+                    {"preSubmission": [{"command": sys.executable, "args": ["-c", "pass"]}]}, f
+                )
+            manager = HookManager(tmpdir, lambda x: None)
+            manager.load_hooks()
+            result = manager.execute_pre_ui_hooks(self._make_metadata(tmpdir))
+            assert result == {}
+
+    def test_returns_merged_output(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            hooks_file = os.path.join(tmpdir, "hooks.yaml")
+            output = {
+                "name": "Prefilled Job",
+                "parameters": {"deadline:priority": 80, "Foo": "bar"},
+            }
+            with open(hooks_file, "w") as f:
+                yaml.dump(
+                    {
+                        "preUI": [
+                            {
+                                "command": sys.executable,
+                                "args": ["-c", f"import json; print(json.dumps({output!r}))"],
+                            }
+                        ]
+                    },
+                    f,
+                )
+            manager = HookManager(tmpdir, lambda x: None)
+            manager.load_hooks()
+            result = manager.execute_pre_ui_hooks(self._make_metadata(tmpdir))
+            assert result["name"] == "Prefilled Job"
+            assert result["parameters"] == {"deadline:priority": 80, "Foo": "bar"}
+
+    def test_later_hook_overrides_scalar(self):
+        """Later hooks override earlier hooks for scalar fields like name."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            hooks_file = os.path.join(tmpdir, "hooks.yaml")
+            with open(hooks_file, "w") as f:
+                yaml.dump(
+                    {
+                        "preUI": [
+                            {
+                                "command": sys.executable,
+                                "args": ["-c", 'import json; print(json.dumps({"name": "first"}))'],
+                            },
+                            {
+                                "command": sys.executable,
+                                "args": [
+                                    "-c",
+                                    'import json; print(json.dumps({"name": "second"}))',
+                                ],
+                            },
+                        ]
+                    },
+                    f,
+                )
+            manager = HookManager(tmpdir, lambda x: None)
+            manager.load_hooks()
+            result = manager.execute_pre_ui_hooks(self._make_metadata(tmpdir))
+            assert result["name"] == "second"
+
+    def test_parameters_merged_across_hooks(self):
+        """Parameters from multiple hooks are merged (not replaced)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            hooks_file = os.path.join(tmpdir, "hooks.yaml")
+            with open(hooks_file, "w") as f:
+                yaml.dump(
+                    {
+                        "preUI": [
+                            {
+                                "command": sys.executable,
+                                "args": [
+                                    "-c",
+                                    'import json; print(json.dumps({"parameters": {"A": "1"}}))',
+                                ],
+                            },
+                            {
+                                "command": sys.executable,
+                                "args": [
+                                    "-c",
+                                    'import json; print(json.dumps({"parameters": {"B": "2"}}))',
+                                ],
+                            },
+                        ]
+                    },
+                    f,
+                )
+            manager = HookManager(tmpdir, lambda x: None)
+            manager.load_hooks()
+            result = manager.execute_pre_ui_hooks(self._make_metadata(tmpdir))
+            assert result["parameters"] == {"A": "1", "B": "2"}
+
+    def test_failure_blocks(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            hooks_file = os.path.join(tmpdir, "hooks.yaml")
+            with open(hooks_file, "w") as f:
+                yaml.dump({"preUI": [{"command": sys.executable, "args": ["-c", "exit(1)"]}]}, f)
+            manager = HookManager(tmpdir, lambda x: None)
+            manager.load_hooks()
+            with pytest.raises(DeadlineOperationError, match="failed with exit code 1"):
+                manager.execute_pre_ui_hooks(self._make_metadata(tmpdir))
+
+    def test_timeout_blocks(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            hooks_file = os.path.join(tmpdir, "hooks.yaml")
+            with open(hooks_file, "w") as f:
+                yaml.dump(
+                    {
+                        "preUI": [
+                            {
+                                "command": sys.executable,
+                                "args": ["-c", "import time; time.sleep(10)"],
+                                "timeout": 1,
+                            }
+                        ]
+                    },
+                    f,
+                )
+            manager = HookManager(tmpdir, lambda x: None)
+            manager.load_hooks()
+            with pytest.raises(DeadlineOperationError, match="timed out"):
+                manager.execute_pre_ui_hooks(self._make_metadata(tmpdir))
+
+    def test_invalid_json_output_raises(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            hooks_file = os.path.join(tmpdir, "hooks.yaml")
+            with open(hooks_file, "w") as f:
+                yaml.dump(
+                    {"preUI": [{"command": sys.executable, "args": ["-c", "print('not json')"]}]},
+                    f,
+                )
+            manager = HookManager(tmpdir, lambda x: None)
+            manager.load_hooks()
+            with pytest.raises(DeadlineOperationError, match="invalid JSON"):
+                manager.execute_pre_ui_hooks(self._make_metadata(tmpdir))
+
+    def test_no_output_returns_empty(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            hooks_file = os.path.join(tmpdir, "hooks.yaml")
+            with open(hooks_file, "w") as f:
+                yaml.dump({"preUI": [{"command": sys.executable, "args": ["-c", "pass"]}]}, f)
+            manager = HookManager(tmpdir, lambda x: None)
+            manager.load_hooks()
+            result = manager.execute_pre_ui_hooks(self._make_metadata(tmpdir))
+            assert result == {}
+
+    def test_deadline_prefix_params_go_to_shared_values(self):
+        """deadline: params land in initial_shared_parameter_values, not initial_settings."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            hooks_file = os.path.join(tmpdir, "hooks.yaml")
+            with open(hooks_file, "w") as f:
+                yaml.dump(
+                    {
+                        "preUI": [
+                            {
+                                "command": sys.executable,
+                                "args": [
+                                    "-c",
+                                    'import json; print(json.dumps({"parameters": {"deadline:priority": 80}}))',
+                                ],
+                            }
+                        ]
+                    },
+                    f,
+                )
+            manager = HookManager(tmpdir, lambda x: None)
+            manager.load_hooks()
+            result = manager.execute_pre_ui_hooks(self._make_metadata(tmpdir))
+            assert result["parameters"]["deadline:priority"] == 80
+
+    def test_confirmation_message_includes_pre_ui(self):
+        from deadline.client.job_bundle._hooks import _generate_hooks_confirmation_message
+
+        hooks = HookConfiguration(
+            version="1.0",
+            pre_ui=[HookDefinition(command="python", args=["prefill.py"])],
+            pre_submission=[],
+            post_submission=[],
+        )
+        message = _generate_hooks_confirmation_message(hooks, "/bundle")
+        assert "Pre-UI hooks:" in message
+        assert "python prefill.py" in message


### PR DESCRIPTION
## Summary

- Adds a new `preUI` hook phase that runs before the job submission dialog opens, allowing studios to pre-populate dialog fields (job name, description, and parameters including `deadline:` prefixed shared job properties) from pipeline context
- Hook output is validated and merged; CLI-supplied `--parameter` values take precedence over hook values
- Gated by existing `allow_bundle_hooks` / `allow_environment_hooks` settings with confirmation prompt unless `auto_accept` is enabled

Based on #1158 by @rickrams with merge conflicts resolved against mainline.

## Test plan

- [x] All 80 hook unit tests pass (`hatch run test --numprocesses=1 -k "test_hooks"`)
- [x] Upstream `test_pre_submission_hook_preserves_job_bundle_dir` test preserved and passing
- [x] All beforeUI test classes preserved and passing