### PR TITLE
fix: populate host requirements from job template in gui-submit

### DIFF
--- a/src/deadline/client/ui/dataclasses/__init__.py
+++ b/src/deadline/client/ui/dataclasses/__init__.py
@@ -19,7 +19,7 @@ __all__ = [
 
 import os
 from dataclasses import dataclass, field
-from typing import Literal, Dict, List, Union
+from typing import Any, Literal, Dict, List, Optional, Union
 
 from ...job_bundle.parameters import JobParameter
 
@@ -347,9 +347,9 @@ class HostRequirements:
     Settings for a HostRequirementsWidget.
     """
 
-    os_requirements: OsRequirements = field(default=None)
-    hardware_requirements: HardwareRequirements = field(default=None)
-    custom_requirements: CustomRequirements = field(default=None)
+    os_requirements: Optional[OsRequirements] = field(default=None)
+    hardware_requirements: Optional[HardwareRequirements] = field(default=None)
+    custom_requirements: Optional[CustomRequirements] = field(default=None)
 
     def __post_init__(self):
         if isinstance(self.os_requirements, dict):
@@ -359,6 +359,95 @@ class HostRequirements:
         if isinstance(self.custom_requirements, dict):
             self.custom_requirements = CustomRequirements(**self.custom_requirements)
 
+    # Maps a well-known OpenJD "amount.worker.*" capability name to the pair of
+    # HardwareRequirements fields (min field, max field) it populates.
+    _HARDWARE_AMOUNTS = {
+        "amount.worker.vcpu": ("cpu_min", "cpu_max"),
+        "amount.worker.memory": ("memory_min", "memory_max"),
+        "amount.worker.gpu": ("acceleration_min", "acceleration_max"),
+        "amount.worker.gpu.memory": ("acceleration_memory_min", "acceleration_memory_max"),
+        "amount.worker.disk.scratch": ("scratch_space_min", "scratch_space_max"),
+    }
+    # The well-known OS/CPU attribute capability names.
+    _OS_FAMILY_ATTRIBUTE = "attr.worker.os.family"
+    _CPU_ARCH_ATTRIBUTE = "attr.worker.cpu.arch"
+    # Prefixes for custom (user-defined) capabilities. OpenJD reserves the
+    # "amount.worker."/"attr.worker." namespace for its own defined capabilities,
+    # so custom capabilities use the bare "amount."/"attr." prefix (this matches
+    # what the host requirements widget emits when serializing custom entries).
+    _CUSTOM_AMOUNT_PREFIX = "amount."
+    _CUSTOM_ATTRIBUTE_PREFIX = "attr."
+
+    @classmethod
+    def from_dict(cls, requirements: Dict[str, Any]) -> "HostRequirements":
+        """
+        Build a HostRequirements from an OpenJD step "hostRequirements" dict, the
+        inverse of serialize(). Well-known os/cpu attributes and the standard
+        hardware amounts populate the OS and hardware sections; everything else
+        becomes a custom requirement.
+        """
+        operating_systems: List[str] = []
+        cpu_archs: List[str] = []
+        hardware_fields: Dict[str, int] = {}
+        custom_amounts: List[CustomAmountRequirement] = []
+        custom_attributes: List[CustomAttributeRequirement] = []
+
+        for amount in (requirements or {}).get("amounts", []):
+            name = amount.get("name", "")
+            if name in cls._HARDWARE_AMOUNTS:
+                min_field, max_field = cls._HARDWARE_AMOUNTS[name]
+                if "min" in amount:
+                    hardware_fields[min_field] = amount["min"]
+                if "max" in amount:
+                    hardware_fields[max_field] = amount["max"]
+            elif name.startswith(cls._CUSTOM_AMOUNT_PREFIX):
+                custom_amounts.append(
+                    CustomAmountRequirement(
+                        name=name[len(cls._CUSTOM_AMOUNT_PREFIX) :],
+                        min=amount.get("min", CustomAmountRequirement.DEFAULT_VALUE),
+                        max=amount.get("max", CustomAmountRequirement.DEFAULT_VALUE),
+                    )
+                )
+
+        for attribute in (requirements or {}).get("attributes", []):
+            name = attribute.get("name", "")
+            option = (
+                CustomAttributeRequirement.ANY_OF
+                if "anyOf" in attribute
+                else (CustomAttributeRequirement.ALL_OF)
+            )
+            values = attribute.get(option, [])
+            if name == cls._OS_FAMILY_ATTRIBUTE:
+                operating_systems = list(values)
+            elif name == cls._CPU_ARCH_ATTRIBUTE:
+                cpu_archs = list(values)
+            elif name.startswith(cls._CUSTOM_ATTRIBUTE_PREFIX):
+                custom_attributes.append(
+                    CustomAttributeRequirement(
+                        name=name[len(cls._CUSTOM_ATTRIBUTE_PREFIX) :],
+                        option=option,
+                        values=list(values),
+                    )
+                )
+
+        os_requirements = (
+            OsRequirements(operating_systems=operating_systems, cpu_archs=cpu_archs)  # type: ignore[arg-type]
+            if operating_systems or cpu_archs
+            else None
+        )
+        hardware_requirements = HardwareRequirements(**hardware_fields) if hardware_fields else None
+        custom_requirements = (
+            CustomRequirements(amounts=custom_amounts, attributes=custom_attributes)
+            if custom_amounts or custom_attributes
+            else None
+        )
+
+        return cls(
+            os_requirements=os_requirements,
+            hardware_requirements=hardware_requirements,
+            custom_requirements=custom_requirements,
+        )
+
     def serialize(self) -> dict:
         requirements: Dict[str, Union[List[str], List[int]]] = {}
         if self.os_requirements is not None:
@@ -367,10 +456,11 @@ class HostRequirements:
         if self.hardware_requirements:
             requirements.setdefault("amounts", []).extend(self.hardware_requirements.serialize())
 
-        custom_requirements = self.custom_requirements.serialize()
-        if custom_requirements.get("amounts", []):
-            requirements.setdefault("amounts", []).extend(custom_requirements["amounts"])
-        if custom_requirements.get("attributes", []):
-            requirements.setdefault("attributes", []).extend(custom_requirements["attributes"])
+        if self.custom_requirements is not None:
+            custom_requirements = self.custom_requirements.serialize()
+            if custom_requirements.get("amounts", []):
+                requirements.setdefault("amounts", []).extend(custom_requirements["amounts"])
+            if custom_requirements.get("attributes", []):
+                requirements.setdefault("attributes", []).extend(custom_requirements["attributes"])
 
         return requirements

--- a/src/deadline/client/ui/job_bundle_submitter.py
+++ b/src/deadline/client/ui/job_bundle_submitter.py
@@ -39,7 +39,7 @@ from ..job_bundle.parameters import (
     read_job_bundle_parameters,
     validate_job_parameter_value,
 )
-from .dataclasses import JobBundleSettings
+from .dataclasses import HostRequirements, JobBundleSettings
 from ..dataclasses import SubmitterInfo
 from .dialogs.submit_job_to_deadline_dialog import (
     SubmitJobToDeadlineDialog,
@@ -74,6 +74,30 @@ def _make_pre_gui_metadata(initial_settings: Any, job_bundle_dir: str) -> _HookM
         submission_payload={},
         storage_profile_id=storage_profile_id,
     )
+
+
+def _resolve_template_host_requirements(template: dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """
+    Determine the host requirements to pre-fill the GUI with, based on the job
+    template's steps.
+
+    - If there is a single step, its ``hostRequirements`` are used.
+    - If there are multiple steps that all declare the same ``hostRequirements``,
+      those are used.
+    - If the steps declare differing (or partially missing) ``hostRequirements``,
+      ``None`` is returned so the GUI leaves the host requirements deactivated.
+    """
+    steps = template.get("steps") or []
+    if not steps:
+        return None
+
+    host_requirements = [step.get("hostRequirements") for step in steps]
+    first = host_requirements[0]
+    if not first:
+        return None
+    if all(req == first for req in host_requirements[1:]):
+        return first
+    return None
 
 
 def _validate_job_parameters_against_definitions(
@@ -391,10 +415,20 @@ def show_job_bundle_submitter(
         if "description" in pre_gui_output:
             initial_settings.description = pre_gui_output["description"]
 
+    # Pre-fill the host requirements tab from the job template's steps so the GUI
+    # reflects the requirements already declared in the bundle.
+    template_host_requirements = _resolve_template_host_requirements(template or {})
+    initial_host_requirements = (
+        HostRequirements.from_dict(template_host_requirements)
+        if template_host_requirements
+        else None
+    )
+
     submitter_dialog = SubmitJobToDeadlineDialog(
         job_setup_widget_type=JobBundleSettingsWidget,
         initial_job_settings=initial_settings,
         show_host_requirements_tab=True,
+        host_requirements=initial_host_requirements,
         initial_shared_parameter_values=initial_shared_parameter_values,
         auto_detected_attachments=asset_references,
         attachments=AssetReferences(),

--- a/test/unit/deadline_client/ui/gui/conftest.py
+++ b/test/unit/deadline_client/ui/gui/conftest.py
@@ -14,6 +14,7 @@ _has_pyside6 = importlib.util.find_spec("PySide6") is not None
 _QT_TEST_FILES = [
     "test_gui_host_requirements.py",
     "test_gui_job_attachments.py",
+    "test_gui_job_bundle_submitter.py",
     "test_gui_job_timeouts.py",
     "test_gui_openjd_parameters.py",
     "test_gui_shared_job_properties.py",

--- a/test/unit/deadline_client/ui/gui/test_gui_dataclasses.py
+++ b/test/unit/deadline_client/ui/gui/test_gui_dataclasses.py
@@ -644,3 +644,149 @@ class TestHostRequirements:
         assert "amount.worker.vcpu" in amount_names
         assert "amount.worker.memory" in amount_names
         assert "amount.worker.licenses" in amount_names
+
+
+class TestHostRequirementsFromDict:
+    """Tests for HostRequirements.from_dict, the inverse of serialize()."""
+
+    def test_empty_dict_returns_empty_requirements(self):
+        """An empty dict should produce a HostRequirements with no settings."""
+        req = HostRequirements.from_dict({})
+        assert req.serialize() == {}
+
+    def test_parses_os_family(self):
+        """attr.worker.os.family should map to os_requirements.operating_systems."""
+        req = HostRequirements.from_dict(
+            {"attributes": [{"name": "attr.worker.os.family", "anyOf": ["linux", "windows"]}]}
+        )
+        assert isinstance(req.os_requirements, OsRequirements)
+        assert req.os_requirements.operating_systems == ["linux", "windows"]
+
+    def test_parses_cpu_arch(self):
+        """attr.worker.cpu.arch should map to os_requirements.cpu_archs."""
+        req = HostRequirements.from_dict(
+            {"attributes": [{"name": "attr.worker.cpu.arch", "anyOf": ["x86_64"]}]}
+        )
+        assert req.os_requirements is not None
+        assert req.os_requirements.cpu_archs == ["x86_64"]
+
+    def test_parses_vcpu_min_and_max(self):
+        """amount.worker.vcpu should map to hardware cpu_min/cpu_max."""
+        req = HostRequirements.from_dict(
+            {"amounts": [{"name": "amount.worker.vcpu", "min": 8, "max": 64}]}
+        )
+        assert req.hardware_requirements is not None
+        assert req.hardware_requirements.cpu_min == 8
+        assert req.hardware_requirements.cpu_max == 64
+
+    def test_parses_memory_in_mib(self):
+        """amount.worker.memory should be stored in MiB (template units)."""
+        req = HostRequirements.from_dict(
+            {"amounts": [{"name": "amount.worker.memory", "min": 16384}]}
+        )
+        # Stored as MiB so it round-trips through serialize()
+        assert req.hardware_requirements is not None
+        assert req.hardware_requirements.memory_min == 16384
+
+    def test_parses_min_only_leaves_max_default(self):
+        """An amount with only a min should leave max at the default."""
+        req = HostRequirements.from_dict({"amounts": [{"name": "amount.worker.vcpu", "min": 4}]})
+        assert req.hardware_requirements is not None
+        assert req.hardware_requirements.cpu_min == 4
+        assert req.hardware_requirements.cpu_max == HardwareRequirements.DEFAULT_VALUE
+
+    def test_parses_max_only_leaves_min_default(self):
+        """An amount with only a max should leave min at the default."""
+        req = HostRequirements.from_dict({"amounts": [{"name": "amount.worker.gpu", "max": 4}]})
+        assert req.hardware_requirements is not None
+        assert req.hardware_requirements.acceleration_max == 4
+        assert req.hardware_requirements.acceleration_min == HardwareRequirements.DEFAULT_VALUE
+
+    def test_parses_gpu_memory_and_scratch(self):
+        """GPU memory and scratch space well-known amounts should be parsed."""
+        req = HostRequirements.from_dict(
+            {
+                "amounts": [
+                    {"name": "amount.worker.gpu.memory", "min": 2048},
+                    {"name": "amount.worker.disk.scratch", "min": 100},
+                ]
+            }
+        )
+        assert req.hardware_requirements is not None
+        assert req.hardware_requirements.acceleration_memory_min == 2048
+        assert req.hardware_requirements.scratch_space_min == 100
+
+    def test_parses_custom_amount(self):
+        """A custom amount (bare 'amount.' prefix) should round-trip with the prefix stripped.
+
+        OpenJD reserves the 'amount.worker.' namespace for its own capabilities,
+        so user-defined amounts use the bare 'amount.' prefix.
+        """
+        req = HostRequirements.from_dict(
+            {"amounts": [{"name": "amount.Bugs", "min": 1, "max": 10}]}
+        )
+        assert req.custom_requirements is not None
+        assert len(req.custom_requirements.amounts) == 1
+        custom = req.custom_requirements.amounts[0]
+        assert custom.name == "Bugs"
+        assert custom.min == 1
+        assert custom.max == 10
+
+    def test_parses_custom_attribute_anyof(self):
+        """A custom attribute (bare 'attr.' prefix) should become a custom attribute (anyOf)."""
+        req = HostRequirements.from_dict(
+            {"attributes": [{"name": "attr.pipelineFeatures", "anyOf": ["feature1", "feature2"]}]}
+        )
+        assert req.custom_requirements is not None
+        assert len(req.custom_requirements.attributes) == 1
+        custom = req.custom_requirements.attributes[0]
+        assert custom.name == "pipelineFeatures"
+        assert custom.option == "anyOf"
+        assert custom.values == ["feature1", "feature2"]
+
+    def test_parses_custom_attribute_allof(self):
+        """A custom attribute using allOf should preserve the allOf option."""
+        req = HostRequirements.from_dict(
+            {"attributes": [{"name": "attr.software", "allOf": ["maya", "nuke"]}]}
+        )
+        assert req.custom_requirements is not None
+        custom = req.custom_requirements.attributes[0]
+        assert custom.option == "allOf"
+        assert custom.values == ["maya", "nuke"]
+
+    @staticmethod
+    def _compare_requirements(first, second):
+        assert len(first.get("amounts", [])) == len(second.get("amounts", []))
+        assert len(first.get("attributes", [])) == len(second.get("attributes", []))
+        for amount in first.get("amounts", []):
+            ref = next(a for a in second["amounts"] if a["name"] == amount["name"])
+            assert ref.get("min") == amount.get("min")
+            assert ref.get("max") == amount.get("max")
+        for attribute in first.get("attributes", []):
+            ref = next(a for a in second["attributes"] if a["name"] == attribute["name"])
+            operation = "anyOf" if "anyOf" in attribute else "allOf"
+            assert operation in ref
+            assert set(attribute[operation]) == set(ref[operation])
+
+    def test_roundtrip_well_known_capabilities_through_serialize(self):
+        """For well-known capabilities, from_dict then serialize reproduces the input.
+
+        Custom capabilities are intentionally excluded here: the widget (the real
+        submission path) and OpenJD use the bare ``attr.``/``amount.`` prefix for
+        custom names, while the dataclass ``serialize()`` re-adds ``attr.worker.``/
+        ``amount.worker.``, so the two are not symmetric for custom entries. The
+        custom-prefix handling is covered by the dedicated ``test_parses_custom_*``
+        tests above.
+        """
+        source = {
+            "attributes": [
+                {"name": "attr.worker.os.family", "anyOf": ["windows"]},
+                {"name": "attr.worker.cpu.arch", "anyOf": ["x86_64"]},
+            ],
+            "amounts": [
+                {"name": "amount.worker.vcpu", "min": 8, "max": 64},
+                {"name": "amount.worker.memory", "min": 16384, "max": 131072},
+            ],
+        }
+        result = HostRequirements.from_dict(source).serialize()
+        self._compare_requirements(result, source)

--- a/test/unit/deadline_client/ui/gui/test_gui_job_bundle_submitter.py
+++ b/test/unit/deadline_client/ui/gui/test_gui_job_bundle_submitter.py
@@ -1,0 +1,61 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Tests for host-requirements prefill logic in the job bundle submitter."""
+
+from deadline.client.ui.job_bundle_submitter import _resolve_template_host_requirements
+
+
+_HR_A = {
+    "amounts": [{"name": "amount.worker.vcpu", "min": 8, "max": 64}],
+    "attributes": [{"name": "attr.worker.os.family", "anyOf": ["linux"]}],
+}
+_HR_B = {
+    "amounts": [{"name": "amount.worker.vcpu", "min": 1}],
+}
+
+
+class TestResolveTemplateHostRequirements:
+    def test_no_steps_returns_none(self):
+        """A template with no steps should resolve to no prefill."""
+        assert _resolve_template_host_requirements({}) is None
+        assert _resolve_template_host_requirements({"steps": []}) is None
+
+    def test_single_step_with_requirements_prefills(self):
+        """A single step's hostRequirements should be returned for prefill."""
+        template = {"steps": [{"name": "Step1", "hostRequirements": _HR_A}]}
+        assert _resolve_template_host_requirements(template) == _HR_A
+
+    def test_single_step_without_requirements_returns_none(self):
+        """A single step lacking hostRequirements should resolve to no prefill."""
+        template = {"steps": [{"name": "Step1"}]}
+        assert _resolve_template_host_requirements(template) is None
+
+    def test_multiple_steps_identical_requirements_prefills(self):
+        """Multiple steps with identical hostRequirements should prefill them."""
+        template = {
+            "steps": [
+                {"name": "Step1", "hostRequirements": _HR_A},
+                {"name": "Step2", "hostRequirements": dict(_HR_A)},
+            ]
+        }
+        assert _resolve_template_host_requirements(template) == _HR_A
+
+    def test_multiple_steps_different_requirements_returns_none(self):
+        """Multiple steps with differing hostRequirements should not prefill (deactivated)."""
+        template = {
+            "steps": [
+                {"name": "Step1", "hostRequirements": _HR_A},
+                {"name": "Step2", "hostRequirements": _HR_B},
+            ]
+        }
+        assert _resolve_template_host_requirements(template) is None
+
+    def test_some_steps_missing_requirements_returns_none(self):
+        """If only some steps declare hostRequirements, treat as differing -> no prefill."""
+        template = {
+            "steps": [
+                {"name": "Step1", "hostRequirements": _HR_A},
+                {"name": "Step2"},
+            ]
+        }
+        assert _resolve_template_host_requirements(template) is None


### PR DESCRIPTION
Fixes #584

### What was the problem/requirement? (What/Why)
When running `deadline bundle gui-submit`, the Host requirements tab always defaulted to "Run on all available worker hosts" even when the job template's steps declared hostRequirements.

### What was the solution? (How)
Add `HostRequirements.from_dict` (the inverse of `serialize`) to parse an OpenJD step `hostRequirements` dict back into the UI dataclass, and have `show_job_bundle_submitter` resolve the requirements across the template's steps before constructing the dialog:

- single step, or multiple steps with identical hostRequirements -> pre-fill the tab from the template
- steps with differing (or partially missing) hostRequirements -> leave the tab deactivated ("Run on all available worker hosts")

### What is the impact of this change?
Makes the GUI submitter work with host requirements.

### How was this change tested?
Unit tests. Also manually opening the GUI submitter with bundles with different steps and host requirements.

### Was this change documented?
n/a

### Does this PR introduce new dependencies?
No

### Is this a breaking change?
No

### Does this change impact security?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
