### PR TITLE
test(dcm-e2e): retry on IdC /platform/authorize 403 and prewarm Firefox

### DIFF
--- a/.github/scripts/dcm_e2e_test.py
+++ b/.github/scripts/dcm_e2e_test.py
@@ -83,6 +83,42 @@ def browser():
     fail(f"browser {BROWSER_NAME!r} not found; apps: {[a.name for a in xa11y.App.list()]}")
 
 
+def prewarm_browser():
+    """Launch Firefox with about:blank so the cold-start (profile init, privacy
+    notice tab) doesn't run inside the IdC PAR token's short TTL window.
+
+    DCM's xdg-open later invokes `firefox <auth-url>`, which the running Firefox
+    handles as a new tab in O(ms) instead of a fresh process taking seconds.
+    """
+    if not IS_LINUX:
+        return
+    subprocess.Popen(
+        ["firefox", "about:blank"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        stdin=subprocess.DEVNULL,
+    )
+    try:
+        browser()
+    except Exception as e:
+        print(f"prewarm: browser app not detected: {e}", flush=True)
+        return
+    time.sleep(3)
+    print("prewarm: Firefox is running and idle on about:blank", flush=True)
+
+
+def is_on_403_page(br):
+    """True if a '403 Forbidden' heading is visible in the browser. The IdC
+    /platform/authorize PAR token is single-use and short-lived; if Firefox is
+    slow to GET it (cold start, privacy-notice tab), AWS responds 403 and the
+    only recovery is to restart `deadline auth login` to mint a new one."""
+    try:
+        br.locator("heading[name='403 Forbidden']").wait_visible(timeout=2)
+        return True
+    except Exception:
+        return False
+
+
 def click_open_link(br):
     """Click the browser's 'Open this link in Deadline Cloud monitor?' dialog."""
     for label in OPEN_LINK_LABELS:
@@ -115,6 +151,8 @@ def _type_into(locator, text):
 
 
 def sign_in():
+    """Drive the IdC sign-in flow. Returns True on success, False if the IdC
+    /platform/authorize page returned 403 (caller should restart the login)."""
     br = browser()
     # Dismiss any first-run welcome screens (Edge has several layered ones)
     for _ in range(6):
@@ -140,6 +178,8 @@ def sign_in():
                 pass
         if not dismissed:
             break
+    if is_on_403_page(br):
+        return False
     user = br.locator("text_field[name='Username']")
     user.wait_visible(timeout=120)
     _type_into(user, USERNAME)
@@ -159,23 +199,34 @@ def sign_in():
     end = time.time() + 60
     while time.time() < end:
         if click_open_link(br):
-            return
+            return True
         time.sleep(1)
     print("No Open Link dialog appeared (browser may have auto-dispatched the scheme)", flush=True)
+    return True
 
 
 def main():
-    cli = subprocess.Popen(["deadline", "auth", "login"])
-    print(f"auth login pid={cli.pid}", flush=True)
-    try:
-        time.sleep(10)
-        sign_in()
-        cli.wait(timeout=180)
-        if cli.returncode:
-            fail(f"auth login failed: {cli.returncode}")
-    finally:
-        if cli.poll() is None:
-            cli.kill()
+    prewarm_browser()
+
+    max_attempts = 3
+    for attempt in range(1, max_attempts + 1):
+        cli = subprocess.Popen(["deadline", "auth", "login"])
+        print(f"auth login attempt {attempt}/{max_attempts} pid={cli.pid}", flush=True)
+        try:
+            time.sleep(10)
+            if sign_in():
+                cli.wait(timeout=180)
+                if cli.returncode:
+                    fail(f"auth login failed: {cli.returncode}")
+                break
+            screenshot(f"403_attempt_{attempt}")
+            print(f"attempt {attempt}: IdC returned 403, restarting login", flush=True)
+        finally:
+            if cli.poll() is None:
+                cli.kill()
+        time.sleep(5)
+    else:
+        fail(f"IdC /platform/authorize returned 403 on all {max_attempts} attempts")
 
     run(["deadline", "auth", "status"])
     run(["deadline", "farm", "list"])


### PR DESCRIPTION
The Linux DCM E2E test intermittently fails because the IdC PAR request_uri in /platform/authorize is single-use and short-lived. On a cold-start runner, Firefox spends seconds initialising the profile and rendering the privacy notice tab, so the actual GET of the auth URL arrives after the token is already consumed/expired and AWS responds 403.

- Prewarm Firefox with about:blank before 'deadline auth login' so DCM's xdg-open hits an already-running browser instead of cold-starting one.
- Detect the 403 page in sign_in() and bubble the failure up so main() can kill the CLI, restart 'deadline auth login' to mint a fresh PAR, and retry up to 3 times before failing.
- Save a screenshot on each 403 attempt for diagnostics.

Fixes: *<insert link to GitHub issue here>*

### What was the problem/requirement? (What/Why)

The `DCM Integration Tests` workflow (`.github/workflows/dcm_integration_test_linux.yml`) is a flaky status check on `mainline` — see failing run [26973252525](https://github.com/aws-deadline/deadline-cloud/actions/runs/26973252525) and prior failures on 2026-06-03 and 2026-05-26. Recent ratio is roughly 4 failures in the last 13 runs, all on the Linux job; macOS and Windows pass.

In every failure, the captured Firefox window is parked on a `403 Forbidden` page at `us-west-2.signin.aws/platform/authorize?...&request_uri=urn:ietf:params:oauth:request_uri:...`. That `request_uri` is a [PAR](https://datatracker.ietf.org/doc/html/rfc9126) (Pushed Authorization Request) token that DCM mints by calling IAM Identity Center's `/par` endpoint immediately before invoking `xdg-open` against the auth URL. PAR tokens are single-use and short-lived (~90s).

On a cold-start GitHub runner the gap between DCM minting the PAR and Firefox actually issuing the GET is large enough — Firefox is starting from scratch, initializing a fresh profile, and rendering both the auth tab and the first-run privacy-notice tab — that the token has been consumed/expired by the time IdC sees the request, and AWS responds 403. Once the test arrives at a 403 page, no amount of retrying within `xa11y` recovers it; the only fix is to mint a new PAR by restarting `deadline auth login`.

### What was the solution? (How)

Two complementary changes in `.github/scripts/dcm_e2e_test.py`:

1. **Prewarm Firefox** before the first `deadline auth login`. Launch `firefox about:blank` and wait for the app to register with AT-SPI, so DCM's later `xdg-open <auth-url>` is handled by an already-running Firefox in O(ms) instead of triggering a cold start. This addresses the dominant cause of PAR-token expiry. Linux-only; no-op on macOS/Windows.
2. **Detect-and-retry on 403**. `sign_in()` now checks for a `heading[name='403 Forbidden']` early in its flow (before the 120s wait on the username field) and returns `False` when seen. `main()` wraps the login attempt in a 3-iteration loop: on `False`, kill the running `deadline auth login` (so the consumed PAR is discarded), screenshot for diagnostics, sleep 5s, and start a fresh login that mints a new PAR. The original CLI-process kill semantics in the `finally` block are preserved.

### What is the impact of this change?

- Reduces `DCM Integration Tests` flake rate. Any single run still hits the cold-start path occasionally, but the retry now masks it.
- No change to the test's success criteria (`deadline auth status`, `deadline farm list`).
- No production code touched. Test-only change scoped to one file.
- Worst case if all 3 attempts hit a real 403 (e.g. legitimate IdC-side rejection): test fails, screenshots from each attempt are uploaded, and the failure is more diagnosable than before because we save 1–3 attempt screenshots instead of just the final state.

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests? **N/A** — this is a CI test-harness script with no unit-test coverage.
- Have you run the integration tests? **Not locally** — the failure mode is Linux-specific (Firefox cold start on a fresh runner) and doesn't reproduce on macOS. Validation was deferred to a CI run of `DCM Integration Test (Linux)` against this branch. Static checks performed: `python -m py_compile .github/scripts/dcm_e2e_test.py`.

### Was this change documented?

- Are relevant docstrings in the code base updated? **Yes** — added module-level docstrings on `prewarm_browser()`, `is_on_403_page()`, and updated `sign_in()`'s docstring to describe the new return contract.
- Has the README.md been updated? **No** — no user-facing CLI surface changed.

### Does this PR introduce new dependencies?

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?

No. CI test harness only; no public Python API, CLI surface, on-disk format, or wire protocol is touched.

### Does this change impact security?

No. The PAR-token retry happens entirely client-side against an existing IdC endpoint; no new files, sockets, credentials, or trust boundaries are introduced. The `MONITOR_USERNAME` / `MONITOR_PASSWORD` env-var contract is unchanged.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
