### PR TITLE
fix: defer timeout validation until focus leaves the row

### DIFF
--- a/src/deadline/client/ui/widgets/job_timeouts_widget.py
+++ b/src/deadline/client/ui/widgets/job_timeouts_widget.py
@@ -10,6 +10,7 @@ from typing import Dict, Optional
 from datetime import timedelta
 
 from qtpy.QtWidgets import (  # type: ignore
+    QApplication as _QApplication,
     QFormLayout,
     QGroupBox,
     QLabel,
@@ -18,7 +19,7 @@ from qtpy.QtWidgets import (  # type: ignore
     QGridLayout,
     QWidget,
 )
-from qtpy.QtCore import Signal
+from qtpy.QtCore import QEvent as _QEvent, Signal, QTimer as _QTimer
 from .._utils import tr
 from ..dataclasses.timeouts import TimeoutTableEntries
 
@@ -39,6 +40,8 @@ class TimeoutEntryWidget(QWidget):
 
     # Signal to indicate any change in the widget
     changed = Signal()
+    # Signal emitted when focus leaves all spinboxes in this row
+    _focus_left = Signal()
 
     def __init__(self, label: str, tooltip: str):
         super().__init__()
@@ -53,14 +56,22 @@ class TimeoutEntryWidget(QWidget):
         self.days_box = QSpinBox(self, minimum=0, maximum=365)
         self.days_box.setSuffix(" days")
         self.days_box.setFixedWidth(90)
+        self.days_box.setKeyboardTracking(False)
 
         self.hours_box = QSpinBox(self, minimum=0, maximum=23)
         self.hours_box.setSuffix(" hours")
         self.hours_box.setFixedWidth(90)
+        self.hours_box.setKeyboardTracking(False)
 
         self.minutes_box = QSpinBox(self, minimum=0, maximum=59)
         self.minutes_box.setSuffix(" minutes")
         self.minutes_box.setFixedWidth(90)
+        self.minutes_box.setKeyboardTracking(False)
+
+        self._spin_boxes = [self.days_box, self.hours_box, self.minutes_box]
+
+        for box in self._spin_boxes:
+            box.installEventFilter(self)
 
         self._build_ui()
         self._connect_signals()
@@ -94,6 +105,23 @@ class TimeoutEntryWidget(QWidget):
         """
         self.update_state()
         self.changed.emit()
+
+    def eventFilter(self, obj, event):
+        """
+        Watches for focus-out on child spinboxes. When focus leaves a spinbox,
+        checks (after Qt processes the focus change) whether the new focus target
+        is still within this row. If not, emits focus_left.
+        """
+        if event.type() == _QEvent.FocusOut and obj in self._spin_boxes:
+            _QTimer.singleShot(0, self._check_focus_left)
+        return super().eventFilter(obj, event)
+
+    def _check_focus_left(self):
+        focus_widget = _QApplication.focusWidget()
+        for box in self._spin_boxes:
+            if focus_widget is box or focus_widget is box.lineEdit():
+                return
+        self._focus_left.emit()
 
     def set_enabled(self, enabled: bool):
         """
@@ -174,21 +202,29 @@ class TimeoutEntryWidget(QWidget):
 
     def update_state(self):
         """
-        Updates the complete state of the row including enabled state, validation indicators,
-        and suffixes based on current values and checkbox state.
+        Updates the non-error state of the row: enabled state, warning icon, and suffixes.
+        Error indicators are cleared immediately when the value becomes valid, but only
+        shown when focus leaves the row (managed by the parent TimeoutTableWidget).
         """
         is_checked = self.checkbox.isChecked()
         if not is_checked:
             self.set_status_icon(WARNING_ICON)
             self.set_error_style(False)
-        elif self.get_timeout_seconds() == 0:
-            self.set_status_icon(ERROR_ICON)
-            self.set_error_style(True)
-        else:
+        elif self.get_timeout_seconds() != 0:
             self.set_status_icon("")
             self.set_error_style(False)
         self.set_enabled(is_checked)
         self.update_suffix()
+
+    def _update_error_state(self):
+        """
+        Updates error indicators based on the current value.
+        Called by the parent widget when focus leaves the row.
+        """
+        is_checked = self.checkbox.isChecked()
+        if is_checked and self.get_timeout_seconds() == 0:
+            self.set_status_icon(ERROR_ICON)
+            self.set_error_style(True)
 
 
 class TimeoutTableWidget(QGroupBox):
@@ -204,7 +240,7 @@ class TimeoutTableWidget(QGroupBox):
     - Individual timeout rows with checkbox activation
     - Time input fields for days, hours, and minutes
     - Visual indicators for warnings and errors
-    - Real-time validation and feedback
+    - Validation on focus-out to avoid premature error display
     - Automatic suffix updates (singular/plural)
     - Comprehensive error messaging
 
@@ -236,7 +272,8 @@ class TimeoutTableWidget(QGroupBox):
             timeout_row = TimeoutEntryWidget(label, entry.tooltip)
             timeouts_layout.addWidget(timeout_row, index, 0, 1, 4)
             self.timeout_rows[label] = timeout_row
-            timeout_row.changed.connect(self._update_ui_state)
+            timeout_row.changed.connect(self._on_row_changed)
+            timeout_row._focus_left.connect(self._update_error_states)
 
         self.error_label = self._create_message_label(ERROR_BG_COLOR)
         self.warning_label = self._create_message_label(WARNING_BG_COLOR)
@@ -268,17 +305,28 @@ class TimeoutTableWidget(QGroupBox):
         label.setWordWrap(True)
         return label
 
-    def _update_ui_state(self):
+    def _on_row_changed(self):
         """
-        Updates the UI state for error and warning messages.
+        Called when any row value changes. Clears errors immediately if the value
+        is now valid, but does not show new errors (that happens on focus-out).
         """
-        self._update_error_states()
+        any_zero = any(
+            row.get_timeout_seconds() == 0 and row.checkbox.isChecked()
+            for row in self.timeout_rows.values()
+        )
+        if not any_zero:
+            self.error_label.setText("")
+            self.error_label.setVisible(False)
         self._update_warning_states()
 
     def _update_error_states(self):
         """
-        Updates the error message label based on validation of all timeout rows.
+        Updates the error message label and per-row error indicators.
+        Called when focus leaves a timeout row.
         """
+        for row in self.timeout_rows.values():
+            row._update_error_state()
+
         any_zero = any(
             row.get_timeout_seconds() == 0 and row.checkbox.isChecked()
             for row in self.timeout_rows.values()
@@ -311,7 +359,8 @@ class TimeoutTableWidget(QGroupBox):
                 row = self.timeout_rows[label]
                 row.checkbox.setChecked(entry.is_activated)
                 row.set_timeout(entry.seconds)
-        self._update_ui_state()
+        self._update_error_states()
+        self._update_warning_states()
 
     def update_settings(self, timeouts: TimeoutTableEntries):
         """

--- a/test/unit/deadline_client/ui/gui/test_gui_job_timeouts.py
+++ b/test/unit/deadline_client/ui/gui/test_gui_job_timeouts.py
@@ -77,8 +77,8 @@ class TestTimeoutEntryWidget:
         assert widget.hours_box.isEnabled()
         assert widget.minutes_box.isEnabled()
 
-    def test_zero_timeout_shows_error_icon(self, qtbot):
-        """Verify error icon appears when timeout is zero and checkbox is checked."""
+    def test_zero_timeout_does_not_show_error_immediately(self, qtbot):
+        """Verify error icon does NOT appear immediately when timeout becomes zero."""
         widget = TimeoutEntryWidget("Test timeout", "A test tooltip")
         qtbot.addWidget(widget)
 
@@ -87,7 +87,36 @@ class TestTimeoutEntryWidget:
         widget.minutes_box.setValue(0)
         widget.update_state()
 
+        assert widget.status_icon.text() != ERROR_ICON
+
+    def test_zero_timeout_shows_error_after_focus_leave(self, qtbot):
+        """Verify error icon appears after _update_error_state is called (focus left)."""
+        widget = TimeoutEntryWidget("Test timeout", "A test tooltip")
+        qtbot.addWidget(widget)
+
+        widget.days_box.setValue(0)
+        widget.hours_box.setValue(0)
+        widget.minutes_box.setValue(0)
+        widget._update_error_state()
+
         assert widget.status_icon.text() == ERROR_ICON
+
+    def test_nonzero_timeout_clears_error_immediately(self, qtbot):
+        """Verify error clears as soon as the value becomes non-zero."""
+        widget = TimeoutEntryWidget("Test timeout", "A test tooltip")
+        qtbot.addWidget(widget)
+
+        # First, put into error state
+        widget.days_box.setValue(0)
+        widget.hours_box.setValue(0)
+        widget.minutes_box.setValue(0)
+        widget._update_error_state()
+        assert widget.status_icon.text() == ERROR_ICON
+
+        # Now set a valid value - error should clear immediately via update_state
+        widget.minutes_box.setValue(30)
+        widget.update_state()
+        assert widget.status_icon.text() == ""
 
     def test_unchecked_shows_warning_icon(self, qtbot):
         """Verify warning icon appears when checkbox is unchecked."""
@@ -147,23 +176,61 @@ class TestTimeoutTableWidget:
 
         assert row.get_timeout_seconds() == 7200
 
-    def test_error_label_visible_for_zero_timeout(self, qtbot):
-        """Verify error message appears when an active timeout is zero."""
+    def test_error_label_not_visible_on_zero_without_focus_leave(self, qtbot):
+        """Verify error message does NOT appear when timeout is set to zero mid-edit."""
         timeouts = _make_timeouts(**{"Task timeout": {"seconds": 3600}})
         widget = TimeoutTableWidget(timeouts=timeouts)
         qtbot.addWidget(widget)
         widget.show()
 
-        # Set timeout to zero while checked
+        row = widget.timeout_rows["Task timeout"]
+        row.days_box.setValue(0)
+        row.hours_box.setValue(0)
+        row.minutes_box.setValue(0)
+
+        assert not widget.error_label.isVisible()
+
+    def test_error_label_visible_after_focus_leave(self, qtbot):
+        """Verify error message appears when focus leaves a row with zero timeout."""
+        timeouts = _make_timeouts(**{"Task timeout": {"seconds": 3600}})
+        widget = TimeoutTableWidget(timeouts=timeouts)
+        qtbot.addWidget(widget)
+        widget.show()
+
         row = widget.timeout_rows["Task timeout"]
         row.days_box.setValue(0)
         row.hours_box.setValue(0)
         row.minutes_box.setValue(0)
         row.checkbox.setChecked(True)
-        row._on_change()
+
+        # Simulate focus leaving the row
+        widget._update_error_states()
 
         assert widget.error_label.isVisible()
         assert "zero" in widget.error_label.text().lower()
+
+    def test_error_label_clears_when_value_becomes_valid(self, qtbot):
+        """Verify error message clears immediately when timeout becomes non-zero."""
+        timeouts = _make_timeouts(**{"Task timeout": {"seconds": 3600}})
+        widget = TimeoutTableWidget(timeouts=timeouts)
+        qtbot.addWidget(widget)
+        widget.show()
+
+        row = widget.timeout_rows["Task timeout"]
+        row.days_box.setValue(0)
+        row.hours_box.setValue(0)
+        row.minutes_box.setValue(0)
+        row.checkbox.setChecked(True)
+
+        # Put into error state
+        widget._update_error_states()
+        assert widget.error_label.isVisible()
+
+        # Fix the value - error should clear immediately via _on_row_changed
+        row.minutes_box.setValue(30)
+        row._on_change()
+
+        assert not widget.error_label.isVisible()
 
     def test_warning_label_visible_when_deactivated(self, qtbot):
         """Verify warning message appears when a timeout is deactivated."""


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Validation for zero-value timeouts was triggering immediately on any spinbox value change, causing error indicators to flash while the user was still editing across the days/hours/minutes fields within a single timeout row. For example, if a user had a 1 hour timeout and wanted to change it to 30 minutes, clearing the hours field would immediately show the "Timeout cannot be set to zero" error before they had a chance to set the minutes value.

### What was the solution? (How)

- Added an event filter on the timeout row's spinboxes that detects when focus leaves the entire row (rather than just moving between sibling fields within the same row)
- Error indicators are now only shown after focus leaves the row via a `focus_left` signal
- Errors clear immediately when the value becomes non-zero (no delay for clearing valid state)
- Added `setKeyboardTracking(False)` to the spinboxes to prevent `valueChanged` from firing on every keystroke, matching the existing pattern used by `FloatDragSpinBox` in `spinbox_widgets.py`

### What is the impact of this change?

Improved UX for DCC submitter plugins that embed `TimeoutTableWidget`. Users will no longer see premature error messages while actively editing timeout values across multiple fields.

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests? Yes — 19/19 GUI unit tests pass (`hatch run test test/unit/deadline_client/ui/gui/test_gui_job_timeouts.py`)
- Have you run the integration tests? Not applicable — this change is UI-only with no AWS API interaction.

Additionally, manually verified the fix by embedding the `TimeoutTableWidget` in the dev GUI (`deadline-dev-gui`) and confirming:
1. Error does not appear when clearing a field and moving to another field within the same row
2. Error appears after focus leaves the row with all fields at zero
3. Error clears immediately when any field becomes non-zero

### Was this change documented?

- Are relevant docstrings in the code base updated? Yes — docstrings on `update_state()`, `update_error_state()`, and `TimeoutTableWidget` class updated to reflect the new validation behavior.
- Has the README.md been updated? No — no CLI or public API changes.

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?

No. The `TimeoutTableWidget` and `TimeoutEntryWidget` public APIs are unchanged. The only behavioral change is the timing of when error indicators are displayed — validation still occurs, just deferred until focus leaves the row.

### Does this change impact security?

- Does the change need to be threat modeled? No — this is a purely cosmetic/UX change to when visual error indicators appear. No files, directories, or permissions are modified.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*