### PR TITLE
fix: dismiss macOS Setup Assistant before DCM E2E test

### DIFF
--- a/.github/workflows/dcm_integration_test_macos.yml
+++ b/.github/workflows/dcm_integration_test_macos.yml
@@ -60,6 +60,15 @@ jobs:
             --monitor-url "https://${MONITOR_SUBDOMAIN}.${MONITOR_REGION}.deadlinecloud.amazonaws.com" \
             --enable-auto-login --set-as-deadline-default
 
+      - name: Dismiss macOS Setup Assistant
+        run: |
+          if pgrep -x "Setup Assistant" > /dev/null 2>&1; then
+            echo "Setup Assistant is running — dismissing it"
+            sudo touch /var/db/.AppleSetupDone
+            sudo killall "Setup Assistant" 2>/dev/null || true
+            sleep 2
+          fi
+
       - name: Run E2E test
         run: python .github/scripts/dcm_e2e_test.py
 


### PR DESCRIPTION
## Summary
- The `macos-latest` GitHub Actions runner occasionally has the macOS Setup Assistant (first-run onboarding wizard) still running, stuck on the "Analytics" consent page.
- This prevents Safari from rendering web content in its accessibility tree, causing the E2E test to timeout after 120s waiting for the IdC sign-in form.
- Added a step to create `/var/db/.AppleSetupDone` (prevents respawn) and kill the Setup Assistant process before running the test.

## Test plan
- ✅ Trigger the workflow manually on this branch via `workflow_dispatch` to verify the fix
-  ✅  Confirm the "Dismiss macOS Setup Assistant" step runs (check logs for "Setup Assistant is running — dismissing it" or a clean no-op if the assistant isn't present)
- ✅  Confirm the E2E test passes end-to-end

Test run on fork: Test run: https://github.com/waninggibbon/deadline-cloud/actions/runs/26469524920/job/77938887894