### PR TITLE
test: fix nondeterministic xdist test collection (KeyError on Py3.14)

### DIFF
--- a/test/unit/deadline_client/ui/widgets/__init__.py
+++ b/test/unit/deadline_client/ui/widgets/__init__.py
@@ -1,0 +1,1 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/test/unit/deadline_client/ui/widgets/test_openjd_parameters_widget.py
+++ b/test/unit/deadline_client/ui/widgets/test_openjd_parameters_widget.py
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 import pytest
-from conftest import STRING_FIELD_MAX_LENGTH
+from .conftest import STRING_FIELD_MAX_LENGTH
 from pathlib import Path
 
 try:

--- a/test/unit/deadline_mcp/__init__.py
+++ b/test/unit/deadline_mcp/__init__.py
@@ -1,0 +1,1 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.


### PR DESCRIPTION
Fixes: *N/A (pre-existing CI flake)*

### What was the problem/requirement? (What/Why)

Intermittent CI failures on the Python 3.14 leg during test collection:

```
KeyError: 'unit.deadline_client.ui.test_translations'
Different tests were collected between gw1 and gw0.
```

The `test/unit` package tree was inconsistently rooted — every dir had an `__init__.py` except `test/unit/deadline_client/ui/widgets/` and `test/unit/deadline_mcp/`. With `pythonpath=["test"]` + prepend import mode, modules in those dirs got bare names, so `deadline_mcp/test_mcp.py` collided with `deadline_client/api/test_mcp.py` (duplicate basename). Under parallel xdist workers collection order became nondeterministic, and Python 3.14's new `sys.modules.pop()` in `_load_unlocked` turned the collision into a collection-time `KeyError`.

### What was the solution? (How)

Made both directories proper packages (added `__init__.py`) so every test module gets a unique, fully-qualified `unit.*` name. Updated the one bare `from conftest import ...` in `test_openjd_parameters_widget.py` to relative `from .conftest import ...`.

### What is the impact of this change?

Stable, deterministic test collection under xdist. Tests-only change; no runtime/library impact.

### How was this change tested?

- [x] Unit tests — full `test/unit` collection under `pytest -n auto` is stable at 2434 tests across repeated runs with no `KeyError` and no worker divergence; previously-failing `test_translations.py` and the widgets suite pass.
- [ ] Integration tests — not applicable.

### Was this change documented?

No code/CLI behavior changed; no docs update needed.

### Does this PR introduce new dependencies?

*   [x] This PR does not add any new dependencies.

### Is this a breaking change?

No.

### Does this change impact security?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
