### PR TITLE
chore: apply default client config to remaining boto clients

### DIFF
--- a/src/deadline/client/api/_job_monitoring.py
+++ b/src/deadline/client/api/_job_monitoring.py
@@ -17,6 +17,7 @@ from deadline.client.exceptions import DeadlineOperationError, DeadlineOperation
 from deadline.client.api._session import (
     get_boto3_client,
     get_boto3_session,
+    get_default_client_config,
     get_queue_user_boto3_session,
     get_user_and_identity_store_id,
 )
@@ -303,7 +304,7 @@ def get_session_logs(
             queue_session = get_queue_user_boto3_session(
                 deadline=deadline, config=config, farm_id=farm_id, queue_id=queue_id
             )
-            logs_client = queue_session.client("logs")
+            logs_client = queue_session.client("logs", config=get_default_client_config())
         except Exception as e:
             raise DeadlineOperationError(f"Failed to get queue credentials: {e}")
     else:
@@ -441,7 +442,9 @@ def get_worker_logs(
                 aws_session_token=credentials["sessionToken"],
             )
             logs_client = fleet_session.client(
-                "logs", region_name=get_boto3_session(config=config).region_name
+                "logs",
+                region_name=get_boto3_session(config=config).region_name,
+                config=get_default_client_config(),
             )
         except Exception as e:
             raise DeadlineOperationError(f"Failed to get fleet credentials: {e}")

--- a/src/deadline/client/cli/_groups/attachment_group.py
+++ b/src/deadline/client/cli/_groups/attachment_group.py
@@ -19,6 +19,7 @@ from ...config import config_file
 from .._main import deadline as main
 
 from ... import api
+from ...api._session import get_default_client_config
 from ....job_attachments.api.attachment import (
     _attachment_download,
     _attachment_upload,
@@ -122,7 +123,7 @@ def attachment_download(
 
         s3_root_uri = s3_settings.to_s3_root_uri()
 
-        deadline_client = boto3_session.client("deadline")
+        deadline_client = boto3_session.client("deadline", config=get_default_client_config())
         boto3_session = api.get_queue_user_boto3_session(deadline=deadline_client, config=config)
 
     if not s3_root_uri:
@@ -224,7 +225,7 @@ def attachment_upload(
 
         s3_root_uri = s3_settings.to_s3_root_uri()
 
-        deadline_client = boto3_session.client("deadline")
+        deadline_client = boto3_session.client("deadline", config=get_default_client_config())
         boto3_session = api.get_queue_user_boto3_session(deadline=deadline_client, config=config)
 
     if not s3_root_uri:

--- a/test/unit/deadline_client/api/test_job_monitoring.py
+++ b/test/unit/deadline_client/api/test_job_monitoring.py
@@ -5,7 +5,7 @@ Tests for the job monitoring API functions.
 """
 
 import datetime
-from unittest.mock import patch, MagicMock
+from unittest.mock import ANY, patch, MagicMock
 import pytest
 
 from deadline.client.api._job_monitoring import (
@@ -553,7 +553,7 @@ def test_get_session_logs_with_monitor_credentials():
         )
 
         # Verify the logs client was created from the queue session
-        queue_session_mock.client.assert_called_once_with("logs")
+        queue_session_mock.client.assert_called_once_with("logs", config=ANY)
 
         # Verify the logs client was called with correct parameters
         logs_client_mock.get_log_events.assert_called_once_with(
@@ -803,7 +803,9 @@ def test_get_worker_logs_with_monitor_credentials():
             aws_secret_access_key="secret",
             aws_session_token="token",
         )
-        fleet_session_mock.client.assert_called_once_with("logs", region_name="us-west-2")
+        fleet_session_mock.client.assert_called_once_with(
+            "logs", region_name="us-west-2", config=ANY
+        )
 
 
 def test_get_worker_logs_resource_not_found():


### PR DESCRIPTION
Fixes: #814

### What was the problem/requirement? (What/Why)
Several boto clients were created directly off a session without the default client config, so they missed the user-agent attribution (app/deadline-client version, submitter, and CLI command name) that get_default_client_config() adds.

### What was the solution? (How)
Pass config=get_default_client_config() at the remaining bare client construction sites.

### What is the impact of this change?
Better tracking of submitter to API requests

### How was this change tested?
Coverlay. And some manual testing.

### Was this change documented?
n/a

### Does this PR introduce new dependencies?
No

### Is this a breaking change?
No

### Does this change impact security?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
