### PR TITLE
feat: consume monitor session_id in telemetry for cross-component cor…

### DIFF
--- a/src/deadline/client/api/_telemetry.py
+++ b/src/deadline/client/api/_telemetry.py
@@ -188,6 +188,11 @@ class TelemetryClient:
         if monitor_id:
             self._system_metadata["monitor_id"] = monitor_id
 
+        monitor_session_id = self._get_monitor_session_id(config=config)
+        if monitor_session_id:
+            self._common_details["monitor_session_id"] = monitor_session_id
+            logger.debug("Telemetry using monitor_session_id: %s", monitor_session_id)
+
         self._initialized = True
         self._start_threads()
 
@@ -231,6 +236,29 @@ class TelemetryClient:
             identifier = str(uuid.uuid4())
             config_file.set_setting("telemetry.identifier", identifier)
         return identifier
+
+    _MONITOR_CONFIG_SECTION = "deadline-cloud-monitor"
+
+    def _get_monitor_session_id(self, config: Optional[ConfigParser] = None) -> Optional[str]:
+        """Reads the Monitor session_id from the deadline config if available."""
+        try:
+            deadline_config = config if config is not None else config_file.read_config()
+            profile_name = config_file.get_setting(
+                "defaults.aws_profile_name", config=deadline_config
+            )
+
+            profile_section = f"profile-{profile_name} {self._MONITOR_CONFIG_SECTION}"
+            session_id = deadline_config.get(profile_section, "session_id", fallback=None)
+            if session_id:
+                return session_id
+
+            return (
+                deadline_config.get(self._MONITOR_CONFIG_SECTION, "session_id", fallback=None)
+                or None
+            )
+        except Exception:
+            logger.debug("Could not read monitor session_id", exc_info=True)
+            return None
 
     def _start_threads(self) -> None:
         """Set up background threads for shutdown checking and request sending"""

