### PR TITLE
test: bump UI test STARTUP_TIMEOUT to 45s to reduce CI flakiness 

### DIFF
--- a/test/ui/helpers.py
+++ b/test/ui/helpers.py
@@ -24,7 +24,7 @@ import xa11y
 # Tuned for mock-backend runs over localhost HTTP. Generous ceilings
 # because Qt/AT-SPI startup under Xvfb on Linux CI and Windows UIA can
 # be substantially slower than a developer workstation.
-STARTUP_TIMEOUT = 15.0
+STARTUP_TIMEOUT = 45.0
 CLOSE_TIMEOUT = 10.0
 TERMINATE_TIMEOUT = 3.0
 SUBMIT_TIMEOUT = 20.0


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The submitter/config GUI launch waits for the Qt window to register in the OS accessibility tree before setup completes. On cold Windows CI runners this occasionally exceeds the 15s ceiling (e.g. 15.4s observed), causing fixture-setup TimeoutErrors that surface as flaky test errors even though nothing is functionally wrong.

### What was the solution? (How)
 Raise the timeout to 45s.

### What is the impact of this change?
Fewer test flakes

### How was this change tested?
CI

### Was this change documented?
n/a

### Does this PR introduce new dependencies?
No

### Is this a breaking change?
No

### Does this change impact security?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