--- a/test/unit/deadline_client/api/test_api_telemetry.py
+++ b/test/unit/deadline_client/api/test_api_telemetry.py
@@ -906,3 +906,81 @@ def test_process_event_queue_thread_skips_account_id_when_resolution_fails(
 
     resolve_mock.assert_called_once()
     assert "accountId" not in mock_telemetry_client._common_details
+
+
+class TestGetMonitorSessionId:
+    """Tests for TelemetryClient._get_monitor_session_id"""
+
+    @pytest.fixture
+    def make_client(self, fresh_deadline_config):
+        """Creates a TelemetryClient with telemetry internals patched out."""
+
+        def _make():
+            with patch.object(api.TelemetryClient, "_start_threads"), patch.object(
+                api._telemetry, "get_monitor_id", return_value=None
+            ), patch.object(
+                api._telemetry, "get_user_and_identity_store_id", return_value=(None, None)
+            ), patch.object(
+                api._telemetry,
+                "get_deadline_endpoint_url",
+                return_value="https://fake-endpoint",
+            ):
+                return TelemetryClient(
+                    package_name="deadline-cloud-library",
+                    package_ver="0.1.2",
+                    config=config.config_file.read_config(),
+                )
+
+        return _make
+
+    def test_reads_profile_scoped_session_id(self, fresh_deadline_config, make_client):
+        """When a profile-scoped monitor session_id exists, it is returned."""
+        config.set_setting("defaults.aws_profile_name", "my-profile-us-west-2")
+        deadline_config = config.config_file.read_config()
+        deadline_config["profile-my-profile-us-west-2 deadline-cloud-monitor"] = {
+            "session_id": "abc123"
+        }
+        config.config_file.write_config(deadline_config)
+
+        client = make_client()
+        assert client._common_details.get("monitor_session_id") == "abc123"
+
+    def test_falls_back_to_global_section(self, fresh_deadline_config, make_client):
+        """When no profile-scoped section exists, falls back to [deadline-cloud-monitor]."""
+        config.set_setting("defaults.aws_profile_name", "my-profile-us-west-2")
+        deadline_config = config.config_file.read_config()
+        deadline_config["deadline-cloud-monitor"] = {"session_id": "global-session-456"}
+        config.config_file.write_config(deadline_config)
+
+        client = make_client()
+        assert client._common_details.get("monitor_session_id") == "global-session-456"
+
+    def test_profile_scoped_takes_precedence_over_global(self, fresh_deadline_config, make_client):
+        """Profile-scoped session_id is preferred over the global one."""
+        config.set_setting("defaults.aws_profile_name", "my-profile-us-west-2")
+        deadline_config = config.config_file.read_config()
+        deadline_config["deadline-cloud-monitor"] = {"session_id": "global-session"}
+        deadline_config["profile-my-profile-us-west-2 deadline-cloud-monitor"] = {
+            "session_id": "profile-session"
+        }
+        config.config_file.write_config(deadline_config)
+
+        client = make_client()
+        assert client._common_details.get("monitor_session_id") == "profile-session"
+
+    def test_no_session_id_when_not_configured(self, fresh_deadline_config, make_client):
+        """When no monitor session_id is in the config, it is not added to common details."""
+        config.set_setting("defaults.aws_profile_name", "my-profile-us-west-2")
+
+        client = make_client()
+        assert "monitor_session_id" not in client._common_details
+
+    def test_empty_session_id_treated_as_absent(self, fresh_deadline_config, make_client):
+        """An empty session_id value in config is treated as absent."""
+        config.set_setting("defaults.aws_profile_name", "my-profile-us-west-2")
+        deadline_config = config.config_file.read_config()
+        deadline_config["profile-my-profile-us-west-2 deadline-cloud-monitor"] = {"session_id": ""}
+        config.config_file.write_config(deadline_config)
+
+        client = make_client()
+        assert "monitor_session_id" not in client._common_details


### PR DESCRIPTION
## Summary

Consume the Monitor session_id from `~/.deadline/config` in CLI telemetry for cross-component session correlation.

Read the Monitor's session_id from ~/.deadline/config and include it as 'monitor_session_id' in telemetry event details. This enables correlating CLI/library telemetry events with the same IDC session used by Monitor and CTDX. Profile-scoped section is checked first, falling back to global.

### What was the problem/requirement? (What/Why)

Monitor and CTDX now write a shared `session_id` (derived from the IDC session token) to `~/.deadline/config` (see CR-276445103). The CLI had no way to correlate its telemetry events with the same session, making cross-component session tracking impossible.

### What was the solution? (How)

During `TelemetryClient.initialize()`, read the `session_id` from the deadline config. Check the profile-scoped section (`[profile-{name} deadline-cloud-monitor]`) first, then fall back to the global `[deadline-cloud-monitor]` section. If found, include it as `monitor_session_id` in telemetry event common details so it appears in every outgoing RUM payload alongside the existing per-process `sessionId`.

### What is the impact of this change?

- Telemetry events from the CLI now include a `monitor_session_id` field in event details when a Monitor session is active
- The existing per-process `sessionId` in `UserDetails` is unchanged — no loss of per-invocation granularity
- If no monitor session_id exists in config (e.g., HOST_PROVIDED credentials path), the field is simply omitted

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests? Yes — 4 new tests added covering profile-scoped lookup, global fallback, precedence, and absent config. All 64 telemetry tests pass.
- Have you run the integration tests? Tested locally with a dev build of CTDX writing session_id to config, confirmed via INFO-level logging that the CLI picks it up.

### Was this change documented?

- Are relevant docstrings in the code base updated? Yes — `_get_monitor_session_id` has a docstring.
- Has the README.md been updated? No changes needed — no CLI argument or public API changes.

### Does this PR introduce new dependencies?

*   [x] This PR does not add any new dependencies.

### Is this a breaking change?

No. This is additive — a new field in telemetry event details. No public API or CLI contract changes.

### Does this change impact security?

No. The `session_id` is a one-way SHA256 hash of the IDC token (first 32 hex chars). It cannot be used to derive the original token. It is read from a file that already exists with user-only permissions.
