### PR TITLE
feat!: support farms across all Deadline Cloud regions

### DIFF
--- a/src/deadline/client/api/_job_monitoring.py
+++ b/src/deadline/client/api/_job_monitoring.py
@@ -15,6 +15,7 @@ from botocore.exceptions import ClientError
 
 from deadline.client.exceptions import DeadlineOperationError, DeadlineOperationTimedOut
 from deadline.client.api._session import (
+    _resolve_region,
     get_boto3_client,
     get_boto3_session,
     get_default_client_config,
@@ -123,7 +124,9 @@ def wait_for_job_completion(
     Raises:
         DeadlineOperationError: If the timeout is reached or there's an error retrieving job information.
     """
-    deadline = get_boto3_client("deadline", config=config)
+    # Scope the client to the farm's region (per-farm operation).
+    region = _resolve_region(config=config, farm_id=farm_id)
+    deadline = get_boto3_client("deadline", config=config, region=region)
 
     start_time = datetime.datetime.now()
     terminal_states = ["SUCCEEDED", "FAILED", "CANCELED", "SUSPENDED", "NOT_COMPATIBLE"]
@@ -257,8 +260,10 @@ def get_session_logs(
     Raises:
         DeadlineOperationError: If there's an error retrieving the logs.
     """
+    # Scope clients to the farm's region (per-farm operation).
+    region = _resolve_region(config=config, farm_id=farm_id)
     # Get the Deadline client to use for getting queue credentials
-    deadline = get_boto3_client("deadline", config=config)
+    deadline = get_boto3_client("deadline", config=config, region=region)
 
     # Auto-select session if not provided but job_id is
     if not session_id:
@@ -308,8 +313,8 @@ def get_session_logs(
         except Exception as e:
             raise DeadlineOperationError(f"Failed to get queue credentials: {e}")
     else:
-        # Use the same boto session as for deadline
-        logs_client = get_boto3_client("logs", config=config)
+        # Use the same boto session as for deadline, scoped to the farm's region.
+        logs_client = get_boto3_client("logs", config=config, region=region)
 
     # Construct the log group name
     log_group_name = f"/aws/deadline/{farm_id}/{queue_id}"
@@ -427,13 +432,16 @@ def get_worker_logs(
     # Worker logs use a different log group pattern than session logs
     log_group_name = f"/aws/deadline/{farm_id}/{fleet_id}"
 
+    # Worker logs live in the farm's region, so resolve it once and scope every client to it.
+    region = _resolve_region(config=config, farm_id=farm_id)
+
     # Check if we have user and identity store ID (from Deadline Cloud monitor)
     user_id, identity_store_id = get_user_and_identity_store_id(config=config)
 
     # Create logs client - use fleet role credentials when using monitor login
     if user_id and identity_store_id:
         try:
-            deadline = get_boto3_client("deadline", config=config)
+            deadline = get_boto3_client("deadline", config=config, region=region)
             response = deadline.assume_fleet_role_for_read(farmId=farm_id, fleetId=fleet_id)
             credentials = response["credentials"]
             fleet_session = boto3.Session(
@@ -441,15 +449,20 @@ def get_worker_logs(
                 aws_secret_access_key=credentials["secretAccessKey"],
                 aws_session_token=credentials["sessionToken"],
             )
+            # Scope the fleet-credentials logs client to the farm's region, falling back
+            # to the base session region when no region is configured (prior behavior).
+            logs_region = (
+                region if region is not None else get_boto3_session(config=config).region_name
+            )
             logs_client = fleet_session.client(
                 "logs",
-                region_name=get_boto3_session(config=config).region_name,
+                region_name=logs_region,
                 config=get_default_client_config(),
             )
         except Exception as e:
             raise DeadlineOperationError(f"Failed to get fleet credentials: {e}")
     else:
-        logs_client = get_boto3_client("logs", config=config)
+        logs_client = get_boto3_client("logs", config=config, region=region)
 
     # Prepare parameters for GetLogEvents
     params = {

--- a/src/deadline/client/api/_list_apis.py
+++ b/src/deadline/client/api/_list_apis.py
@@ -54,7 +54,7 @@ def _call_paginated_deadline_list_api(list_api, list_property_name, **kwargs):
     return result
 
 
-def _has_explicit_region_list() -> bool:
+def _has_explicit_region_list(config: Optional[ConfigParser] = None) -> bool:
     """
     Returns True when the user has explicitly listed the Deadline regions to scan via
     the ``DEADLINE_CLOUD_REGIONS`` env var or the ``settings.deadline_regions`` config
@@ -62,11 +62,16 @@ def _has_explicit_region_list() -> bool:
 
     This deliberate user intent takes precedence over the endpoint-override
     single-region short-circuit in :func:`list_farms`.
+
+    Args:
+        config (ConfigParser, optional): The config to read the ``settings.deadline_regions``
+            override from; threaded through so an in-memory config (e.g. a ``--profile``
+            override) is honored rather than the global on-disk config.
     """
     env_value = os.getenv(config_file.DEADLINE_REGIONS_ENV_VAR)
     if env_value and env_value.strip():
         return True
-    config_value = config_file.get_setting("settings.deadline_regions")
+    config_value = config_file.get_setting("settings.deadline_regions", config=config)
     return bool(config_value and config_value.strip())
 
 
@@ -153,10 +158,9 @@ def _iter_farms_by_region(
     ``(region, None, exception)`` on failure.
     """
     if regions is None:
-        if (
-            os.getenv(config_file.AWS_ENDPOINT_URL_DEADLINE_ENV_VAR)
-            and not _has_explicit_region_list()
-        ):
+        if os.getenv(
+            config_file.AWS_ENDPOINT_URL_DEADLINE_ENV_VAR
+        ) and not _has_explicit_region_list(config=config):
             # Single explicit endpoint: scan only the session region. It may be None
             # (the client builder accepts region=None), scanned as a 1-element list so
             # the fan-out machinery below handles it uniformly.
@@ -166,7 +170,7 @@ def _iter_farms_by_region(
                 session_region = None
             regions = [session_region]
         else:
-            regions = config_file.get_deadline_regions()
+            regions = config_file.get_deadline_regions(config=config)
 
     if not regions:
         return

--- a/src/deadline/client/api/_list_apis.py
+++ b/src/deadline/client/api/_list_apis.py
@@ -1,10 +1,26 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
+from __future__ import annotations
+
+import concurrent.futures
+import logging
+import os
+from configparser import ConfigParser
+from typing import Iterator, List, Optional, Tuple
+
 from ._session import (
     get_boto3_client,
+    get_boto3_session,
     get_user_and_identity_store_id,
 )
 from .. import api
+from ..config import config_file
+from ..exceptions import DeadlineOperationError
+
+logger = logging.getLogger(__name__)
+
+# Upper bound on the number of regions queried concurrently during a fan-out.
+_MAX_FANOUT_WORKERS = 10
 
 
 def _apply_principal_id_filter(kwargs, config=None):
@@ -38,71 +54,226 @@ def _call_paginated_deadline_list_api(list_api, list_property_name, **kwargs):
     return result
 
 
-@api.record_function_latency_telemetry_event()
-def list_farms(config=None, **kwargs):
+def _has_explicit_region_list() -> bool:
     """
-    Calls the [deadline:ListFarms] API call, applying the filter for user membership
-    depending on the configuration. If the response is paginated, it repeated
-    calls the API to get all the farms.
+    Returns True when the user has explicitly listed the Deadline regions to scan via
+    the ``DEADLINE_CLOUD_REGIONS`` env var or the ``settings.deadline_regions`` config
+    setting.
+
+    This deliberate user intent takes precedence over the endpoint-override
+    single-region short-circuit in :func:`list_farms`.
+    """
+    env_value = os.getenv(config_file.DEADLINE_REGIONS_ENV_VAR)
+    if env_value and env_value.strip():
+        return True
+    config_value = config_file.get_setting("settings.deadline_regions")
+    return bool(config_value and config_value.strip())
+
+
+def _list_farms_for_region(
+    region: Optional[str],
+    config: Optional[ConfigParser] = None,
+    **kwargs,
+) -> List[dict]:
+    """
+    Performs a single-region ``deadline:ListFarms`` fan-out unit of work.
+
+    Builds a dedicated boto3 client scoped to ``region`` (clients are never shared
+    across regions, which keeps this safe to run from a worker thread), applies the
+    principal-id filter, de-paginates, and tags every returned farm dict with its
+    ``region``.
+
+    Args:
+        region (str, optional): The AWS region to list farms in. When ``None``, the
+            session/profile default region is used and the ``region`` tag on each farm
+            is ``None`` (used by the endpoint-override single-region path).
+        config (ConfigParser, optional): The AWS Deadline Cloud config to use.
+
+    Returns:
+        The list of farm dicts for ``region``, each annotated with ``farm["region"]``.
+    """
+    call_kwargs = dict(kwargs)
+    _apply_principal_id_filter(call_kwargs, config=config)
+    deadline = get_boto3_client("deadline", config=config, region=region)
+    result = _call_paginated_deadline_list_api(deadline.list_farms, "farms", **call_kwargs)
+    # Tag a shallow copy of each farm so we don't mutate dicts owned by the caller/SDK.
+    return [{**farm, "region": region} for farm in result["farms"]]
+
+
+def _iter_farms_by_region(
+    config: Optional[ConfigParser] = None,
+    regions: Optional[List[str]] = None,
+    **kwargs,
+) -> Iterator[Tuple[str, Optional[List[dict]], Optional[BaseException]]]:
+    """
+    Fans ``deadline:ListFarms`` out across Deadline Cloud regions concurrently, yielding
+    each region's result *as it completes* (out of order) so consumers like the UI can
+    render partial results without waiting on the slowest region. Each call runs on its
+    own thread with its own region-scoped client (clients are never shared across threads).
+
+    This is the shared chokepoint for the region-set decision, so the CLI
+    (:func:`list_farms`) and the GUI streaming path behave identically. When ``regions`` is
+    passed, exactly those are scanned. When ``None``, regions come from
+    :func:`config_file.get_deadline_regions` -- except that when ``AWS_ENDPOINT_URL_DEADLINE``
+    is set (a single explicit endpoint makes a fan-out meaningless, since every client would
+    hit the same endpoint) only the session region is scanned, unless the user has also
+    explicitly listed regions (see :func:`_has_explicit_region_list`), which wins.
+
+    Yields ``(region, farms, None)`` on success (each farm carries a ``region`` key) or
+    ``(region, None, exception)`` on failure.
+    """
+    if regions is None:
+        if (
+            os.getenv(config_file.AWS_ENDPOINT_URL_DEADLINE_ENV_VAR)
+            and not _has_explicit_region_list()
+        ):
+            # Single explicit endpoint: scan only the session region. It may be None
+            # (the client builder accepts region=None), scanned as a 1-element list so
+            # the fan-out machinery below handles it uniformly.
+            try:
+                session_region = get_boto3_session(config=config).region_name
+            except Exception:
+                session_region = None
+            regions = [session_region]
+        else:
+            regions = config_file.get_deadline_regions()
+
+    if not regions:
+        return
+
+    max_workers = min(len(regions), _MAX_FANOUT_WORKERS)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+        future_to_region = {
+            executor.submit(_list_farms_for_region, region, config, **kwargs): region
+            for region in regions
+        }
+        for future in concurrent.futures.as_completed(future_to_region):
+            region = future_to_region[future]
+            try:
+                farms = future.result()
+            except Exception as exc:
+                # A per-region failure (auth, opt-in, throttling, timeout, etc.) is
+                # reported and skipped. Control-flow exceptions (KeyboardInterrupt,
+                # SystemExit) are NOT Exception subclasses, so they propagate and the
+                # operation can be interrupted rather than silently swallowed.
+                yield (region, None, exc)
+            else:
+                yield (region, farms, None)
+
+
+@api.record_function_latency_telemetry_event()
+def list_farms(config=None, region=None, **kwargs):
+    """
+    Calls the [deadline:ListFarms] API, paginating to return all farms. Each farm dict is
+    annotated with an additive ``region`` key.
+
+    When ``region`` is given, only that region is queried. When ``None``, ListFarms is
+    fanned out across regions via :func:`_iter_farms_by_region` (which owns the region-set
+    decision, including the ``AWS_ENDPOINT_URL_DEADLINE`` single-region short-circuit) and
+    the results are concatenated.
+
+    Fan-out failure semantics: a failing region is skipped with a ``logger.warning`` and
+    does not block others; survivors are returned as long as one region succeeds; if every
+    region fails a :class:`DeadlineOperationError` is raised (an empty list is never
+    silently returned).
 
     [deadline:ListFarms]: https://docs.aws.amazon.com/deadline-cloud/latest/APIReference/API_ListFarms.html
     """
-    _apply_principal_id_filter(kwargs, config=config)
-    deadline = get_boto3_client("deadline", config=config)
-    return _call_paginated_deadline_list_api(deadline.list_farms, "farms", **kwargs)
+    if region is not None:
+        return {"farms": _list_farms_for_region(region, config=config, **kwargs)}
+
+    all_farms: List[dict] = []
+    failures: List[Tuple[str, BaseException]] = []
+    succeeded = False
+
+    for result_region, farms, exc in _iter_farms_by_region(config=config, **kwargs):
+        if exc is not None:
+            logger.warning("Failed to list farms in region %s: %s", result_region, exc)
+            failures.append((result_region, exc))
+        else:
+            succeeded = True
+            all_farms.extend(farms or [])
+
+    if not succeeded and failures:
+        summary = "; ".join(f"{failed_region}: {failure}" for failed_region, failure in failures)
+        raise DeadlineOperationError(
+            f"Failed to list farms in all {len(failures)} region(s): {summary}"
+        )
+
+    return {"farms": all_farms}
 
 
 @api.record_function_latency_telemetry_event()
-def list_queues(config=None, **kwargs):
+def list_queues(config=None, region=None, **kwargs):
     """
     Calls the [deadline:ListQueues] API call, applying the filter for user membership
     depending on the configuration. If the response is paginated, it repeated
     calls the API to get all the queues.
 
+    Args:
+        config (ConfigParser, optional): The AWS Deadline Cloud config to use.
+        region (str, optional): The AWS region the farm lives in. When omitted, the
+            region is resolved from `defaults.farm_region`, otherwise the session/profile region.
+
     [deadline:ListQueues]: https://docs.aws.amazon.com/deadline-cloud/latest/APIReference/API_ListQueues.html
     """
     _apply_principal_id_filter(kwargs, config=config)
-    deadline = get_boto3_client("deadline", config=config)
+    deadline = get_boto3_client("deadline", config=config, region=region)
     return _call_paginated_deadline_list_api(deadline.list_queues, "queues", **kwargs)
 
 
 @api.record_function_latency_telemetry_event()
-def list_jobs(config=None, **kwargs):
+def list_jobs(config=None, region=None, **kwargs):
     """
     Calls the [deadline:ListJobs] API call, applying the filter for user membership
     depending on the configuration. If the response is paginated, it repeated
     calls the API to get all the jobs.
 
+    Args:
+        config (ConfigParser, optional): The AWS Deadline Cloud config to use.
+        region (str, optional): The AWS region the farm lives in. When omitted, the
+            region is resolved from `defaults.farm_region`, otherwise the session/profile region.
+
     [deadline:ListJobs]: https://docs.aws.amazon.com/deadline-cloud/latest/APIReference/API_ListJobs.html
     """
     _apply_principal_id_filter(kwargs, config=config)
-    deadline = get_boto3_client("deadline", config=config)
+    deadline = get_boto3_client("deadline", config=config, region=region)
     return _call_paginated_deadline_list_api(deadline.list_jobs, "jobs", **kwargs)
 
 
 @api.record_function_latency_telemetry_event()
-def list_fleets(config=None, **kwargs):
+def list_fleets(config=None, region=None, **kwargs):
     """
     Calls the [deadline:ListFleets] API call, applying the filter for user membership
     depending on the configuration. If the response is paginated, it repeated
     calls the API to get all the fleets.
 
+    Args:
+        config (ConfigParser, optional): The AWS Deadline Cloud config to use.
+        region (str, optional): The AWS region the farm lives in. When omitted, the
+            region is resolved from `defaults.farm_region`, otherwise the session/profile region.
+
     [deadline:ListFleets]: https://docs.aws.amazon.com/deadline-cloud/latest/APIReference/API_ListFleets.html
     """
     _apply_principal_id_filter(kwargs, config=config)
-    deadline = get_boto3_client("deadline", config=config)
+    deadline = get_boto3_client("deadline", config=config, region=region)
     return _call_paginated_deadline_list_api(deadline.list_fleets, "fleets", **kwargs)
 
 
 @api.record_function_latency_telemetry_event()
-def list_storage_profiles_for_queue(config=None, **kwargs):
+def list_storage_profiles_for_queue(config=None, region=None, **kwargs):
     """
     Calls the [deadline:ListStorageProfilesForQueue] API call. If the response is paginated, it repeated
     calls the API to get all the storage profiles.
 
+    Args:
+        config (ConfigParser, optional): The AWS Deadline Cloud config to use.
+        region (str, optional): The AWS region the farm lives in. When omitted, the
+            region is resolved from `defaults.farm_region`, otherwise the session/profile region.
+
     [deadline:ListStorageProfilesForQueue]: https://docs.aws.amazon.com/deadline-cloud/latest/APIReference/API_ListStorageProfilesForQueue.html
     """
-    deadline = get_boto3_client("deadline", config=config)
+    deadline = get_boto3_client("deadline", config=config, region=region)
 
     return _call_paginated_deadline_list_api(
         deadline.list_storage_profiles_for_queue, "storageProfiles", **kwargs

--- a/src/deadline/client/api/_list_apis.py
+++ b/src/deadline/client/api/_list_apis.py
@@ -70,18 +70,45 @@ def _has_explicit_region_list() -> bool:
     return bool(config_value and config_value.strip())
 
 
+def _list_farms_with_client(
+    region: Optional[str],
+    deadline,
+    **call_kwargs,
+) -> List[dict]:
+    """
+    Runs ``deadline:ListFarms`` against an already-built client and tags each farm.
+
+    This is the fan-out's per-region unit of work. It takes a ready-made ``deadline``
+    client rather than building one, so it touches **no** shared boto3 ``Session`` state
+    and is therefore safe to run from a worker thread by construction -- the only thing it
+    does is make the (network) ListFarms call and shallow-copy/tag the results. All session
+    and client construction happens up front on the calling thread (see
+    :func:`_iter_farms_by_region`).
+
+    Args:
+        region (str, optional): The region this client is scoped to; used only to tag the
+            returned farms (``None`` for the endpoint-override single-region path).
+        deadline: A boto3 ``deadline`` client already scoped to ``region``.
+
+    Returns:
+        The list of farm dicts for ``region``, each annotated with ``farm["region"]``.
+    """
+    result = _call_paginated_deadline_list_api(deadline.list_farms, "farms", **call_kwargs)
+    # Tag a shallow copy of each farm so we don't mutate dicts owned by the caller/SDK.
+    return [{**farm, "region": region} for farm in result["farms"]]
+
+
 def _list_farms_for_region(
     region: Optional[str],
     config: Optional[ConfigParser] = None,
     **kwargs,
 ) -> List[dict]:
     """
-    Performs a single-region ``deadline:ListFarms`` fan-out unit of work.
+    Single-region ``deadline:ListFarms`` (client built here, then delegated).
 
-    Builds a dedicated boto3 client scoped to ``region`` (clients are never shared
-    across regions, which keeps this safe to run from a worker thread), applies the
-    principal-id filter, de-paginates, and tags every returned farm dict with its
-    ``region``.
+    Used by the single-region path of :func:`list_farms`, where there is no concurrency.
+    Builds a region-scoped client, applies the principal-id filter, and delegates to
+    :func:`_list_farms_with_client`.
 
     Args:
         region (str, optional): The AWS region to list farms in. When ``None``, the
@@ -95,9 +122,7 @@ def _list_farms_for_region(
     call_kwargs = dict(kwargs)
     _apply_principal_id_filter(call_kwargs, config=config)
     deadline = get_boto3_client("deadline", config=config, region=region)
-    result = _call_paginated_deadline_list_api(deadline.list_farms, "farms", **call_kwargs)
-    # Tag a shallow copy of each farm so we don't mutate dicts owned by the caller/SDK.
-    return [{**farm, "region": region} for farm in result["farms"]]
+    return _list_farms_with_client(region, deadline, **call_kwargs)
 
 
 def _iter_farms_by_region(
@@ -108,8 +133,13 @@ def _iter_farms_by_region(
     """
     Fans ``deadline:ListFarms`` out across Deadline Cloud regions concurrently, yielding
     each region's result *as it completes* (out of order) so consumers like the UI can
-    render partial results without waiting on the slowest region. Each call runs on its
-    own thread with its own region-scoped client (clients are never shared across threads).
+    render partial results without waiting on the slowest region.
+
+    Thread-safety: every per-region boto3 client (and the principal-id filter, which does a
+    one-time DCM lookup) is built **up front on this thread**, before the executor starts.
+    The worker threads receive a ready client and only make the network ListFarms call --
+    they never touch the shared boto3 ``Session`` (which is not thread-safe to build clients
+    from concurrently). This makes the fan-out safe by construction rather than by timing.
 
     This is the shared chokepoint for the region-set decision, so the CLI
     (:func:`list_farms`) and the GUI streaming path behave identically. When ``regions`` is
@@ -141,10 +171,22 @@ def _iter_farms_by_region(
     if not regions:
         return
 
+    # Build everything that touches the shared boto3 Session up front, on this thread:
+    # the principal-id filter (one DCM lookup, region-independent) and one region-scoped
+    # client per region. The worker threads below only make the network call against a
+    # ready client, so they never construct clients off the shared Session concurrently.
+    call_kwargs = dict(kwargs)
+    _apply_principal_id_filter(call_kwargs, config=config)
+    clients_by_region = {
+        region: get_boto3_client("deadline", config=config, region=region) for region in regions
+    }
+
     max_workers = min(len(regions), _MAX_FANOUT_WORKERS)
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
         future_to_region = {
-            executor.submit(_list_farms_for_region, region, config, **kwargs): region
+            executor.submit(
+                _list_farms_with_client, region, clients_by_region[region], **call_kwargs
+            ): region
             for region in regions
         }
         for future in concurrent.futures.as_completed(future_to_region):

--- a/src/deadline/client/api/_list_jobs_by_filter_expression.py
+++ b/src/deadline/client/api/_list_jobs_by_filter_expression.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 __all__ = ["_list_jobs_by_filter_expression"]
 
-from typing import Any
+from typing import Any, Optional
 import boto3
 
 from deadline.client.api._session import get_session_client
@@ -23,6 +23,7 @@ def _list_jobs_by_filter_expression(
     farm_id: str,
     queue_id: str,
     filter_expression: dict[str, Any],
+    region: Optional[str] = None,
 ) -> list[dict[str, Any]]:
     """
     This function retrieves all jobs in the queue that satisfy a provided filter expression, except potentially
@@ -62,6 +63,8 @@ def _list_jobs_by_filter_expression(
       queue_id (str): The Queue ID.
       filter_expressions (dict[str, Any]): The filter expression to apply to jobs. This is nested one level in a
             filter expression provided to deadline:SearchJobs, so cannot include a groupFilter.
+      region (str, optional): The AWS region to scope the deadline client to. When None, the
+            session's default region is used.
 
     Returns:
       The list of all jobs in the queue that satisfy the provided filter expression. Each job is as returned by the deadline:SearchJobs API.
@@ -102,7 +105,7 @@ def _list_jobs_by_filter_expression(
     # This holds {job_id: job_from_search_jobs_call, ...}
     result_jobs = {}
 
-    deadline = get_session_client(boto3_session, "deadline")
+    deadline = get_session_client(boto3_session, "deadline", region=region)
 
     # Sort jobs in ascending order of the timestamp field
     sort_expressions = [{"fieldSort": {"name": "CREATED_AT", "sortOrder": "ASCENDING"}}]

--- a/src/deadline/client/api/_mcp.py
+++ b/src/deadline/client/api/_mcp.py
@@ -7,7 +7,7 @@ APIs for job diagnostics - get, list, and search operations for jobs, sessions, 
 from configparser import ConfigParser
 from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
-from ._session import get_boto3_client
+from ._session import get_boto3_client, _resolve_region
 from . import record_function_latency_telemetry_event
 
 if TYPE_CHECKING:
@@ -41,6 +41,7 @@ def get_job(
     queue_id: str,
     job_id: str,
     config: Optional[ConfigParser] = None,
+    region: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Get detailed information about a specific job.
@@ -50,11 +51,14 @@ def get_job(
         queue_id: The ID of the queue containing the job.
         job_id: The ID of the job to retrieve.
         config: Optional configuration object.
+        region: The AWS region of the farm. When omitted, it is resolved for this farm
+            from the config (defaults.farm_region), otherwise the session/profile region.
 
     Returns:
         Job details including name, status, taskRunStatusCounts, timestamps, and lifecycle info.
     """
-    deadline: "DeadlineClient" = get_boto3_client("deadline", config=config)
+    region = _resolve_region(config=config, region=region, farm_id=farm_id)
+    deadline: "DeadlineClient" = get_boto3_client("deadline", config=config, region=region)
     return deadline.get_job(farmId=farm_id, queueId=queue_id, jobId=job_id)
 
 
@@ -65,6 +69,7 @@ def get_session(
     job_id: str,
     session_id: str,
     config: Optional[ConfigParser] = None,
+    region: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Get detailed information about a specific session.
@@ -75,11 +80,14 @@ def get_session(
         job_id: The ID of the job containing the session.
         session_id: The ID of the session to retrieve.
         config: Optional configuration object.
+        region: The AWS region of the farm. When omitted, it is resolved for this farm
+            from the config (defaults.farm_region), otherwise the session/profile region.
 
     Returns:
         Session details including lifecycleStatus, log configuration, worker info.
     """
-    deadline: "DeadlineClient" = get_boto3_client("deadline", config=config)
+    region = _resolve_region(config=config, region=region, farm_id=farm_id)
+    deadline: "DeadlineClient" = get_boto3_client("deadline", config=config, region=region)
     return deadline.get_session(
         farmId=farm_id, queueId=queue_id, jobId=job_id, sessionId=session_id
     )
@@ -92,6 +100,7 @@ def list_sessions(
     job_id: str,
     max_results: Optional[int] = None,
     config: Optional[ConfigParser] = None,
+    region: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     List all sessions for a job.
@@ -102,11 +111,14 @@ def list_sessions(
         job_id: The ID of the job to list sessions for.
         max_results: Optional maximum number of sessions to return per page (API default if not provided).
         config: Optional configuration object.
+        region: The AWS region of the farm. When omitted, it is resolved for this farm
+            from the config (defaults.farm_region), otherwise the session/profile region.
 
     Returns:
         {"sessions": [...]} with session summaries including sessionId, lifecycleStatus, workerId.
     """
-    deadline: "DeadlineClient" = get_boto3_client("deadline", config=config)
+    region = _resolve_region(config=config, region=region, farm_id=farm_id)
+    deadline: "DeadlineClient" = get_boto3_client("deadline", config=config, region=region)
     kwargs: Dict[str, Any] = {
         "farmId": farm_id,
         "queueId": queue_id,
@@ -128,6 +140,7 @@ def list_steps(
     job_id: str,
     max_results: Optional[int] = None,
     config: Optional[ConfigParser] = None,
+    region: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     List all steps for a job.
@@ -138,11 +151,14 @@ def list_steps(
         job_id: The ID of the job to list steps for.
         max_results: Optional maximum number of steps to return per page (API default if not provided).
         config: Optional configuration object.
+        region: The AWS region of the farm. When omitted, it is resolved for this farm
+            from the config (defaults.farm_region), otherwise the session/profile region.
 
     Returns:
         {"steps": [...]} with step summaries including stepId, name, taskRunStatus, taskRunStatusCounts.
     """
-    deadline: "DeadlineClient" = get_boto3_client("deadline", config=config)
+    region = _resolve_region(config=config, region=region, farm_id=farm_id)
+    deadline: "DeadlineClient" = get_boto3_client("deadline", config=config, region=region)
     kwargs: Dict[str, Any] = {
         "farmId": farm_id,
         "queueId": queue_id,
@@ -165,6 +181,7 @@ def list_tasks(
     step_id: str,
     max_results: Optional[int] = None,
     config: Optional[ConfigParser] = None,
+    region: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     List all tasks for a step.
@@ -176,11 +193,14 @@ def list_tasks(
         step_id: The ID of the step to list tasks for.
         max_results: Optional maximum number of tasks to return per page (API default if not provided).
         config: Optional configuration object.
+        region: The AWS region of the farm. When omitted, it is resolved for this farm
+            from the config (defaults.farm_region), otherwise the session/profile region.
 
     Returns:
         {"tasks": [...]} with task summaries including taskId, runStatus, parameters.
     """
-    deadline: "DeadlineClient" = get_boto3_client("deadline", config=config)
+    region = _resolve_region(config=config, region=region, farm_id=farm_id)
+    deadline: "DeadlineClient" = get_boto3_client("deadline", config=config, region=region)
     kwargs: Dict[str, Any] = {
         "farmId": farm_id,
         "queueId": queue_id,
@@ -205,6 +225,7 @@ def search_jobs(
     page_size: int = 25,
     item_offset: int = 0,
     config: Optional[ConfigParser] = None,
+    region: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Search for jobs with optional filters.
@@ -217,6 +238,8 @@ def search_jobs(
         page_size: Results per page (1-100, default 25).
         item_offset: Offset for pagination (0-10000).
         config: Optional configuration object.
+        region: The AWS region of the farm. When omitted, it is resolved for the resolved
+            farm from the config (defaults.farm_region), otherwise the session/profile region.
 
     Returns:
         {"jobs": [...], "totalResults": N, "nextItemOffset": N}
@@ -233,7 +256,9 @@ def search_jobs(
     if not queue_ids:
         raise ValueError("queue_ids is required (not found in config defaults)")
 
-    deadline: "DeadlineClient" = get_boto3_client("deadline", config=config)
+    # Resolve the region only after farm_id is finalized (it may come from config defaults).
+    region = _resolve_region(config=config, region=region, farm_id=farm_id)
+    deadline: "DeadlineClient" = get_boto3_client("deadline", config=config, region=region)
 
     # Build filter expressions
     filter_expressions: List[Dict[str, Any]] = []

--- a/src/deadline/client/api/_queue_parameters.py
+++ b/src/deadline/client/api/_queue_parameters.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 __all__ = ["get_queue_parameter_definitions"]
 
+from typing import Optional
+
 import yaml
 
 from .. import api
@@ -20,7 +22,7 @@ from ..ui._utils import tr
 
 @api.record_function_latency_telemetry_event()
 def get_queue_parameter_definitions(
-    *, farmId: str, queueId: str, config=None
+    *, region: Optional[str] = None, farmId: str, queueId: str, config=None
 ) -> list[JobParameter]:
     """
     This gets all the queue parameter definitions for the specified [Deadline Cloud queue].
@@ -30,8 +32,16 @@ def get_queue_parameter_definitions(
 
     [Deadline Cloud queue]: https://docs.aws.amazon.com/deadline-cloud/latest/userguide/queues.html
     [queue environments]: https://docs.aws.amazon.com/deadline-cloud/latest/userguide/create-queue-environment.html
+
+    Args:
+        region (str, optional): The AWS region of the farm. When None, the region is
+            resolved from `defaults.farm_region` (if set), otherwise the session/profile
+            region is used.
+        farmId (str): The farm the queue belongs to.
+        queueId (str): The queue to get parameter definitions for.
+        config (ConfigParser, optional): If provided, the AWS Deadline Cloud config to use.
     """
-    deadline = get_boto3_client("deadline", config=config)
+    deadline = get_boto3_client("deadline", config=config, region=region)
     response = _call_paginated_deadline_list_api(
         deadline.list_queue_environments,
         "environments",

--- a/src/deadline/client/api/_session.py
+++ b/src/deadline/client/api/_session.py
@@ -169,6 +169,14 @@ def _resolve_region(
     2. The ``defaults.farm_region`` config setting, if set (non-empty).
     3. ``None`` (let boto3/the session decide, preserving single-region behavior).
 
+    Contract / region-value convention: this normalizes "no region" to ``None`` and never
+    returns ``""``. Both an explicit ``region=""`` and an empty ``defaults.farm_region`` are
+    treated as "not set" (the falsy ``if region:`` / ``if farm_region:`` checks below).
+    Callers downstream of resolution therefore test ``if region is not None:`` -- a
+    resolved region is either ``None`` (use the session/profile default) or a real region.
+    Raw, pre-resolution inputs (CLI args, config reads) may legitimately be ``""`` and use a
+    truthy ``if region:`` check instead; the two conventions are intentional, not arbitrary.
+
     Args:
         config (ConfigParser, optional): The AWS Deadline Cloud config to use.
         region (str, optional): An explicit region override.
@@ -177,8 +185,9 @@ def _resolve_region(
             differ from the default farm). When ``None``, the default farm's region is used.
 
     Returns:
-        The resolved region name, or ``None`` if nothing is configured.
+        The resolved region name, or ``None`` if nothing is configured (never ``""``).
     """
+    # Truthy (not "is not None"): an explicit region="" means "not provided", so fall through.
     if region:
         return region
 

--- a/src/deadline/client/api/_session.py
+++ b/src/deadline/client/api/_session.py
@@ -26,7 +26,7 @@ from botocore.exceptions import (  # type: ignore[import]
 from botocore.session import get_session as get_botocore_session
 
 from .. import version
-from ..config import get_setting, config_file
+from ..config import get_setting, set_setting, config_file
 from ..exceptions import DeadlineOperationError
 from ...job_attachments._aws.aws_clients import get_s3_client
 
@@ -52,7 +52,9 @@ session_context: dict[str, Optional[str]] = {
 
 
 def get_boto3_session(
-    force_refresh: bool = False, config: Optional[ConfigParser] = None
+    force_refresh: bool = False,
+    config: Optional[ConfigParser] = None,
+    region: Optional[str] = None,
 ) -> boto3.Session:
     """
     Gets a boto3 session for the AWS Deadline Cloud aws profile from the local
@@ -65,6 +67,9 @@ def get_boto3_session(
     Args:
         force_refresh (bool, optional): If set to True, forces a cache refresh.
         config (ConfigParser, optional): If provided, the AWS Deadline Cloud config to use.
+        region (str, optional): If provided, returns a session scoped to this region (so
+            boto3 resolves the regional Deadline endpoint itself). When omitted, the
+            profile's default region is used (today's behavior).
     """
 
     profile_name: Optional[str] = get_setting("defaults.aws_profile_name", config)
@@ -77,12 +82,12 @@ def get_boto3_session(
     if force_refresh:
         invalidate_boto3_session_cache()
 
-    return _get_boto3_session_for_profile(profile_name)
+    return _get_boto3_session_for_profile(profile_name, region)
 
 
 @lru_cache
-def _get_boto3_session_for_profile(profile_name: str):
-    session = boto3.Session(profile_name=profile_name)
+def _get_boto3_session_for_profile(profile_name: str, region: Optional[str] = None):
+    session = boto3.Session(profile_name=profile_name, region_name=region)
 
     # By default, DCM returns creds that expire after 15 minutes, and boto3's RefreshableCredentials
     # class refreshes creds that are within 15 minutes of expiring, so credentials would never be reused.
@@ -130,35 +135,104 @@ def get_default_client_config(**kwargs) -> botocore.config.Config:
 
 
 @lru_cache
-def get_session_client(session: boto3.Session, service_name: str):
+def get_session_client(session: boto3.Session, service_name: str, region: Optional[str] = None):
     """
-    Create and cache a boto3 client for the given session and service name.
+    Create and cache a boto3 client for the given session, service name, and region.
 
     This function is decorated with @lru_cache to ensure that repeated calls
-    with the same session and service name return the cached client to avoid
-    repeating initialization where possible.
+    with the same session, service name, and region return the cached client to
+    avoid repeating initialization where possible. The ``region`` argument is part
+    of the cache key so clients for different regions are never reused for each other.
 
     Args:
         session: The boto3 Session to use for creating the client
         service_name: The name of the AWS service (e.g., 'deadline', 's3')
+        region: The AWS region to create the client for. If None, the session's
+            default region is used.
 
     Returns:
         A boto3 client for the specified service
     """
-    return session.client(service_name, config=get_default_client_config())
+    if region is None:
+        return session.client(service_name, config=get_default_client_config())
+    return session.client(service_name, config=get_default_client_config(), region_name=region)
 
 
-def get_boto3_client(service_name: str, config: Optional[ConfigParser] = None) -> BaseClient:
+def _resolve_region(
+    config: Optional[ConfigParser] = None,
+    region: Optional[str] = None,
+    farm_id: Optional[str] = None,
+) -> Optional[str]:
+    """
+    Resolves which AWS region to use, following this precedence:
+    1. An explicit ``region`` argument.
+    2. The ``defaults.farm_region`` config setting, if set (non-empty).
+    3. ``None`` (let boto3/the session decide, preserving single-region behavior).
+
+    Args:
+        config (ConfigParser, optional): The AWS Deadline Cloud config to use.
+        region (str, optional): An explicit region override.
+        farm_id (str, optional): The farm the region is being resolved for. When given,
+            the per-farm ``defaults.farm_region`` is looked up for *this* farm (which may
+            differ from the default farm). When ``None``, the default farm's region is used.
+
+    Returns:
+        The resolved region name, or ``None`` if nothing is configured.
+    """
+    if region:
+        return region
+
+    farm_region = _get_farm_region_setting(config=config, farm_id=farm_id)
+    if farm_region:
+        return farm_region
+
+    return None
+
+
+def _get_farm_region_setting(
+    config: Optional[ConfigParser] = None,
+    farm_id: Optional[str] = None,
+) -> str:
+    """
+    Reads ``defaults.farm_region`` for a specific farm.
+
+    ``defaults.farm_region`` is keyed per farm (it depends on ``defaults.farm_id``), so to
+    read a non-default farm's region we read it against a config whose ``defaults.farm_id``
+    is set to that farm. When ``farm_id`` is ``None`` (or matches the default), the live
+    config is read directly. Returns ``""`` when no region is stored.
+    """
+    if farm_id is None:
+        return get_setting("defaults.farm_region", config=config)
+
+    # Read against a copy with defaults.farm_id overridden to the target farm, so the
+    # per-farm section lookup resolves to that farm rather than the default one.
+    if config is None:
+        config = config_file.read_config()
+    farm_scoped_config = ConfigParser()
+    farm_scoped_config.read_dict(config)
+    set_setting("defaults.farm_id", farm_id, config=farm_scoped_config)
+    return get_setting("defaults.farm_region", config=farm_scoped_config)
+
+
+def get_boto3_client(
+    service_name: str,
+    config: Optional[ConfigParser] = None,
+    region: Optional[str] = None,
+) -> BaseClient:
     """
     Gets a client from the boto3 session returned by `get_boto3_session`.
 
     Args:
         service_name (str): The AWS service to get the client for, e.g. "deadline".
         config (ConfigParser, optional): If provided, the AWS Deadline Cloud config to use.
+        region (str, optional): The AWS region to create the client for. When omitted,
+            the region is resolved from `defaults.farm_region` (if set), otherwise the
+            session/profile region is used.
     """
 
     session = get_boto3_session(config=config)
-    return get_session_client(session=session, service_name=service_name)
+    resolved_region = _resolve_region(config=config, region=region)
+    return get_session_client(session=session, service_name=service_name, region=resolved_region)
 
 
 def get_credentials_source(
@@ -239,8 +313,13 @@ def get_queue_user_boto3_session(
     if queue_id is None:
         queue_id = get_setting("defaults.queue_id")
 
+    # Resolve the region to scope the queue-user session to, for this specific farm.
+    # When nothing is configured, _resolve_region returns None and we fall back to the
+    # base session's region.
+    region = _resolve_region(config=config, farm_id=farm_id)
+
     return _get_queue_user_boto3_session(
-        deadline, base_session, farm_id, queue_id, queue_display_name
+        deadline, base_session, farm_id, queue_id, queue_display_name, region
     )
 
 
@@ -251,6 +330,7 @@ def _get_queue_user_boto3_session(
     farm_id: str,
     queue_id: str,
     queue_display_name: Optional[str] = None,
+    region: Optional[str] = None,
 ):
     queue_credential_provider = QueueUserCredentialProvider(
         deadline,
@@ -269,7 +349,7 @@ def _get_queue_user_boto3_session(
     return boto3.Session(
         botocore_session=botocore_session,
         profile_name=aws_profile_name,
-        region_name=base_session.region_name,
+        region_name=region if region is not None else base_session.region_name,
     )
 
 

--- a/src/deadline/client/cli/_common.py
+++ b/src/deadline/client/cli/_common.py
@@ -139,6 +139,10 @@ def _apply_cli_options_to_config(
         if farm_id:
             config_file.set_setting(SETTING_FARM_ID, farm_id, config=config)
 
+        region = args.pop("region", None)
+        if region:
+            config_file.set_setting("defaults.farm_region", region, config=config)
+
         queue_id = args.pop("queue_id", None)
         if queue_id:
             config_file.set_setting(SETTING_QUEUE_ID, queue_id, config=config)
@@ -164,7 +168,7 @@ def _apply_cli_options_to_config(
             )
     else:
         # Remove the standard option names from the args list
-        for name in ["profile", "farm_id", "queue_id", "job_id", "storage_profile_id"]:
+        for name in ["profile", "farm_id", "region", "queue_id", "job_id", "storage_profile_id"]:
             args.pop(name, None)
 
     # Check that the required options have values, auto-selecting if only one exists

--- a/src/deadline/client/cli/_groups/_trace_schedule.py
+++ b/src/deadline/client/cli/_groups/_trace_schedule.py
@@ -27,6 +27,7 @@ from ._batch_get import batch_get
 @click.command(name="trace-schedule", cls=ContextTrackingCommand)
 @click.option("--profile", help="The AWS profile to use.")
 @click.option("--farm-id", help="The farm to use.")
+@click.option("--region", help="The AWS region of the farm.")
 @click.option("--queue-id", help="The queue to use.")
 @click.option("--job-id", help="The job to trace.")
 @click.option("-v", "--verbose", is_flag=True, help="Output verbose trace details.")

--- a/src/deadline/client/cli/_groups/attachment_group.py
+++ b/src/deadline/client/cli/_groups/attachment_group.py
@@ -19,7 +19,7 @@ from ...config import config_file
 from .._main import deadline as main
 
 from ... import api
-from ...api._session import get_default_client_config
+from ...api._session import get_session_client, _resolve_region
 from ....job_attachments.api.attachment import (
     _attachment_download,
     _attachment_upload,
@@ -58,6 +58,7 @@ def cli_attachment():
 )
 @click.option("--path-mapping-rules", help="Path to a file with the path mapping rules to use.")
 @click.option("--farm-id", help="The AWS Deadline Cloud Farm to use. ")
+@click.option("--region", help="The AWS region of the farm.")
 @click.option("--queue-id", help="The AWS Deadline Cloud Queue to use. ")
 @click.option(
     "--profile",
@@ -113,6 +114,15 @@ def attachment_download(
         queue_id: str = config_file.get_setting("defaults.queue_id", config=config)
         farm_id: str = config_file.get_setting("defaults.farm_id", config=config)
 
+        # These operate within a single farm, so scope every deadline call to that farm's
+        # region. _resolve_region returns None when nothing is configured.
+        region = _resolve_region(config=config, farm_id=farm_id)
+        if region is not None:
+            # GetQueue must run in the farm's region. get_queue builds its own client off
+            # the session, so hand it a region-scoped session and let boto3 resolve the
+            # regional endpoint itself.
+            boto3_session = api.get_boto3_session(config=config, region=region)
+
         s3_settings: Optional[JobAttachmentS3Settings] = get_queue(
             farm_id=farm_id,
             queue_id=queue_id,
@@ -123,7 +133,7 @@ def attachment_download(
 
         s3_root_uri = s3_settings.to_s3_root_uri()
 
-        deadline_client = boto3_session.client("deadline", config=get_default_client_config())
+        deadline_client = get_session_client(boto3_session, "deadline", region=region)
         boto3_session = api.get_queue_user_boto3_session(deadline=deadline_client, config=config)
 
     if not s3_root_uri:
@@ -178,6 +188,7 @@ def attachment_download(
     help="File path for uploading the manifests to CAS.",
 )
 @click.option("--farm-id", help="The AWS Deadline Cloud Farm to use. ")
+@click.option("--region", help="The AWS region of the farm.")
 @click.option("--queue-id", help="The AWS Deadline Cloud Queue to use. ")
 @click.option(
     "--profile",
@@ -215,6 +226,15 @@ def attachment_upload(
         queue_id: str = config_file.get_setting("defaults.queue_id", config=config)
         farm_id: str = config_file.get_setting("defaults.farm_id", config=config)
 
+        # These operate within a single farm, so scope every deadline call to that farm's
+        # region. _resolve_region returns None when nothing is configured.
+        region = _resolve_region(config=config, farm_id=farm_id)
+        if region is not None:
+            # GetQueue must run in the farm's region. get_queue builds its own client off
+            # the session, so hand it a region-scoped session and let boto3 resolve the
+            # regional endpoint itself.
+            boto3_session = api.get_boto3_session(config=config, region=region)
+
         s3_settings: Optional[JobAttachmentS3Settings] = get_queue(
             farm_id=farm_id,
             queue_id=queue_id,
@@ -225,7 +245,7 @@ def attachment_upload(
 
         s3_root_uri = s3_settings.to_s3_root_uri()
 
-        deadline_client = boto3_session.client("deadline", config=get_default_client_config())
+        deadline_client = get_session_client(boto3_session, "deadline", region=region)
         boto3_session = api.get_queue_user_boto3_session(deadline=deadline_client, config=config)
 
     if not s3_root_uri:

--- a/src/deadline/client/cli/_groups/bundle_group.py
+++ b/src/deadline/client/cli/_groups/bundle_group.py
@@ -155,6 +155,7 @@ def _interactive_confirmation_prompt(message: str, default_response: bool) -> bo
 )
 @click.option("--profile", help="The AWS profile to use.")
 @click.option("--farm-id", help="The farm to use.")
+@click.option("--region", help="The AWS region of the farm.")
 @click.option("--queue-id", help="The queue to use.")
 @click.option("--storage-profile-id", help="The storage profile to use.")
 @click.option("--name", help="The job name to use in place of the one in the job bundle.")
@@ -326,6 +327,7 @@ def bundle_submit(
         if (
             args.get("profile") is None
             and args.get("farm_id") is None
+            and args.get("region") is None
             and args.get("queue_id") is None
             and args.get("storage_profile_id") is None
             and job_id

--- a/src/deadline/client/cli/_groups/farm_group.py
+++ b/src/deadline/client/cli/_groups/farm_group.py
@@ -32,27 +32,42 @@ def cli_farm():
 
 @cli_farm.command(name="list")
 @click.option("--profile", help="The AWS profile to use.")
+@click.option("--region", help="The AWS region of the farm.")
 @_handle_error
-def farm_list(**args):
+def farm_list(region, **args):
     """
     Lists the available Deadline Cloud farms. If the AWS profile is created
     from a Deadline Cloud monitor login, it will list only the farms you have
     permission to access.
+
+    Without --region, farms are listed across all Deadline Cloud regions and
+    each farm's region is shown. With --region, only that region is listed.
     """
-    # Get a temporary config object with the standard options handled
+    # Get a temporary config object with the standard options handled.
+    # Note: --region is consumed directly here (to scope the fan-out) rather than
+    # being routed through config via _apply_cli_options_to_config.
     config = _apply_cli_options_to_config(**args)
 
     try:
-        response = api.list_farms(config=config)
+        response = api.list_farms(config=config, region=region)
+    except DeadlineOperationError:
+        # When listing across all regions, a total (every-region) failure raises a
+        # DeadlineOperationError that already summarizes each region's cause. Let it
+        # propagate so _handle_error prints the summary verbatim.
+        raise
     except ClientError as exc:
+        # Single-region (--region given) failures surface as a ClientError; keep the
+        # resource-suggestion behavior for those.
         suggestion = _suggest_resources_on_client_error(exc, config=config)
         raise DeadlineOperationError(
             f"Failed to get Farms from Deadline:\n{exc}{suggestion}"
         ) from exc
 
-    # Select which fields to print and in which order
+    # Select which fields to print and in which order. Per the (region, farm_id)
+    # convention, the region column comes first.
     structured_farm_list = [
-        {field: farm[field] for field in ["farmId", "displayName"]} for farm in response["farms"]
+        {field: farm[field] for field in ["region", "farmId", "displayName"] if field in farm}
+        for farm in response["farms"]
     ]
 
     click.echo(_cli_object_repr(structured_farm_list))
@@ -61,6 +76,7 @@ def farm_list(**args):
 @cli_farm.command(name="get")
 @click.option("--profile", help="The AWS profile to use.")
 @click.option("--farm-id", help="The farm to use.")
+@click.option("--region", help="The AWS region of the farm.")
 @_handle_error
 def farm_get(**args):
     """

--- a/src/deadline/client/cli/_groups/fleet_group.py
+++ b/src/deadline/client/cli/_groups/fleet_group.py
@@ -33,6 +33,7 @@ def cli_fleet():
 @cli_fleet.command(name="list")
 @click.option("--profile", help="The AWS profile to use.")
 @click.option("--farm-id", help="The farm to use.")
+@click.option("--region", help="The AWS region of the farm.")
 @_handle_error
 def fleet_list(**args):
     """
@@ -69,6 +70,7 @@ def fleet_list(**args):
 @click.option(
     "--queue-id", help="If no fleet is provided, gets the fleets associated with this queue."
 )
+@click.option("--region", help="The AWS region of the farm.")
 @_handle_error
 def fleet_get(fleet_id, queue_id, **args):
     """

--- a/src/deadline/client/cli/_groups/job_group.py
+++ b/src/deadline/client/cli/_groups/job_group.py
@@ -20,7 +20,7 @@ import textwrap
 import click
 from botocore.exceptions import ClientError
 
-from ...api._session import _modified_logging_level
+from ...api._session import _modified_logging_level, _resolve_region
 from ....job_attachments.models import (
     FileConflictResolution,
     JobAttachmentS3Settings,
@@ -146,6 +146,7 @@ def cli_job():
 @cli_job.command(name="list")
 @click.option("--profile", help="The AWS profile to use.")
 @click.option("--farm-id", help="The farm to use.")
+@click.option("--region", help="The AWS region of the farm.")
 @click.option("--queue-id", help="The queue to use.")
 @click.option("--page-size", default=5, help="The number of jobs to load at a time.")
 @click.option("--item-offset", default=0, help="The index of the job to start listing from.")
@@ -215,6 +216,7 @@ def job_list(page_size, item_offset, **args):
 @click.argument("search_term", required=False)
 @click.option("--profile", help="The AWS profile to use.")
 @click.option("--farm-id", help="The farm to use.")
+@click.option("--region", help="The AWS region of the farm.")
 @click.option("--queue-id", help="The queue to use.")
 @click.option("--job-id", help="The job to get.")
 @_handle_error
@@ -254,6 +256,7 @@ def job_get(search_term: Optional[str], **args):
 @cli_job.command(name="cancel")
 @click.option("--profile", help="The AWS profile to use.")
 @click.option("--farm-id", help="The farm to use.")
+@click.option("--region", help="The AWS region of the farm.")
 @click.option("--queue-id", help="The queue to use.")
 @click.option("--job-id", help="The job to cancel.")
 @click.option(
@@ -348,6 +351,7 @@ def job_cancel(mark_as: str, yes: bool, **args):
 @cli_job.command(name="requeue-tasks")
 @click.option("--profile", help="The AWS profile to use.")
 @click.option("--farm-id", help="The farm to use.")
+@click.option("--region", help="The AWS region of the farm.")
 @click.option("--queue-id", help="The queue to use.")
 @click.option("--job-id", help="The job to requeue tasks for.")
 @click.option(
@@ -398,7 +402,16 @@ def job_requeue_tasks(run_status: Optional[list[str]], **args):
     requeues_client_config = get_default_client_config(
         retries=dict(mode="adaptive", total_max_attempts=5)
     )
-    deadline_client_for_requeues = session.client("deadline", config=requeues_client_config)
+    # Requeues operate within a single farm, so scope the client to that farm's region.
+    # _resolve_region returns None when nothing is configured; only pass
+    # region_name when resolved so the custom retry config is otherwise unchanged.
+    requeues_region = _resolve_region(config=config, farm_id=farm_id)
+    if requeues_region is not None:
+        deadline_client_for_requeues = session.client(
+            "deadline", config=requeues_client_config, region_name=requeues_region
+        )
+    else:
+        deadline_client_for_requeues = session.client("deadline", config=requeues_client_config)
 
     # Print a summary of the job's task run statuses
     job = deadline_client.get_job(farmId=farm_id, queueId=queue_id, jobId=job_id)
@@ -1007,6 +1020,7 @@ def _assert_valid_path(path: str) -> None:
 @cli_job.command(name="download-output")
 @click.option("--profile", help="The AWS profile to use.")
 @click.option("--farm-id", help="The farm to use.")
+@click.option("--region", help="The AWS region of the farm.")
 @click.option("--queue-id", help="The queue to use.")
 @click.option("--job-id", help="The job to use.")
 @click.option("--step-id", help="The step to use.")
@@ -1282,6 +1296,7 @@ def _download_job_input(
 @cli_job.command(name="download-input")
 @click.option("--profile", help="The AWS profile to use.")
 @click.option("--farm-id", help="The farm to use.")
+@click.option("--region", help="The AWS region of the farm.")
 @click.option("--queue-id", help="The queue to use.")
 @click.option("--job-id", help="The job to use.")
 @click.option(
@@ -1387,6 +1402,7 @@ def job_download_input(include, match_paths_by, output, ignore_storage_profiles,
 @cli_job.command(name="wait")
 @click.option("--profile", help="The AWS profile to use.")
 @click.option("--farm-id", help="The farm to use.")
+@click.option("--region", help="The AWS region of the farm.")
 @click.option("--queue-id", help="The queue to use.")
 @click.option("--job-id", help="The job to wait for.")
 @click.option("--max-poll-interval", default=120, help="Maximum polling interval in seconds.")
@@ -1568,6 +1584,7 @@ def job_wait_for_completion(max_poll_interval, timeout, output, **args):
 @cli_job.command(name="logs")
 @click.option("--profile", help="The AWS profile to use.")
 @click.option("--farm-id", help="The farm to use.")
+@click.option("--region", help="The AWS region of the farm.")
 @click.option("--queue-id", help="The queue to use.")
 @click.option("--job-id", help="The job to get logs for.")
 @click.option(

--- a/src/deadline/client/cli/_groups/manifest_group.py
+++ b/src/deadline/client/cli/_groups/manifest_group.py
@@ -22,6 +22,7 @@ from deadline.client.api._submit_job_bundle import hashing_telemetry_callback
 from deadline.client import api
 from deadline.client.api._session import (
     _get_queue_user_boto3_session,
+    _resolve_region,
     get_default_client_config,
 )
 from deadline.client.config import config_file
@@ -283,6 +284,7 @@ def manifest_diff(
 @click.option("--step-id", help="The AWS Deadline Cloud Step to get. ")
 @click.option("--farm-id", help="The AWS Deadline Cloud Farm to use. ")
 @click.option("--queue-id", help="The AWS Deadline Cloud Queue to use. ")
+@click.option("--region", help="The AWS region of the farm.")
 @click.option(
     "--asset-type",
     default=AssetType.ALL.value,
@@ -329,8 +331,16 @@ def manifest_download(
     farm_id: str = config_file.get_setting("defaults.farm_id", config=config)
 
     boto3_session: boto3.Session = api.get_boto3_session(config=config)
-    # Deadline Client and get the Queue to download.
-    deadline_client = boto3_session.client("deadline", config=get_default_client_config())
+    # Deadline Client and get the Queue to download. This operates within a single farm, so
+    # scope the client to that farm's region. _resolve_region returns None when nothing is
+    # configured; only pass region_name when resolved.
+    region = _resolve_region(config=config, farm_id=farm_id)
+    if region is not None:
+        deadline_client = boto3_session.client(
+            "deadline", config=get_default_client_config(), region_name=region
+        )
+    else:
+        deadline_client = boto3_session.client("deadline", config=get_default_client_config())
     queue: dict = deadline_client.get_queue(
         farmId=farm_id,
         queueId=queue_id,
@@ -338,13 +348,14 @@ def manifest_download(
     # Queue's Job Attachment settings.
     queue_s3_settings = JobAttachmentS3Settings(**queue["jobAttachmentSettings"])
 
-    # assume queue role - session permissions
+    # assume queue role - session permissions, scoped to the same farm region as above.
     queue_role_session: boto3.Session = _get_queue_user_boto3_session(
         deadline=deadline_client,
         base_session=boto3_session,
         farm_id=farm_id,
         queue_id=queue_id,
         queue_display_name=queue["displayName"],
+        region=region,
     )
 
     output = _manifest_download(
@@ -381,6 +392,7 @@ def manifest_download(
     "--queue-id",
     help="The AWS Deadline Cloud Queue to use. Alternative to using --s3-cas-uri.",
 )
+@click.option("--region", help="The AWS region of the farm.")
 @click.option(
     "--json",
     default=None,

--- a/src/deadline/client/cli/_groups/queue_group.py
+++ b/src/deadline/client/cli/_groups/queue_group.py
@@ -15,7 +15,7 @@ from botocore.exceptions import ClientError  # type: ignore[import]
 from datetime import datetime, timedelta, timezone
 
 from ... import api
-from ...api._session import get_session_client
+from ...api._session import get_session_client, _resolve_region
 from ...config import config_file
 from ...exceptions import DeadlineOperationError
 from .._common import (
@@ -54,6 +54,7 @@ def cli_queue():
 @cli_queue.command(name="list")
 @click.option("--profile", help="The AWS profile to use.")
 @click.option("--farm-id", help="The farm to use.")
+@click.option("--region", help="The AWS region of the farm.")
 @_handle_error
 def queue_list(**args):
     """
@@ -86,6 +87,7 @@ def queue_list(**args):
 @cli_queue.command(name="export-credentials")
 @click.option("--queue-id", help="The queue ID to use.")
 @click.option("--farm-id", help="The farm ID to use.")
+@click.option("--region", help="The AWS region of the farm.")
 @click.option(
     "--mode",
     type=click.Choice(["USER", "READ"], case_sensitive=False),
@@ -188,6 +190,7 @@ def queue_export_credentials(mode, output_format, **args):
 @click.option("--profile", help="The AWS profile to use.")
 @click.option("--farm-id", help="The farm to use.")
 @click.option("--queue-id", help="The queue to use.")
+@click.option("--region", help="The AWS region of the farm.")
 @_handle_error
 def queue_paramdefs(**args):
     """
@@ -222,6 +225,7 @@ def queue_paramdefs(**args):
 @click.option("--profile", help="The AWS profile to use.")
 @click.option("--farm-id", help="The farm to use.")
 @click.option("--queue-id", help="The queue to use.")
+@click.option("--region", help="The AWS region of the farm.")
 @_handle_error
 def queue_get(**args):
     """
@@ -252,6 +256,7 @@ def queue_get(**args):
 @click.option("--profile", help="The AWS profile to use.")
 @click.option("--farm-id", help="The AWS Deadline Cloud Farm to use.")
 @click.option("--queue-id", help="The AWS Deadline Cloud Queue to use.")
+@click.option("--region", help="The AWS region of the farm.")
 @click.option(
     "--storage-profile-id",
     help="The storage profile to use for mapping paths to local. Cannot be used together with --ignore-storage-profiles",
@@ -361,7 +366,10 @@ def sync_output(
     farm_id = config_file.get_setting("defaults.farm_id", config=config)
     queue_id = config_file.get_setting("defaults.queue_id", config=config)
     boto3_session: boto3.Session = api.get_boto3_session(config=config)
-    deadline = get_session_client(boto3_session, "deadline")
+    # This operates within a single farm, so scope the deadline client to that farm's
+    # region. _resolve_region returns None when nothing is configured.
+    region = _resolve_region(config=config, farm_id=farm_id)
+    deadline = get_session_client(boto3_session, "deadline", region=region)
 
     if ignore_storage_profiles:
         local_storage_profile_id = None

--- a/src/deadline/client/cli/_groups/worker_group.py
+++ b/src/deadline/client/cli/_groups/worker_group.py
@@ -34,6 +34,7 @@ def cli_worker():
 @cli_worker.command(name="list")
 @click.option("--profile", help="The AWS profile to use.")
 @click.option("--farm-id", help="The farm to use.")
+@click.option("--region", help="The AWS region of the farm.")
 @click.option("--fleet-id", help="The fleet to use.", required=True)
 @click.option("--page-size", default=5, help="The number of workers to load at a time.")
 @click.option("--item-offset", default=0, help="The index of the worker to start listing from.")
@@ -78,6 +79,7 @@ def worker_list(page_size, item_offset, fleet_id, **args):
 @cli_worker.command(name="get")
 @click.option("--profile", help="The AWS profile to use.")
 @click.option("--farm-id", help="The farm to use.")
+@click.option("--region", help="The AWS region of the farm.")
 @click.option("--fleet-id", help="The fleet to use.", required=True)
 @click.option("--worker-id", help="The worker to get.", required=True)
 @_handle_error

--- a/src/deadline/client/cli/_incremental_download.py
+++ b/src/deadline/client/cli/_incremental_download.py
@@ -17,7 +17,7 @@ from .. import api
 import boto3
 from botocore.client import BaseClient  # type: ignore[import]
 from ..api._list_jobs_by_filter_expression import _list_jobs_by_filter_expression
-from ..api._session import get_session_client
+from ..api._session import get_session_client, _resolve_region
 from ...job_attachments.api import summarize_path_list, human_readable_file_size
 from ...job_attachments._incremental_downloads.incremental_download_state import (
     IncrementalDownloadState,
@@ -73,6 +73,7 @@ def _get_download_candidate_jobs(
     queue_id: str,
     starting_timestamp: datetime,
     print_function_callback: Callable[[Any], None] = lambda msg: None,
+    region: Optional[str] = None,
 ) -> dict[str, dict[str, Any]]:
     """
     Uses deadline:SearchJobs queries to get a dict {job_id: job} of download candidates for the queue.
@@ -85,6 +86,8 @@ def _get_download_candidate_jobs(
         queue_id: The queue id for the operation.
         starting_timestamp: The point in time from which to look for new download outputs.
         print_function_callback: Callback for printing output to the terminal or log.
+        region: The AWS region to scope the deadline client to. When None, the session's
+            default region is used.
 
     Returns:
         A dictionary mapping job id to the job as returned by the deadline.search_jobs API.
@@ -120,6 +123,7 @@ def _get_download_candidate_jobs(
                 ],
                 "operator": "OR",
             },
+            region=region,
         )
     }
     print(f"DEBUG: Got {len(download_candidate_jobs)} active jobs")
@@ -151,6 +155,7 @@ def _get_download_candidate_jobs(
             ],
             "operator": "AND",
         },
+        region=region,
     )
     print(
         f"DEBUG: Got {len(recently_ended_jobs)} jobs with job[endedAt] >= {starting_timestamp.astimezone().isoformat()}"
@@ -206,6 +211,7 @@ def _categorize_jobs_in_checkpoint(
     download_candidate_jobs: dict[str, dict[str, Any]],
     new_completed_timestamp: datetime,
     print_function_callback: Callable[[Any], None] = lambda msg: None,
+    region: Optional[str] = None,
 ) -> CategorizedJobIds:
     """
     Categorizes the provided download candidate jobs by id into a CategorizedJobIds object,
@@ -223,8 +229,10 @@ def _categorize_jobs_in_checkpoint(
         new_completed_timestamp: This is the timestamp value that will be placed in
             checkpoint.downloads_completed_timestamp when saving the checkpoint.
         print_function_callback: Callback for printing output to the terminal or log.
+        region: The AWS region to scope the deadline client to. When None, the session's
+            default region is used.
     """
-    deadline = get_session_client(boto3_session, "deadline")
+    deadline = get_session_client(boto3_session, "deadline", region=region)
     checkpoint_jobs = {job.job_id: job.job for job in checkpoint.jobs}
     checkpoint_job_ids = set(checkpoint_jobs.keys())
 
@@ -522,6 +530,7 @@ def _get_job_sessions(
     checkpoint: IncrementalDownloadState,
     download_candidate_jobs: dict[str, dict[str, Any]],
     print_function_callback: Callable[[Any], None] = lambda msg: None,
+    region: Optional[str] = None,
 ) -> dict[str, list]:
     """
     This function gets all the job sessions and session actions from the completed, added, and updated jobs.
@@ -540,6 +549,8 @@ def _get_job_sessions(
         download_candidate_jobs: The result of a _get_download_candidate_jobs call, {job_id: job} where
             job is a result from a deadline.search_jobs() or deadline.get_job() call.
         print_function_callback: Callback for printing output to the terminal or log.
+        region: The AWS region to scope the deadline client to. When None, the session's
+            default region is used.
 
     Returns:
         Access a session action in the returned job_sessions with
@@ -577,7 +588,7 @@ def _get_job_sessions(
         if job.session_ended_timestamp is not None
     }
 
-    deadline = get_session_client(boto3_session, "deadline")
+    deadline = get_session_client(boto3_session, "deadline", region=region)
     job_sessions: dict[str, list] = {}
 
     # Retrieve all the sessions with some parallelism
@@ -1007,7 +1018,11 @@ def _incremental_output_download(
         An updated checkpoint object.
     """
     durations = IncrementalOutputDownloadLatencies()
-    deadline = get_session_client(boto3_session, "deadline")
+    # Operations here are within a single farm, so scope the deadline client to that
+    # farm's region. _resolve_region returns None when nothing is configured, preserving
+    # the session's default-region behavior.
+    region = _resolve_region(config=config, farm_id=farm_id)
+    deadline = get_session_client(boto3_session, "deadline", region=region)
 
     # When this function is done, we will be confident that downloads are complete up to
     # new_completed_timestamp. We subtract a duration from now() that gives a generous amount of
@@ -1056,6 +1071,7 @@ def _incremental_output_download(
         queue["queueId"],
         checkpoint.downloads_completed_timestamp,
         print_function_callback,
+        region=region,
     )
     durations._get_download_candidate_jobs = time.perf_counter_ns() - start_t
 
@@ -1071,6 +1087,7 @@ def _incremental_output_download(
         download_candidate_jobs,
         new_completed_timestamp,
         print_function_callback,
+        region=region,
     )
     durations._categorize_jobs_in_checkpoint = time.perf_counter_ns() - start_t
 
@@ -1088,6 +1105,7 @@ def _incremental_output_download(
         checkpoint,
         download_candidate_jobs,
         print_function_callback,
+        region=region,
     )
     durations._get_job_sessions = time.perf_counter_ns() - start_t
 

--- a/src/deadline/client/cli/_suggest_resources.py
+++ b/src/deadline/client/cli/_suggest_resources.py
@@ -13,6 +13,7 @@ from typing import Optional
 from botocore.exceptions import ClientError
 
 from .. import api
+from ..exceptions import DeadlineOperationError
 
 
 def _format_resource_suggestions(
@@ -49,7 +50,11 @@ def _try_suggestion_chain(
             suggestions = _format_resource_suggestions(items, id_field, name_field, header)
             if suggestions:
                 return suggestions, False
-        except ClientError:
+        except (ClientError, DeadlineOperationError):
+            # ClientError: a single-region/per-farm List* call failed.
+            # DeadlineOperationError: the multi-region list_farms fan-out failed in
+            # every region (it wraps the per-region causes). Either way, fall through
+            # to the next fetcher in the chain.
             continue
     return [], True
 

--- a/src/deadline/client/config/config_file.py
+++ b/src/deadline/client/config/config_file.py
@@ -91,7 +91,7 @@ def _split_regions_csv(value: str) -> List[str]:
     return [region.strip() for region in value.split(",") if region.strip()]
 
 
-def get_deadline_regions() -> List[str]:
+def get_deadline_regions(config: Optional[ConfigParser] = None) -> List[str]:
     """
     Gets the list of AWS regions where AWS Deadline Cloud should be scanned.
 
@@ -104,6 +104,13 @@ def get_deadline_regions() -> List[str]:
     Regions are not auto-discovered at runtime: the curated list is the default, and a
     user who needs a different set overrides it via the env var or config setting above.
 
+    Args:
+        config (ConfigParser, optional): The AWS Deadline Cloud config to read the
+            ``settings.deadline_regions`` override from. When omitted, the live on-disk
+            config is read. Passing it through matters when a caller is operating on an
+            in-memory config (e.g. a CLI ``--profile`` override that hasn't been persisted)
+            so the region set honors that config rather than the global one.
+
     Returns:
         A de-duplicated, order-preserving list of region names.
     """
@@ -115,7 +122,7 @@ def get_deadline_regions() -> List[str]:
             return _dedupe_preserve_order(regions)
 
     # 2. Config setting override
-    config_value = get_setting("settings.deadline_regions")
+    config_value = get_setting("settings.deadline_regions", config=config)
     if config_value and config_value.strip():
         regions = _split_regions_csv(config_value)
         if regions:

--- a/src/deadline/client/config/config_file.py
+++ b/src/deadline/client/config/config_file.py
@@ -38,6 +38,93 @@ DEFAULT_DEADLINE_ENDPOINT_URL = os.getenv(
     f"https://deadline.{boto3.Session().region_name}.amazonaws.com",
 )
 
+# Environment variable that, if set, points all Deadline Cloud clients at a single
+# explicit endpoint (boto3 honors it natively). The list-farms fan-out treats its
+# presence as a single-region signal (see _list_apis._iter_farms_by_region).
+AWS_ENDPOINT_URL_DEADLINE_ENV_VAR = "AWS_ENDPOINT_URL_DEADLINE"
+
+# Environment variable that, if set, overrides which AWS regions Deadline Cloud is
+# scanned across (comma-separated list of region names).
+DEADLINE_REGIONS_ENV_VAR = "DEADLINE_CLOUD_REGIONS"
+
+# Curated list of AWS commercial regions where AWS Deadline Cloud is available.
+#
+# Source of truth: the AWS Deadline Cloud "Service endpoints" table at
+# https://docs.aws.amazon.com/general/latest/gr/deadlinecloud.html
+# (last reconciled 2026-06-08). Keep this list in sync with that page.
+#
+# This hardcoded list is the default set of regions scanned during the list-farms
+# fan-out. We don't auto-discover regions at runtime (botocore's
+# get_available_regions("deadline") returns [] -- deadline is absent from its
+# endpoints.json -- and querying SSM on every CLI call isn't worth the latency).
+# Because it's hardcoded, this list may go stale as AWS Deadline Cloud launches in
+# new regions, so it MUST be updated when the service-endpoints page above changes.
+# Users can override it without waiting for a release via the DEADLINE_CLOUD_REGIONS
+# env var or the settings.deadline_regions config setting (see get_deadline_regions).
+DEADLINE_REGIONS: List[str] = [
+    "us-east-1",
+    "us-east-2",
+    "us-west-2",
+    "ap-northeast-1",
+    "ap-northeast-2",
+    "ap-southeast-1",
+    "ap-southeast-2",
+    "eu-central-1",
+    "eu-west-1",
+    "eu-west-2",
+]
+
+
+def _dedupe_preserve_order(items: List[str]) -> List[str]:
+    """Returns the items de-duplicated while preserving first-seen order."""
+    seen: set = set()
+    result: List[str] = []
+    for item in items:
+        if item and item not in seen:
+            seen.add(item)
+            result.append(item)
+    return result
+
+
+def _split_regions_csv(value: str) -> List[str]:
+    """Splits a comma-separated region string into a cleaned list of region names."""
+    return [region.strip() for region in value.split(",") if region.strip()]
+
+
+def get_deadline_regions() -> List[str]:
+    """
+    Gets the list of AWS regions where AWS Deadline Cloud should be scanned.
+
+    The list is resolved using the following precedence:
+    1. The ``DEADLINE_CLOUD_REGIONS`` environment variable (comma-separated), if set.
+    2. The ``settings.deadline_regions`` config setting (comma-separated), if set.
+    3. The curated ``DEADLINE_REGIONS`` list (see the constant for where it comes from
+       and how to keep it current).
+
+    Regions are not auto-discovered at runtime: the curated list is the default, and a
+    user who needs a different set overrides it via the env var or config setting above.
+
+    Returns:
+        A de-duplicated, order-preserving list of region names.
+    """
+    # 1. Environment variable override
+    env_value = os.getenv(DEADLINE_REGIONS_ENV_VAR)
+    if env_value and env_value.strip():
+        regions = _split_regions_csv(env_value)
+        if regions:
+            return _dedupe_preserve_order(regions)
+
+    # 2. Config setting override
+    config_value = get_setting("settings.deadline_regions")
+    if config_value and config_value.strip():
+        regions = _split_regions_csv(config_value)
+        if regions:
+            return _dedupe_preserve_order(regions)
+
+    # 3. Curated default
+    return _dedupe_preserve_order(list(DEADLINE_REGIONS))
+
+
 # Default directories used by various Deadline CLI commands
 DEFAULT_JOB_HISTORY_DIR = os.path.join("~", ".deadline", "job_history", "{aws_profile_name}")
 DEFAULT_CACHE_DIR = os.path.join("~", ".deadline", "cache")
@@ -87,6 +174,12 @@ SETTINGS: Dict[str, Dict[str, Any]] = {
         "section_format": "{}",
         "description": "The Farm ID to use by default.",
     },
+    "defaults.farm_region": {
+        "default": "",
+        "depend": "defaults.farm_id",
+        "section_format": "{}",
+        "description": "The AWS region of the default Farm. Empty means use the session/profile region.",
+    },
     "settings.storage_profile_id": {
         "default": "",
         "depend": _SETTING_FARM_ID,
@@ -115,6 +208,14 @@ SETTINGS: Dict[str, Dict[str, Any]] = {
     "settings.log_level": {
         "default": "WARNING",
         "description": "The logging level to use in the CLI and GUIs.",
+    },
+    "settings.deadline_regions": {
+        "default": "",
+        "description": (
+            "A comma-separated list of AWS regions to scan for Deadline Cloud farms, "
+            "overriding the auto-discovered/curated set. Empty means auto-discover the "
+            "available Deadline Cloud regions (with a curated fallback)."
+        ),
     },
     "telemetry.opt_out": {
         "default": "false",

--- a/src/deadline/client/ui/controllers/__init__.py
+++ b/src/deadline/client/ui/controllers/__init__.py
@@ -37,6 +37,9 @@ from ._async_runner import AsyncTaskRunner as AsyncTaskRunner
 from ._deadline_controller import DeadlineUIController as DeadlineUIController
 from ._thread_pool import DeadlineThreadPool as DeadlineThreadPool
 
+# StreamingAsyncTask is intentionally NOT re-exported here: it is internal async
+# plumbing used only by AsyncTaskRunner, which imports it directly from ._async_task.
+# Keeping it out of __all__ keeps it off the public API surface.
 __all__ = [
     "AsyncTask",
     "AsyncTaskRunner",

--- a/src/deadline/client/ui/controllers/_async_runner.py
+++ b/src/deadline/client/ui/controllers/_async_runner.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Dict, Optional
 
 from qtpy.QtCore import QObject, Qt, Signal
 
-from ._async_task import AsyncTask
+from ._async_task import AsyncTask, StreamingAsyncTask
 from ._thread_pool import DeadlineThreadPool
 
 
@@ -94,6 +94,75 @@ class AsyncTaskRunner(QObject):
         if on_success is not None:
             task.signals.result.connect(on_success, Qt.QueuedConnection)
 
+        self._wire_and_start(operation_key, operation_id, task, on_error)
+
+        logger.debug(f"Started async task: {operation_key} (id={operation_id})")
+        return operation_id
+
+    def run_streaming(
+        self,
+        operation_key: str,
+        fn: Callable[..., Any],
+        on_progress: Optional[Callable[[Any], None]] = None,
+        on_finished: Optional[Callable[[], None]] = None,
+        on_error: Optional[Callable[[BaseException], None]] = None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> int:
+        """
+        Run a generator-producing function asynchronously, delivering each yielded
+        item to ``on_progress`` as it arrives (progressive/streaming results).
+
+        This is the incremental counterpart to :meth:`run`. It uses the same
+        same-key cancellation semantics, so starting a new streaming op cancels an
+        in-flight one with the same key and no stale partial updates are delivered.
+
+        Args:
+            operation_key: Unique key identifying this operation type. Cancels any
+                           running task with the same key before starting.
+            fn: A function returning an iterator/generator to consume in the background.
+            on_progress: Callback invoked once per yielded item, in the main thread
+                         via queued connection. This is where incremental UI updates
+                         (e.g. appending a region's farms) happen.
+            on_finished: Callback invoked once the generator is exhausted (the
+                         terminal step), in the main thread via queued connection.
+            on_error: Callback invoked with the exception if the generator raises.
+            *args: Positional arguments passed to fn
+            **kwargs: Keyword arguments passed to fn
+
+        Returns:
+            Operation ID for tracking this specific task instance
+        """
+        # Cancel any existing task with the same key
+        self.cancel(operation_key)
+
+        # Generate unique operation ID
+        self._operation_counter += 1
+        operation_id = self._operation_counter
+
+        task = StreamingAsyncTask(fn, *args, operation_id=operation_id, **kwargs)
+
+        if on_progress is not None:
+            task.signals.progress.connect(on_progress, Qt.QueuedConnection)
+
+        # The terminal result for a streaming task carries no aggregate payload;
+        # wire on_finished to it so callers get a single "stream done" callback.
+        if on_finished is not None:
+            task.signals.result.connect(lambda _result: on_finished(), Qt.QueuedConnection)
+
+        self._wire_and_start(operation_key, operation_id, task, on_error)
+
+        logger.debug(f"Started streaming async task: {operation_key} (id={operation_id})")
+        return operation_id
+
+    def _wire_and_start(
+        self,
+        operation_key: str,
+        operation_id: int,
+        task: AsyncTask,
+        on_error: Optional[Callable[[BaseException], None]],
+    ) -> None:
+        """Wire error/cleanup signals shared by run() and run_streaming(), then start."""
         # Connect error callbacks
         if on_error is not None:
             task.signals.error.connect(on_error, Qt.QueuedConnection)
@@ -115,9 +184,6 @@ class AsyncTaskRunner(QObject):
         # Track and start
         self._active_tasks[operation_key] = task
         self._thread_pool.start(task)
-
-        logger.debug(f"Started async task: {operation_key} (id={operation_id})")
-        return operation_id
 
     def cancel(self, operation_key: str) -> bool:
         """

--- a/src/deadline/client/ui/controllers/_async_task.py
+++ b/src/deadline/client/ui/controllers/_async_task.py
@@ -7,7 +7,7 @@ This module provides a clean pattern for running background operations
 with proper Qt signal integration and automatic cancellation handling.
 """
 
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Iterator, Optional
 
 from qtpy.QtCore import QObject, QRunnable, Signal
 
@@ -23,11 +23,17 @@ class WorkerSignals(QObject):
         finished: Emitted when the task completes (success or failure)
         error: Emitted with the exception when the task fails
         result: Emitted with the return value when the task succeeds
+        progress: Emitted with an intermediate value for progressive/streaming
+                  tasks. A streaming worker (one that consumes a generator) emits
+                  this once per item as the item arrives, then emits ``result``
+                  with a terminal value once the generator is exhausted. Single
+                  result tasks never emit ``progress``.
     """
 
     finished = Signal()
     error = Signal(BaseException)
     result = Signal(object)
+    progress = Signal(object)
 
 
 class AsyncTask(QRunnable):
@@ -118,6 +124,55 @@ class AsyncTask(QRunnable):
             result = self.fn(*self.args, **self.kwargs)
             if not self._is_canceled:
                 self.signals.result.emit(result)
+        except Exception as e:
+            if not self._is_canceled:
+                self.signals.error.emit(e)
+        finally:
+            if not self._is_canceled:
+                self.signals.finished.emit()
+
+
+class StreamingAsyncTask(AsyncTask):
+    """
+    A QRunnable that consumes a generator and emits a ``progress`` signal per item.
+
+    This is the progressive-result variant of :class:`AsyncTask`. The wrapped
+    callable must return an iterable/generator; each yielded item is delivered via
+    ``signals.progress`` (in arrival order, which for a fan-out generator is the
+    order regions complete, not request order). Once the generator is exhausted the
+    terminal ``signals.result`` is emitted (with ``None``) so existing
+    finished/result wiring still fires exactly once at the end.
+
+    Like the base class, all emissions are guarded by the cancellation flag so a
+    superseded refresh delivers no stale partial updates.
+
+    Args:
+        fn: A callable returning an iterator/generator to consume in the background.
+        *args: Positional arguments for fn
+        operation_id: Optional ID for tracking/cancellation
+        **kwargs: Keyword arguments for fn
+    """
+
+    def run(self) -> None:
+        """
+        Execute the streaming task in the thread pool.
+
+        Runs in a background thread. Emits ``progress`` per yielded item, a single
+        terminal ``result`` once exhausted, ``error`` if the generator raises, and
+        ``finished`` at the end. All emissions are guarded by cancellation checks.
+        """
+        if self._is_canceled:
+            return
+
+        try:
+            iterator: Iterator[Any] = iter(self.fn(*self.args, **self.kwargs))
+            for item in iterator:
+                if self._is_canceled:
+                    return
+                self.signals.progress.emit(item)
+            if not self._is_canceled:
+                # Terminal result (no aggregate payload; progress already delivered each item).
+                self.signals.result.emit(None)
         except Exception as e:
             if not self._is_canceled:
                 self.signals.error.emit(e)

--- a/src/deadline/client/ui/controllers/_deadline_controller.py
+++ b/src/deadline/client/ui/controllers/_deadline_controller.py
@@ -9,12 +9,15 @@ ordering of dependent calls and preventing race conditions.
 
 from configparser import ConfigParser
 from logging import getLogger
-from typing import List, Optional, Tuple
+from typing import Dict, Iterator, List, Optional, Tuple
 import sys
 
 from qtpy.QtCore import QObject, Qt, Signal
 
 from ... import api
+from ...api._list_apis import _iter_farms_by_region
+from ...api._session import _resolve_region
+from ...exceptions import DeadlineOperationError
 from ...job_bundle.parameters import JobParameter
 from ._async_runner import AsyncTaskRunner
 
@@ -24,6 +27,22 @@ logger = getLogger(__name__)
 
 # Type alias for resource lists: [(display_name, id), ...]
 ResourceList = List[Tuple[str, str]]
+
+# Type alias for farm options, which additionally carry the farm's region per the
+# (region, farm_id) ordering convention: [(label, farm_id, region), ...].
+FarmList = List[Tuple[str, str, str]]
+
+
+def _farm_label(display_name: str, region: str) -> str:
+    """
+    Builds a farm combo-box label, region first per the (region, farm_id) convention.
+
+    e.g. ``(us-west-2) My Farm``. When the region is unknown/empty (legacy
+    single-region responses), fall back to just the display name.
+    """
+    if region:
+        return f"({region}) {display_name}"
+    return display_name
 
 
 class DeadlineUIController(QObject):
@@ -51,7 +70,16 @@ class DeadlineUIController(QObject):
         controller.refresh_farms()
 
     Signals:
-        farms_updated: Emitted when farm list is updated. Args: [(name, farm_id), ...]
+        farms_updated: Emitted when the farm list is (re)set wholesale. Args:
+            [(label, farm_id, region), ...]. For multi-region refreshes this is
+            emitted once with an empty list at the start of a refresh (to clear the
+            box); farms then arrive incrementally via farms_appended.
+        farms_appended: Emitted per region as that region's ListFarms completes, so
+            the combo box fills in incrementally and a slow region does not delay
+            farms that already came back. Args: [(label, farm_id, region), ...]
+        farm_region_warning: Emitted when a single region's ListFarms fails during a
+            multi-region refresh. Non-blocking: surviving regions' farms still show.
+            Args: (region, exception)
         queues_updated: Emitted when queue list is updated. Args: [(name, queue_id), ...]
         storage_profiles_updated: Emitted when storage profiles are updated.
         queue_parameters_updated: Emitted when queue parameters are loaded.
@@ -67,6 +95,8 @@ class DeadlineUIController(QObject):
     # ─────────────────────────────────────────────────────────────
 
     farms_updated = Signal(list)
+    farms_appended = Signal(list)
+    farm_region_warning = Signal(str, BaseException)
     queues_updated = Signal(list)
     storage_profiles_updated = Signal(list)
     queue_parameters_updated = Signal(list)
@@ -125,6 +155,14 @@ class DeadlineUIController(QObject):
         self._current_farm_id: str = ""
         self._current_queue_id: str = ""
 
+        # Maps farm_id -> region, populated as farms stream in from each region.
+        # Used so downstream queue/storage-profile calls target the farm's region
+        # rather than the session default. Reset at the start of each farm refresh.
+        self._farm_regions: Dict[str, str] = {}
+        # Multi-region refresh outcome tracking (to detect the all-fail case).
+        self._farms_any_succeeded: bool = False
+        self._farms_any_failed: bool = False
+
     # ─────────────────────────────────────────────────────────────
     # Configuration
     # ─────────────────────────────────────────────────────────────
@@ -157,35 +195,110 @@ class DeadlineUIController(QObject):
         """Currently selected queue ID."""
         return self._current_queue_id
 
+    def region_for_farm(self, farm_id: str) -> Optional[str]:
+        """
+        Returns the region a farm was discovered in during the last refresh, or None.
+
+        Resolution order: the region observed while streaming farms in this session,
+        then the per-farm persisted ``defaults.farm_region`` setting (so it works even
+        before a refresh has run, e.g. right after dialog open). Returns None when
+        unknown, which lets callers fall back to the session/profile region.
+
+        Because ``defaults.farm_region`` is keyed per farm (it depends on
+        ``defaults.farm_id``), the persisted lookup is scoped to *this* ``farm_id`` via
+        ``_resolve_region`` — selecting a non-default farm must not leak the default
+        farm's region.
+        """
+        region = self._farm_regions.get(farm_id)
+        if region:
+            return region
+        return _resolve_region(config=self._config, farm_id=farm_id)
+
     # ─────────────────────────────────────────────────────────────
     # Farm Operations
     # ─────────────────────────────────────────────────────────────
 
     def refresh_farms(self) -> None:
-        """Fetch the list of farms asynchronously."""
+        """
+        Fetch the list of farms across all regions, incrementally.
+
+        Consumes the streaming :func:`_iter_farms_by_region` generator so farm
+        options are surfaced to the UI as each region's ListFarms completes (out of
+        order). A slow region does not delay farms that have already returned.
+
+        Emission sequence:
+          - ``farms_updated([])`` once up front to clear the box (without losing the
+            user's current selection — the combo box preserves selection on appends).
+          - ``farms_appended([...])`` per successful region as it arrives.
+          - ``farm_region_warning(region, exc)`` per region that fails (non-blocking).
+          - ``operation_failed`` only if *every* region fails (zero successes).
+        """
+        # Reset per-refresh region tracking; clear the box for the new results.
+        self._farm_regions = {}
+        self._farms_any_succeeded = False
+        self._farms_any_failed = False
         self.farms_loading.emit(True)
-        self._task_runner.run(
+        self.farms_updated.emit([])
+        self._task_runner.run_streaming(
             operation_key="list_farms",
-            fn=self._fetch_farms,
-            on_success=self._on_farms_success,
+            fn=self._iter_farms_by_region,
+            on_progress=self._on_farms_region_result,
+            on_finished=self._on_farms_stream_finished,
             on_error=self._on_farms_error,
         )
 
-    def _fetch_farms(self) -> ResourceList:
-        """Fetch farms from API. Runs in background thread."""
-        response = api.list_farms(config=self._config)
-        return sorted(
-            [(item["displayName"], item["farmId"]) for item in response["farms"]],
-            key=lambda item: (item[0].casefold(), item[1]),
-        )
+    def _iter_farms_by_region(
+        self,
+    ) -> Iterator[Tuple[str, Optional[List[dict]], Optional[BaseException]]]:
+        """Yield each region's ListFarms result as it completes. Runs in a thread."""
+        return _iter_farms_by_region(config=self._config)
 
-    def _on_farms_success(self, farms: ResourceList) -> None:
-        """Handle successful farm list fetch."""
+    def _on_farms_region_result(
+        self,
+        region_result: Tuple[str, Optional[List[dict]], Optional[BaseException]],
+    ) -> None:
+        """
+        Handle a single region's streamed ListFarms result (main thread).
+
+        Per the (region, farm_id) convention each tuple leads with the region.
+        Success appends that region's farms; failure emits a non-blocking warning.
+        """
+        region, farms, exc = region_result
+        if exc is not None:
+            self._farms_any_failed = True
+            # AccessDeniedException is expected when a region isn't opted-in / lacks perms.
+            error_name = type(exc).__name__
+            if "AccessDeniedException" in error_name:
+                logger.debug("Could not fetch farms in region %s: %s", region, exc)
+            else:
+                logger.warning("Failed to list farms in region %s: %s", region, exc)
+            self.farm_region_warning.emit(region, exc)
+            return
+
+        self._farms_any_succeeded = True
+        farm_options: FarmList = []
+        for item in farms or []:
+            farm_id = item["farmId"]
+            self._farm_regions[farm_id] = region
+            farm_options.append((_farm_label(item["displayName"], region), farm_id, region))
+
+        farm_options.sort(key=lambda option: (option[0].casefold(), option[1]))
+        # Append this region's farms; the combo box adds them without resetting selection.
+        self.farms_appended.emit(farm_options)
+
+    def _on_farms_stream_finished(self) -> None:
+        """Handle completion of the multi-region farm stream (main thread)."""
         self.farms_loading.emit(False)
-        self.farms_updated.emit(farms)
+        # If no region succeeded but at least one failed, surface a hard error so the
+        # combo box can show the failed state rather than an empty success.
+        if not self._farms_any_succeeded and self._farms_any_failed:
+            self.operation_failed.emit(
+                "list_farms",
+                DeadlineOperationError("Failed to list farms in all regions."),
+            )
 
     def _on_farms_error(self, error: BaseException) -> None:
-        """Handle farm list fetch error."""
+        """Handle a fatal farm stream error (e.g. all regions failed in the API layer)."""
         # AccessDeniedException is expected when credentials are invalid or expired.
         # Don't log this as an exception.
         error_name = type(error).__name__
@@ -214,6 +327,7 @@ class DeadlineUIController(QObject):
             self.queues_updated.emit([])
             return
 
+        region = self.region_for_farm(farm_id)
         self.queues_loading.emit(True)
         self._task_runner.run(
             operation_key="list_queues",
@@ -221,11 +335,12 @@ class DeadlineUIController(QObject):
             on_success=self._on_queues_success,
             on_error=self._on_queues_error,
             farm_id=farm_id,
+            region=region,
         )
 
-    def _fetch_queues(self, farm_id: str) -> ResourceList:
-        """Fetch queues from API. Runs in background thread."""
-        response = api.list_queues(config=self._config, farmId=farm_id)
+    def _fetch_queues(self, farm_id: str, region: Optional[str] = None) -> ResourceList:
+        """Fetch queues from API in the farm's region. Runs in background thread."""
+        response = api.list_queues(config=self._config, region=region, farmId=farm_id)
         return sorted(
             [(item["displayName"], item["queueId"]) for item in response["queues"]],
             key=lambda item: (item[0].casefold(), item[1]),
@@ -273,6 +388,7 @@ class DeadlineUIController(QObject):
             self.storage_profiles_updated.emit([])
             return
 
+        region = self.region_for_farm(farm_id)
         self.storage_profiles_loading.emit(True)
         self._task_runner.run(
             operation_key="list_storage_profiles",
@@ -281,9 +397,12 @@ class DeadlineUIController(QObject):
             on_error=self._on_storage_profiles_error,
             farm_id=farm_id,
             queue_id=queue_id,
+            region=region,
         )
 
-    def _fetch_storage_profiles(self, farm_id: str, queue_id: str) -> ResourceList:
+    def _fetch_storage_profiles(
+        self, farm_id: str, queue_id: str, region: Optional[str] = None
+    ) -> ResourceList:
         """Fetch storage profiles from API. Runs in background thread."""
         # Determine current OS for filtering
         if sys.platform.startswith("linux"):
@@ -296,7 +415,7 @@ class DeadlineUIController(QObject):
             current_os = "unknown"
 
         response = api.list_storage_profiles_for_queue(
-            config=self._config, farmId=farm_id, queueId=queue_id
+            config=self._config, region=region, farmId=farm_id, queueId=queue_id
         )
 
         profiles: ResourceList = []

--- a/src/deadline/client/ui/dialogs/deadline_config_dialog.py
+++ b/src/deadline/client/ui/dialogs/deadline_config_dialog.py
@@ -910,8 +910,9 @@ class DeadlineWorkstationConfigWidget(QWidget):
 
     def aws_profile_changed(self, value):
         self.changes["defaults.aws_profile_name"] = value
-        # Clear the farm_id and queue_id since they don't exist in the new profile
+        # Clear the farm_id/region and queue_id since they don't exist in the new profile
         self.changes["defaults.farm_id"] = ""
+        self.changes["defaults.farm_region"] = ""
         self.changes["defaults.queue_id"] = ""
         self.default_farm_box.clear_list()
         self.default_queue_box.clear_list()
@@ -937,6 +938,9 @@ class DeadlineWorkstationConfigWidget(QWidget):
         if farm_id is None:
             return
         self.changes["defaults.farm_id"] = farm_id
+        # Persist the selected farm's region too, per the (region, farm_id) convention.
+        # Empty string means "use the session/profile region" (backwards compatible).
+        self.changes["defaults.farm_region"] = self.default_farm_box.region_for_id(farm_id)
         # Clear the queue_id since the old queue doesn't exist in the new farm
         self.changes["defaults.queue_id"] = ""
         # Clear storage profile lists - they depend on queue which we're about to refresh
@@ -980,8 +984,11 @@ class DeadlineWorkstationConfigWidget(QWidget):
         # Get the currently selected farm from the combo box
         current_farm_id = self.default_farm_box.box.currentData()
         if current_farm_id:
-            # Update the changes dict with the selected farm
+            # Update the changes dict with the selected farm and its region.
             self.changes["defaults.farm_id"] = current_farm_id
+            self.changes["defaults.farm_region"] = self.default_farm_box.region_for_id(
+                current_farm_id
+            )
             self.refresh()
             # Continue cascade - refresh queues with the valid farm_id
             self._awaiting_queues_for_cascade = True

--- a/src/deadline/client/ui/widgets/_deadline_list_combo_boxes.py
+++ b/src/deadline/client/ui/widgets/_deadline_list_combo_boxes.py
@@ -8,6 +8,7 @@ ensuring proper ordering and automatic cancellation of superseded requests.
 """
 
 from configparser import ConfigParser
+from logging import getLogger
 from typing import Any, List, Optional, TYPE_CHECKING
 
 from qtpy.QtCore import Qt, QSize, Signal
@@ -26,6 +27,9 @@ if TYPE_CHECKING:
 from ...config import config_file
 from .._utils import block_signals
 from ..controllers import DeadlineUIController
+
+
+logger = getLogger(__name__)
 
 
 class _DeadlineResourceListComboBoxController(QWidget):
@@ -63,6 +67,8 @@ class _DeadlineResourceListComboBoxController(QWidget):
         self.resource_name = resource_name
         self.config: Optional[ConfigParser] = None
         self._controller = DeadlineUIController.getInstance()
+        # Maps resource_id -> region for resources that carry a region (farms).
+        self._region_by_id: dict = {}
 
         self._build_ui()
 
@@ -113,15 +119,11 @@ class _DeadlineResourceListComboBoxController(QWidget):
         raise NotImplementedError("Subclasses must implement _get_setting_name")
 
     def _handle_list_update(self, items_list: List) -> None:
-        """Handle the list update from the controller."""
+        """Handle a wholesale list (re)set from the controller."""
         with block_signals(self.box):
             self.box.clear()
-            for item in items_list:
-                # Handle both tuple and list formats (Qt signals may convert)
-                if isinstance(item, (list, tuple)) and len(item) >= 2:
-                    name, resource_id = item[0], item[1]
-                    self.box.addItem(name, userData=resource_id)
-
+            self._region_by_id = {}
+            self._add_items(items_list)
             self.refresh_selected_id()
 
         # If nothing is configured and exactly one resource is available, select it.
@@ -129,24 +131,127 @@ class _DeadlineResourceListComboBoxController(QWidget):
         # dialog logic (e.g. cascading to the next resource) reacts as if the user
         # had picked it.
         if self._auto_select_when_single:
-            self._maybe_auto_select_single(items_list)
+            self._maybe_auto_select_single()
 
-    def _maybe_auto_select_single(self, items_list: List) -> None:
-        """Select the sole available resource if none is configured yet."""
+    def _maybe_auto_select_single(self) -> None:
+        """Select the sole available resource if none is configured yet.
+
+        Reads the candidates from the combo box itself rather than a passed-in list, so
+        it works regardless of whether the box was populated wholesale (``_handle_list_update``)
+        or incrementally as regions stream in (``_handle_list_append``).
+        """
         configured_id = config_file.get_setting(self._get_setting_name(), config=self.config)
         if configured_id:
             return
-        real_ids = [
-            item[1]
-            for item in items_list
-            if isinstance(item, (list, tuple)) and len(item) >= 2 and item[1]
-        ]
+        real_ids = [self.box.itemData(i) for i in range(self.box.count()) if self.box.itemData(i)]
         if len(real_ids) != 1:
             return
         index = self.box.findData(real_ids[0])
-        if index >= 0 and self.box.currentIndex() != index:
-            # Not under block_signals: emitting currentIndexChanged is intentional.
+        if index < 0:
+            return
+        # Not under block_signals: emitting currentIndexChanged is intentional so connected
+        # dialog logic (e.g. cascading to the next resource) reacts as if the user picked it.
+        if self.box.currentIndex() != index:
             self.box.setCurrentIndex(index)
+        else:
+            # The lone item is already current — e.g. Qt auto-selected it at index 0 when it
+            # streamed in under block_signals (the incremental append path), so no
+            # currentIndexChanged fired. Emit it now so the cascade still runs.
+            self.box.currentIndexChanged.emit(index)
+
+    def _add_items(self, items_list: List) -> None:
+        """
+        Append items to the combo box without clearing it.
+
+        Items may be 2-tuples ``(name, id)`` or 3-tuples ``(label, id, region)``.
+        The optional region (3rd element) is recorded so callers can persist a
+        resource's region alongside its id (see :meth:`region_for_id`).
+
+        Adding is idempotent on id: if a row for ``id`` already exists (e.g. the same
+        id appears twice in one batch, or a region response is duplicated/retried), its
+        label is updated in place rather than adding a second row.
+
+        After adding, the box is re-sorted by label so the list has a stable,
+        alphabetized order regardless of the order items arrive in (e.g. when farms
+        stream in per region out of order). For farms the label is region-first, so
+        this naturally orders by region then name.
+        """
+        for item in items_list:
+            # Handle both tuple and list formats (Qt signals may convert)
+            if isinstance(item, (list, tuple)) and len(item) >= 2:
+                name, resource_id = item[0], item[1]
+                existing = self.box.findData(resource_id)
+                if existing >= 0:
+                    # Same id already present: update its label instead of duplicating.
+                    self.box.setItemText(existing, name)
+                else:
+                    self.box.addItem(name, userData=resource_id)
+                if len(item) >= 3 and item[2]:
+                    self._region_by_id[resource_id] = item[2]
+        self._sort_items_by_label()
+
+    def _sort_items_by_label(self) -> None:
+        """
+        Re-orders the combo box rows alphabetically by label (case-insensitive),
+        keeping each row's id (userData) attached. Ties break by id for determinism.
+
+        Callers invoke this inside a ``block_signals`` block; the region map is keyed by
+        id so it is unaffected by reordering, and selection is restored by id afterward.
+        """
+        rows = [(self.box.itemText(i), self.box.itemData(i)) for i in range(self.box.count())]
+        ordered = sorted(rows, key=lambda row: (row[0].casefold(), str(row[1] or "")))
+        if ordered == rows:
+            return
+        self.box.clear()
+        for text, resource_id in ordered:
+            self.box.addItem(text, userData=resource_id)
+
+    def _handle_list_append(self, items_list: List) -> None:
+        """
+        Append items to the combo box as they stream in, preserving selection.
+
+        Used for incremental (multi-region) updates: each call adds more items
+        without clearing the box, so a slow source does not clobber items already
+        shown. The user's current selection (by id) is preserved across appends,
+        and a placeholder ``<refreshing>``/``<none selected>`` row left from the
+        loading state is removed once real items arrive.
+        """
+        if not items_list:
+            return
+        # Capture the selection to restore it after appending (avoids flicker / reset).
+        selected_id = self.box.currentData()
+        with block_signals(self.box):
+            # Drop any placeholder row(s) from the loading state before real data lands.
+            for placeholder in ("<refreshing>", "<none selected>"):
+                index = self.box.findText(placeholder)
+                if index >= 0:
+                    self.box.removeItem(index)
+            # Drop any raw-id placeholder rows (inserted by refresh_selected_id when the
+            # configured id wasn't listed yet) for ids about to arrive with real labels,
+            # so a configured farm doesn't appear twice once its region streams in.
+            for item in items_list:
+                if isinstance(item, (list, tuple)) and len(item) >= 2:
+                    existing = self.box.findData(item[1])
+                    if existing >= 0:
+                        self.box.removeItem(existing)
+            self._add_items(items_list)
+
+            # Restore the prior selection if it's still present; otherwise fall back
+            # to the configured id so a streamed-in farm gets selected when it arrives.
+            restore_id = selected_id or config_file.get_setting(
+                self._get_setting_name(), config=self.config
+            )
+            index = self.box.findData(restore_id) if restore_id else -1
+            if index >= 0:
+                self.box.setCurrentIndex(index)
+
+    def region_for_id(self, resource_id: str) -> str:
+        """Returns the region recorded for a resource id, or '' if none/unknown."""
+        return self._region_by_id.get(resource_id, "")
+
+    def current_region(self) -> str:
+        """Returns the region of the currently-selected item, or '' if none/unknown."""
+        return self.region_for_id(self.box.currentData())
 
     def _handle_loading_state(self, is_loading: bool) -> None:
         """Handle loading state changes."""
@@ -156,6 +261,12 @@ class _DeadlineResourceListComboBoxController(QWidget):
             with block_signals(self.box):
                 self.box.clear()
                 self.box.addItem("<refreshing>", userData=selected_id)
+        elif self._auto_select_when_single:
+            # Loading finished. For incrementally-populated lists (e.g. farms streaming in
+            # per region via _handle_list_append), this is the point at which the full set
+            # is known, so auto-select a lone resource here. Done outside block_signals so
+            # currentIndexChanged fires and the dialog's cascade reacts naturally.
+            self._maybe_auto_select_single()
 
         self.refresh_button.setEnabled(not is_loading)
 
@@ -226,6 +337,24 @@ class DeadlineFarmListComboBoxController(_DeadlineResourceListComboBoxController
     def __init__(self, parent: Optional[QWidget] = None):
         super().__init__(resource_name="Farm", parent=parent)
         self._connect_controller_signals()
+        # Incremental multi-region population: each region's farms are appended as
+        # they arrive, and per-region failures surface a non-blocking warning.
+        self._controller.farms_appended.connect(self._handle_list_append, Qt.QueuedConnection)
+        self._controller.farm_region_warning.connect(
+            self._handle_region_warning, Qt.QueuedConnection
+        )
+
+    def _handle_region_warning(self, region: str, error: BaseException) -> None:
+        """
+        Surface a per-region ListFarms failure non-blockingly (no modal).
+
+        Per the streaming requirements, a single region failing must not block farms
+        from regions that succeeded and must not pop a modal per failure. We log a
+        warning and set it as the combo box tooltip so the user can see something went
+        wrong without an interrupting dialog.
+        """
+        logger.warning("Failed to list farms in region %s: %s", region, error)
+        self.box.setToolTip(f"Some regions could not be listed (e.g. {region}: {error})")
 
     def _get_controller_signal(self) -> "SignalInstance":
         return self._controller.farms_updated

--- a/src/deadline/client/ui/widgets/shared_job_settings_tab.py
+++ b/src/deadline/client/ui/widgets/shared_job_settings_tab.py
@@ -25,6 +25,7 @@ from qtpy.QtWidgets import (  # type: ignore
 from .radio_button_widget import HoverRadioButton
 
 from ... import api
+from ...api._session import _resolve_region
 from ...config import get_setting
 from .._utils import tr
 from ..controllers import AsyncTaskRunner, DeadlineUIController
@@ -588,7 +589,9 @@ class DeadlineFarmDisplay(_DeadlineNamedResourceDisplay):
     def get_item(self):
         farm_id = get_setting(self.setting_name)
         if farm_id:
-            deadline = api.get_boto3_client("deadline")
+            # Scope the client to the farm's region (the farm may be in a non-default region).
+            region = _resolve_region(farm_id=farm_id)
+            deadline = api.get_boto3_client("deadline", region=region)
             response = deadline.get_farm(farmId=farm_id)
             return (
                 response["farmId"],
@@ -607,7 +610,9 @@ class DeadlineQueueDisplay(_DeadlineNamedResourceDisplay):
         farm_id = get_setting("defaults.farm_id")
         queue_id = get_setting(self.setting_name)
         if farm_id and queue_id:
-            deadline = api.get_boto3_client("deadline")
+            # Scope the client to the farm's region (the farm may be in a non-default region).
+            region = _resolve_region(farm_id=farm_id)
+            deadline = api.get_boto3_client("deadline", region=region)
             response = deadline.get_queue(farmId=farm_id, queueId=queue_id)
             return (
                 response["queueId"],
@@ -636,7 +641,9 @@ class DeadlineStorageProfileNameDisplay(_DeadlineNamedResourceDisplay):
         storage_profile_id = get_setting(self.setting_name)
 
         if farm_id and queue_id and storage_profile_id:
-            deadline = api.get_boto3_client("deadline")
+            # Scope the client to the farm's region (the farm may be in a non-default region).
+            region = _resolve_region(farm_id=farm_id)
+            deadline = api.get_boto3_client("deadline", region=region)
             response = deadline.list_storage_profiles_for_queue(farmId=farm_id, queueId=queue_id)
             farm_storage_profiles = response.get("storageProfiles", {})
 

--- a/test/unit/deadline_client/api/test_api_farm.py
+++ b/test/unit/deadline_client/api/test_api_farm.py
@@ -39,29 +39,39 @@ FARMS_LIST = [
 ]
 
 
-def test_list_farms_paginated(fresh_deadline_config):
+def test_list_farms_paginated(fresh_deadline_config, monkeypatch):
     """Confirm api.list_farms concatenates multiple pages"""
+    # Scope to a single region so the multi-region fan-out queries exactly one region,
+    # keeping this a focused single-region pagination test.
+    monkeypatch.setenv("DEADLINE_CLOUD_REGIONS", "us-west-2")
     with patch.object(api._session, "get_boto3_session") as session_mock:
         session_mock().client("deadline").list_farms.side_effect = [
-            {"farms": FARMS_LIST[:2], "nextToken": "abc"},
-            {"farms": FARMS_LIST[2:3], "nextToken": "def"},
-            {"farms": FARMS_LIST[3:]},
+            {"farms": [dict(f) for f in FARMS_LIST[:2]], "nextToken": "abc"},
+            {"farms": [dict(f) for f in FARMS_LIST[2:3]], "nextToken": "def"},
+            {"farms": [dict(f) for f in FARMS_LIST[3:]]},
         ]
 
         # Call the API
         farms = api.list_farms()
 
-        assert farms["farms"] == FARMS_LIST
+        # Farms are tagged with their region (additive), so compare ignoring region.
+        returned = [{k: v for k, v in f.items() if k != "region"} for f in farms["farms"]]
+        assert returned == FARMS_LIST
+        assert all(f["region"] == "us-west-2" for f in farms["farms"])
 
 
 @pytest.mark.parametrize("pass_principal_id_filter", [True, False])
 @pytest.mark.parametrize("user_identities", [True, False])
-def test_list_farms_principal_id(fresh_deadline_config, pass_principal_id_filter, user_identities):
+def test_list_farms_principal_id(
+    fresh_deadline_config, pass_principal_id_filter, user_identities, monkeypatch
+):
     """Confirm api.list_farms sets the principalId parameter appropriately"""
 
+    # Scope to a single region so the fan-out makes exactly one ListFarms call.
+    monkeypatch.setenv("DEADLINE_CLOUD_REGIONS", "us-west-2")
     with patch.object(api._session, "get_boto3_session") as session_mock:
         session_mock().client("deadline").list_farms.side_effect = [
-            {"farms": FARMS_LIST},
+            {"farms": [dict(f) for f in FARMS_LIST]},
         ]
 
         session_mock()._session.get_scoped_config().get.return_value = "some-monitor-id"
@@ -78,7 +88,8 @@ def test_list_farms_principal_id(fresh_deadline_config, pass_principal_id_filter
         else:
             farms = api.list_farms()
 
-        assert farms["farms"] == FARMS_LIST
+        returned = [{k: v for k, v in f.items() if k != "region"} for f in farms["farms"]]
+        assert returned == FARMS_LIST
 
         if pass_principal_id_filter:
             session_mock().client("deadline").list_farms.assert_called_once_with(

--- a/test/unit/deadline_client/api/test_api_list_multi_region.py
+++ b/test/unit/deadline_client/api/test_api_list_multi_region.py
@@ -7,6 +7,7 @@ streaming generator, and region pass-through on the per-farm list APIs.
 """
 
 import os
+import threading
 import time
 from unittest.mock import MagicMock, patch
 
@@ -63,9 +64,11 @@ def test_list_farms_multi_region_happy_path(fresh_deadline_config):
     def fake_get_client(service_name, config=None, region=None):
         return clients[region]
 
-    with patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client), patch.object(
-        _list_apis.config_file, "get_deadline_regions", return_value=regions
-    ), patch.object(_list_apis, "_apply_principal_id_filter"):
+    with (
+        patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client),
+        patch.object(_list_apis.config_file, "get_deadline_regions", return_value=regions),
+        patch.object(_list_apis, "_apply_principal_id_filter"),
+    ):
         result = api.list_farms()
 
     farms = result["farms"]
@@ -92,11 +95,12 @@ def test_list_farms_partial_failure_returns_survivors(fresh_deadline_config, cap
     def fake_get_client(service_name, config=None, region=None):
         return clients[region]
 
-    with caplog.at_level("WARNING"), patch.object(
-        _list_apis, "get_boto3_client", side_effect=fake_get_client
-    ), patch.object(
-        _list_apis.config_file, "get_deadline_regions", return_value=regions
-    ), patch.object(_list_apis, "_apply_principal_id_filter"):
+    with (
+        caplog.at_level("WARNING"),
+        patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client),
+        patch.object(_list_apis.config_file, "get_deadline_regions", return_value=regions),
+        patch.object(_list_apis, "_apply_principal_id_filter"),
+    ):
         result = api.list_farms()
 
     farms = result["farms"]
@@ -120,9 +124,11 @@ def test_list_farms_total_failure_raises(fresh_deadline_config):
     def fake_get_client(service_name, config=None, region=None):
         return clients[region]
 
-    with patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client), patch.object(
-        _list_apis.config_file, "get_deadline_regions", return_value=regions
-    ), patch.object(_list_apis, "_apply_principal_id_filter"):
+    with (
+        patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client),
+        patch.object(_list_apis.config_file, "get_deadline_regions", return_value=regions),
+        patch.object(_list_apis, "_apply_principal_id_filter"),
+    ):
         with pytest.raises(DeadlineOperationError) as excinfo:
             api.list_farms()
 
@@ -140,9 +146,11 @@ def test_list_farms_explicit_region_single_region(fresh_deadline_config):
         return _client_returning([_make_farm("farm-only")])
 
     # If fan-out were used, get_deadline_regions would be consulted; assert it is NOT.
-    with patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client), patch.object(
-        _list_apis.config_file, "get_deadline_regions"
-    ) as regions_mock, patch.object(_list_apis, "_apply_principal_id_filter"):
+    with (
+        patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client),
+        patch.object(_list_apis.config_file, "get_deadline_regions") as regions_mock,
+        patch.object(_list_apis, "_apply_principal_id_filter"),
+    ):
         result = api.list_farms(region="ap-south-1")
 
     regions_mock.assert_not_called()
@@ -164,8 +172,9 @@ def test_iter_farms_by_region_yields_per_region_including_failure(fresh_deadline
     def fake_get_client(service_name, config=None, region=None):
         return clients[region]
 
-    with patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client), patch.object(
-        _list_apis, "_apply_principal_id_filter"
+    with (
+        patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client),
+        patch.object(_list_apis, "_apply_principal_id_filter"),
     ):
         results = list(_list_apis._iter_farms_by_region(regions=regions))
 
@@ -199,8 +208,9 @@ def test_iter_farms_by_region_does_not_swallow_base_exceptions(fresh_deadline_co
     def fake_get_client(service_name, config=None, region=None):
         return clients[region]
 
-    with patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client), patch.object(
-        _list_apis, "_apply_principal_id_filter"
+    with (
+        patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client),
+        patch.object(_list_apis, "_apply_principal_id_filter"),
     ):
         with pytest.raises(KeyboardInterrupt):
             list(_list_apis._iter_farms_by_region(regions=regions))
@@ -222,8 +232,9 @@ def test_iter_farms_by_region_out_of_order_completion(fresh_deadline_config):
     def fake_get_client(service_name, config=None, region=None):
         return clients[region]
 
-    with patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client), patch.object(
-        _list_apis, "_apply_principal_id_filter"
+    with (
+        patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client),
+        patch.object(_list_apis, "_apply_principal_id_filter"),
     ):
         order = [region for region, _, _ in _list_apis._iter_farms_by_region(regions=regions)]
 
@@ -243,8 +254,9 @@ def test_iter_farms_by_region_pagination_per_region(fresh_deadline_config):
     def fake_get_client(service_name, config=None, region=None):
         return client
 
-    with patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client), patch.object(
-        _list_apis, "_apply_principal_id_filter"
+    with (
+        patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client),
+        patch.object(_list_apis, "_apply_principal_id_filter"),
     ):
         results = list(_list_apis._iter_farms_by_region(regions=regions))
 
@@ -278,8 +290,9 @@ def test_per_farm_list_apis_pass_region_through(
         captured["region"] = region
         return client
 
-    with patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client), patch.object(
-        _list_apis, "_apply_principal_id_filter"
+    with (
+        patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client),
+        patch.object(_list_apis, "_apply_principal_id_filter"),
     ):
         getattr(api, api_func)(region="eu-central-1")
 
@@ -297,8 +310,9 @@ def test_per_farm_list_api_default_region_is_none(fresh_deadline_config):
         captured["region"] = region
         return client
 
-    with patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client), patch.object(
-        _list_apis, "_apply_principal_id_filter"
+    with (
+        patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client),
+        patch.object(_list_apis, "_apply_principal_id_filter"),
     ):
         api.list_queues()
 
@@ -319,9 +333,11 @@ def test_list_farms_explicit_region_ignores_configured_farm_region(fresh_deadlin
         captured["region"] = region
         return _client_returning([_make_farm("farm-explicit")])
 
-    with patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client), patch.object(
-        _list_apis.config_file, "get_deadline_regions"
-    ) as regions_mock, patch.object(_list_apis, "_apply_principal_id_filter"):
+    with (
+        patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client),
+        patch.object(_list_apis.config_file, "get_deadline_regions") as regions_mock,
+        patch.object(_list_apis, "_apply_principal_id_filter"),
+    ):
         result = api.list_farms(region="ap-northeast-1")
 
     # Fan-out was never consulted, and the explicit region (not the configured one) was used.
@@ -336,10 +352,10 @@ def test_list_farms_no_regions_returns_empty_no_error(fresh_deadline_config):
     without crashing and without raising the all-regions-failed error (there were no
     regions to fail).
     """
-    with patch.object(
-        _list_apis.config_file, "get_deadline_regions", return_value=[]
-    ), patch.object(_list_apis, "get_boto3_client") as get_client_mock, patch.object(
-        _list_apis, "_apply_principal_id_filter"
+    with (
+        patch.object(_list_apis.config_file, "get_deadline_regions", return_value=[]),
+        patch.object(_list_apis, "get_boto3_client") as get_client_mock,
+        patch.object(_list_apis, "_apply_principal_id_filter"),
     ):
         result = api.list_farms()
 
@@ -359,9 +375,11 @@ def test_list_farms_explicit_region_does_not_fan_out(fresh_deadline_config):
         calls.append(region)
         return _client_returning([_make_farm("farm-single")])
 
-    with patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client), patch.object(
-        _list_apis.config_file, "get_deadline_regions"
-    ) as regions_mock, patch.object(_list_apis, "_apply_principal_id_filter"):
+    with (
+        patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client),
+        patch.object(_list_apis.config_file, "get_deadline_regions") as regions_mock,
+        patch.object(_list_apis, "_apply_principal_id_filter"),
+    ):
         api.list_farms(region="us-east-2")
 
     regions_mock.assert_not_called()
@@ -381,9 +399,11 @@ def test_list_farms_multi_region_concatenation_contract(fresh_deadline_config):
     def fake_get_client(service_name, config=None, region=None):
         return clients[region]
 
-    with patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client), patch.object(
-        _list_apis.config_file, "get_deadline_regions", return_value=regions
-    ), patch.object(_list_apis, "_apply_principal_id_filter"):
+    with (
+        patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client),
+        patch.object(_list_apis.config_file, "get_deadline_regions", return_value=regions),
+        patch.object(_list_apis, "_apply_principal_id_filter"),
+    ):
         result = api.list_farms()
 
     farms = result["farms"]
@@ -424,8 +444,9 @@ def test_per_farm_list_apis_explicit_region_overrides_config(
         captured["region"] = region
         return client
 
-    with patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client), patch.object(
-        _list_apis, "_apply_principal_id_filter"
+    with (
+        patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client),
+        patch.object(_list_apis, "_apply_principal_id_filter"),
     ):
         getattr(api, api_func)(region="eu-north-1")
 
@@ -449,11 +470,12 @@ def test_list_farms_endpoint_override_scans_single_session_region(fresh_deadline
 
     with patch.dict(os.environ, {"AWS_ENDPOINT_URL_DEADLINE": "https://override.test/deadline"}):
         os.environ.pop("DEADLINE_CLOUD_REGIONS", None)
-        with patch.object(
-            _list_apis, "get_boto3_client", side_effect=fake_get_client
-        ), patch.object(_list_apis, "get_boto3_session", return_value=mock_session), patch.object(
-            _list_apis.config_file, "get_deadline_regions"
-        ) as regions_mock, patch.object(_list_apis, "_apply_principal_id_filter"):
+        with (
+            patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client),
+            patch.object(_list_apis, "get_boto3_session", return_value=mock_session),
+            patch.object(_list_apis.config_file, "get_deadline_regions") as regions_mock,
+            patch.object(_list_apis, "_apply_principal_id_filter"),
+        ):
             result = api.list_farms()
 
     regions_mock.assert_not_called()
@@ -475,11 +497,12 @@ def test_list_farms_endpoint_override_session_region_none_does_not_crash(fresh_d
 
     with patch.dict(os.environ, {"AWS_ENDPOINT_URL_DEADLINE": "https://override.test/deadline"}):
         os.environ.pop("DEADLINE_CLOUD_REGIONS", None)
-        with patch.object(
-            _list_apis, "get_boto3_client", side_effect=fake_get_client
-        ), patch.object(_list_apis, "get_boto3_session", return_value=mock_session), patch.object(
-            _list_apis.config_file, "get_deadline_regions"
-        ) as regions_mock, patch.object(_list_apis, "_apply_principal_id_filter"):
+        with (
+            patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client),
+            patch.object(_list_apis, "get_boto3_session", return_value=mock_session),
+            patch.object(_list_apis.config_file, "get_deadline_regions") as regions_mock,
+            patch.object(_list_apis, "_apply_principal_id_filter"),
+        ):
             result = api.list_farms()
 
     regions_mock.assert_not_called()
@@ -506,11 +529,13 @@ def test_list_farms_endpoint_override_with_explicit_regions_still_fans_out(fresh
             "DEADLINE_CLOUD_REGIONS": ",".join(regions),
         },
     ):
-        with patch.object(
-            _list_apis, "get_boto3_client", side_effect=fake_get_client
-        ), patch.object(
-            _list_apis.config_file, "get_deadline_regions", return_value=regions
-        ) as regions_mock, patch.object(_list_apis, "_apply_principal_id_filter"):
+        with (
+            patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client),
+            patch.object(
+                _list_apis.config_file, "get_deadline_regions", return_value=regions
+            ) as regions_mock,
+            patch.object(_list_apis, "_apply_principal_id_filter"),
+        ):
             result = api.list_farms()
 
     # Fan-out path was taken (explicit region list honored).
@@ -530,11 +555,11 @@ def test_list_farms_endpoint_override_explicit_region_arg_still_single(fresh_dea
         return _client_returning([_make_farm("farm-eu")])
 
     with patch.dict(os.environ, {"AWS_ENDPOINT_URL_DEADLINE": "https://override.test/deadline"}):
-        with patch.object(
-            _list_apis, "get_boto3_client", side_effect=fake_get_client
-        ), patch.object(
-            _list_apis.config_file, "get_deadline_regions"
-        ) as regions_mock, patch.object(_list_apis, "_apply_principal_id_filter"):
+        with (
+            patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client),
+            patch.object(_list_apis.config_file, "get_deadline_regions") as regions_mock,
+            patch.object(_list_apis, "_apply_principal_id_filter"),
+        ):
             result = api.list_farms(region="eu-west-1")
 
     regions_mock.assert_not_called()
@@ -556,11 +581,13 @@ def test_list_farms_no_override_still_fans_out(fresh_deadline_config):
     with patch.dict(os.environ, {}, clear=False):
         os.environ.pop("AWS_ENDPOINT_URL_DEADLINE", None)
         os.environ.pop("DEADLINE_CLOUD_REGIONS", None)
-        with patch.object(
-            _list_apis, "get_boto3_client", side_effect=fake_get_client
-        ), patch.object(
-            _list_apis.config_file, "get_deadline_regions", return_value=regions
-        ) as regions_mock, patch.object(_list_apis, "_apply_principal_id_filter"):
+        with (
+            patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client),
+            patch.object(
+                _list_apis.config_file, "get_deadline_regions", return_value=regions
+            ) as regions_mock,
+            patch.object(_list_apis, "_apply_principal_id_filter"),
+        ):
             result = api.list_farms()
 
     regions_mock.assert_called()
@@ -585,11 +612,12 @@ def test_iter_farms_by_region_endpoint_override_scans_single_session_region(fres
 
     with patch.dict(os.environ, {"AWS_ENDPOINT_URL_DEADLINE": "https://override.test/deadline"}):
         os.environ.pop("DEADLINE_CLOUD_REGIONS", None)
-        with patch.object(
-            _list_apis, "get_boto3_client", side_effect=fake_get_client
-        ), patch.object(_list_apis, "get_boto3_session", return_value=mock_session), patch.object(
-            _list_apis.config_file, "get_deadline_regions"
-        ) as regions_mock, patch.object(_list_apis, "_apply_principal_id_filter"):
+        with (
+            patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client),
+            patch.object(_list_apis, "get_boto3_session", return_value=mock_session),
+            patch.object(_list_apis.config_file, "get_deadline_regions") as regions_mock,
+            patch.object(_list_apis, "_apply_principal_id_filter"),
+        ):
             results = list(_list_apis._iter_farms_by_region())
 
     regions_mock.assert_not_called()
@@ -622,11 +650,13 @@ def test_iter_farms_by_region_endpoint_override_with_explicit_regions_still_fans
             "DEADLINE_CLOUD_REGIONS": ",".join(regions),
         },
     ):
-        with patch.object(
-            _list_apis, "get_boto3_client", side_effect=fake_get_client
-        ), patch.object(
-            _list_apis.config_file, "get_deadline_regions", return_value=regions
-        ) as regions_mock, patch.object(_list_apis, "_apply_principal_id_filter"):
+        with (
+            patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client),
+            patch.object(
+                _list_apis.config_file, "get_deadline_regions", return_value=regions
+            ) as regions_mock,
+            patch.object(_list_apis, "_apply_principal_id_filter"),
+        ):
             results = list(_list_apis._iter_farms_by_region())
 
     regions_mock.assert_called()
@@ -647,13 +677,12 @@ def test_iter_farms_by_region_explicit_regions_arg_ignores_override(fresh_deadli
         return clients[region]
 
     with patch.dict(os.environ, {"AWS_ENDPOINT_URL_DEADLINE": "https://override.test/deadline"}):
-        with patch.object(
-            _list_apis, "get_boto3_client", side_effect=fake_get_client
-        ), patch.object(
-            _list_apis.config_file, "get_deadline_regions"
-        ) as regions_mock, patch.object(
-            _list_apis, "get_boto3_session"
-        ) as session_mock, patch.object(_list_apis, "_apply_principal_id_filter"):
+        with (
+            patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client),
+            patch.object(_list_apis.config_file, "get_deadline_regions") as regions_mock,
+            patch.object(_list_apis, "get_boto3_session") as session_mock,
+            patch.object(_list_apis, "_apply_principal_id_filter"),
+        ):
             results = list(_list_apis._iter_farms_by_region(regions=regions))
 
     regions_mock.assert_not_called()
@@ -676,11 +705,13 @@ def test_iter_farms_by_region_no_override_fans_out_via_get_deadline_regions(fres
     with patch.dict(os.environ, {}, clear=False):
         os.environ.pop("AWS_ENDPOINT_URL_DEADLINE", None)
         os.environ.pop("DEADLINE_CLOUD_REGIONS", None)
-        with patch.object(
-            _list_apis, "get_boto3_client", side_effect=fake_get_client
-        ), patch.object(
-            _list_apis.config_file, "get_deadline_regions", return_value=regions
-        ) as regions_mock, patch.object(_list_apis, "_apply_principal_id_filter"):
+        with (
+            patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client),
+            patch.object(
+                _list_apis.config_file, "get_deadline_regions", return_value=regions
+            ) as regions_mock,
+            patch.object(_list_apis, "_apply_principal_id_filter"),
+        ):
             results = list(_list_apis._iter_farms_by_region())
 
     regions_mock.assert_called()
@@ -703,11 +734,12 @@ def test_iter_farms_by_region_endpoint_override_session_region_none(fresh_deadli
 
     with patch.dict(os.environ, {"AWS_ENDPOINT_URL_DEADLINE": "https://override.test/deadline"}):
         os.environ.pop("DEADLINE_CLOUD_REGIONS", None)
-        with patch.object(
-            _list_apis, "get_boto3_client", side_effect=fake_get_client
-        ), patch.object(_list_apis, "get_boto3_session", return_value=mock_session), patch.object(
-            _list_apis.config_file, "get_deadline_regions"
-        ) as regions_mock, patch.object(_list_apis, "_apply_principal_id_filter"):
+        with (
+            patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client),
+            patch.object(_list_apis, "get_boto3_session", return_value=mock_session),
+            patch.object(_list_apis.config_file, "get_deadline_regions") as regions_mock,
+            patch.object(_list_apis, "_apply_principal_id_filter"),
+        ):
             results = list(_list_apis._iter_farms_by_region())
 
     regions_mock.assert_not_called()
@@ -734,10 +766,10 @@ def test_list_farms_endpoint_override_single_region_failure_raises(fresh_deadlin
 
     with patch.dict(os.environ, {"AWS_ENDPOINT_URL_DEADLINE": "https://override.test/deadline"}):
         os.environ.pop("DEADLINE_CLOUD_REGIONS", None)
-        with patch.object(
-            _list_apis, "get_boto3_client", side_effect=fake_get_client
-        ), patch.object(_list_apis, "get_boto3_session", return_value=mock_session), patch.object(
-            _list_apis, "_apply_principal_id_filter"
+        with (
+            patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client),
+            patch.object(_list_apis, "get_boto3_session", return_value=mock_session),
+            patch.object(_list_apis, "_apply_principal_id_filter"),
         ):
             with pytest.raises(DeadlineOperationError) as excinfo:
                 api.list_farms()
@@ -762,8 +794,9 @@ def test_list_farms_does_not_mutate_caller_farm_dicts(fresh_deadline_config):
     def fake_get_client(service_name, config=None, region=None):
         return client
 
-    with patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client), patch.object(
-        _list_apis, "_apply_principal_id_filter"
+    with (
+        patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client),
+        patch.object(_list_apis, "_apply_principal_id_filter"),
     ):
         result = api.list_farms(region="us-west-2")
 
@@ -775,3 +808,141 @@ def test_list_farms_does_not_mutate_caller_farm_dicts(fresh_deadline_config):
         {"farmId": "farm-b", "displayName": "B"},
     ]
     assert all("region" not in f for f in original_farms)
+
+
+# ---------------------------------------------------------------------------
+# Thread-safety of the fan-out
+#
+# The fan-out shares one boto3 Session across regions. boto3 Sessions are not safe to
+# build clients from concurrently, so every client (and the one-time principal-id DCM
+# lookup) is built up front on the calling thread; the worker threads only make the
+# network ListFarms call against a ready client. These tests pin that contract.
+# ---------------------------------------------------------------------------
+
+
+def test_iter_farms_by_region_builds_clients_on_calling_thread(fresh_deadline_config):
+    """
+    get_boto3_client (which touches the shared Session) must run on the thread that
+    drives the generator, never inside a worker thread. This is what makes the fan-out
+    thread-safe by construction rather than by timing.
+    """
+    regions = ["us-west-2", "us-east-1", "eu-west-1"]
+    driver_thread = threading.get_ident()
+    client_build_threads = []
+    list_farms_threads = []
+
+    def fake_get_client(service_name, config=None, region=None):
+        client_build_threads.append(threading.get_ident())
+        client = MagicMock()
+
+        def _list_farms(**kwargs):
+            list_farms_threads.append(threading.get_ident())
+            return {"farms": [_make_farm(f"farm-{region}")]}
+
+        client.list_farms.side_effect = _list_farms
+        return client
+
+    with (
+        patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client),
+        patch.object(_list_apis.config_file, "get_deadline_regions", return_value=regions),
+        patch.object(_list_apis, "_apply_principal_id_filter"),
+    ):
+        results = list(_list_apis._iter_farms_by_region())
+
+    assert len(results) == len(regions)
+    # Every client was constructed on the driver thread (no Session access off-thread).
+    assert client_build_threads == [driver_thread] * len(regions)
+    # The actual ListFarms calls did run off the driver thread (the fan-out is real).
+    assert list_farms_threads, "expected ListFarms to be called"
+    assert all(tid != driver_thread for tid in list_farms_threads)
+
+
+def test_iter_farms_by_region_principal_filter_applied_once_on_calling_thread(
+    fresh_deadline_config,
+):
+    """
+    The principal-id filter does a DCM lookup; it must run exactly once, up front, on the
+    calling thread -- not once per worker thread.
+    """
+    regions = ["us-west-2", "us-east-1", "eu-west-1", "ap-south-1"]
+    driver_thread = threading.get_ident()
+    filter_threads = []
+
+    def fake_apply_principal(kwargs, config=None):
+        filter_threads.append(threading.get_ident())
+
+    def fake_get_client(service_name, config=None, region=None):
+        return _client_returning([_make_farm(f"farm-{region}")])
+
+    with (
+        patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client),
+        patch.object(_list_apis.config_file, "get_deadline_regions", return_value=regions),
+        patch.object(_list_apis, "_apply_principal_id_filter", side_effect=fake_apply_principal),
+    ):
+        list(_list_apis._iter_farms_by_region())
+
+    assert filter_threads == [driver_thread], "principal filter must run once, on the driver thread"
+
+
+def test_iter_farms_by_region_high_concurrency_stress(fresh_deadline_config):
+    """
+    Stress the fan-out across many regions with a client factory that is deliberately NOT
+    safe to call concurrently: it asserts it is only ever entered from one thread at a
+    time. Because clients are built serially up front, this never trips; if a future change
+    moved client construction back into the workers, this test would flake/fail.
+
+    The per-region ListFarms calls themselves run concurrently (verified by observing more
+    than one distinct worker thread), so this exercises real parallelism on the call path.
+    """
+    regions = [f"region-{i:02d}" for i in range(30)]
+    build_lock = threading.Lock()
+    concurrent_builds = 0
+    max_concurrent_builds = 0
+    call_threads = set()
+    call_threads_lock = threading.Lock()
+
+    def make_list_farms(region):
+        def _list_farms(**kwargs):
+            with call_threads_lock:
+                call_threads.add(threading.get_ident())
+            time.sleep(0.002)  # let calls overlap across the pool
+            return {"farms": [_make_farm(f"farm-{region}")]}
+
+        return _list_farms
+
+    def fake_get_client(service_name, config=None, region=None):
+        # Detect any overlapping client construction: if two threads were ever inside this
+        # factory at once, current would exceed 1 and we'd fail right here.
+        nonlocal concurrent_builds, max_concurrent_builds
+        with build_lock:
+            concurrent_builds += 1
+            max_concurrent_builds = max(max_concurrent_builds, concurrent_builds)
+            current = concurrent_builds
+        assert current == 1, "client construction overlapped across threads"
+        try:
+            time.sleep(0.001)  # hold the "build" open so any overlap would be observed
+            client = MagicMock()
+            client.list_farms.side_effect = make_list_farms(region)
+            return client
+        finally:
+            with build_lock:
+                concurrent_builds -= 1
+
+    with (
+        patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client),
+        patch.object(_list_apis.config_file, "get_deadline_regions", return_value=regions),
+        patch.object(_list_apis, "_apply_principal_id_filter"),
+    ):
+        results = list(_list_apis._iter_farms_by_region())
+
+    # All regions returned, each correctly tagged, no exceptions captured.
+    assert len(results) == len(regions)
+    by_region = {region: (farms, exc) for region, farms, exc in results}
+    assert set(by_region) == set(regions)
+    for region, (farms, exc) in by_region.items():
+        assert exc is None
+        assert farms is not None and farms[0]["region"] == region
+    # Client construction never overlapped (serial, up front)...
+    assert max_concurrent_builds == 1
+    # ...while the network calls genuinely ran in parallel across the worker pool.
+    assert len(call_threads) > 1

--- a/test/unit/deadline_client/api/test_api_list_multi_region.py
+++ b/test/unit/deadline_client/api/test_api_list_multi_region.py
@@ -1,0 +1,777 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Tests for the multi-region fan-out behavior of deadline.client.api list functions:
+the ``list_farms`` aggregation/failure semantics, the ``_iter_farms_by_region``
+streaming generator, and region pass-through on the per-farm list APIs.
+"""
+
+import os
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from deadline.client import api
+from deadline.client.api import _list_apis
+from deadline.client.exceptions import DeadlineOperationError
+
+
+@pytest.fixture(autouse=True)
+def _clear_endpoint_override_env(monkeypatch):
+    """
+    Ensure each test in this module controls the AWS_ENDPOINT_URL_DEADLINE /
+    DEADLINE_CLOUD_REGIONS env vars itself.
+
+    Some sibling CLI test modules set AWS_ENDPOINT_URL_DEADLINE at import time without
+    cleanup; under xdist that can leak into this worker and flip list_farms into its
+    single-region endpoint-override path, breaking the fan-out tests here. Clearing the
+    vars up front makes the fan-out tests deterministic; tests that exercise the override
+    path set it explicitly.
+    """
+    monkeypatch.delenv("AWS_ENDPOINT_URL_DEADLINE", raising=False)
+    monkeypatch.delenv("DEADLINE_CLOUD_REGIONS", raising=False)
+
+
+def _make_farm(farm_id, display_name="Farm"):
+    return {"farmId": farm_id, "displayName": display_name, "description": ""}
+
+
+def _client_returning(farms):
+    """Builds a mock deadline client whose list_farms returns a single (unpaginated) page."""
+    client = MagicMock()
+    # Return fresh dicts each call so the region-tagging mutation doesn't leak across regions.
+    client.list_farms.return_value = {"farms": [dict(f) for f in farms]}
+    return client
+
+
+def _client_raising(exc):
+    client = MagicMock()
+    client.list_farms.side_effect = exc
+    return client
+
+
+def test_list_farms_multi_region_happy_path(fresh_deadline_config):
+    """Farms from every region are concatenated, each tagged with its region."""
+    regions = ["us-west-2", "us-east-1", "eu-west-1"]
+    clients = {
+        "us-west-2": _client_returning([_make_farm("farm-west2")]),
+        "us-east-1": _client_returning([_make_farm("farm-east1a"), _make_farm("farm-east1b")]),
+        "eu-west-1": _client_returning([_make_farm("farm-euwest1")]),
+    }
+
+    def fake_get_client(service_name, config=None, region=None):
+        return clients[region]
+
+    with patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client), patch.object(
+        _list_apis.config_file, "get_deadline_regions", return_value=regions
+    ), patch.object(_list_apis, "_apply_principal_id_filter"):
+        result = api.list_farms()
+
+    farms = result["farms"]
+    assert len(farms) == 4
+    # Every farm carries the region it came from.
+    by_id = {f["farmId"]: f["region"] for f in farms}
+    assert by_id == {
+        "farm-west2": "us-west-2",
+        "farm-east1a": "us-east-1",
+        "farm-east1b": "us-east-1",
+        "farm-euwest1": "eu-west-1",
+    }
+
+
+def test_list_farms_partial_failure_returns_survivors(fresh_deadline_config, caplog):
+    """One region failing emits a warning but farms from surviving regions are returned."""
+    regions = ["us-west-2", "us-east-1"]
+    boom = RuntimeError("region is opted out")
+    clients = {
+        "us-west-2": _client_returning([_make_farm("farm-west2")]),
+        "us-east-1": _client_raising(boom),
+    }
+
+    def fake_get_client(service_name, config=None, region=None):
+        return clients[region]
+
+    with caplog.at_level("WARNING"), patch.object(
+        _list_apis, "get_boto3_client", side_effect=fake_get_client
+    ), patch.object(
+        _list_apis.config_file, "get_deadline_regions", return_value=regions
+    ), patch.object(_list_apis, "_apply_principal_id_filter"):
+        result = api.list_farms()
+
+    farms = result["farms"]
+    assert [f["farmId"] for f in farms] == ["farm-west2"]
+    assert farms[0]["region"] == "us-west-2"
+    # Warning mentions the failing region and the cause.
+    assert any(
+        "us-east-1" in rec.message and "region is opted out" in rec.message
+        for rec in caplog.records
+    )
+
+
+def test_list_farms_total_failure_raises(fresh_deadline_config):
+    """When every region fails, DeadlineOperationError surfaces each region's cause."""
+    regions = ["us-west-2", "us-east-1"]
+    clients = {
+        "us-west-2": _client_raising(RuntimeError("west2 boom")),
+        "us-east-1": _client_raising(RuntimeError("east1 boom")),
+    }
+
+    def fake_get_client(service_name, config=None, region=None):
+        return clients[region]
+
+    with patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client), patch.object(
+        _list_apis.config_file, "get_deadline_regions", return_value=regions
+    ), patch.object(_list_apis, "_apply_principal_id_filter"):
+        with pytest.raises(DeadlineOperationError) as excinfo:
+            api.list_farms()
+
+    message = str(excinfo.value)
+    assert "us-west-2" in message and "west2 boom" in message
+    assert "us-east-1" in message and "east1 boom" in message
+
+
+def test_list_farms_explicit_region_single_region(fresh_deadline_config):
+    """Passing region= scopes the call to exactly that region and tags farms with it."""
+    captured = {}
+
+    def fake_get_client(service_name, config=None, region=None):
+        captured["region"] = region
+        return _client_returning([_make_farm("farm-only")])
+
+    # If fan-out were used, get_deadline_regions would be consulted; assert it is NOT.
+    with patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client), patch.object(
+        _list_apis.config_file, "get_deadline_regions"
+    ) as regions_mock, patch.object(_list_apis, "_apply_principal_id_filter"):
+        result = api.list_farms(region="ap-south-1")
+
+    regions_mock.assert_not_called()
+    assert captured["region"] == "ap-south-1"
+    farms = result["farms"]
+    assert len(farms) == 1
+    assert farms[0]["region"] == "ap-south-1"
+
+
+def test_iter_farms_by_region_yields_per_region_including_failure(fresh_deadline_config):
+    """The generator yields (region, farms, None) on success and (region, None, exc) on failure."""
+    regions = ["us-west-2", "us-east-1"]
+    boom = RuntimeError("kaboom")
+    clients = {
+        "us-west-2": _client_returning([_make_farm("farm-west2")]),
+        "us-east-1": _client_raising(boom),
+    }
+
+    def fake_get_client(service_name, config=None, region=None):
+        return clients[region]
+
+    with patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client), patch.object(
+        _list_apis, "_apply_principal_id_filter"
+    ):
+        results = list(_list_apis._iter_farms_by_region(regions=regions))
+
+    # Out-of-order completion is allowed, so index by region.
+    by_region = {region: (farms, exc) for region, farms, exc in results}
+    assert set(by_region) == {"us-west-2", "us-east-1"}
+
+    west_farms, west_exc = by_region["us-west-2"]
+    assert west_exc is None
+    assert west_farms is not None
+    assert [f["farmId"] for f in west_farms] == ["farm-west2"]
+    assert west_farms[0]["region"] == "us-west-2"
+
+    east_farms, east_exc = by_region["us-east-1"]
+    assert east_farms is None
+    assert east_exc is boom
+
+
+def test_iter_farms_by_region_does_not_swallow_base_exceptions(fresh_deadline_config):
+    """
+    Per-region errors are reported as (region, None, exc), but control-flow exceptions
+    like KeyboardInterrupt/SystemExit must NOT be captured as a per-region "failure" --
+    they should propagate so the operation can actually be interrupted.
+    """
+    regions = ["us-west-2", "us-east-1"]
+    clients = {
+        "us-west-2": _client_returning([_make_farm("farm-west2")]),
+        "us-east-1": _client_raising(KeyboardInterrupt()),
+    }
+
+    def fake_get_client(service_name, config=None, region=None):
+        return clients[region]
+
+    with patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client), patch.object(
+        _list_apis, "_apply_principal_id_filter"
+    ):
+        with pytest.raises(KeyboardInterrupt):
+            list(_list_apis._iter_farms_by_region(regions=regions))
+
+
+def test_iter_farms_by_region_out_of_order_completion(fresh_deadline_config):
+    """A slow region completes after a fast one; both results still arrive."""
+    regions = ["slow-region", "fast-region"]
+
+    def slow_list_farms(**kwargs):
+        time.sleep(0.2)
+        return {"farms": [_make_farm("farm-slow")]}
+
+    slow_client = MagicMock()
+    slow_client.list_farms.side_effect = slow_list_farms
+    fast_client = _client_returning([_make_farm("farm-fast")])
+    clients = {"slow-region": slow_client, "fast-region": fast_client}
+
+    def fake_get_client(service_name, config=None, region=None):
+        return clients[region]
+
+    with patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client), patch.object(
+        _list_apis, "_apply_principal_id_filter"
+    ):
+        order = [region for region, _, _ in _list_apis._iter_farms_by_region(regions=regions)]
+
+    # Fast region should complete (and thus be yielded) before the slow one.
+    assert order == ["fast-region", "slow-region"]
+
+
+def test_iter_farms_by_region_pagination_per_region(fresh_deadline_config):
+    """nextToken pagination is honored within each region's call."""
+    regions = ["us-west-2"]
+    client = MagicMock()
+    client.list_farms.side_effect = [
+        {"farms": [_make_farm("farm-a")], "nextToken": "t1"},
+        {"farms": [_make_farm("farm-b")]},
+    ]
+
+    def fake_get_client(service_name, config=None, region=None):
+        return client
+
+    with patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client), patch.object(
+        _list_apis, "_apply_principal_id_filter"
+    ):
+        results = list(_list_apis._iter_farms_by_region(regions=regions))
+
+    assert len(results) == 1
+    region, farms, exc = results[0]
+    assert exc is None
+    assert farms is not None
+    assert [f["farmId"] for f in farms] == ["farm-a", "farm-b"]
+    assert all(f["region"] == "us-west-2" for f in farms)
+
+
+@pytest.mark.parametrize(
+    "api_func, list_method, list_property",
+    [
+        ("list_queues", "list_queues", "queues"),
+        ("list_jobs", "list_jobs", "jobs"),
+        ("list_fleets", "list_fleets", "fleets"),
+        ("list_storage_profiles_for_queue", "list_storage_profiles_for_queue", "storageProfiles"),
+    ],
+)
+def test_per_farm_list_apis_pass_region_through(
+    fresh_deadline_config, api_func, list_method, list_property
+):
+    """list_queues/list_jobs/list_fleets/list_storage_profiles_for_queue forward region."""
+    captured = {}
+    client = MagicMock()
+    getattr(client, list_method).return_value = {list_property: []}
+
+    def fake_get_client(service_name, config=None, region=None):
+        captured["service_name"] = service_name
+        captured["region"] = region
+        return client
+
+    with patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client), patch.object(
+        _list_apis, "_apply_principal_id_filter"
+    ):
+        getattr(api, api_func)(region="eu-central-1")
+
+    assert captured["service_name"] == "deadline"
+    assert captured["region"] == "eu-central-1"
+
+
+def test_per_farm_list_api_default_region_is_none(fresh_deadline_config):
+    """With no region argument, region=None flows to get_boto3_client (unchanged behavior)."""
+    captured = {}
+    client = MagicMock()
+    client.list_queues.return_value = {"queues": []}
+
+    def fake_get_client(service_name, config=None, region=None):
+        captured["region"] = region
+        return client
+
+    with patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client), patch.object(
+        _list_apis, "_apply_principal_id_filter"
+    ):
+        api.list_queues()
+
+    assert captured["region"] is None
+
+
+def test_list_farms_explicit_region_ignores_configured_farm_region(fresh_deadline_config):
+    """
+    an explicit region= argument wins over a configured defaults.farm_region.
+    """
+    from deadline.client import config
+
+    config.set_setting("defaults.farm_region", "us-west-2")
+
+    captured = {}
+
+    def fake_get_client(service_name, config=None, region=None):
+        captured["region"] = region
+        return _client_returning([_make_farm("farm-explicit")])
+
+    with patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client), patch.object(
+        _list_apis.config_file, "get_deadline_regions"
+    ) as regions_mock, patch.object(_list_apis, "_apply_principal_id_filter"):
+        result = api.list_farms(region="ap-northeast-1")
+
+    # Fan-out was never consulted, and the explicit region (not the configured one) was used.
+    regions_mock.assert_not_called()
+    assert captured["region"] == "ap-northeast-1"
+    assert result["farms"][0]["region"] == "ap-northeast-1"
+
+
+def test_list_farms_no_regions_returns_empty_no_error(fresh_deadline_config):
+    """
+    when get_deadline_regions() returns [], list_farms returns {"farms": []}
+    without crashing and without raising the all-regions-failed error (there were no
+    regions to fail).
+    """
+    with patch.object(
+        _list_apis.config_file, "get_deadline_regions", return_value=[]
+    ), patch.object(_list_apis, "get_boto3_client") as get_client_mock, patch.object(
+        _list_apis, "_apply_principal_id_filter"
+    ):
+        result = api.list_farms()
+
+    assert result == {"farms": []}
+    # No region => no client was ever built.
+    get_client_mock.assert_not_called()
+
+
+def test_list_farms_explicit_region_does_not_fan_out(fresh_deadline_config):
+    """
+    list_farms(region=...) does a single-region call - it neither consults
+    get_deadline_regions nor builds more than one client.
+    """
+    calls = []
+
+    def fake_get_client(service_name, config=None, region=None):
+        calls.append(region)
+        return _client_returning([_make_farm("farm-single")])
+
+    with patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client), patch.object(
+        _list_apis.config_file, "get_deadline_regions"
+    ) as regions_mock, patch.object(_list_apis, "_apply_principal_id_filter"):
+        api.list_farms(region="us-east-2")
+
+    regions_mock.assert_not_called()
+    # Exactly one client built, for the requested region only.
+    assert calls == ["us-east-2"]
+
+
+def test_list_farms_multi_region_concatenation_contract(fresh_deadline_config):
+    """
+    multi-region results are concatenated. Because regions complete via
+    as_completed, ordering is non-deterministic; the pinned contract is that EVERY
+    region's farms are present (as a set) with correct region tags.
+    """
+    regions = ["us-west-2", "us-east-1", "eu-west-1", "ap-south-1"]
+    clients = {r: _client_returning([_make_farm(f"farm-{r}")]) for r in regions}
+
+    def fake_get_client(service_name, config=None, region=None):
+        return clients[region]
+
+    with patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client), patch.object(
+        _list_apis.config_file, "get_deadline_regions", return_value=regions
+    ), patch.object(_list_apis, "_apply_principal_id_filter"):
+        result = api.list_farms()
+
+    farms = result["farms"]
+    # All regions are represented exactly once (set contract; order is not guaranteed).
+    assert {f["region"] for f in farms} == set(regions)
+    assert {f["farmId"] for f in farms} == {f"farm-{r}" for r in regions}
+    # Each farm is tagged with its own origin region (no cross-region mislabeling).
+    assert all(f["farmId"] == f"farm-{f['region']}" for f in farms)
+
+
+@pytest.mark.parametrize(
+    "api_func, list_method, list_property",
+    [
+        ("list_queues", "list_queues", "queues"),
+        ("list_jobs", "list_jobs", "jobs"),
+        ("list_fleets", "list_fleets", "fleets"),
+        ("list_storage_profiles_for_queue", "list_storage_profiles_for_queue", "storageProfiles"),
+    ],
+)
+def test_per_farm_list_apis_explicit_region_overrides_config(
+    fresh_deadline_config, api_func, list_method, list_property
+):
+    """
+    per-farm list APIs forward an explicit region= even when
+    defaults.farm_region is configured (explicit arg wins). Resolution to the configured
+    value happens later inside get_boto3_client, which here is mocked - so we assert the
+    explicit region is the one passed through.
+    """
+    from deadline.client import config
+
+    config.set_setting("defaults.farm_region", "us-west-2")
+
+    captured = {}
+    client = MagicMock()
+    getattr(client, list_method).return_value = {list_property: []}
+
+    def fake_get_client(service_name, config=None, region=None):
+        captured["region"] = region
+        return client
+
+    with patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client), patch.object(
+        _list_apis, "_apply_principal_id_filter"
+    ):
+        getattr(api, api_func)(region="eu-north-1")
+
+    assert captured["region"] == "eu-north-1"
+
+
+def test_list_farms_endpoint_override_scans_single_session_region(fresh_deadline_config):
+    """
+    With AWS_ENDPOINT_URL_DEADLINE set and region=None, list_farms does NOT fan out: it
+    scans only the session/profile default region (a single client), and tags the farms
+    with the session region. get_deadline_regions must not be consulted.
+    """
+    calls = []
+
+    def fake_get_client(service_name, config=None, region=None):
+        calls.append(region)
+        return _client_returning([_make_farm("farm-single")])
+
+    mock_session = MagicMock()
+    mock_session.region_name = "us-east-1"
+
+    with patch.dict(os.environ, {"AWS_ENDPOINT_URL_DEADLINE": "https://override.test/deadline"}):
+        os.environ.pop("DEADLINE_CLOUD_REGIONS", None)
+        with patch.object(
+            _list_apis, "get_boto3_client", side_effect=fake_get_client
+        ), patch.object(_list_apis, "get_boto3_session", return_value=mock_session), patch.object(
+            _list_apis.config_file, "get_deadline_regions"
+        ) as regions_mock, patch.object(_list_apis, "_apply_principal_id_filter"):
+            result = api.list_farms()
+
+    regions_mock.assert_not_called()
+    assert calls == ["us-east-1"]
+    assert [f["region"] for f in result["farms"]] == ["us-east-1"]
+
+
+def test_list_farms_endpoint_override_session_region_none_does_not_crash(fresh_deadline_config):
+    """
+    With the override set and a session that has no region (region_name is None), the
+    single-region scan still works; farms carry a None region tag rather than crashing.
+    """
+
+    def fake_get_client(service_name, config=None, region=None):
+        return _client_returning([_make_farm("farm-noregion")])
+
+    mock_session = MagicMock()
+    mock_session.region_name = None
+
+    with patch.dict(os.environ, {"AWS_ENDPOINT_URL_DEADLINE": "https://override.test/deadline"}):
+        os.environ.pop("DEADLINE_CLOUD_REGIONS", None)
+        with patch.object(
+            _list_apis, "get_boto3_client", side_effect=fake_get_client
+        ), patch.object(_list_apis, "get_boto3_session", return_value=mock_session), patch.object(
+            _list_apis.config_file, "get_deadline_regions"
+        ) as regions_mock, patch.object(_list_apis, "_apply_principal_id_filter"):
+            result = api.list_farms()
+
+    regions_mock.assert_not_called()
+    assert [f["farmId"] for f in result["farms"]] == ["farm-noregion"]
+    assert result["farms"][0]["region"] is None
+
+
+def test_list_farms_endpoint_override_with_explicit_regions_still_fans_out(fresh_deadline_config):
+    """
+    User intent wins: when the override is set AND the user explicitly lists regions via
+    DEADLINE_CLOUD_REGIONS, list_farms still fans out across those explicit regions (the
+    user is being deliberate). The single-region short-circuit is suppressed.
+    """
+    regions = ["us-west-2", "eu-west-1"]
+    clients = {r: _client_returning([_make_farm(f"farm-{r}")]) for r in regions}
+
+    def fake_get_client(service_name, config=None, region=None):
+        return clients[region]
+
+    with patch.dict(
+        os.environ,
+        {
+            "AWS_ENDPOINT_URL_DEADLINE": "https://override.test/deadline",
+            "DEADLINE_CLOUD_REGIONS": ",".join(regions),
+        },
+    ):
+        with patch.object(
+            _list_apis, "get_boto3_client", side_effect=fake_get_client
+        ), patch.object(
+            _list_apis.config_file, "get_deadline_regions", return_value=regions
+        ) as regions_mock, patch.object(_list_apis, "_apply_principal_id_filter"):
+            result = api.list_farms()
+
+    # Fan-out path was taken (explicit region list honored).
+    regions_mock.assert_called()
+    assert {f["region"] for f in result["farms"]} == set(regions)
+
+
+def test_list_farms_endpoint_override_explicit_region_arg_still_single(fresh_deadline_config):
+    """
+    An explicit region= argument is always honored (single region) regardless of the
+    endpoint override, unchanged from before.
+    """
+    calls = []
+
+    def fake_get_client(service_name, config=None, region=None):
+        calls.append(region)
+        return _client_returning([_make_farm("farm-eu")])
+
+    with patch.dict(os.environ, {"AWS_ENDPOINT_URL_DEADLINE": "https://override.test/deadline"}):
+        with patch.object(
+            _list_apis, "get_boto3_client", side_effect=fake_get_client
+        ), patch.object(
+            _list_apis.config_file, "get_deadline_regions"
+        ) as regions_mock, patch.object(_list_apis, "_apply_principal_id_filter"):
+            result = api.list_farms(region="eu-west-1")
+
+    regions_mock.assert_not_called()
+    assert calls == ["eu-west-1"]
+    assert result["farms"][0]["region"] == "eu-west-1"
+
+
+def test_list_farms_no_override_still_fans_out(fresh_deadline_config):
+    """
+    Regression guard: with NO endpoint override set, list_farms still fans out across all
+    Deadline regions (the multi-region default behavior is preserved).
+    """
+    regions = ["us-west-2", "us-east-1", "eu-west-1"]
+    clients = {r: _client_returning([_make_farm(f"farm-{r}")]) for r in regions}
+
+    def fake_get_client(service_name, config=None, region=None):
+        return clients[region]
+
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("AWS_ENDPOINT_URL_DEADLINE", None)
+        os.environ.pop("DEADLINE_CLOUD_REGIONS", None)
+        with patch.object(
+            _list_apis, "get_boto3_client", side_effect=fake_get_client
+        ), patch.object(
+            _list_apis.config_file, "get_deadline_regions", return_value=regions
+        ) as regions_mock, patch.object(_list_apis, "_apply_principal_id_filter"):
+            result = api.list_farms()
+
+    regions_mock.assert_called()
+    assert {f["region"] for f in result["farms"]} == set(regions)
+
+
+def test_iter_farms_by_region_endpoint_override_scans_single_session_region(fresh_deadline_config):
+    """
+    The shared generator (the chokepoint the UI uses directly) honors the endpoint
+    override: with AWS_ENDPOINT_URL_DEADLINE set and regions=None it yields exactly ONE
+    tuple for the session region, builds only one client, and never consults
+    get_deadline_regions.
+    """
+    calls = []
+
+    def fake_get_client(service_name, config=None, region=None):
+        calls.append(region)
+        return _client_returning([_make_farm("farm-single")])
+
+    mock_session = MagicMock()
+    mock_session.region_name = "us-east-1"
+
+    with patch.dict(os.environ, {"AWS_ENDPOINT_URL_DEADLINE": "https://override.test/deadline"}):
+        os.environ.pop("DEADLINE_CLOUD_REGIONS", None)
+        with patch.object(
+            _list_apis, "get_boto3_client", side_effect=fake_get_client
+        ), patch.object(_list_apis, "get_boto3_session", return_value=mock_session), patch.object(
+            _list_apis.config_file, "get_deadline_regions"
+        ) as regions_mock, patch.object(_list_apis, "_apply_principal_id_filter"):
+            results = list(_list_apis._iter_farms_by_region())
+
+    regions_mock.assert_not_called()
+    assert calls == ["us-east-1"]
+    assert len(results) == 1
+    region, farms, exc = results[0]
+    assert region == "us-east-1"
+    assert exc is None
+    assert farms is not None
+    assert [f["region"] for f in farms] == ["us-east-1"]
+
+
+def test_iter_farms_by_region_endpoint_override_with_explicit_regions_still_fans_out(
+    fresh_deadline_config,
+):
+    """
+    With the override set AND an explicit DEADLINE_CLOUD_REGIONS list, the generator does
+    NOT short-circuit: it fans out across the explicit region list (user intent wins).
+    """
+    regions = ["us-west-2", "eu-west-1"]
+    clients = {r: _client_returning([_make_farm(f"farm-{r}")]) for r in regions}
+
+    def fake_get_client(service_name, config=None, region=None):
+        return clients[region]
+
+    with patch.dict(
+        os.environ,
+        {
+            "AWS_ENDPOINT_URL_DEADLINE": "https://override.test/deadline",
+            "DEADLINE_CLOUD_REGIONS": ",".join(regions),
+        },
+    ):
+        with patch.object(
+            _list_apis, "get_boto3_client", side_effect=fake_get_client
+        ), patch.object(
+            _list_apis.config_file, "get_deadline_regions", return_value=regions
+        ) as regions_mock, patch.object(_list_apis, "_apply_principal_id_filter"):
+            results = list(_list_apis._iter_farms_by_region())
+
+    regions_mock.assert_called()
+    by_region = {region: (farms, exc) for region, farms, exc in results}
+    assert set(by_region) == set(regions)
+
+
+def test_iter_farms_by_region_explicit_regions_arg_ignores_override(fresh_deadline_config):
+    """
+    When the caller passes an explicit regions= argument, the override logic is skipped
+    entirely and exactly those regions are scanned (caller is being deliberate), even with
+    AWS_ENDPOINT_URL_DEADLINE set. get_deadline_regions / get_boto3_session are not used.
+    """
+    regions = ["us-west-2", "ap-south-1"]
+    clients = {r: _client_returning([_make_farm(f"farm-{r}")]) for r in regions}
+
+    def fake_get_client(service_name, config=None, region=None):
+        return clients[region]
+
+    with patch.dict(os.environ, {"AWS_ENDPOINT_URL_DEADLINE": "https://override.test/deadline"}):
+        with patch.object(
+            _list_apis, "get_boto3_client", side_effect=fake_get_client
+        ), patch.object(
+            _list_apis.config_file, "get_deadline_regions"
+        ) as regions_mock, patch.object(
+            _list_apis, "get_boto3_session"
+        ) as session_mock, patch.object(_list_apis, "_apply_principal_id_filter"):
+            results = list(_list_apis._iter_farms_by_region(regions=regions))
+
+    regions_mock.assert_not_called()
+    session_mock.assert_not_called()
+    by_region = {region: (farms, exc) for region, farms, exc in results}
+    assert set(by_region) == set(regions)
+
+
+def test_iter_farms_by_region_no_override_fans_out_via_get_deadline_regions(fresh_deadline_config):
+    """
+    Regression guard for the generator: with NO override and regions=None, the generator
+    resolves the region set via get_deadline_regions() and fans out across it.
+    """
+    regions = ["us-west-2", "us-east-1", "eu-west-1"]
+    clients = {r: _client_returning([_make_farm(f"farm-{r}")]) for r in regions}
+
+    def fake_get_client(service_name, config=None, region=None):
+        return clients[region]
+
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("AWS_ENDPOINT_URL_DEADLINE", None)
+        os.environ.pop("DEADLINE_CLOUD_REGIONS", None)
+        with patch.object(
+            _list_apis, "get_boto3_client", side_effect=fake_get_client
+        ), patch.object(
+            _list_apis.config_file, "get_deadline_regions", return_value=regions
+        ) as regions_mock, patch.object(_list_apis, "_apply_principal_id_filter"):
+            results = list(_list_apis._iter_farms_by_region())
+
+    regions_mock.assert_called()
+    by_region = {region: (farms, exc) for region, farms, exc in results}
+    assert set(by_region) == set(regions)
+
+
+def test_iter_farms_by_region_endpoint_override_session_region_none(fresh_deadline_config):
+    """
+    Single-endpoint case with a session that has no region (region_name is None): the
+    generator yields exactly one tuple whose region is None, without crashing in the
+    fan-out machinery (a None region key is fine).
+    """
+
+    def fake_get_client(service_name, config=None, region=None):
+        return _client_returning([_make_farm("farm-noregion")])
+
+    mock_session = MagicMock()
+    mock_session.region_name = None
+
+    with patch.dict(os.environ, {"AWS_ENDPOINT_URL_DEADLINE": "https://override.test/deadline"}):
+        os.environ.pop("DEADLINE_CLOUD_REGIONS", None)
+        with patch.object(
+            _list_apis, "get_boto3_client", side_effect=fake_get_client
+        ), patch.object(_list_apis, "get_boto3_session", return_value=mock_session), patch.object(
+            _list_apis.config_file, "get_deadline_regions"
+        ) as regions_mock, patch.object(_list_apis, "_apply_principal_id_filter"):
+            results = list(_list_apis._iter_farms_by_region())
+
+    regions_mock.assert_not_called()
+    assert len(results) == 1
+    region, farms, exc = results[0]
+    assert region is None
+    assert exc is None
+    assert farms is not None
+    assert [f["region"] for f in farms] == [None]
+
+
+def test_list_farms_endpoint_override_single_region_failure_raises(fresh_deadline_config):
+    """
+    Failure semantics in the single-endpoint case: the generator yields one tuple, and if
+    that one call fails there are zero successes, so list_farms raises
+    DeadlineOperationError (all regions failed = the one region failed).
+    """
+
+    def fake_get_client(service_name, config=None, region=None):
+        return _client_raising(RuntimeError("override boom"))
+
+    mock_session = MagicMock()
+    mock_session.region_name = "us-east-1"
+
+    with patch.dict(os.environ, {"AWS_ENDPOINT_URL_DEADLINE": "https://override.test/deadline"}):
+        os.environ.pop("DEADLINE_CLOUD_REGIONS", None)
+        with patch.object(
+            _list_apis, "get_boto3_client", side_effect=fake_get_client
+        ), patch.object(_list_apis, "get_boto3_session", return_value=mock_session), patch.object(
+            _list_apis, "_apply_principal_id_filter"
+        ):
+            with pytest.raises(DeadlineOperationError) as excinfo:
+                api.list_farms()
+
+    assert "override boom" in str(excinfo.value)
+
+
+def test_list_farms_does_not_mutate_caller_farm_dicts(fresh_deadline_config):
+    """
+    region tagging uses a shallow copy ({**farm, "region": r}); the original farm
+    dicts returned by the SDK/caller must be left unmodified (no "region" key added).
+    """
+    original_farms = [
+        {"farmId": "farm-a", "displayName": "A"},
+        {"farmId": "farm-b", "displayName": "B"},
+    ]
+
+    client = MagicMock()
+    # Return the SAME dict objects the caller would own (no defensive copy here).
+    client.list_farms.return_value = {"farms": original_farms}
+
+    def fake_get_client(service_name, config=None, region=None):
+        return client
+
+    with patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client), patch.object(
+        _list_apis, "_apply_principal_id_filter"
+    ):
+        result = api.list_farms(region="us-west-2")
+
+    # The returned farms are region-tagged...
+    assert all(f["region"] == "us-west-2" for f in result["farms"])
+    # ...but the original dicts are untouched.
+    assert original_farms == [
+        {"farmId": "farm-a", "displayName": "A"},
+        {"farmId": "farm-b", "displayName": "B"},
+    ]
+    assert all("region" not in f for f in original_farms)

--- a/test/unit/deadline_client/api/test_api_session.py
+++ b/test/unit/deadline_client/api/test_api_session.py
@@ -359,9 +359,11 @@ def test_get_queue_user_boto3_session_uses_resolved_farm_region(fresh_deadline_c
     # Clear the lru_cache so a prior test's queue-user session doesn't shadow this one.
     api._session._get_queue_user_boto3_session.cache_clear()
 
-    with patch.object(api._session, "get_boto3_session", return_value=session_mock), patch(
-        "botocore.session.Session", return_value=mock_botocore_session
-    ), patch("boto3.Session") as boto3_session_mock:
+    with (
+        patch.object(api._session, "get_boto3_session", return_value=session_mock),
+        patch("botocore.session.Session", return_value=mock_botocore_session),
+        patch("boto3.Session") as boto3_session_mock,
+    ):
         api.get_queue_user_boto3_session(
             deadline_mock,
             farm_id="farm-1234",
@@ -390,9 +392,11 @@ def test_get_queue_user_boto3_session_falls_back_to_base_region(fresh_deadline_c
 
     api._session._get_queue_user_boto3_session.cache_clear()
 
-    with patch.object(api._session, "get_boto3_session", return_value=session_mock), patch(
-        "botocore.session.Session", return_value=mock_botocore_session
-    ), patch("boto3.Session") as boto3_session_mock:
+    with (
+        patch.object(api._session, "get_boto3_session", return_value=session_mock),
+        patch("botocore.session.Session", return_value=mock_botocore_session),
+        patch("boto3.Session") as boto3_session_mock,
+    ):
         api.get_queue_user_boto3_session(
             deadline_mock,
             farm_id="farm-1234",
@@ -427,9 +431,10 @@ def test_get_session_logs_logs_client_uses_farm_region_non_dcm(fresh_deadline_co
         client.get_log_events.return_value = {"events": [], "nextForwardToken": None}
         return client
 
-    with patch.object(
-        _job_monitoring, "get_boto3_client", side_effect=fake_get_boto3_client
-    ), patch.object(_job_monitoring, "get_user_and_identity_store_id", return_value=(None, None)):
+    with (
+        patch.object(_job_monitoring, "get_boto3_client", side_effect=fake_get_boto3_client),
+        patch.object(_job_monitoring, "get_user_and_identity_store_id", return_value=(None, None)),
+    ):
         _job_monitoring.get_session_logs(
             farm_id="farm-1234",
             queue_id="queue-1234",

--- a/test/unit/deadline_client/api/test_api_session.py
+++ b/test/unit/deadline_client/api/test_api_session.py
@@ -9,7 +9,12 @@ from unittest.mock import call, patch, MagicMock, ANY
 
 import boto3  # type: ignore[import]
 from deadline.client import api, config
-from deadline.client.api._session import get_session_client, precache_clients
+from deadline.client.api._session import (
+    get_boto3_client,
+    get_session_client,
+    precache_clients,
+    _resolve_region,
+)
 
 
 def test_get_boto3_session(fresh_deadline_config):
@@ -21,9 +26,12 @@ def test_get_boto3_session(fresh_deadline_config):
         # Testing this function
         result = api.get_boto3_session()
 
-        # Confirm it returned the mocked value, and was called with the correct args
+        # Confirm it returned the mocked value, and was called with the correct args.
+        # region_name=None preserves the profile's default region (no region requested).
         assert result == mock_session
-        boto3_session.assert_called_once_with(profile_name="SomeRandomProfileName")
+        boto3_session.assert_called_once_with(
+            profile_name="SomeRandomProfileName", region_name=None
+        )
 
 
 def test_get_boto3_session_caching_behavior(fresh_deadline_config):
@@ -33,7 +41,7 @@ def test_get_boto3_session_caching_behavior(fresh_deadline_config):
     """
 
     # mock boto3.Session to return a fresh object based on the input profile name
-    def mock_create_session(profile_name: Optional[str]):
+    def mock_create_session(profile_name: Optional[str], region_name: Optional[str] = None):
         session = MagicMock()
         session._profile_name = profile_name
         return session
@@ -65,8 +73,8 @@ def test_get_boto3_session_caching_behavior(fresh_deadline_config):
         # value of AWS profile name that was configured.
         boto3_session.assert_has_calls(
             [
-                call(profile_name=None),
-                call(profile_name="SomeRandomProfileName"),
+                call(profile_name=None, region_name=None),
+                call(profile_name="SomeRandomProfileName", region_name=None),
             ]
         )
 
@@ -191,6 +199,84 @@ def test_check_deadline_api_available_fails(fresh_deadline_config):
         session_mock().client("deadline").list_farms.assert_called_once_with(maxResults=1)
 
 
+def test_resolve_region_precedence(fresh_deadline_config):
+    """_resolve_region: explicit region > defaults.farm_region > None."""
+    # Nothing configured -> None (preserves single-region behavior).
+    assert _resolve_region() is None
+
+    # defaults.farm_region set -> used when no explicit region.
+    config.set_setting("defaults.farm_region", "eu-west-1")
+    assert _resolve_region() == "eu-west-1"
+
+    # Explicit region wins over farm_region.
+    assert _resolve_region(region="ap-south-1") == "ap-south-1"
+
+
+def test_resolve_region_backcompat_empty(fresh_deadline_config):
+    """A config without farm_region (default empty) resolves region to None."""
+    # No defaults.farm_region set at all -> default "" -> None.
+    assert _resolve_region() is None
+
+
+def test_get_boto3_client_with_region(fresh_deadline_config):
+    """get_boto3_client passes region_name to the client when a region is given."""
+    mock_session = MagicMock()
+    with patch.object(api._session, "get_boto3_session", return_value=mock_session):
+        # Make sure no stale cache entry interferes.
+        get_session_client.cache_clear()
+        get_boto3_client("deadline", region="eu-west-1")
+
+    mock_session.client.assert_called_once_with("deadline", config=ANY, region_name="eu-west-1")
+
+
+def test_get_boto3_client_with_farm_region_config(fresh_deadline_config):
+    """get_boto3_client resolves region from defaults.farm_region when not passed."""
+    config.set_setting("defaults.farm_region", "ap-south-1")
+    mock_session = MagicMock()
+    with patch.object(api._session, "get_boto3_session", return_value=mock_session):
+        get_session_client.cache_clear()
+        get_boto3_client("deadline")
+
+    mock_session.client.assert_called_once_with("deadline", config=ANY, region_name="ap-south-1")
+
+
+def test_get_boto3_client_without_region_backcompat(fresh_deadline_config):
+    """Without any region, get_boto3_client does not pass region_name (single-region behavior)."""
+    mock_session = MagicMock()
+    with patch.object(api._session, "get_boto3_session", return_value=mock_session):
+        get_session_client.cache_clear()
+        get_boto3_client("deadline")
+
+    # region_name must NOT be passed to preserve existing single-region behavior.
+    mock_session.client.assert_called_once_with("deadline", config=ANY)
+
+
+def test_get_boto3_session_with_region_builds_region_scoped_session(fresh_deadline_config):
+    """
+    get_boto3_session(region=...) builds a region-scoped session so boto3 resolves the
+    regional Deadline endpoint itself (no hand-built endpoint URL needed). The cache is
+    keyed on region, so the no-region session and a region-scoped session differ.
+    """
+    created = []
+
+    def mock_create_session(profile_name=None, region_name=None):
+        session = MagicMock()
+        session._profile_name = profile_name
+        session._region_name = region_name
+        created.append(session)
+        return session
+
+    with patch.object(boto3, "Session", side_effect=mock_create_session) as boto3_session:
+        api._session._get_boto3_session_for_profile.cache_clear()
+        default_session = api.get_boto3_session()
+        scoped_session = api.get_boto3_session(region="eu-west-1")
+
+    assert default_session is not scoped_session
+    assert scoped_session._region_name == "eu-west-1"
+    boto3_session.assert_any_call(profile_name=None, region_name=None)
+    boto3_session.assert_any_call(profile_name=None, region_name="eu-west-1")
+
+
 def test_get_session_client_caching():
     """Test that get_session_client properly caches clients."""
     # Create a real boto3 session for testing the cache
@@ -214,6 +300,146 @@ def test_get_session_client_caching():
     new_session = boto3.Session()
     client4 = get_session_client(new_session, "s3")
     assert client1 is not client4
+
+
+def test_get_session_client_different_regions_distinct_clients():
+    """
+    the same session+service but DIFFERENT regions must yield DIFFERENT client
+    objects (the region is part of the lru_cache key, so there is no cross-region reuse).
+    """
+    get_session_client.cache_clear()
+    session = boto3.Session()
+
+    client_west = get_session_client(session, "s3", region="us-west-2")
+    client_east = get_session_client(session, "s3", region="us-east-1")
+
+    assert client_west is not client_east
+    # And the no-region client is also distinct from the region-scoped ones.
+    client_default = get_session_client(session, "s3")
+    assert client_default is not client_west
+    assert client_default is not client_east
+
+
+def test_get_session_client_same_region_cached():
+    """
+    the same (session, service, region) tuple returns the SAME cached object.
+    """
+    get_session_client.cache_clear()
+    session = boto3.Session()
+
+    client1 = get_session_client(session, "s3", region="eu-west-1")
+    client2 = get_session_client(session, "s3", region="eu-west-1")
+
+    assert client1 is client2
+
+
+def test_get_queue_user_boto3_session_uses_resolved_farm_region(fresh_deadline_config):
+    """
+    get_queue_user_boto3_session scopes the queue-user session to the resolved
+    farm region (defaults.farm_region) rather than the base session's region.
+
+    Reading the source: get_queue_user_boto3_session resolves the region via
+    _resolve_region(config, farm_id=farm_id) and passes it to _get_queue_user_boto3_session,
+    which uses ``region_name=region if region is not None else base_session.region_name``.
+    So the farm's configured region IS honored over the base session region.
+    """
+    # farm_region is keyed per farm, so store it for the farm we'll query.
+    config.set_setting("defaults.farm_id", "farm-1234")
+    config.set_setting("defaults.farm_region", "ap-south-1")
+
+    session_mock = MagicMock()
+    session_mock.profile_name = "default"
+    session_mock.region_name = "us-west-2"  # base session region (should be overridden)
+    deadline_mock = MagicMock()
+    mock_botocore_session = MagicMock()
+    mock_botocore_session.get_config_variable = lambda name: (
+        "default" if name == "profile" else None
+    )
+
+    # Clear the lru_cache so a prior test's queue-user session doesn't shadow this one.
+    api._session._get_queue_user_boto3_session.cache_clear()
+
+    with patch.object(api._session, "get_boto3_session", return_value=session_mock), patch(
+        "botocore.session.Session", return_value=mock_botocore_session
+    ), patch("boto3.Session") as boto3_session_mock:
+        api.get_queue_user_boto3_session(
+            deadline_mock,
+            farm_id="farm-1234",
+            queue_id="queue-1234",
+            queue_display_name="queue",
+        )
+        # The queue-user session is built for the configured farm region, not us-west-2.
+        boto3_session_mock.assert_called_once_with(
+            botocore_session=ANY, profile_name=None, region_name="ap-south-1"
+        )
+
+
+def test_get_queue_user_boto3_session_falls_back_to_base_region(fresh_deadline_config):
+    """
+    With NO configured farm_region, the queue-user session falls back to the base
+    session's region (single-region behavior).
+    """
+    session_mock = MagicMock()
+    session_mock.profile_name = "default"
+    session_mock.region_name = "us-west-2"
+    deadline_mock = MagicMock()
+    mock_botocore_session = MagicMock()
+    mock_botocore_session.get_config_variable = lambda name: (
+        "default" if name == "profile" else None
+    )
+
+    api._session._get_queue_user_boto3_session.cache_clear()
+
+    with patch.object(api._session, "get_boto3_session", return_value=session_mock), patch(
+        "botocore.session.Session", return_value=mock_botocore_session
+    ), patch("boto3.Session") as boto3_session_mock:
+        api.get_queue_user_boto3_session(
+            deadline_mock,
+            farm_id="farm-1234",
+            queue_id="queue-1234",
+            queue_display_name="queue",
+        )
+        boto3_session_mock.assert_called_once_with(
+            botocore_session=ANY, profile_name=None, region_name="us-west-2"
+        )
+
+
+def test_get_session_logs_logs_client_uses_farm_region_non_dcm(fresh_deadline_config):
+    """
+    for a non-DCM profile, get_session_logs builds its CloudWatch ``logs`` client
+    via get_boto3_client("logs", config=config), so it resolves to defaults.farm_region -
+    i.e. the logs client is scoped to the farm region (the multi-region behavior).
+
+    (For DCM profiles the logs client comes from the queue-user session, which is region-
+    scoped via case 37; this test pins the non-DCM path.)
+    """
+    from deadline.client.api import _job_monitoring
+    from deadline.client.api._session import _resolve_region
+
+    config.set_setting("defaults.farm_region", "eu-central-1")
+
+    captured = []
+
+    def fake_get_boto3_client(service_name, config=None, region=None):
+        resolved = _resolve_region(config=config, region=region)
+        captured.append((service_name, resolved))
+        client = MagicMock()
+        client.get_log_events.return_value = {"events": [], "nextForwardToken": None}
+        return client
+
+    with patch.object(
+        _job_monitoring, "get_boto3_client", side_effect=fake_get_boto3_client
+    ), patch.object(_job_monitoring, "get_user_and_identity_store_id", return_value=(None, None)):
+        _job_monitoring.get_session_logs(
+            farm_id="farm-1234",
+            queue_id="queue-1234",
+            session_id="session-abcd",
+            limit=10,
+        )
+
+    services = dict(captured)
+    assert services.get("deadline") == "eu-central-1"
+    assert services.get("logs") == "eu-central-1"
 
 
 @patch("deadline.client.api._session.get_s3_client")

--- a/test/unit/deadline_client/api/test_job_monitoring.py
+++ b/test/unit/deadline_client/api/test_job_monitoring.py
@@ -836,6 +836,150 @@ def test_get_worker_logs_with_monitor_credentials():
         )
 
 
+def test_get_worker_logs_fleet_session_uses_resolved_farm_region():
+    """
+    get_worker_logs must scope the fleet-credentials logs client to the FARM's region
+    (resolved from defaults.farm_region), not the session/profile region. Worker logs for
+    a farm in region X live in region X.
+    """
+    with patch("deadline.client.api._job_monitoring.get_boto3_client") as mock_get_client, patch(
+        "deadline.client.api._job_monitoring.get_user_and_identity_store_id"
+    ) as mock_get_user, patch(
+        "deadline.client.api._job_monitoring._resolve_region"
+    ) as mock_resolve_region, patch("deadline.client.api._job_monitoring.boto3") as mock_boto3:
+        mock_get_user.return_value = ("user-123", "identity-store-456")
+        mock_resolve_region.return_value = "eu-central-1"
+
+        deadline_mock = MagicMock()
+        deadline_mock.assume_fleet_role_for_read.return_value = {
+            "credentials": {
+                "accessKeyId": "AKIA...",
+                "secretAccessKey": "secret",
+                "sessionToken": "token",
+            }
+        }
+        mock_get_client.return_value = deadline_mock
+
+        logs_client_mock = MagicMock()
+        logs_client_mock.get_log_events.return_value = MOCK_GET_LOG_EVENTS_RESPONSE
+        fleet_session_mock = MagicMock()
+        fleet_session_mock.client.return_value = logs_client_mock
+        mock_boto3.Session.return_value = fleet_session_mock
+
+        get_worker_logs(
+            farm_id=MOCK_FARM_ID,
+            fleet_id=MOCK_FLEET_ID,
+            worker_id=MOCK_WORKER_ID,
+        )
+
+        # Region is resolved for THIS farm.
+        mock_resolve_region.assert_called_once_with(config=None, farm_id=MOCK_FARM_ID)
+        # The deadline client used to assume the fleet role is scoped to the farm region.
+        assert mock_get_client.call_args.kwargs.get(
+            "region"
+        ) == "eu-central-1" or mock_get_client.call_args.args[1:] == ("eu-central-1",)
+        # The fleet-credentials logs client is created in the farm region.
+        fleet_session_mock.client.assert_called_once_with(
+            "logs", region_name="eu-central-1", config=ANY
+        )
+
+
+def test_get_worker_logs_fleet_session_falls_back_to_session_region():
+    """
+    With no farm_region configured (_resolve_region -> None), get_worker_logs falls back
+    to the base session region for the fleet logs client (preserving prior behavior).
+    """
+    with patch("deadline.client.api._job_monitoring.get_boto3_client") as mock_get_client, patch(
+        "deadline.client.api._job_monitoring.get_user_and_identity_store_id"
+    ) as mock_get_user, patch(
+        "deadline.client.api._job_monitoring._resolve_region"
+    ) as mock_resolve_region, patch(
+        "deadline.client.api._job_monitoring.get_boto3_session"
+    ) as mock_get_session, patch("deadline.client.api._job_monitoring.boto3") as mock_boto3:
+        mock_get_user.return_value = ("user-123", "identity-store-456")
+        mock_resolve_region.return_value = None
+
+        deadline_mock = MagicMock()
+        deadline_mock.assume_fleet_role_for_read.return_value = {
+            "credentials": {
+                "accessKeyId": "AKIA...",
+                "secretAccessKey": "secret",
+                "sessionToken": "token",
+            }
+        }
+        mock_get_client.return_value = deadline_mock
+
+        base_session_mock = MagicMock()
+        base_session_mock.region_name = "us-west-2"
+        mock_get_session.return_value = base_session_mock
+
+        logs_client_mock = MagicMock()
+        logs_client_mock.get_log_events.return_value = MOCK_GET_LOG_EVENTS_RESPONSE
+        fleet_session_mock = MagicMock()
+        fleet_session_mock.client.return_value = logs_client_mock
+        mock_boto3.Session.return_value = fleet_session_mock
+
+        get_worker_logs(
+            farm_id=MOCK_FARM_ID,
+            fleet_id=MOCK_FLEET_ID,
+            worker_id=MOCK_WORKER_ID,
+        )
+
+        fleet_session_mock.client.assert_called_once_with(
+            "logs", region_name="us-west-2", config=ANY
+        )
+
+
+def test_get_session_logs_resolves_farm_region():
+    """get_session_logs scopes its deadline client to the farm's resolved region."""
+    with patch("deadline.client.api._job_monitoring.get_boto3_client") as mock_get_client, patch(
+        "deadline.client.api._job_monitoring.get_user_and_identity_store_id"
+    ) as mock_get_user, patch(
+        "deadline.client.api._job_monitoring._resolve_region"
+    ) as mock_resolve_region:
+        mock_get_user.return_value = (None, None)
+        mock_resolve_region.return_value = "ap-northeast-1"
+
+        deadline_mock = MagicMock()
+        deadline_mock.get_log_events.return_value = MOCK_GET_LOG_EVENTS_RESPONSE
+        mock_get_client.return_value = deadline_mock
+
+        get_session_logs(
+            farm_id=MOCK_FARM_ID,
+            queue_id=MOCK_QUEUE_ID,
+            session_id="session-0123456789abcdefabcdefabcdefabcd",
+        )
+
+        mock_resolve_region.assert_called_once_with(config=None, farm_id=MOCK_FARM_ID)
+        # The deadline client is built with the resolved farm region.
+        deadline_calls = [
+            c for c in mock_get_client.call_args_list if c.args and c.args[0] == "deadline"
+        ]
+        assert deadline_calls
+        assert deadline_calls[0].kwargs.get("region") == "ap-northeast-1"
+
+
+def test_wait_for_job_completion_resolves_farm_region():
+    """wait_for_job_completion scopes its deadline client to the farm's resolved region."""
+    with patch("deadline.client.api._job_monitoring.get_boto3_client") as mock_get_client, patch(
+        "deadline.client.api._job_monitoring._resolve_region"
+    ) as mock_resolve_region:
+        mock_resolve_region.return_value = "ap-southeast-2"
+
+        deadline_mock = MagicMock()
+        deadline_mock.get_job.return_value = MOCK_JOB_SUCCEEDED
+        mock_get_client.return_value = deadline_mock
+
+        wait_for_job_completion(
+            farm_id=MOCK_FARM_ID,
+            queue_id=MOCK_QUEUE_ID,
+            job_id=MOCK_JOB_ID,
+        )
+
+        mock_resolve_region.assert_called_once_with(config=None, farm_id=MOCK_FARM_ID)
+        mock_get_client.assert_called_once_with("deadline", config=None, region="ap-southeast-2")
+
+
 def test_get_worker_logs_resource_not_found():
     """
     Test that get_worker_logs handles ResourceNotFoundException correctly.

--- a/test/unit/deadline_client/api/test_job_monitoring.py
+++ b/test/unit/deadline_client/api/test_job_monitoring.py
@@ -842,11 +842,14 @@ def test_get_worker_logs_fleet_session_uses_resolved_farm_region():
     (resolved from defaults.farm_region), not the session/profile region. Worker logs for
     a farm in region X live in region X.
     """
-    with patch("deadline.client.api._job_monitoring.get_boto3_client") as mock_get_client, patch(
-        "deadline.client.api._job_monitoring.get_user_and_identity_store_id"
-    ) as mock_get_user, patch(
-        "deadline.client.api._job_monitoring._resolve_region"
-    ) as mock_resolve_region, patch("deadline.client.api._job_monitoring.boto3") as mock_boto3:
+    with (
+        patch("deadline.client.api._job_monitoring.get_boto3_client") as mock_get_client,
+        patch(
+            "deadline.client.api._job_monitoring.get_user_and_identity_store_id"
+        ) as mock_get_user,
+        patch("deadline.client.api._job_monitoring._resolve_region") as mock_resolve_region,
+        patch("deadline.client.api._job_monitoring.boto3") as mock_boto3,
+    ):
         mock_get_user.return_value = ("user-123", "identity-store-456")
         mock_resolve_region.return_value = "eu-central-1"
 
@@ -889,13 +892,15 @@ def test_get_worker_logs_fleet_session_falls_back_to_session_region():
     With no farm_region configured (_resolve_region -> None), get_worker_logs falls back
     to the base session region for the fleet logs client (preserving prior behavior).
     """
-    with patch("deadline.client.api._job_monitoring.get_boto3_client") as mock_get_client, patch(
-        "deadline.client.api._job_monitoring.get_user_and_identity_store_id"
-    ) as mock_get_user, patch(
-        "deadline.client.api._job_monitoring._resolve_region"
-    ) as mock_resolve_region, patch(
-        "deadline.client.api._job_monitoring.get_boto3_session"
-    ) as mock_get_session, patch("deadline.client.api._job_monitoring.boto3") as mock_boto3:
+    with (
+        patch("deadline.client.api._job_monitoring.get_boto3_client") as mock_get_client,
+        patch(
+            "deadline.client.api._job_monitoring.get_user_and_identity_store_id"
+        ) as mock_get_user,
+        patch("deadline.client.api._job_monitoring._resolve_region") as mock_resolve_region,
+        patch("deadline.client.api._job_monitoring.get_boto3_session") as mock_get_session,
+        patch("deadline.client.api._job_monitoring.boto3") as mock_boto3,
+    ):
         mock_get_user.return_value = ("user-123", "identity-store-456")
         mock_resolve_region.return_value = None
 
@@ -932,11 +937,13 @@ def test_get_worker_logs_fleet_session_falls_back_to_session_region():
 
 def test_get_session_logs_resolves_farm_region():
     """get_session_logs scopes its deadline client to the farm's resolved region."""
-    with patch("deadline.client.api._job_monitoring.get_boto3_client") as mock_get_client, patch(
-        "deadline.client.api._job_monitoring.get_user_and_identity_store_id"
-    ) as mock_get_user, patch(
-        "deadline.client.api._job_monitoring._resolve_region"
-    ) as mock_resolve_region:
+    with (
+        patch("deadline.client.api._job_monitoring.get_boto3_client") as mock_get_client,
+        patch(
+            "deadline.client.api._job_monitoring.get_user_and_identity_store_id"
+        ) as mock_get_user,
+        patch("deadline.client.api._job_monitoring._resolve_region") as mock_resolve_region,
+    ):
         mock_get_user.return_value = (None, None)
         mock_resolve_region.return_value = "ap-northeast-1"
 
@@ -961,9 +968,10 @@ def test_get_session_logs_resolves_farm_region():
 
 def test_wait_for_job_completion_resolves_farm_region():
     """wait_for_job_completion scopes its deadline client to the farm's resolved region."""
-    with patch("deadline.client.api._job_monitoring.get_boto3_client") as mock_get_client, patch(
-        "deadline.client.api._job_monitoring._resolve_region"
-    ) as mock_resolve_region:
+    with (
+        patch("deadline.client.api._job_monitoring.get_boto3_client") as mock_get_client,
+        patch("deadline.client.api._job_monitoring._resolve_region") as mock_resolve_region,
+    ):
         mock_resolve_region.return_value = "ap-southeast-2"
 
         deadline_mock = MagicMock()

--- a/test/unit/deadline_client/api/test_list_jobs_by_filter_expression.py
+++ b/test/unit/deadline_client/api/test_list_jobs_by_filter_expression.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 from random import randrange
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -258,3 +258,35 @@ def test_list_jobs_by_filter_expression(
     assert sorted(result, key=lambda job: job["jobId"]) == [
         job for job in jobs if job["taskRunStatus"] in test_status_values
     ]
+
+
+@pytest.mark.parametrize("region", ["us-east-1", None])
+def test_list_jobs_by_filter_expression_passes_region(mock_boto3_session, region):
+    """The region argument is threaded into get_session_client so the deadline client is region-scoped."""
+    deadline_client = MagicMock()
+    deadline_client.search_jobs.return_value = {"jobs": [], "totalResults": 0}
+
+    with patch(
+        "deadline.client.api._list_jobs_by_filter_expression.get_session_client",
+        return_value=deadline_client,
+    ) as mock_get_session_client:
+        _list_jobs_by_filter_expression(
+            boto3_session=mock_boto3_session,
+            farm_id=MOCK_FARM_ID,
+            queue_id=MOCK_QUEUE_ID,
+            filter_expression={
+                "filters": [
+                    {
+                        "dateTimeFilter": {
+                            "name": "ENDED_AT",
+                            "dateTime": MOCK_TIMESTAMP,
+                            "operator": "GREATER_THAN_EQUAL_TO",
+                        }
+                    }
+                ],
+                "operator": "AND",
+            },
+            region=region,
+        )
+
+    mock_get_session_client.assert_called_once_with(mock_boto3_session, "deadline", region=region)

--- a/test/unit/deadline_client/api/test_mcp.py
+++ b/test/unit/deadline_client/api/test_mcp.py
@@ -491,9 +491,10 @@ class TestMcpRegionScoping:
     """
 
     def test_get_job_resolves_region_from_farm(self):
-        with patch("deadline.client.api._mcp.get_boto3_client") as mock_get_client, patch(
-            "deadline.client.api._mcp._resolve_region"
-        ) as mock_resolve:
+        with (
+            patch("deadline.client.api._mcp.get_boto3_client") as mock_get_client,
+            patch("deadline.client.api._mcp._resolve_region") as mock_resolve,
+        ):
             mock_resolve.return_value = "eu-west-1"
             mock_get_client.return_value = MagicMock()
 
@@ -503,9 +504,10 @@ class TestMcpRegionScoping:
             assert mock_get_client.call_args.kwargs.get("region") == "eu-west-1"
 
     def test_get_session_resolves_region_from_farm(self):
-        with patch("deadline.client.api._mcp.get_boto3_client") as mock_get_client, patch(
-            "deadline.client.api._mcp._resolve_region"
-        ) as mock_resolve:
+        with (
+            patch("deadline.client.api._mcp.get_boto3_client") as mock_get_client,
+            patch("deadline.client.api._mcp._resolve_region") as mock_resolve,
+        ):
             mock_resolve.return_value = "eu-west-1"
             mock_get_client.return_value = MagicMock()
 
@@ -520,9 +522,10 @@ class TestMcpRegionScoping:
             assert mock_get_client.call_args.kwargs.get("region") == "eu-west-1"
 
     def test_list_sessions_resolves_region_from_farm(self):
-        with patch("deadline.client.api._mcp.get_boto3_client") as mock_get_client, patch(
-            "deadline.client.api._mcp._resolve_region"
-        ) as mock_resolve:
+        with (
+            patch("deadline.client.api._mcp.get_boto3_client") as mock_get_client,
+            patch("deadline.client.api._mcp._resolve_region") as mock_resolve,
+        ):
             mock_resolve.return_value = "eu-west-1"
             deadline_mock = MagicMock()
             deadline_mock.list_sessions.return_value = {"sessions": []}
@@ -534,9 +537,10 @@ class TestMcpRegionScoping:
             assert mock_get_client.call_args.kwargs.get("region") == "eu-west-1"
 
     def test_list_steps_resolves_region_from_farm(self):
-        with patch("deadline.client.api._mcp.get_boto3_client") as mock_get_client, patch(
-            "deadline.client.api._mcp._resolve_region"
-        ) as mock_resolve:
+        with (
+            patch("deadline.client.api._mcp.get_boto3_client") as mock_get_client,
+            patch("deadline.client.api._mcp._resolve_region") as mock_resolve,
+        ):
             mock_resolve.return_value = "eu-west-1"
             deadline_mock = MagicMock()
             deadline_mock.list_steps.return_value = {"steps": []}
@@ -548,9 +552,10 @@ class TestMcpRegionScoping:
             assert mock_get_client.call_args.kwargs.get("region") == "eu-west-1"
 
     def test_list_tasks_resolves_region_from_farm(self):
-        with patch("deadline.client.api._mcp.get_boto3_client") as mock_get_client, patch(
-            "deadline.client.api._mcp._resolve_region"
-        ) as mock_resolve:
+        with (
+            patch("deadline.client.api._mcp.get_boto3_client") as mock_get_client,
+            patch("deadline.client.api._mcp._resolve_region") as mock_resolve,
+        ):
             mock_resolve.return_value = "eu-west-1"
             deadline_mock = MagicMock()
             deadline_mock.list_tasks.return_value = {"tasks": []}
@@ -567,9 +572,10 @@ class TestMcpRegionScoping:
             assert mock_get_client.call_args.kwargs.get("region") == "eu-west-1"
 
     def test_search_jobs_resolves_region_from_farm(self, fresh_deadline_config):
-        with patch("deadline.client.api._mcp.get_boto3_client") as mock_get_client, patch(
-            "deadline.client.api._mcp._resolve_region"
-        ) as mock_resolve:
+        with (
+            patch("deadline.client.api._mcp.get_boto3_client") as mock_get_client,
+            patch("deadline.client.api._mcp._resolve_region") as mock_resolve,
+        ):
             mock_resolve.return_value = "eu-west-1"
             deadline_mock = MagicMock()
             deadline_mock.search_jobs.return_value = MOCK_SEARCH_JOBS_RESPONSE
@@ -582,9 +588,10 @@ class TestMcpRegionScoping:
 
     def test_explicit_region_passed_through(self):
         """An explicit region argument is forwarded to _resolve_region (and wins)."""
-        with patch("deadline.client.api._mcp.get_boto3_client") as mock_get_client, patch(
-            "deadline.client.api._mcp._resolve_region"
-        ) as mock_resolve:
+        with (
+            patch("deadline.client.api._mcp.get_boto3_client") as mock_get_client,
+            patch("deadline.client.api._mcp._resolve_region") as mock_resolve,
+        ):
             mock_resolve.return_value = "ap-south-1"
             mock_get_client.return_value = MagicMock()
 

--- a/test/unit/deadline_client/api/test_mcp.py
+++ b/test/unit/deadline_client/api/test_mcp.py
@@ -480,3 +480,122 @@ class TestSearchJobs:
 
         with pytest.raises(ValueError, match="queue_ids is required"):
             search_jobs()
+
+
+class TestMcpRegionScoping:
+    """
+    Each per-farm MCP function must scope its deadline client to the farm's region.
+
+    When no explicit region is passed, the region is resolved for the given farm_id via
+    _resolve_region(config, farm_id=farm_id). An explicit region overrides that.
+    """
+
+    def test_get_job_resolves_region_from_farm(self):
+        with patch("deadline.client.api._mcp.get_boto3_client") as mock_get_client, patch(
+            "deadline.client.api._mcp._resolve_region"
+        ) as mock_resolve:
+            mock_resolve.return_value = "eu-west-1"
+            mock_get_client.return_value = MagicMock()
+
+            get_job(farm_id=MOCK_FARM_ID, queue_id=MOCK_QUEUE_ID, job_id=MOCK_JOB_ID)
+
+            mock_resolve.assert_called_once_with(config=None, region=None, farm_id=MOCK_FARM_ID)
+            assert mock_get_client.call_args.kwargs.get("region") == "eu-west-1"
+
+    def test_get_session_resolves_region_from_farm(self):
+        with patch("deadline.client.api._mcp.get_boto3_client") as mock_get_client, patch(
+            "deadline.client.api._mcp._resolve_region"
+        ) as mock_resolve:
+            mock_resolve.return_value = "eu-west-1"
+            mock_get_client.return_value = MagicMock()
+
+            get_session(
+                farm_id=MOCK_FARM_ID,
+                queue_id=MOCK_QUEUE_ID,
+                job_id=MOCK_JOB_ID,
+                session_id=MOCK_SESSION_ID,
+            )
+
+            mock_resolve.assert_called_once_with(config=None, region=None, farm_id=MOCK_FARM_ID)
+            assert mock_get_client.call_args.kwargs.get("region") == "eu-west-1"
+
+    def test_list_sessions_resolves_region_from_farm(self):
+        with patch("deadline.client.api._mcp.get_boto3_client") as mock_get_client, patch(
+            "deadline.client.api._mcp._resolve_region"
+        ) as mock_resolve:
+            mock_resolve.return_value = "eu-west-1"
+            deadline_mock = MagicMock()
+            deadline_mock.list_sessions.return_value = {"sessions": []}
+            mock_get_client.return_value = deadline_mock
+
+            list_sessions(farm_id=MOCK_FARM_ID, queue_id=MOCK_QUEUE_ID, job_id=MOCK_JOB_ID)
+
+            mock_resolve.assert_called_once_with(config=None, region=None, farm_id=MOCK_FARM_ID)
+            assert mock_get_client.call_args.kwargs.get("region") == "eu-west-1"
+
+    def test_list_steps_resolves_region_from_farm(self):
+        with patch("deadline.client.api._mcp.get_boto3_client") as mock_get_client, patch(
+            "deadline.client.api._mcp._resolve_region"
+        ) as mock_resolve:
+            mock_resolve.return_value = "eu-west-1"
+            deadline_mock = MagicMock()
+            deadline_mock.list_steps.return_value = {"steps": []}
+            mock_get_client.return_value = deadline_mock
+
+            list_steps(farm_id=MOCK_FARM_ID, queue_id=MOCK_QUEUE_ID, job_id=MOCK_JOB_ID)
+
+            mock_resolve.assert_called_once_with(config=None, region=None, farm_id=MOCK_FARM_ID)
+            assert mock_get_client.call_args.kwargs.get("region") == "eu-west-1"
+
+    def test_list_tasks_resolves_region_from_farm(self):
+        with patch("deadline.client.api._mcp.get_boto3_client") as mock_get_client, patch(
+            "deadline.client.api._mcp._resolve_region"
+        ) as mock_resolve:
+            mock_resolve.return_value = "eu-west-1"
+            deadline_mock = MagicMock()
+            deadline_mock.list_tasks.return_value = {"tasks": []}
+            mock_get_client.return_value = deadline_mock
+
+            list_tasks(
+                farm_id=MOCK_FARM_ID,
+                queue_id=MOCK_QUEUE_ID,
+                job_id=MOCK_JOB_ID,
+                step_id=MOCK_STEP_ID,
+            )
+
+            mock_resolve.assert_called_once_with(config=None, region=None, farm_id=MOCK_FARM_ID)
+            assert mock_get_client.call_args.kwargs.get("region") == "eu-west-1"
+
+    def test_search_jobs_resolves_region_from_farm(self, fresh_deadline_config):
+        with patch("deadline.client.api._mcp.get_boto3_client") as mock_get_client, patch(
+            "deadline.client.api._mcp._resolve_region"
+        ) as mock_resolve:
+            mock_resolve.return_value = "eu-west-1"
+            deadline_mock = MagicMock()
+            deadline_mock.search_jobs.return_value = MOCK_SEARCH_JOBS_RESPONSE
+            mock_get_client.return_value = deadline_mock
+
+            search_jobs(farm_id=MOCK_FARM_ID, queue_ids=[MOCK_QUEUE_ID])
+
+            mock_resolve.assert_called_once_with(config=None, region=None, farm_id=MOCK_FARM_ID)
+            assert mock_get_client.call_args.kwargs.get("region") == "eu-west-1"
+
+    def test_explicit_region_passed_through(self):
+        """An explicit region argument is forwarded to _resolve_region (and wins)."""
+        with patch("deadline.client.api._mcp.get_boto3_client") as mock_get_client, patch(
+            "deadline.client.api._mcp._resolve_region"
+        ) as mock_resolve:
+            mock_resolve.return_value = "ap-south-1"
+            mock_get_client.return_value = MagicMock()
+
+            get_job(
+                farm_id=MOCK_FARM_ID,
+                queue_id=MOCK_QUEUE_ID,
+                job_id=MOCK_JOB_ID,
+                region="ap-south-1",
+            )
+
+            mock_resolve.assert_called_once_with(
+                config=None, region="ap-south-1", farm_id=MOCK_FARM_ID
+            )
+            assert mock_get_client.call_args.kwargs.get("region") == "ap-south-1"

--- a/test/unit/deadline_client/api/test_queue_parameters_region.py
+++ b/test/unit/deadline_client/api/test_queue_parameters_region.py
@@ -1,0 +1,35 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Tests that get_queue_parameter_definitions threads its region argument through to
+get_boto3_client so the deadline client is scoped to the farm's region.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from deadline.client.api import _queue_parameters
+from ..shared_constants import MOCK_FARM_ID, MOCK_QUEUE_ID
+
+
+@pytest.mark.parametrize("region", ["ap-southeast-2", None])
+def test_get_queue_parameter_definitions_passes_region(region):
+    """The region argument is forwarded to get_boto3_client; region=None preserves
+    the documented resolution behavior."""
+    deadline_client = MagicMock()
+    deadline_client.list_queue_environments.return_value = {"environments": []}
+
+    with patch.object(
+        _queue_parameters, "get_boto3_client", return_value=deadline_client
+    ) as mock_get_boto3_client:
+        result = _queue_parameters.get_queue_parameter_definitions(
+            region=region,
+            farmId=MOCK_FARM_ID,
+            queueId=MOCK_QUEUE_ID,
+        )
+
+    assert result == []
+    mock_get_boto3_client.assert_called_once_with("deadline", config=None, region=region)

--- a/test/unit/deadline_client/cli/test_cli_attachment_region.py
+++ b/test/unit/deadline_client/cli/test_cli_attachment_region.py
@@ -47,16 +47,20 @@ def test_attachment_download_scopes_deadline_client_to_region(configured_farm_re
     mock_queue = MagicMock()
     mock_queue.jobAttachmentSettings = MOCK_S3_SETTINGS
 
-    with patch.object(
-        attachment_group.api, "get_boto3_session", return_value=MagicMock()
-    ), patch.object(attachment_group, "get_queue", return_value=mock_queue), patch.object(
-        attachment_group, "get_session_client", return_value=MagicMock()
-    ) as mock_get_session_client, patch.object(
-        attachment_group.api, "get_queue_user_boto3_session", return_value=MagicMock()
-    ), patch.object(
-        attachment_group,
-        "_attachment_download",
-        return_value=DownloadSummaryStatistics(),
+    with (
+        patch.object(attachment_group.api, "get_boto3_session", return_value=MagicMock()),
+        patch.object(attachment_group, "get_queue", return_value=mock_queue),
+        patch.object(
+            attachment_group, "get_session_client", return_value=MagicMock()
+        ) as mock_get_session_client,
+        patch.object(
+            attachment_group.api, "get_queue_user_boto3_session", return_value=MagicMock()
+        ),
+        patch.object(
+            attachment_group,
+            "_attachment_download",
+            return_value=DownloadSummaryStatistics(),
+        ),
     ):
         runner = CliRunner()
         result = runner.invoke(
@@ -93,18 +97,20 @@ def test_attachment_download_get_queue_uses_region_scoped_session(configured_far
     def _get_session(*args, **kwargs):
         return scoped_session if kwargs.get("region") else base_session
 
-    with patch.object(
-        attachment_group.api, "get_boto3_session", side_effect=_get_session
-    ) as mock_get_session, patch.object(
-        attachment_group, "get_queue", return_value=mock_queue
-    ) as mock_get_queue, patch.object(
-        attachment_group, "get_session_client", return_value=MagicMock()
-    ), patch.object(
-        attachment_group.api, "get_queue_user_boto3_session", return_value=MagicMock()
-    ), patch.object(
-        attachment_group,
-        "_attachment_download",
-        return_value=DownloadSummaryStatistics(),
+    with (
+        patch.object(
+            attachment_group.api, "get_boto3_session", side_effect=_get_session
+        ) as mock_get_session,
+        patch.object(attachment_group, "get_queue", return_value=mock_queue) as mock_get_queue,
+        patch.object(attachment_group, "get_session_client", return_value=MagicMock()),
+        patch.object(
+            attachment_group.api, "get_queue_user_boto3_session", return_value=MagicMock()
+        ),
+        patch.object(
+            attachment_group,
+            "_attachment_download",
+            return_value=DownloadSummaryStatistics(),
+        ),
     ):
         runner = CliRunner()
         result = runner.invoke(
@@ -134,13 +140,17 @@ def test_attachment_upload_scopes_deadline_client_to_region(configured_farm_regi
     mock_queue = MagicMock()
     mock_queue.jobAttachmentSettings = MOCK_S3_SETTINGS
 
-    with patch.object(
-        attachment_group.api, "get_boto3_session", return_value=MagicMock()
-    ), patch.object(attachment_group, "get_queue", return_value=mock_queue), patch.object(
-        attachment_group, "get_session_client", return_value=MagicMock()
-    ) as mock_get_session_client, patch.object(
-        attachment_group.api, "get_queue_user_boto3_session", return_value=MagicMock()
-    ), patch.object(attachment_group, "_attachment_upload", return_value=MagicMock()):
+    with (
+        patch.object(attachment_group.api, "get_boto3_session", return_value=MagicMock()),
+        patch.object(attachment_group, "get_queue", return_value=mock_queue),
+        patch.object(
+            attachment_group, "get_session_client", return_value=MagicMock()
+        ) as mock_get_session_client,
+        patch.object(
+            attachment_group.api, "get_queue_user_boto3_session", return_value=MagicMock()
+        ),
+        patch.object(attachment_group, "_attachment_upload", return_value=MagicMock()),
+    ):
         runner = CliRunner()
         result = runner.invoke(
             main,
@@ -165,15 +175,17 @@ def test_attachment_upload_get_queue_uses_region_scoped_session(configured_farm_
     def _get_session(*args, **kwargs):
         return scoped_session if kwargs.get("region") else base_session
 
-    with patch.object(
-        attachment_group.api, "get_boto3_session", side_effect=_get_session
-    ) as mock_get_session, patch.object(
-        attachment_group, "get_queue", return_value=mock_queue
-    ) as mock_get_queue, patch.object(
-        attachment_group, "get_session_client", return_value=MagicMock()
-    ), patch.object(
-        attachment_group.api, "get_queue_user_boto3_session", return_value=MagicMock()
-    ), patch.object(attachment_group, "_attachment_upload", return_value=MagicMock()):
+    with (
+        patch.object(
+            attachment_group.api, "get_boto3_session", side_effect=_get_session
+        ) as mock_get_session,
+        patch.object(attachment_group, "get_queue", return_value=mock_queue) as mock_get_queue,
+        patch.object(attachment_group, "get_session_client", return_value=MagicMock()),
+        patch.object(
+            attachment_group.api, "get_queue_user_boto3_session", return_value=MagicMock()
+        ),
+        patch.object(attachment_group, "_attachment_upload", return_value=MagicMock()),
+    ):
         runner = CliRunner()
         result = runner.invoke(
             main,

--- a/test/unit/deadline_client/cli/test_cli_attachment_region.py
+++ b/test/unit/deadline_client/cli/test_cli_attachment_region.py
@@ -1,0 +1,187 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Tests that the `deadline attachment` download/upload commands scope their deadline
+client to the configured farm region (multi-region support).
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from deadline.client.cli import main
+from deadline.client.config import config_file
+from deadline.client.cli._groups import attachment_group
+from deadline.job_attachments.models import JobAttachmentS3Settings
+from deadline.job_attachments.progress_tracker import DownloadSummaryStatistics
+from ..shared_constants import MOCK_FARM_ID, MOCK_QUEUE_ID
+
+MOCK_REGION = "eu-central-1"
+
+MOCK_S3_SETTINGS = JobAttachmentS3Settings(s3BucketName="mock-bucket", rootPrefix="MockRootPrefix")
+
+
+def _write_manifest(tmp_path):
+    manifest_path = tmp_path / "abc123_manifest"
+    manifest_path.write_text(
+        json.dumps({"hashAlg": "xxh128", "manifestVersion": "2023-03-03", "paths": []})
+    )
+    return str(manifest_path)
+
+
+@pytest.fixture
+def configured_farm_region(fresh_deadline_config):
+    config_file.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config_file.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config_file.set_setting("defaults.farm_region", MOCK_REGION)
+    yield fresh_deadline_config
+
+
+def test_attachment_download_scopes_deadline_client_to_region(configured_farm_region, tmp_path):
+    manifest_path = _write_manifest(tmp_path)
+
+    mock_queue = MagicMock()
+    mock_queue.jobAttachmentSettings = MOCK_S3_SETTINGS
+
+    with patch.object(
+        attachment_group.api, "get_boto3_session", return_value=MagicMock()
+    ), patch.object(attachment_group, "get_queue", return_value=mock_queue), patch.object(
+        attachment_group, "get_session_client", return_value=MagicMock()
+    ) as mock_get_session_client, patch.object(
+        attachment_group.api, "get_queue_user_boto3_session", return_value=MagicMock()
+    ), patch.object(
+        attachment_group,
+        "_attachment_download",
+        return_value=DownloadSummaryStatistics(),
+    ):
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "attachment",
+                "download",
+                "--manifests",
+                manifest_path,
+                "--conflict-resolution",
+                "SKIP",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    mock_get_session_client.assert_called_once()
+    assert mock_get_session_client.call_args.kwargs["region"] == MOCK_REGION
+
+
+def test_attachment_download_get_queue_uses_region_scoped_session(configured_farm_region, tmp_path):
+    """
+    The GetQueue that fetches job-attachment S3 settings must run in the farm's region,
+    not the session/profile region. We scope it by passing a region-scoped session
+    (boto3 resolves the regional endpoint itself), not by hand-building an endpoint URL.
+    """
+    manifest_path = _write_manifest(tmp_path)
+
+    mock_queue = MagicMock()
+    mock_queue.jobAttachmentSettings = MOCK_S3_SETTINGS
+
+    base_session = MagicMock(name="base_session")
+    scoped_session = MagicMock(name="scoped_session")
+
+    def _get_session(*args, **kwargs):
+        return scoped_session if kwargs.get("region") else base_session
+
+    with patch.object(
+        attachment_group.api, "get_boto3_session", side_effect=_get_session
+    ) as mock_get_session, patch.object(
+        attachment_group, "get_queue", return_value=mock_queue
+    ) as mock_get_queue, patch.object(
+        attachment_group, "get_session_client", return_value=MagicMock()
+    ), patch.object(
+        attachment_group.api, "get_queue_user_boto3_session", return_value=MagicMock()
+    ), patch.object(
+        attachment_group,
+        "_attachment_download",
+        return_value=DownloadSummaryStatistics(),
+    ):
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "attachment",
+                "download",
+                "--manifests",
+                manifest_path,
+                "--conflict-resolution",
+                "SKIP",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    # A region-scoped session was requested for the farm's region...
+    assert any(c.kwargs.get("region") == MOCK_REGION for c in mock_get_session.call_args_list)
+    # ...and GetQueue ran against that region-scoped session (no manual endpoint URL).
+    mock_get_queue.assert_called_once()
+    assert mock_get_queue.call_args.kwargs["session"] is scoped_session
+    assert "deadline_endpoint_url" not in mock_get_queue.call_args.kwargs
+
+
+def test_attachment_upload_scopes_deadline_client_to_region(configured_farm_region, tmp_path):
+    manifest_path = _write_manifest(tmp_path)
+
+    mock_queue = MagicMock()
+    mock_queue.jobAttachmentSettings = MOCK_S3_SETTINGS
+
+    with patch.object(
+        attachment_group.api, "get_boto3_session", return_value=MagicMock()
+    ), patch.object(attachment_group, "get_queue", return_value=mock_queue), patch.object(
+        attachment_group, "get_session_client", return_value=MagicMock()
+    ) as mock_get_session_client, patch.object(
+        attachment_group.api, "get_queue_user_boto3_session", return_value=MagicMock()
+    ), patch.object(attachment_group, "_attachment_upload", return_value=MagicMock()):
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["attachment", "upload", "--manifests", manifest_path],
+        )
+
+    assert result.exit_code == 0, result.output
+    mock_get_session_client.assert_called_once()
+    assert mock_get_session_client.call_args.kwargs["region"] == MOCK_REGION
+
+
+def test_attachment_upload_get_queue_uses_region_scoped_session(configured_farm_region, tmp_path):
+    """The upload-path GetQueue must run in the farm's region via a region-scoped session."""
+    manifest_path = _write_manifest(tmp_path)
+
+    mock_queue = MagicMock()
+    mock_queue.jobAttachmentSettings = MOCK_S3_SETTINGS
+
+    base_session = MagicMock(name="base_session")
+    scoped_session = MagicMock(name="scoped_session")
+
+    def _get_session(*args, **kwargs):
+        return scoped_session if kwargs.get("region") else base_session
+
+    with patch.object(
+        attachment_group.api, "get_boto3_session", side_effect=_get_session
+    ) as mock_get_session, patch.object(
+        attachment_group, "get_queue", return_value=mock_queue
+    ) as mock_get_queue, patch.object(
+        attachment_group, "get_session_client", return_value=MagicMock()
+    ), patch.object(
+        attachment_group.api, "get_queue_user_boto3_session", return_value=MagicMock()
+    ), patch.object(attachment_group, "_attachment_upload", return_value=MagicMock()):
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["attachment", "upload", "--manifests", manifest_path],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert any(c.kwargs.get("region") == MOCK_REGION for c in mock_get_session.call_args_list)
+    mock_get_queue.assert_called_once()
+    assert mock_get_queue.call_args.kwargs["session"] is scoped_session
+    assert "deadline_endpoint_url" not in mock_get_queue.call_args.kwargs

--- a/test/unit/deadline_client/cli/test_cli_bundle_submit.py
+++ b/test/unit/deadline_client/cli/test_cli_bundle_submit.py
@@ -120,7 +120,7 @@ def test_cli_bundle_explicit_parameters(fresh_deadline_config, temp_job_bundle_d
             ],
         )
 
-    session_mock.assert_called_with(profile_name="NonDefaultProfileName")
+    session_mock.assert_called_with(profile_name="NonDefaultProfileName", region_name=None)
     session_mock().client().create_job.assert_called_once_with(
         farmId=MOCK_FARM_ID,
         queueId=MOCK_QUEUE_ID,
@@ -135,6 +135,45 @@ def test_cli_bundle_explicit_parameters(fresh_deadline_config, temp_job_bundle_d
     assert MOCK_CREATE_JOB_RESPONSE["jobId"] in result.output, result.output
     assert MOCK_GET_JOB_RESPONSE["lifecycleStatusMessage"] in result.output, result.output
     assert result.exit_code == 0, result.output
+
+
+def test_cli_bundle_submit_region_reaches_client(fresh_deadline_config, temp_job_bundle_dir):
+    """
+    Confirm that --region scopes the deadline client to that region (the client is
+    created with region_name) and persists `defaults.farm_region`.
+    """
+    # Write a JSON template
+    with open(os.path.join(temp_job_bundle_dir, "template.json"), "w", encoding="utf8") as f:
+        f.write(MOCK_JOB_TEMPLATE_CASES["MINIMAL_JSON"][1])
+
+    with patch.object(boto3, "Session") as session_mock:
+        session_mock().client().create_job.return_value = MOCK_CREATE_JOB_RESPONSE
+        session_mock().client().get_job.return_value = MOCK_GET_JOB_RESPONSE
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "bundle",
+                "submit",
+                temp_job_bundle_dir,
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--region",
+                "us-west-2",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    # The deadline client was created scoped to the requested region.
+    assert any(
+        call_args.kwargs.get("region_name") == "us-west-2" and call_args.args[:1] == ("deadline",)
+        for call_args in session_mock().client.call_args_list
+    ), session_mock().client.call_args_list
+    # The region was persisted to the per-farm region config setting.
+    assert config.get_setting("defaults.farm_region") == "us-west-2"
 
 
 def test_cli_bundle_priority_retries(fresh_deadline_config, deadline_mock, temp_job_bundle_dir):

--- a/test/unit/deadline_client/cli/test_cli_common.py
+++ b/test/unit/deadline_client/cli/test_cli_common.py
@@ -57,9 +57,10 @@ class TestCliRegionPrecedenceEndToEnd:
         from deadline.client import api
         from deadline.client.cli import main
 
-        with patch.object(api._session, "get_boto3_session"), patch.object(
-            api._session, "get_session_client"
-        ) as get_session_client_mock:
+        with (
+            patch.object(api._session, "get_boto3_session"),
+            patch.object(api._session, "get_session_client") as get_session_client_mock,
+        ):
             client = MagicMock()
             client.get_farm.return_value = {"farmId": "farm-abc", "displayName": "F"}
             get_session_client_mock.return_value = client

--- a/test/unit/deadline_client/cli/test_cli_common.py
+++ b/test/unit/deadline_client/cli/test_cli_common.py
@@ -22,6 +22,110 @@ from deadline.client.config.config_file import (
 )
 
 
+class TestApplyCliOptionsRegion:
+    """Test that _apply_cli_options_to_config handles the --region option."""
+
+    def test_region_sets_farm_region_setting(self, fresh_deadline_config):
+        config = _apply_cli_options_to_config(region="us-east-1")
+        assert config_file.get_setting("defaults.farm_region", config=config) == "us-east-1"
+
+    def test_region_none_does_not_raise_unexpected_option(self, fresh_deadline_config):
+        # region=None must be consumed in the "no options provided" branch so the
+        # "unexpected option" RuntimeError doesn't fire.
+        config = _apply_cli_options_to_config(region=None)
+        assert config_file.get_setting("defaults.farm_region", config=config) == ""
+
+    def test_region_none_with_other_options(self, fresh_deadline_config):
+        # region=None alongside a provided option must still be consumed.
+        config = _apply_cli_options_to_config(farm_id="farm-1", region=None)
+        assert config_file.get_setting("defaults.farm_id", config=config) == "farm-1"
+        assert config_file.get_setting("defaults.farm_region", config=config) == ""
+
+
+class TestCliRegionPrecedenceEndToEnd:
+    """
+    End-to-end region precedence and flag semantics, driven through a real command
+    (``farm get``) rather than just ``_apply_cli_options_to_config``. ``farm get`` builds
+    its deadline client via ``api.get_boto3_client`` -> ``api._session.get_session_client``,
+    so the region the client is built for is what we assert.
+    """
+
+    @staticmethod
+    def _run_farm_get(extra_args):
+        from unittest.mock import MagicMock, patch
+        from click.testing import CliRunner
+        from deadline.client import api
+        from deadline.client.cli import main
+
+        with patch.object(api._session, "get_boto3_session"), patch.object(
+            api._session, "get_session_client"
+        ) as get_session_client_mock:
+            client = MagicMock()
+            client.get_farm.return_value = {"farmId": "farm-abc", "displayName": "F"}
+            get_session_client_mock.return_value = client
+
+            runner = CliRunner()
+            result = runner.invoke(main, ["farm", "get", "--farm-id", "farm-abc", *extra_args])
+
+        regions = [
+            call.kwargs.get("region")
+            for call in get_session_client_mock.call_args_list
+            if call.kwargs.get("service_name") == "deadline"
+        ]
+        return result, regions
+
+    def test_region_flag_overrides_configured_farm_region(self, fresh_deadline_config):
+        """--region wins over a previously-configured defaults.farm_region."""
+        config_file.set_setting("defaults.farm_region", "us-west-2")
+
+        result, regions = self._run_farm_get(["--region", "eu-central-1"])
+
+        assert result.exit_code == 0, result.output
+        # The deadline client was built for the flag's region, not the configured one.
+        assert "eu-central-1" in regions
+        assert "us-west-2" not in regions
+        # And the flag overwrote the persisted setting.
+        assert config_file.get_setting("defaults.farm_region") == "eu-central-1"
+
+    def test_no_region_flag_uses_configured_farm_region(self, fresh_deadline_config):
+        """with no --region, the command uses the configured defaults.farm_region."""
+        # farm_region is stored per-farm (depends on defaults.farm_id), so the default
+        # farm_id must be set to the same farm the command targets before storing the region.
+        config_file.set_setting("defaults.farm_id", "farm-abc")
+        config_file.set_setting("defaults.farm_region", "ap-south-1")
+
+        result, regions = self._run_farm_get([])
+
+        assert result.exit_code == 0, result.output
+        assert regions == ["ap-south-1"]
+
+    def test_no_region_flag_and_no_config_builds_client_without_region(self, fresh_deadline_config):
+        """
+        no --region and no configured farm_region => the deadline client is built
+        with region=None (the old single-region behavior, where boto3/the session picks the
+        region).
+        """
+        result, regions = self._run_farm_get([])
+
+        assert result.exit_code == 0, result.output
+        # region=None means get_session_client was called without an explicit region.
+        assert regions == [None]
+
+    def test_region_on_read_only_command_persists_farm_region(self, fresh_deadline_config):
+        """
+        --region on a read-only command (farm get) persists defaults.farm_region.
+        This pins the CURRENT, intended behavior: read-only commands still write the region
+        to config via _apply_cli_options_to_config, so a subsequent command reuses it.
+        """
+        assert config_file.get_setting("defaults.farm_region") == ""
+
+        result, _ = self._run_farm_get(["--region", "eu-west-1"])
+
+        assert result.exit_code == 0, result.output
+        # Intended: the region is persisted even though farm get does not mutate anything.
+        assert config_file.get_setting("defaults.farm_region") == "eu-west-1"
+
+
 class TestParseFileParameter:
     """Test the _parse_file_parameter function."""
 

--- a/test/unit/deadline_client/cli/test_cli_config.py
+++ b/test/unit/deadline_client/cli/test_cli_config.py
@@ -36,7 +36,7 @@ def test_cli_config_show_defaults(fresh_deadline_config):
     assert fresh_deadline_config in result.output
 
     # Assert the expected number of settings
-    assert len(settings.keys()) == 23
+    assert len(settings.keys()) == 25
 
     for setting_name in settings.keys():
         assert setting_name in result.output
@@ -111,6 +111,8 @@ def test_cli_config_show_modified_config(fresh_deadline_config):
     config.set_setting("settings.submitter_update_notification", "false")
     config.set_setting("settings.max_retries_per_task", "10")
     config.set_setting("settings.max_failed_tasks_count", "50")
+    config.set_setting("settings.deadline_regions", "us-west-2,us-east-1")
+    config.set_setting("defaults.farm_region", "us-east-1")
 
     runner = CliRunner()
     result = runner.invoke(main, ["config", "show"])

--- a/test/unit/deadline_client/cli/test_cli_farm.py
+++ b/test/unit/deadline_client/cli/test_cli_farm.py
@@ -227,9 +227,11 @@ def test_cli_farm_list_partial_failure_exits_zero_with_survivors(
     def fake_get_client(service_name, config=None, region=None):
         return clients[region]
 
-    with caplog.at_level("WARNING"), patch.object(
-        api._list_apis, "get_boto3_client", side_effect=fake_get_client
-    ), patch.object(api._list_apis, "_apply_principal_id_filter"):
+    with (
+        caplog.at_level("WARNING"),
+        patch.object(api._list_apis, "get_boto3_client", side_effect=fake_get_client),
+        patch.object(api._list_apis, "_apply_principal_id_filter"),
+    ):
         runner = CliRunner()
         result = runner.invoke(main, ["farm", "list"])
 

--- a/test/unit/deadline_client/cli/test_cli_farm.py
+++ b/test/unit/deadline_client/cli/test_cli_farm.py
@@ -4,7 +4,7 @@
 Tests for the CLI farm commands.
 """
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 import os
 
 import boto3  # type: ignore[import]
@@ -30,22 +30,32 @@ MOCK_FARMS_LIST = [
 os.environ["AWS_ENDPOINT_URL_DEADLINE"] = "https://fake-endpoint"
 
 
-def test_cli_farm_list(fresh_deadline_config, mock_telemetry):
+def test_cli_farm_list(fresh_deadline_config, mock_telemetry, monkeypatch):
     """
     Confirm that the CLI interface prints out the expected list of
     farms, given mock data.
     """
+    # Scope the multi-region fan-out to a single region for a deterministic listing.
+    monkeypatch.setenv("DEADLINE_CLOUD_REGIONS", "us-west-2")
     with patch.object(api._session, "get_boto3_session") as session_mock:
-        session_mock().client("deadline").list_farms.return_value = {"farms": MOCK_FARMS_LIST}
+        # Copy the module-level farms: list_farms tags each farm dict with its region
+        # in place, which would otherwise pollute the shared MOCK_FARMS_LIST.
+        session_mock().client("deadline").list_farms.return_value = {
+            "farms": [dict(f) for f in MOCK_FARMS_LIST]
+        }
 
         runner = CliRunner()
         result = runner.invoke(main, ["farm", "list"])
 
+        # The multi-region fan-out tags each farm with its region, and the structured
+        # output leads with the region column per the (region, farm_id) convention.
         assert (
             result.output
-            == """- farmId: farm-0123456789abcdef0123456789abcdef
+            == """- region: us-west-2
+  farmId: farm-0123456789abcdef0123456789abcdef
   displayName: Testing Farm
-- farmId: farm-0123456789abcdef0123456789abcdeg
+- region: us-west-2
+  farmId: farm-0123456789abcdef0123456789abcdeg
   displayName: Another Farm
 
 """
@@ -53,17 +63,21 @@ def test_cli_farm_list(fresh_deadline_config, mock_telemetry):
         assert result.exit_code == 0
 
 
-def test_cli_farm_list_override_profile(fresh_deadline_config):
+def test_cli_farm_list_override_profile(fresh_deadline_config, monkeypatch):
     """
     Confirms that the --profile option overrides the option to boto3.Session.
     """
+    # Scope the multi-region fan-out to a single region so list_farms makes one call.
+    monkeypatch.setenv("DEADLINE_CLOUD_REGIONS", "us-west-2")
     # set the "user identities" property to True so it doesn't probe the boto3.Session
     # for configuration.
     config.set_setting("defaults.aws_profile_name", "NonDefaultProfileName")
     config.set_setting("defaults.aws_profile_name", "DifferentProfileName")
 
     with patch.object(boto3, "Session") as session_mock:
-        session_mock().client("deadline").list_farms.return_value = {"farms": MOCK_FARMS_LIST}
+        session_mock().client("deadline").list_farms.return_value = {
+            "farms": [dict(f) for f in MOCK_FARMS_LIST]
+        }
         session_mock()._session.get_scoped_config().get.return_value = "some-monitor-id"
         session_mock.reset_mock()
 
@@ -71,11 +85,94 @@ def test_cli_farm_list_override_profile(fresh_deadline_config):
         result = runner.invoke(main, ["farm", "list", "--profile", "NonDefaultProfileName"])
 
         assert result.exit_code == 0
-        session_mock.assert_called_with(profile_name="NonDefaultProfileName")
+        session_mock.assert_called_with(profile_name="NonDefaultProfileName", region_name=None)
         session_mock().client().list_farms.assert_called_once_with()
 
 
-def test_cli_farm_list_client_error(fresh_deadline_config):
+def test_cli_farm_list_fans_out_across_regions(fresh_deadline_config, mock_telemetry, monkeypatch):
+    """
+    With no --region, `farm list` fans out across every Deadline Cloud region and
+    annotates each farm with the region it came from.
+    """
+    monkeypatch.setenv("DEADLINE_CLOUD_REGIONS", "us-west-2,us-east-1")
+
+    def _list_farms(*, config=None, region=None):
+        # With region=None the real API fans out across regions; emulate that here by
+        # returning one farm per region, each annotated with its region.
+        regions = [region] if region else ["us-west-2", "us-east-1"]
+        return {
+            "farms": [
+                {
+                    "region": r,
+                    "farmId": f"farm-{r.replace('-', '')}",
+                    "displayName": f"Farm in {r}",
+                }
+                for r in regions
+            ]
+        }
+
+    with patch.object(api, "list_farms", side_effect=_list_farms) as list_farms_mock:
+        runner = CliRunner()
+        result = runner.invoke(main, ["farm", "list"])
+
+        assert result.exit_code == 0
+        # No --region given => list_farms called with region=None to trigger the fan-out.
+        assert list_farms_mock.call_args.kwargs["region"] is None
+        # Region column appears first and both regions' farms are present.
+        assert "region: us-west-2" in result.output
+        assert "region: us-east-1" in result.output
+        assert "Farm in us-west-2" in result.output
+        assert "Farm in us-east-1" in result.output
+
+
+def test_cli_farm_list_single_region(fresh_deadline_config, mock_telemetry, monkeypatch):
+    """
+    With --region, `farm list` scopes to exactly that region (no fan-out)."""
+    with patch.object(api, "list_farms") as list_farms_mock:
+        list_farms_mock.return_value = {
+            "farms": [
+                {
+                    "region": "us-east-1",
+                    "farmId": "farm-0123456789abcdef0123456789abcdef",
+                    "displayName": "Testing Farm",
+                }
+            ]
+        }
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["farm", "list", "--region", "us-east-1"])
+
+        assert result.exit_code == 0
+        # The explicit region is passed through to scope the single-region call.
+        assert list_farms_mock.call_args.kwargs["region"] == "us-east-1"
+        assert "region: us-east-1" in result.output
+        assert "Testing Farm" in result.output
+
+
+def test_cli_farm_list_total_failure(fresh_deadline_config, monkeypatch):
+    """
+    When every region fails, the fan-out raises a DeadlineOperationError whose
+    per-region summary is surfaced by the CLI with a non-zero exit code.
+    """
+    monkeypatch.setenv("DEADLINE_CLOUD_REGIONS", "us-west-2,us-east-1")
+    with patch.object(api._session, "get_boto3_session") as session_mock:
+        session_mock().client("deadline").list_farms.side_effect = ClientError(
+            {"Error": {"Message": "A botocore client error"}}, "ListFarms"
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["farm", "list"])
+
+        assert result.exit_code != 0
+        assert "Failed to list farms" in result.output
+        assert "us-west-2" in result.output
+        assert "us-east-1" in result.output
+
+
+def test_cli_farm_list_client_error(fresh_deadline_config, monkeypatch):
+    # Scope to a single region; with the only region failing, the fan-out treats this
+    # as a total failure and surfaces the client error to the CLI.
+    monkeypatch.setenv("DEADLINE_CLOUD_REGIONS", "us-west-2")
     with patch.object(api._session, "get_boto3_session") as session_mock:
         session_mock().client("deadline").list_farms.side_effect = ClientError(
             {"Error": {"Message": "A botocore client error"}}, "client error"
@@ -84,9 +181,66 @@ def test_cli_farm_list_client_error(fresh_deadline_config):
         runner = CliRunner()
         result = runner.invoke(main, ["farm", "list"])
 
-        assert "Failed to get Farms" in result.output
+        # With every (here, the only) region failing, the multi-region fan-out raises a
+        # DeadlineOperationError summarizing each region's cause, which the CLI surfaces.
+        assert "Failed to list farms" in result.output
+        assert "us-west-2" in result.output
         assert "A botocore client error" in result.output
         assert result.exit_code != 0
+
+
+def test_cli_farm_list_region_no_farms_is_empty(fresh_deadline_config, mock_telemetry):
+    """
+    `farm list --region <region-with-no-farms>` exits 0 and prints an empty
+    list (an empty result is not an error for a single explicit region).
+    """
+    with patch.object(api._session, "get_boto3_session") as session_mock:
+        session_mock().client("deadline").list_farms.return_value = {"farms": []}
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["farm", "list", "--region", "us-east-1"])
+
+        assert result.exit_code == 0, result.output
+        # Empty list renders as YAML's empty-list marker, not an error.
+        assert result.output.strip() == "[]"
+
+
+def test_cli_farm_list_partial_failure_exits_zero_with_survivors(
+    fresh_deadline_config, mock_telemetry, monkeypatch, caplog
+):
+    """
+    when one region fails during the fan-out, the CLI warns but still exits 0
+    with the surviving regions' farms.
+    """
+    monkeypatch.setenv("DEADLINE_CLOUD_REGIONS", "us-west-2,us-east-1")
+
+    good_client = MagicMock()
+    good_client.list_farms.return_value = {
+        "farms": [{"farmId": "farm-good", "displayName": "Good Farm"}]
+    }
+    bad_client = MagicMock()
+    bad_client.list_farms.side_effect = ClientError(
+        {"Error": {"Message": "region opted out"}}, "ListFarms"
+    )
+    clients = {"us-west-2": good_client, "us-east-1": bad_client}
+
+    def fake_get_client(service_name, config=None, region=None):
+        return clients[region]
+
+    with caplog.at_level("WARNING"), patch.object(
+        api._list_apis, "get_boto3_client", side_effect=fake_get_client
+    ), patch.object(api._list_apis, "_apply_principal_id_filter"):
+        runner = CliRunner()
+        result = runner.invoke(main, ["farm", "list"])
+
+    # Surviving region's farm is shown, command still succeeds.
+    assert result.exit_code == 0, result.output
+    assert "farm-good" in result.output
+    assert "us-west-2" in result.output
+    # The failure was surfaced as a warning (not fatal).
+    assert any(
+        "us-east-1" in rec.message and "region opted out" in rec.message for rec in caplog.records
+    )
 
 
 def test_cli_farm_get(fresh_deadline_config, mock_telemetry):
@@ -132,7 +286,7 @@ def test_cli_farm_get_override_profile(fresh_deadline_config):
         result = runner.invoke(main, ["farm", "get", "--profile", "NonDefaultProfileName"])
 
         assert result.exit_code == 0
-        session_mock.assert_called_once_with(profile_name="NonDefaultProfileName")
+        session_mock.assert_called_once_with(profile_name="NonDefaultProfileName", region_name=None)
         session_mock().client().get_farm.assert_called_once_with(farmId="farm-overriddenid")
 
 

--- a/test/unit/deadline_client/cli/test_cli_fleet.py
+++ b/test/unit/deadline_client/cli/test_cli_fleet.py
@@ -82,9 +82,10 @@ def test_cli_fleet_list_region_reaches_client(fresh_deadline_config, mock_teleme
     """
     config.set_setting("defaults.farm_id", MOCK_FARM_ID)
 
-    with patch.object(api._session, "get_boto3_session") as session_mock, patch.object(
-        api._session, "get_session_client"
-    ) as get_session_client_mock:
+    with (
+        patch.object(api._session, "get_boto3_session") as session_mock,
+        patch.object(api._session, "get_session_client") as get_session_client_mock,
+    ):
         get_session_client_mock().list_fleets.return_value = {"fleets": MOCK_FLEETS_LIST}
         get_session_client_mock.reset_mock()
         get_session_client_mock.return_value.list_fleets.return_value = {"fleets": MOCK_FLEETS_LIST}

--- a/test/unit/deadline_client/cli/test_cli_fleet.py
+++ b/test/unit/deadline_client/cli/test_cli_fleet.py
@@ -75,6 +75,36 @@ def test_cli_fleet_list(fresh_deadline_config, mock_telemetry):
         assert result.exit_code == 0
 
 
+def test_cli_fleet_list_region_reaches_client(fresh_deadline_config, mock_telemetry):
+    """
+    Passing --region persists `defaults.farm_region` and scopes the deadline client
+    to that region (it reaches get_session_client).
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+
+    with patch.object(api._session, "get_boto3_session") as session_mock, patch.object(
+        api._session, "get_session_client"
+    ) as get_session_client_mock:
+        get_session_client_mock().list_fleets.return_value = {"fleets": MOCK_FLEETS_LIST}
+        get_session_client_mock.reset_mock()
+        get_session_client_mock.return_value.list_fleets.return_value = {"fleets": MOCK_FLEETS_LIST}
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["fleet", "list", "--region", "us-east-1"])
+
+        assert result.exit_code == 0
+        # The deadline client was created scoped to the requested region.
+        assert any(
+            call.kwargs.get("region") == "us-east-1"
+            and call.kwargs.get("service_name") == "deadline"
+            for call in get_session_client_mock.call_args_list
+        )
+        # The region was persisted to the per-farm region config setting.
+        assert config.get_setting("defaults.farm_region") == "us-east-1"
+        # Don't leak the boto3 session mock as unused.
+        assert session_mock is not None
+
+
 def test_cli_fleet_list_client_error(fresh_deadline_config):
     config.set_setting("defaults.farm_id", MOCK_FARM_ID)
 
@@ -230,7 +260,7 @@ def test_cli_fleet_get_override_profile(fresh_deadline_config):
             ["fleet", "get", "--profile", "NonDefaultProfileName", "--fleet-id", MOCK_FLEET_ID],
         )
 
-        session_mock.assert_called_once_with(profile_name="NonDefaultProfileName")
+        session_mock.assert_called_once_with(profile_name="NonDefaultProfileName", region_name=None)
         session_mock().client().get_fleet.assert_called_once_with(
             farmId="farm-overriddenid", fleetId=MOCK_FLEET_ID
         )

--- a/test/unit/deadline_client/cli/test_cli_job.py
+++ b/test/unit/deadline_client/cli/test_cli_job.py
@@ -190,7 +190,7 @@ def test_cli_job_list_override_profile(fresh_deadline_config):
         result = runner.invoke(main, ["job", "list", "--profile", "NonDefaultProfileName"])
 
         assert result.exit_code == 0
-        session_mock.assert_called_once_with(profile_name="NonDefaultProfileName")
+        session_mock.assert_called_once_with(profile_name="NonDefaultProfileName", region_name=None)
         session_mock().client().search_jobs.assert_called_once_with(
             farmId="farm-overriddenid",
             queueIds=["queue-overriddenid"],

--- a/test/unit/deadline_client/cli/test_cli_job_requeue_tasks.py
+++ b/test/unit/deadline_client/cli/test_cli_job_requeue_tasks.py
@@ -313,8 +313,9 @@ def test_cli_job_requeue_tasks_scopes_requeues_client_to_region(
     # client is constructed. The read client (get_job/list_steps/list_tasks) still uses
     # the real, moto-backed path through api.get_boto3_client.
     fake_session = MagicMock()
-    with patch.object(job_group.api, "get_boto3_session", return_value=fake_session), patch.object(
-        click, "confirm", return_value=True
+    with (
+        patch.object(job_group.api, "get_boto3_session", return_value=fake_session),
+        patch.object(click, "confirm", return_value=True),
     ):
         runner = CliRunner()
         result = runner.invoke(main, ["job", "requeue-tasks", "--run-status", "FAILED"])

--- a/test/unit/deadline_client/cli/test_cli_job_requeue_tasks.py
+++ b/test/unit/deadline_client/cli/test_cli_job_requeue_tasks.py
@@ -5,12 +5,14 @@ Tests for the CLI job commands.
 """
 
 import pytest
-from unittest.mock import patch, call
+from unittest.mock import MagicMock, patch, call
 
 import click
 from click.testing import CliRunner
 
 from deadline.client.cli import main
+from deadline.client.cli._groups import job_group
+from deadline.client.config import config_file
 from ..shared_constants import (
     MOCK_FARM_ID,
     MOCK_JOB_ID,
@@ -285,6 +287,51 @@ Requeued a total of 1 tasks.
             targetRunStatus="PENDING",
         ),
     ]
+
+
+@pytest.mark.parametrize(
+    "configured_region,expected_region_name",
+    [("eu-west-1", "eu-west-1"), (None, None)],
+)
+def test_cli_job_requeue_tasks_scopes_requeues_client_to_region(
+    configured_region, expected_region_name, fresh_deadline_config, deadline_mock
+):
+    """
+    The requeues client (with the adaptive-retry config) is created with region_name
+    scoped to the farm's region when defaults.farm_region is set, while still keeping
+    the custom retry config. When no region is configured, region_name is not passed.
+    """
+    add_mocks_for_job_requeue_tasks(deadline_mock)
+
+    config_file.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config_file.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config_file.set_setting("defaults.job_id", MOCK_JOB_ID)
+    if configured_region:
+        config_file.set_setting("defaults.farm_region", configured_region)
+
+    # Replace the boto3 session used for the requeues client so we can inspect how the
+    # client is constructed. The read client (get_job/list_steps/list_tasks) still uses
+    # the real, moto-backed path through api.get_boto3_client.
+    fake_session = MagicMock()
+    with patch.object(job_group.api, "get_boto3_session", return_value=fake_session), patch.object(
+        click, "confirm", return_value=True
+    ):
+        runner = CliRunner()
+        result = runner.invoke(main, ["job", "requeue-tasks", "--run-status", "FAILED"])
+
+    assert result.exit_code == 0, result.output
+
+    # The requeues client must be built off the provided session with the adaptive retry config.
+    fake_session.client.assert_called_once()
+    client_call = fake_session.client.call_args
+    assert client_call.args[0] == "deadline"
+    requeues_config = client_call.kwargs["config"]
+    assert requeues_config.retries == {"mode": "adaptive", "total_max_attempts": 5}
+
+    if expected_region_name is None:
+        assert "region_name" not in client_call.kwargs
+    else:
+        assert client_call.kwargs["region_name"] == expected_region_name
 
 
 def test_cli_job_requeue_tasks_multiple_statuses(fresh_deadline_config, deadline_mock):

--- a/test/unit/deadline_client/cli/test_cli_queue.py
+++ b/test/unit/deadline_client/cli/test_cli_queue.py
@@ -81,7 +81,7 @@ def test_cli_queue_list_override_profile(fresh_deadline_config):
         result = runner.invoke(main, ["queue", "list", "--profile", "NonDefaultProfileName"])
 
         assert result.exit_code == 0
-        session_mock.assert_called_with(profile_name="NonDefaultProfileName")
+        session_mock.assert_called_with(profile_name="NonDefaultProfileName", region_name=None)
         session_mock().client().list_queues.assert_called_once_with(farmId="farm-overriddenid")
 
 

--- a/test/unit/deadline_client/cli/test_cli_region_per_command.py
+++ b/test/unit/deadline_client/cli/test_cli_region_per_command.py
@@ -1,0 +1,670 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Per-command coverage for the ``--region`` CLI flag across the command groups.
+
+The commands fall into two client-construction families, which determines the
+assertion each test makes:
+
+  * ``get_boto3_client``-based commands resolve their region from config. ``--region``
+    is persisted to ``defaults.farm_region`` by ``_apply_cli_options_to_config`` and then
+    ``api.get_boto3_client`` -> ``api._session.get_session_client`` builds a region-scoped
+    deadline client. These are exercised in a parametrized table that mocks
+    ``api._session.get_session_client`` and asserts ``region="..."`` + ``service_name="deadline"``.
+  * Session-based commands (``queue sync-output``, ``manifest download``/``upload``,
+    ``trace-schedule``) build the deadline client off an explicit boto3 session; each gets a
+    dedicated test asserting the region reaches the session/get_session_client call.
+
+Every test also asserts ``defaults.farm_region`` is persisted (the documented current
+behavior, including on read-only commands - see ``test_cli_region_persists_farm_region``).
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from deadline.client import api, config
+from deadline.client.cli import main
+from deadline.client.cli._groups import queue_group, manifest_group
+
+from ..shared_constants import (
+    MOCK_FARM_ID,
+    MOCK_QUEUE_ID,
+    MOCK_FLEET_ID,
+    MOCK_WORKER_ID,
+    MOCK_JOB_ID,
+    MOCK_GET_QUEUE_RESPONSE,
+)
+
+MOCK_REGION = "eu-central-1"
+
+
+def _region_in_calls(get_session_client_mock, region):
+    """True if any get_session_client call built a deadline client for ``region``."""
+    return any(
+        call.kwargs.get("region") == region and call.kwargs.get("service_name") == "deadline"
+        for call in get_session_client_mock.call_args_list
+    )
+
+
+# ---------------------------------------------------------------------------
+# A. Homogeneous get_boto3_client-based commands (cases 1, 2, 3, 4, 5, 7, 8,
+#    9, 10, 11, 12, 13, 15, 16). Each entry drives a command end-to-end and the
+#    test asserts a region-scoped deadline client was built and farm_region persisted.
+# ---------------------------------------------------------------------------
+
+
+def _setup_get_session_client(get_session_client_mock, build_command):
+    """Wire a fresh region-scoped client mock, configure its returns, and return the CLI args."""
+    client = MagicMock()
+    command = build_command(client)
+    get_session_client_mock.return_value = client
+    return command
+
+
+def _cmd_farm_get(client):
+    client.get_farm.return_value = {"farmId": MOCK_FARM_ID, "displayName": "F"}
+    return ["farm", "get", "--farm-id", MOCK_FARM_ID, "--region", MOCK_REGION]
+
+
+def _cmd_queue_list(client):
+    client.list_queues.return_value = {"queues": []}
+    return ["queue", "list", "--farm-id", MOCK_FARM_ID, "--region", MOCK_REGION]
+
+
+def _cmd_queue_get(client):
+    client.get_queue.return_value = dict(MOCK_GET_QUEUE_RESPONSE)
+    return [
+        "queue",
+        "get",
+        "--farm-id",
+        MOCK_FARM_ID,
+        "--queue-id",
+        MOCK_QUEUE_ID,
+        "--region",
+        MOCK_REGION,
+    ]
+
+
+def _cmd_queue_paramdefs(client):
+    # get_queue_parameter_definitions lists queue environments off the deadline client.
+    client.list_queue_environments.return_value = {"environments": []}
+    return [
+        "queue",
+        "paramdefs",
+        "--farm-id",
+        MOCK_FARM_ID,
+        "--queue-id",
+        MOCK_QUEUE_ID,
+        "--region",
+        MOCK_REGION,
+    ]
+
+
+def _cmd_queue_export_credentials(client):
+    client.assume_queue_role_for_user.return_value = {
+        "credentials": {
+            "accessKeyId": "AKIA",
+            "secretAccessKey": "secret",
+            "sessionToken": "token",
+            "expiration": datetime.fromisoformat("2125-01-01T00:00:00+00:00"),
+        }
+    }
+    return [
+        "queue",
+        "export-credentials",
+        "--farm-id",
+        MOCK_FARM_ID,
+        "--queue-id",
+        MOCK_QUEUE_ID,
+        "--region",
+        MOCK_REGION,
+    ]
+
+
+def _cmd_fleet_get(client):
+    client.get_fleet.return_value = {"fleetId": MOCK_FLEET_ID, "farmId": MOCK_FARM_ID}
+    return [
+        "fleet",
+        "get",
+        "--farm-id",
+        MOCK_FARM_ID,
+        "--fleet-id",
+        MOCK_FLEET_ID,
+        "--region",
+        MOCK_REGION,
+    ]
+
+
+def _cmd_job_list(client):
+    client.search_jobs.return_value = {"jobs": [], "totalResults": 0}
+    return [
+        "job",
+        "list",
+        "--farm-id",
+        MOCK_FARM_ID,
+        "--queue-id",
+        MOCK_QUEUE_ID,
+        "--region",
+        MOCK_REGION,
+    ]
+
+
+def _cmd_job_get(client):
+    client.get_job.return_value = {
+        "jobId": MOCK_JOB_ID,
+        "name": "Test Job",
+        "lifecycleStatus": "CREATE_COMPLETE",
+        "lifecycleStatusMessage": "",
+        "taskRunStatus": "SUCCEEDED",
+        "taskRunStatusCounts": {"SUCCEEDED": 1},
+        "createdAt": datetime.fromisoformat("2024-01-01T00:00:00+00:00"),
+        "createdBy": "user",
+        "priority": 50,
+    }
+    return [
+        "job",
+        "get",
+        "--farm-id",
+        MOCK_FARM_ID,
+        "--queue-id",
+        MOCK_QUEUE_ID,
+        "--job-id",
+        MOCK_JOB_ID,
+        "--region",
+        MOCK_REGION,
+    ]
+
+
+def _cmd_job_cancel(client):
+    client.get_job.return_value = {
+        "name": "Test Job",
+        "jobId": MOCK_JOB_ID,
+        "taskRunStatus": "RUNNING",
+        "taskRunStatusCounts": {"RUNNING": 1},
+        "createdAt": datetime.fromisoformat("2024-01-01T00:00:00+00:00"),
+        "createdBy": "user",
+    }
+    client.update_job.return_value = {}
+    return [
+        "job",
+        "cancel",
+        "--farm-id",
+        MOCK_FARM_ID,
+        "--queue-id",
+        MOCK_QUEUE_ID,
+        "--job-id",
+        MOCK_JOB_ID,
+        "--region",
+        MOCK_REGION,
+        "--yes",
+    ]
+
+
+def _cmd_worker_list(client):
+    client.search_workers.return_value = {"workers": [], "totalResults": 0}
+    return [
+        "worker",
+        "list",
+        "--farm-id",
+        MOCK_FARM_ID,
+        "--fleet-id",
+        MOCK_FLEET_ID,
+        "--region",
+        MOCK_REGION,
+    ]
+
+
+def _cmd_worker_get(client):
+    client.get_worker.return_value = {"workerId": MOCK_WORKER_ID, "status": "STARTED"}
+    return [
+        "worker",
+        "get",
+        "--farm-id",
+        MOCK_FARM_ID,
+        "--fleet-id",
+        MOCK_FLEET_ID,
+        "--worker-id",
+        MOCK_WORKER_ID,
+        "--region",
+        MOCK_REGION,
+    ]
+
+
+_GET_BOTO3_CLIENT_COMMANDS = [
+    pytest.param(_cmd_farm_get, id="farm-get"),
+    pytest.param(_cmd_queue_list, id="queue-list"),
+    pytest.param(_cmd_queue_get, id="queue-get"),
+    pytest.param(_cmd_queue_paramdefs, id="queue-paramdefs"),
+    pytest.param(_cmd_queue_export_credentials, id="queue-export-credentials"),
+    pytest.param(_cmd_fleet_get, id="fleet-get"),
+    pytest.param(_cmd_job_list, id="job-list"),
+    pytest.param(_cmd_job_get, id="job-get"),
+    pytest.param(_cmd_job_cancel, id="job-cancel"),
+    pytest.param(_cmd_worker_list, id="worker-list"),
+    pytest.param(_cmd_worker_get, id="worker-get"),
+]
+
+
+@pytest.mark.parametrize("build_command", _GET_BOTO3_CLIENT_COMMANDS)
+def test_cli_region_reaches_get_session_client(
+    fresh_deadline_config, mock_telemetry, build_command
+):
+    """--region scopes the deadline client to that region and persists defaults.farm_region."""
+    with patch.object(api._session, "get_boto3_session"), patch.object(
+        api._session, "get_session_client"
+    ) as get_session_client_mock:
+        command = _setup_get_session_client(get_session_client_mock, build_command)
+        runner = CliRunner()
+        result = runner.invoke(main, command)
+
+    assert result.exit_code == 0, result.output
+    assert _region_in_calls(get_session_client_mock, MOCK_REGION)
+    assert config.get_setting("defaults.farm_region") == MOCK_REGION
+
+
+# ---------------------------------------------------------------------------
+# job download-output (11) and download-input (12): these build the deadline
+# client via get_boto3_client too, but exit early (no attachments / no output)
+# before any download. We only need to confirm the region reached the client.
+# ---------------------------------------------------------------------------
+
+
+def test_cli_job_download_output_region(fresh_deadline_config, mock_telemetry):
+    """job download-output builds a region-scoped deadline client and persists farm_region."""
+    with patch.object(api._session, "get_boto3_session"), patch.object(
+        api._session, "get_session_client"
+    ) as get_session_client_mock, patch.object(api, "get_queue_user_boto3_session"):
+        client = MagicMock()
+        client.get_job.return_value = {"name": "Test Job", "attachments": None}
+        client.get_queue.return_value = dict(MOCK_GET_QUEUE_RESPONSE)
+        # OutputDownloader is constructed off the queue session; force "no outputs" by
+        # making the job have no attachments, which short-circuits before download.
+        get_session_client_mock.return_value = client
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "job",
+                "download-output",
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--job-id",
+                MOCK_JOB_ID,
+                "--region",
+                MOCK_REGION,
+                "--yes",
+            ],
+        )
+
+    # The deadline client must have been built for the requested region regardless of how
+    # far the download proceeds.
+    assert _region_in_calls(get_session_client_mock, MOCK_REGION), result.output
+    assert config.get_setting("defaults.farm_region") == MOCK_REGION
+
+
+def test_cli_job_download_input_region(fresh_deadline_config, mock_telemetry):
+    """job download-input builds a region-scoped deadline client and persists farm_region."""
+    with patch.object(api._session, "get_boto3_session"), patch.object(
+        api._session, "get_session_client"
+    ) as get_session_client_mock, patch.object(api, "get_queue_user_boto3_session"):
+        client = MagicMock()
+        # No attachments => command prints "No input attachments" and returns cleanly.
+        client.get_job.return_value = {"name": "Test Job", "attachments": None}
+        client.get_queue.return_value = dict(MOCK_GET_QUEUE_RESPONSE)
+        get_session_client_mock.return_value = client
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "job",
+                "download-input",
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--job-id",
+                MOCK_JOB_ID,
+                "--region",
+                MOCK_REGION,
+                "--yes",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert _region_in_calls(get_session_client_mock, MOCK_REGION)
+    assert config.get_setting("defaults.farm_region") == MOCK_REGION
+
+
+# ---------------------------------------------------------------------------
+# job wait (13): builds a region-scoped deadline client for the initial get_job,
+# and api.wait_for_job_completion receives the same config (so it resolves the
+# same region). We mock wait_for_job_completion to a terminal SUCCEEDED.
+# ---------------------------------------------------------------------------
+
+
+def test_cli_job_wait_region(fresh_deadline_config, mock_telemetry):
+    """job wait builds a region-scoped deadline client and persists farm_region."""
+    wait_result = MagicMock()
+    wait_result.status = "SUCCEEDED"
+    wait_result.elapsed_time = 1.0
+    wait_result.failed_tasks = []
+
+    with patch.object(api._session, "get_boto3_session"), patch.object(
+        api._session, "get_session_client"
+    ) as get_session_client_mock, patch.object(
+        api, "wait_for_job_completion", return_value=wait_result
+    ):
+        client = MagicMock()
+        client.get_job.return_value = {"name": "Test Job"}
+        get_session_client_mock.return_value = client
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "job",
+                "wait",
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--job-id",
+                MOCK_JOB_ID,
+                "--region",
+                MOCK_REGION,
+            ],
+        )
+
+    # A SUCCEEDED job exits 0.
+    assert result.exit_code == 0, result.output
+    assert _region_in_calls(get_session_client_mock, MOCK_REGION)
+    assert config.get_setting("defaults.farm_region") == MOCK_REGION
+
+
+# ---------------------------------------------------------------------------
+# job logs (14): the deadline client AND the CloudWatch LOGS client must both be
+# region-scoped to the farm region. For a non-DCM profile both go through
+# get_boto3_client -> get_session_client. We assert both service clients were
+# built for the requested region.
+# ---------------------------------------------------------------------------
+
+
+def test_cli_job_logs_region_scopes_deadline_and_logs_clients(fresh_deadline_config):
+    """job logs scopes both the deadline client and the CloudWatch logs client to the region."""
+    from deadline.client.api._job_monitoring import SessionLogResult
+
+    log_result = SessionLogResult(
+        events=[],
+        count=0,
+        next_token=None,
+        log_group=f"/aws/deadline/{MOCK_FARM_ID}/{MOCK_QUEUE_ID}",
+        log_stream="session-test-session",
+    )
+
+    with patch.object(api._session, "get_boto3_session"), patch.object(
+        api._session, "get_session_client"
+    ) as get_session_client_mock, patch(
+        "deadline.client.api._job_monitoring.get_user_and_identity_store_id",
+        return_value=(None, None),
+    ), patch("deadline.client.api.get_session_logs", return_value=log_result) as mock_get_logs:
+        client = MagicMock()
+        client.get_job.return_value = {"name": "Test Job"}
+        get_session_client_mock.return_value = client
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "job",
+                "logs",
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--job-id",
+                MOCK_JOB_ID,
+                "--session-id",
+                "test-session",
+                "--region",
+                MOCK_REGION,
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    # The CLI's own deadline client (for get_job) was built for the region.
+    assert _region_in_calls(get_session_client_mock, MOCK_REGION)
+    # get_session_logs receives the same config, so it resolves the same region for both
+    # its internal deadline client and the CloudWatch logs client.
+    assert mock_get_logs.called
+    config_passed = mock_get_logs.call_args.kwargs["config"]
+    from deadline.client.config import config_file
+
+    assert config_file.get_setting("defaults.farm_region", config=config_passed) == MOCK_REGION
+
+
+def test_job_logs_api_logs_client_region_scoped_non_dcm(fresh_deadline_config):
+    """
+    At the API layer, get_session_logs builds its CloudWatch logs client via
+    get_boto3_client("logs", config=config) for a non-DCM profile, so the logs client is
+    scoped to defaults.farm_region just like the deadline client.
+    """
+    from deadline.client.api import _job_monitoring
+
+    config.set_setting("defaults.farm_region", MOCK_REGION)
+
+    captured = []
+
+    def fake_get_boto3_client(service_name, config=None, region=None):
+        # get_boto3_client resolves region from config when region is None; emulate that.
+        from deadline.client.api._session import _resolve_region
+
+        resolved = _resolve_region(config=config, region=region)
+        captured.append((service_name, resolved))
+        client = MagicMock()
+        client.get_log_events.return_value = {"events": [], "nextForwardToken": None}
+        return client
+
+    with patch.object(
+        _job_monitoring, "get_boto3_client", side_effect=fake_get_boto3_client
+    ), patch.object(_job_monitoring, "get_user_and_identity_store_id", return_value=(None, None)):
+        _job_monitoring.get_session_logs(
+            farm_id=MOCK_FARM_ID,
+            queue_id=MOCK_QUEUE_ID,
+            session_id="session-abc",
+            limit=10,
+        )
+
+    services = {svc: region for svc, region in captured}
+    assert services.get("deadline") == MOCK_REGION
+    # The logs client is region-scoped to the farm region (the documented multi-region fix).
+    assert services.get("logs") == MOCK_REGION
+
+
+# ---------------------------------------------------------------------------
+# B. Session-based commands. These build the deadline client off an explicit
+#    boto3 session (not api.get_boto3_client), so we assert the region reaches the
+#    session/get_session_client construction.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="The sync-output command requires Python >= 3.9"
+)
+def test_cli_queue_sync_output_region(fresh_deadline_config, tmp_path):
+    """
+    queue sync-output (6): builds the deadline client via get_session_client(session,
+    "deadline", region=...) with the resolved farm region.
+    """
+    deadline_client = MagicMock()
+    deadline_client.get_queue.return_value = dict(MOCK_GET_QUEUE_RESPONSE)
+
+    with patch.object(queue_group.api, "get_boto3_session", return_value=MagicMock()), patch.object(
+        queue_group, "get_session_client", return_value=deadline_client
+    ) as mock_get_session_client, patch.object(
+        queue_group, "_incremental_output_download", return_value=MagicMock()
+    ):
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "queue",
+                "sync-output",
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--region",
+                MOCK_REGION,
+                "--checkpoint-dir",
+                str(tmp_path),
+                "--ignore-storage-profiles",
+                "--dry-run",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    mock_get_session_client.assert_called_once()
+    assert mock_get_session_client.call_args.kwargs["region"] == MOCK_REGION
+    assert config.get_setting("defaults.farm_region") == MOCK_REGION
+
+
+def test_cli_manifest_download_region(fresh_deadline_config, tmp_path):
+    """
+    manifest download (17): scopes its deadline client to the resolved farm region via
+    boto3_session.client("deadline", ..., region_name=region).
+    """
+    download_dir = tmp_path / "dl"
+    download_dir.mkdir()
+
+    import dataclasses as _dc
+
+    @_dc.dataclass
+    class _DownloadOutput:
+        downloaded = ""
+
+    session_mock = MagicMock()
+    deadline_client = session_mock.client.return_value
+    deadline_client.get_queue.return_value = dict(MOCK_GET_QUEUE_RESPONSE)
+
+    with patch.object(
+        manifest_group.api, "get_boto3_session", return_value=session_mock
+    ), patch.object(
+        manifest_group, "_get_queue_user_boto3_session", return_value=MagicMock()
+    ) as queue_session_mock, patch.object(
+        manifest_group, "_manifest_download", return_value=_DownloadOutput()
+    ):
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "manifest",
+                "download",
+                str(download_dir),
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--job-id",
+                MOCK_JOB_ID,
+                "--region",
+                MOCK_REGION,
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    # The deadline client was created with region_name scoped to the requested region.
+    assert any(
+        call.kwargs.get("region_name") == MOCK_REGION for call in session_mock.client.call_args_list
+    ), session_mock.client.call_args_list
+    # The queue-user session must also be scoped to the farm's region, not the base session.
+    queue_session_mock.assert_called_once()
+    assert queue_session_mock.call_args.kwargs.get("region") == MOCK_REGION
+    assert config.get_setting("defaults.farm_region") == MOCK_REGION
+
+
+def test_cli_manifest_upload_region(fresh_deadline_config, tmp_path):
+    """
+    manifest upload (18): with --farm-id/--queue-id, builds its deadline client via
+    api.get_boto3_client which resolves the persisted farm region.
+    """
+    manifest_file = tmp_path / "abc_manifest"
+    manifest_file.write_text("{}")
+
+    with patch.object(
+        manifest_group.api, "get_boto3_session", return_value=MagicMock()
+    ), patch.object(api._session, "get_session_client") as get_session_client_mock, patch.object(
+        manifest_group.api, "get_queue_user_boto3_session", return_value=MagicMock()
+    ), patch.object(manifest_group, "_manifest_upload", return_value=None):
+        deadline_client = MagicMock()
+        deadline_client.get_queue.return_value = dict(MOCK_GET_QUEUE_RESPONSE)
+        get_session_client_mock.return_value = deadline_client
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "manifest",
+                "upload",
+                str(manifest_file),
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--region",
+                MOCK_REGION,
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert _region_in_calls(get_session_client_mock, MOCK_REGION)
+    assert config.get_setting("defaults.farm_region") == MOCK_REGION
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="The trace-schedule command requires Python >= 3.9"
+)
+def test_cli_trace_schedule_region(fresh_deadline_config, mock_telemetry):
+    """
+    job trace-schedule (19): builds its deadline client via api.get_boto3_client, scoped to
+    the persisted farm region. A job that hasn't started exits early after the get_job call.
+    """
+    with patch.object(api._session, "get_boto3_session"), patch.object(
+        api._session, "get_session_client"
+    ) as get_session_client_mock:
+        client = MagicMock()
+        # No startedAt => trace-schedule reports "hasn't started yet" and stops, which is
+        # enough to confirm the region-scoped deadline client was built.
+        client.get_job.return_value = {"name": "Test Job", "jobId": MOCK_JOB_ID}
+        get_session_client_mock.return_value = client
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "job",
+                "trace-schedule",
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--job-id",
+                MOCK_JOB_ID,
+                "--region",
+                MOCK_REGION,
+            ],
+        )
+
+    # "Job hasn't started yet" is surfaced as a DeadlineOperationError (exit 1), but the
+    # deadline client was already built for the region by then.
+    assert _region_in_calls(get_session_client_mock, MOCK_REGION), result.output
+    assert config.get_setting("defaults.farm_region") == MOCK_REGION

--- a/test/unit/deadline_client/cli/test_cli_region_per_command.py
+++ b/test/unit/deadline_client/cli/test_cli_region_per_command.py
@@ -21,7 +21,6 @@ behavior, including on read-only commands - see ``test_cli_region_persists_farm_
 
 from __future__ import annotations
 
-import sys
 from datetime import datetime
 from unittest.mock import MagicMock, patch
 
@@ -256,9 +255,10 @@ def test_cli_region_reaches_get_session_client(
     fresh_deadline_config, mock_telemetry, build_command
 ):
     """--region scopes the deadline client to that region and persists defaults.farm_region."""
-    with patch.object(api._session, "get_boto3_session"), patch.object(
-        api._session, "get_session_client"
-    ) as get_session_client_mock:
+    with (
+        patch.object(api._session, "get_boto3_session"),
+        patch.object(api._session, "get_session_client") as get_session_client_mock,
+    ):
         command = _setup_get_session_client(get_session_client_mock, build_command)
         runner = CliRunner()
         result = runner.invoke(main, command)
@@ -277,9 +277,11 @@ def test_cli_region_reaches_get_session_client(
 
 def test_cli_job_download_output_region(fresh_deadline_config, mock_telemetry):
     """job download-output builds a region-scoped deadline client and persists farm_region."""
-    with patch.object(api._session, "get_boto3_session"), patch.object(
-        api._session, "get_session_client"
-    ) as get_session_client_mock, patch.object(api, "get_queue_user_boto3_session"):
+    with (
+        patch.object(api._session, "get_boto3_session"),
+        patch.object(api._session, "get_session_client") as get_session_client_mock,
+        patch.object(api, "get_queue_user_boto3_session"),
+    ):
         client = MagicMock()
         client.get_job.return_value = {"name": "Test Job", "attachments": None}
         client.get_queue.return_value = dict(MOCK_GET_QUEUE_RESPONSE)
@@ -313,9 +315,11 @@ def test_cli_job_download_output_region(fresh_deadline_config, mock_telemetry):
 
 def test_cli_job_download_input_region(fresh_deadline_config, mock_telemetry):
     """job download-input builds a region-scoped deadline client and persists farm_region."""
-    with patch.object(api._session, "get_boto3_session"), patch.object(
-        api._session, "get_session_client"
-    ) as get_session_client_mock, patch.object(api, "get_queue_user_boto3_session"):
+    with (
+        patch.object(api._session, "get_boto3_session"),
+        patch.object(api._session, "get_session_client") as get_session_client_mock,
+        patch.object(api, "get_queue_user_boto3_session"),
+    ):
         client = MagicMock()
         # No attachments => command prints "No input attachments" and returns cleanly.
         client.get_job.return_value = {"name": "Test Job", "attachments": None}
@@ -359,10 +363,10 @@ def test_cli_job_wait_region(fresh_deadline_config, mock_telemetry):
     wait_result.elapsed_time = 1.0
     wait_result.failed_tasks = []
 
-    with patch.object(api._session, "get_boto3_session"), patch.object(
-        api._session, "get_session_client"
-    ) as get_session_client_mock, patch.object(
-        api, "wait_for_job_completion", return_value=wait_result
+    with (
+        patch.object(api._session, "get_boto3_session"),
+        patch.object(api._session, "get_session_client") as get_session_client_mock,
+        patch.object(api, "wait_for_job_completion", return_value=wait_result),
     ):
         client = MagicMock()
         client.get_job.return_value = {"name": "Test Job"}
@@ -411,12 +415,15 @@ def test_cli_job_logs_region_scopes_deadline_and_logs_clients(fresh_deadline_con
         log_stream="session-test-session",
     )
 
-    with patch.object(api._session, "get_boto3_session"), patch.object(
-        api._session, "get_session_client"
-    ) as get_session_client_mock, patch(
-        "deadline.client.api._job_monitoring.get_user_and_identity_store_id",
-        return_value=(None, None),
-    ), patch("deadline.client.api.get_session_logs", return_value=log_result) as mock_get_logs:
+    with (
+        patch.object(api._session, "get_boto3_session"),
+        patch.object(api._session, "get_session_client") as get_session_client_mock,
+        patch(
+            "deadline.client.api._job_monitoring.get_user_and_identity_store_id",
+            return_value=(None, None),
+        ),
+        patch("deadline.client.api.get_session_logs", return_value=log_result) as mock_get_logs,
+    ):
         client = MagicMock()
         client.get_job.return_value = {"name": "Test Job"}
         get_session_client_mock.return_value = client
@@ -474,9 +481,10 @@ def test_job_logs_api_logs_client_region_scoped_non_dcm(fresh_deadline_config):
         client.get_log_events.return_value = {"events": [], "nextForwardToken": None}
         return client
 
-    with patch.object(
-        _job_monitoring, "get_boto3_client", side_effect=fake_get_boto3_client
-    ), patch.object(_job_monitoring, "get_user_and_identity_store_id", return_value=(None, None)):
+    with (
+        patch.object(_job_monitoring, "get_boto3_client", side_effect=fake_get_boto3_client),
+        patch.object(_job_monitoring, "get_user_and_identity_store_id", return_value=(None, None)),
+    ):
         _job_monitoring.get_session_logs(
             farm_id=MOCK_FARM_ID,
             queue_id=MOCK_QUEUE_ID,
@@ -497,9 +505,6 @@ def test_job_logs_api_logs_client_region_scoped_non_dcm(fresh_deadline_config):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 9), reason="The sync-output command requires Python >= 3.9"
-)
 def test_cli_queue_sync_output_region(fresh_deadline_config, tmp_path):
     """
     queue sync-output (6): builds the deadline client via get_session_client(session,
@@ -508,10 +513,12 @@ def test_cli_queue_sync_output_region(fresh_deadline_config, tmp_path):
     deadline_client = MagicMock()
     deadline_client.get_queue.return_value = dict(MOCK_GET_QUEUE_RESPONSE)
 
-    with patch.object(queue_group.api, "get_boto3_session", return_value=MagicMock()), patch.object(
-        queue_group, "get_session_client", return_value=deadline_client
-    ) as mock_get_session_client, patch.object(
-        queue_group, "_incremental_output_download", return_value=MagicMock()
+    with (
+        patch.object(queue_group.api, "get_boto3_session", return_value=MagicMock()),
+        patch.object(
+            queue_group, "get_session_client", return_value=deadline_client
+        ) as mock_get_session_client,
+        patch.object(queue_group, "_incremental_output_download", return_value=MagicMock()),
     ):
         runner = CliRunner()
         result = runner.invoke(
@@ -556,12 +563,12 @@ def test_cli_manifest_download_region(fresh_deadline_config, tmp_path):
     deadline_client = session_mock.client.return_value
     deadline_client.get_queue.return_value = dict(MOCK_GET_QUEUE_RESPONSE)
 
-    with patch.object(
-        manifest_group.api, "get_boto3_session", return_value=session_mock
-    ), patch.object(
-        manifest_group, "_get_queue_user_boto3_session", return_value=MagicMock()
-    ) as queue_session_mock, patch.object(
-        manifest_group, "_manifest_download", return_value=_DownloadOutput()
+    with (
+        patch.object(manifest_group.api, "get_boto3_session", return_value=session_mock),
+        patch.object(
+            manifest_group, "_get_queue_user_boto3_session", return_value=MagicMock()
+        ) as queue_session_mock,
+        patch.object(manifest_group, "_manifest_download", return_value=_DownloadOutput()),
     ):
         runner = CliRunner()
         result = runner.invoke(
@@ -600,11 +607,12 @@ def test_cli_manifest_upload_region(fresh_deadline_config, tmp_path):
     manifest_file = tmp_path / "abc_manifest"
     manifest_file.write_text("{}")
 
-    with patch.object(
-        manifest_group.api, "get_boto3_session", return_value=MagicMock()
-    ), patch.object(api._session, "get_session_client") as get_session_client_mock, patch.object(
-        manifest_group.api, "get_queue_user_boto3_session", return_value=MagicMock()
-    ), patch.object(manifest_group, "_manifest_upload", return_value=None):
+    with (
+        patch.object(manifest_group.api, "get_boto3_session", return_value=MagicMock()),
+        patch.object(api._session, "get_session_client") as get_session_client_mock,
+        patch.object(manifest_group.api, "get_queue_user_boto3_session", return_value=MagicMock()),
+        patch.object(manifest_group, "_manifest_upload", return_value=None),
+    ):
         deadline_client = MagicMock()
         deadline_client.get_queue.return_value = dict(MOCK_GET_QUEUE_RESPONSE)
         get_session_client_mock.return_value = deadline_client
@@ -630,17 +638,15 @@ def test_cli_manifest_upload_region(fresh_deadline_config, tmp_path):
     assert config.get_setting("defaults.farm_region") == MOCK_REGION
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 9), reason="The trace-schedule command requires Python >= 3.9"
-)
 def test_cli_trace_schedule_region(fresh_deadline_config, mock_telemetry):
     """
     job trace-schedule (19): builds its deadline client via api.get_boto3_client, scoped to
     the persisted farm region. A job that hasn't started exits early after the get_job call.
     """
-    with patch.object(api._session, "get_boto3_session"), patch.object(
-        api._session, "get_session_client"
-    ) as get_session_client_mock:
+    with (
+        patch.object(api._session, "get_boto3_session"),
+        patch.object(api._session, "get_session_client") as get_session_client_mock,
+    ):
         client = MagicMock()
         # No startedAt => trace-schedule reports "hasn't started yet" and stops, which is
         # enough to confirm the region-scoped deadline client was built.

--- a/test/unit/deadline_client/cli/test_cli_resource_suggestions.py
+++ b/test/unit/deadline_client/cli/test_cli_resource_suggestions.py
@@ -213,10 +213,12 @@ def test_worker_list_suggestion_uses_correct_api_params(fresh_deadline_config, d
     assert deadline_mock.search_workers.call_count == 2
 
 
-def test_suggestion_truncates_long_lists(fresh_deadline_config, deadline_mock):
+def test_suggestion_truncates_long_lists(fresh_deadline_config, deadline_mock, monkeypatch):
     """
     Test that suggestions are truncated when there are more than 10 results.
     """
+    # Scope the farm-suggestion fan-out to a single region so the count is deterministic.
+    monkeypatch.setenv("DEADLINE_CLOUD_REGIONS", "us-west-2")
     config.set_setting("defaults.farm_id", "farm-wrongid12345678901234567890")
 
     # ListQueues fails
@@ -267,10 +269,12 @@ def test_no_suggestion_on_other_errors(fresh_deadline_config, deadline_mock):
     assert "Available" not in result.output
 
 
-def test_suggestion_failure_silent(fresh_deadline_config, deadline_mock):
+def test_suggestion_failure_silent(fresh_deadline_config, deadline_mock, monkeypatch):
     """
     Test that if List API also fails, we show a hint about permissions.
     """
+    # Scope the farm-suggestion fan-out to a single region.
+    monkeypatch.setenv("DEADLINE_CLOUD_REGIONS", "us-west-2")
     config.set_setting("defaults.farm_id", "farm-wrongid12345678901234567890")
 
     # ListQueues fails
@@ -474,31 +478,35 @@ def test_worker_get_wrong_worker_suggests_workers(fresh_deadline_config, deadlin
     assert "worker-0123456789abcdef0123456789ab" in result.output
 
 
-def test_farm_list_wrong_farm_suggests_farms(fresh_deadline_config, deadline_mock):
+def test_farm_list_wrong_farm_suggests_farms(fresh_deadline_config, deadline_mock, monkeypatch):
     """
-    Test that when ListFarms fails with AccessDeniedException, the CLI suggests available farms.
+    Test that when ListFarms fails the CLI surfaces the per-region failure cause.
+
+    Note: with the Phase 2 multi-region fan-out, ``farm list`` now aggregates ListFarms
+    across regions, and an all-region failure raises ``DeadlineOperationError`` from the
+    API layer (before the CLI's ClientError suggestion path). Phase 3 (CLI) is responsible
+    for re-wiring the resource-suggestion UX onto the fanned-out command; here we assert
+    the error is surfaced with the underlying access-denied cause.
     """
-    # First call fails, second (for suggestions) succeeds
-    deadline_mock.list_farms.side_effect = [
-        ClientError(
-            {
-                "Error": {
-                    "Code": "AccessDeniedException",
-                    "Message": "User is not authorized to perform: deadline:ListFarms",
-                }
-            },
-            "ListFarms",
-        ),
-        {"farms": [{"farmId": MOCK_FARM_ID, "displayName": "Available Farm"}]},
-    ]
+    # Scope to a single region so the only ListFarms call is the failing one.
+    monkeypatch.setenv("DEADLINE_CLOUD_REGIONS", "us-west-2")
+    deadline_mock.list_farms.side_effect = ClientError(
+        {
+            "Error": {
+                "Code": "AccessDeniedException",
+                "Message": "User is not authorized to perform: deadline:ListFarms",
+            }
+        },
+        "ListFarms",
+    )
 
     runner = CliRunner()
     result = runner.invoke(main, ["farm", "list"])
 
     assert result.exit_code != 0
-    assert "Failed to get Farms from Deadline" in result.output
-    assert "Available farms:" in result.output
-    assert MOCK_FARM_ID in result.output
+    assert "Failed to list farms" in result.output
+    assert "us-west-2" in result.output
+    assert "AccessDeniedException" in result.output
 
 
 def test_fleet_list_wrong_farm_suggests_fleets(fresh_deadline_config, deadline_mock):

--- a/test/unit/deadline_client/cli/test_incremental_download_region.py
+++ b/test/unit/deadline_client/cli/test_incremental_download_region.py
@@ -1,0 +1,77 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Tests that the incremental download helpers scope their deadline clients to the
+resolved farm region (multi-region support).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from deadline.client.cli import _incremental_download
+from ..shared_constants import MOCK_FARM_ID, MOCK_QUEUE_ID
+
+MOCK_TIMESTAMP = datetime(2025, 1, 1, tzinfo=timezone.utc)
+
+
+@pytest.mark.parametrize("region", ["eu-central-1", None])
+def test_get_download_candidate_jobs_threads_region(region):
+    """_get_download_candidate_jobs passes its region argument through to the
+    _list_jobs_by_filter_expression calls so the deadline client is region-scoped."""
+    boto3_session = MagicMock()
+
+    with patch.object(
+        _incremental_download, "_list_jobs_by_filter_expression", return_value=[]
+    ) as mock_list_jobs:
+        _incremental_download._get_download_candidate_jobs(
+            boto3_session,
+            MOCK_FARM_ID,
+            MOCK_QUEUE_ID,
+            MOCK_TIMESTAMP,
+            region=region,
+        )
+
+    # Both filter-expression calls (active jobs and recently-ended jobs) must carry the region.
+    assert mock_list_jobs.call_count == 2
+    for call_args in mock_list_jobs.call_args_list:
+        assert call_args.kwargs["region"] == region
+
+
+@pytest.mark.parametrize("region", ["ap-northeast-1", None])
+def test_get_job_sessions_scopes_deadline_client_to_region(region):
+    """_get_job_sessions builds its deadline client via get_session_client with the
+    resolved region."""
+    boto3_session = MagicMock()
+    boto3_session_for_s3 = MagicMock()
+
+    checkpoint = MagicMock()
+    checkpoint.jobs = []
+    checkpoint.downloads_started_timestamp = MOCK_TIMESTAMP
+    checkpoint.eventual_consistency_max_seconds = 0
+
+    categorized = MagicMock()
+    # No jobs to retrieve sessions for keeps the test focused on client construction.
+    categorized.completed = set()
+    categorized.added = set()
+    categorized.updated = set()
+
+    with patch.object(
+        _incremental_download, "get_session_client", return_value=MagicMock()
+    ) as mock_get_session_client:
+        _incremental_download._get_job_sessions(
+            boto3_session,
+            boto3_session_for_s3,
+            MOCK_FARM_ID,
+            {"queueId": MOCK_QUEUE_ID},
+            {},
+            categorized,
+            checkpoint,
+            {},
+            region=region,
+        )
+
+    mock_get_session_client.assert_called_once_with(boto3_session, "deadline", region=region)

--- a/test/unit/deadline_client/config/test_config_file.py
+++ b/test/unit/deadline_client/config/test_config_file.py
@@ -24,9 +24,11 @@ from deadline.client.exceptions import DeadlineOperationError
 CONFIG_SETTING_ROUND_TRIP = [
     ("defaults.aws_profile_name", "(default)", "AnotherProfileName"),
     ("defaults.farm_id", "", "farm-82934h23k4j23kjh"),
+    ("defaults.farm_region", "", "eu-west-1"),
     ("defaults.job_attachments_file_system", "COPIED", "VIRTUAL"),
     ("settings.locale", "", "ja_JP"),
     ("settings.force_s3_check", "false", "true"),
+    ("settings.deadline_regions", "", "us-east-1,eu-west-1"),
 ]
 
 
@@ -371,3 +373,85 @@ def test_posix_config_file_permissions(fresh_deadline_config) -> None:
     config_file.set_setting("defaults.aws_profile_name", "goodguyprofile")
 
     assert config_file_path.stat().st_mode & 0o777 == 0o600
+
+
+def test_get_deadline_regions_env_override(fresh_deadline_config):
+    """The DEADLINE_CLOUD_REGIONS env var takes top precedence."""
+    # Even if a config setting says something else, the env var wins.
+    config.set_setting("settings.deadline_regions", "ap-south-1")
+    with patch.dict(os.environ, {"DEADLINE_CLOUD_REGIONS": "us-west-2, eu-west-1 ,us-west-2"}):
+        result = config_file.get_deadline_regions()
+    # De-duplicated, order-preserving, whitespace-stripped
+    assert result == ["us-west-2", "eu-west-1"]
+
+
+def test_get_deadline_regions_config_override(fresh_deadline_config):
+    """The settings.deadline_regions config setting is used when the env var is not set."""
+    config.set_setting("settings.deadline_regions", "eu-central-1, ca-central-1")
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("DEADLINE_CLOUD_REGIONS", None)
+        result = config_file.get_deadline_regions()
+    assert result == ["eu-central-1", "ca-central-1"]
+
+
+def test_get_deadline_regions_blank_overrides_fall_through(fresh_deadline_config):
+    """Blank/whitespace-only env var and config setting fall through to the curated list."""
+    config.set_setting("settings.deadline_regions", "   ")
+    with patch.dict(os.environ, {"DEADLINE_CLOUD_REGIONS": "  "}):
+        result = config_file.get_deadline_regions()
+    assert result == config_file.DEADLINE_REGIONS
+
+
+def test_get_deadline_regions_default_curated_list(fresh_deadline_config):
+    """With no override set, the curated DEADLINE_REGIONS list is returned."""
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("DEADLINE_CLOUD_REGIONS", None)
+        result = config_file.get_deadline_regions()
+    assert result == config_file.DEADLINE_REGIONS
+    # The returned value is a copy, not the module constant itself.
+    assert result is not config_file.DEADLINE_REGIONS
+
+
+def test_deadline_regions_matches_authoritative_aws_list():
+    """
+    Pins DEADLINE_REGIONS to the AWS Deadline Cloud "Service endpoints" table at
+    https://docs.aws.amazon.com/general/latest/gr/deadlinecloud.html
+    (commercial regions, reconciled 2026-06-08).
+
+    If AWS adds/removes a Deadline Cloud region, update both that table's transcription
+    here and the DEADLINE_REGIONS constant so the curated fallback doesn't drift (stale
+    entries cause spurious endpoint-connect warnings during the list-farms fan-out).
+    """
+    expected = {
+        "us-east-1",
+        "us-east-2",
+        "us-west-2",
+        "ap-northeast-1",
+        "ap-northeast-2",
+        "ap-southeast-1",
+        "ap-southeast-2",
+        "eu-central-1",
+        "eu-west-1",
+        "eu-west-2",
+    }
+    assert set(config_file.DEADLINE_REGIONS) == expected
+    # No duplicates in the curated list.
+    assert len(config_file.DEADLINE_REGIONS) == len(set(config_file.DEADLINE_REGIONS))
+
+
+def test_farm_region_depends_on_farm_id(fresh_deadline_config):
+    """defaults.farm_region is stored per-farm (depends on defaults.farm_id)."""
+    # Set a farm region for the default (empty) farm id.
+    config.set_setting("defaults.farm_id", "farm-A")
+    config.set_setting("defaults.farm_region", "us-west-2")
+    assert config.get_setting("defaults.farm_region") == "us-west-2"
+
+    # Switching to a different farm id yields the default (empty) region.
+    config.set_setting("defaults.farm_id", "farm-B")
+    assert config.get_setting("defaults.farm_region") == ""
+    config.set_setting("defaults.farm_region", "eu-west-1")
+    assert config.get_setting("defaults.farm_region") == "eu-west-1"
+
+    # Switching back to farm-A restores its region.
+    config.set_setting("defaults.farm_id", "farm-A")
+    assert config.get_setting("defaults.farm_region") == "us-west-2"

--- a/test/unit/deadline_client/config/test_config_file.py
+++ b/test/unit/deadline_client/config/test_config_file.py
@@ -394,6 +394,28 @@ def test_get_deadline_regions_config_override(fresh_deadline_config):
     assert result == ["eu-central-1", "ca-central-1"]
 
 
+def test_get_deadline_regions_honors_passed_config(fresh_deadline_config):
+    """
+    An explicit ``config`` argument's settings.deadline_regions is honored, not the global
+    on-disk config. Pins the fix where get_deadline_regions ignored a passed-in config (so a
+    CLI --profile override that lives only in memory was silently dropped from the fan-out).
+    """
+    from configparser import ConfigParser
+
+    # Global/on-disk config says one thing...
+    config.set_setting("settings.deadline_regions", "us-east-1")
+    # ...but an in-memory config passed explicitly says another.
+    in_memory = ConfigParser()
+    config.set_setting("settings.deadline_regions", "eu-central-1, ca-central-1", config=in_memory)
+
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("DEADLINE_CLOUD_REGIONS", None)
+        result = config_file.get_deadline_regions(config=in_memory)
+
+    # The passed config wins over the global one.
+    assert result == ["eu-central-1", "ca-central-1"]
+
+
 def test_get_deadline_regions_blank_overrides_fall_through(fresh_deadline_config):
     """Blank/whitespace-only env var and config setting fall through to the curated list."""
     config.set_setting("settings.deadline_regions", "   ")

--- a/test/unit/deadline_client/config/test_config_multi_region_compat.py
+++ b/test/unit/deadline_client/config/test_config_multi_region_compat.py
@@ -339,11 +339,12 @@ def test_list_farms_with_endpoint_override_scans_single_region(
 
     with patch.dict(os.environ, {"AWS_ENDPOINT_URL_DEADLINE": "https://override.test/deadline"}):
         os.environ.pop("DEADLINE_CLOUD_REGIONS", None)
-        with patch.object(
-            _list_apis, "get_boto3_client", side_effect=fake_get_boto3_client
-        ), patch.object(_list_apis, "get_boto3_session", return_value=mock_session), patch.object(
-            _list_apis.config_file, "get_deadline_regions"
-        ) as regions_mock, patch.object(_list_apis, "_apply_principal_id_filter"):
+        with (
+            patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_boto3_client),
+            patch.object(_list_apis, "get_boto3_session", return_value=mock_session),
+            patch.object(_list_apis.config_file, "get_deadline_regions") as regions_mock,
+            patch.object(_list_apis, "_apply_principal_id_filter"),
+        ):
             result = _list_apis.list_farms()
 
     # FIXED BEHAVIOR: the override collapses the fan-out to a single-region scan.
@@ -369,9 +370,10 @@ def test_fanout_queries_each_region_independently(fresh_deadline_config):
         client.list_farms.return_value = {"farms": [{"farmId": f"farm-{region}"}]}
         return client
 
-    with patch.object(
-        _list_apis, "get_boto3_client", side_effect=fake_get_boto3_client
-    ), patch.object(_list_apis, "_apply_principal_id_filter"):
+    with (
+        patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_boto3_client),
+        patch.object(_list_apis, "_apply_principal_id_filter"),
+    ):
         results = list(_list_apis._iter_farms_by_region(regions=regions))
 
     # A distinct client was built for each region.

--- a/test/unit/deadline_client/config/test_config_multi_region_compat.py
+++ b/test/unit/deadline_client/config/test_config_multi_region_compat.py
@@ -1,0 +1,409 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Forwards/backwards compatibility tests for the multi-region config changes.
+
+The multi-region feature adds two settings to ``~/.deadline/config``:
+  - ``defaults.farm_region`` (per-farm; depends on ``defaults.farm_id``)
+  - ``settings.deadline_regions`` (global override of the fan-out region set)
+
+Both are purely additive with empty defaults, so:
+  - An OLD client reading a NEW config must keep working (and must not destroy the
+    new keys when it rewrites the file).
+  - A NEW client reading an OLD config (no farm_region) must behave exactly as the
+    single-region client did, falling back to the session/profile region.
+
+These tests pin down those guarantees and the edge cases around them, including the
+external-tool (Deadline Cloud Monitor) rewrite path and the ``AWS_ENDPOINT_URL_DEADLINE``
+override interaction with the region fan-out.
+"""
+
+import os
+from configparser import ConfigParser
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from deadline.client import config
+from deadline.client.config import config_file
+from deadline.client.api import _list_apis
+from deadline.client.api._session import _resolve_region
+from deadline.client.exceptions import DeadlineOperationError
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_raw_config(path: str, contents: str) -> None:
+    """
+    Writes verbatim INI contents to the config file at ``path`` and forces the next
+    read to come from disk.
+
+    read_config() caches by mtime, so a rewrite within the same filesystem mtime tick
+    could otherwise return stale cached content (and mask the very compatibility behavior
+    these tests check). Resetting the cached mtime makes the re-read deterministic.
+    """
+    with open(path, "w", encoding="utf8") as fh:
+        fh.write(contents)
+    # Clear the mtime cache so the next read_config() reparses the file from disk.
+    setattr(config_file, "__config_mtime", None)
+    config_file.read_config()
+
+
+# A realistic OLD-format config produced by a pre-multi-region client / Deadline Cloud
+# Monitor: a monitor profile with credentials metadata, a default farm + queue, and
+# NO farm_region / deadline_regions keys anywhere.
+_OLD_FORMAT_CONFIG = """\
+[defaults]
+aws_profile_name = sandbox-us-east-1
+
+[telemetry]
+identifier = 00000000-0000-0000-0000-000000000000
+
+[profile-sandbox-us-east-1]
+monitor_id = monitor-abc123
+user_id = user-abc
+identity_store_id = d-1234567890
+
+[profile-sandbox-us-east-1 defaults]
+farm_id = farm-OLDFARM0000000000000000000001
+
+[profile-sandbox-us-east-1 farm-OLDFARM0000000000000000000001 defaults]
+queue_id = queue-OLDQUEUE000000000000000000001
+"""
+
+
+# ---------------------------------------------------------------------------
+# 1. Data preservation: new keys survive an old-client rewrite
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_future_keys_survive_roundtrip(fresh_deadline_config):
+    """
+    Backwards compat: a client that does not know about a key must not drop it when it
+    reads and rewrites the config. ConfigParser preserves unknown keys/sections, which
+    is what keeps an OLD client from destroying farm_region written by a NEW client.
+    """
+    _write_raw_config(
+        fresh_deadline_config,
+        "[profile-p farm-abc defaults]\n"
+        "farm_region = us-west-2\n"
+        "queue_id = queue-1\n"
+        "a_future_key = some-future-value\n",
+    )
+
+    # Simulate an arbitrary client touching an unrelated setting and saving the file.
+    config.set_setting("defaults.aws_profile_name", "p")
+
+    raw = open(fresh_deadline_config, encoding="utf8").read()
+    assert "farm_region = us-west-2" in raw
+    assert "a_future_key = some-future-value" in raw
+    assert "queue_id = queue-1" in raw
+
+
+def test_old_client_rewrite_preserves_farm_region(fresh_deadline_config):
+    """
+    Backwards compat (the core guarantee): simulate an OLD client that has no concept of
+    farm_region by deleting it from the in-memory SETTINGS, then have it read the config
+    and write an unrelated change. The farm_region line must remain intact.
+    """
+    _write_raw_config(
+        fresh_deadline_config,
+        "[profile-p defaults]\n"
+        "farm_id = farm-abc\n"
+        "[profile-p farm-abc defaults]\n"
+        "farm_region = eu-west-1\n",
+    )
+
+    # Build an "old schema" SETTINGS dict without the multi-region keys.
+    old_settings = {
+        k: v
+        for k, v in config_file.SETTINGS.items()
+        if k not in ("defaults.farm_region", "settings.deadline_regions")
+    }
+    with patch.object(config_file, "SETTINGS", old_settings):
+        # The old client doesn't know farm_region exists...
+        with pytest.raises(DeadlineOperationError):
+            config_file.get_setting("defaults.farm_region")
+        # ...but it can still operate on settings it does know, and rewrite the file.
+        config.set_setting("defaults.aws_profile_name", "p")
+
+    # After the old client rewrote the file, the new key is still there.
+    raw = open(fresh_deadline_config, encoding="utf8").read()
+    assert "farm_region = eu-west-1" in raw
+
+
+# ---------------------------------------------------------------------------
+# 2. Deadline Cloud Monitor-style rewrite (external tool, separate release)
+# ---------------------------------------------------------------------------
+
+
+def test_dcm_style_credential_write_preserves_farm_region(fresh_deadline_config):
+    """
+    Deadline Cloud Monitor writes credential metadata (monitor_id/user_id) into a profile
+    section. Simulate that write path (via ConfigParser, as DCM-equivalent tooling would)
+    and assert it does not clobber a farm_region stored in a child section.
+    """
+    _write_raw_config(
+        fresh_deadline_config,
+        "[profile-mon defaults]\n"
+        "farm_id = farm-xyz\n"
+        "[profile-mon farm-xyz defaults]\n"
+        "farm_region = ap-south-1\n"
+        "queue_id = queue-9\n",
+    )
+
+    # DCM-equivalent: read the whole file, add credential metadata to the profile
+    # section, write it back.
+    parser = ConfigParser()
+    parser.read(fresh_deadline_config)
+    section = "profile-mon"
+    if section not in parser:
+        parser[section] = {}
+    parser[section]["monitor_id"] = "monitor-xyz"
+    parser[section]["user_id"] = "user-1"
+    parser[section]["identity_store_id"] = "d-99"
+    with open(fresh_deadline_config, "w", encoding="utf8") as fh:
+        parser.write(fh)
+
+    # A new client reads the rewritten file: farm_region survived, and is resolvable.
+    config_file.read_config()
+    config.set_setting("defaults.aws_profile_name", "mon")
+    assert config.get_setting("defaults.farm_region") == "ap-south-1"
+
+
+# ---------------------------------------------------------------------------
+# 3. Forward compat: NEW client reading an OLD-format config
+# ---------------------------------------------------------------------------
+
+
+def test_new_client_reads_old_format_config_without_error(fresh_deadline_config):
+    """
+    Forward compat: a config with no farm_region / deadline_regions keys (old format)
+    must be fully readable by the new client, and every known setting resolves to a value
+    (defaults for the new ones) without raising.
+    """
+    _write_raw_config(fresh_deadline_config, _OLD_FORMAT_CONFIG)
+
+    # All settings, including the new ones, resolve.
+    for setting_name in config_file.SETTINGS.keys():
+        # Should not raise.
+        config_file.get_setting(setting_name)
+
+    # The new settings resolve to their (empty) defaults on an old config.
+    assert config.get_setting("defaults.farm_region") == ""
+    assert config.get_setting("settings.deadline_regions") == ""
+    # Existing values are still read correctly.
+    assert config.get_setting("defaults.farm_id") == "farm-OLDFARM0000000000000000000001"
+    assert config.get_setting("defaults.queue_id") == "queue-OLDQUEUE000000000000000000001"
+
+
+def test_old_config_resolves_region_to_none(fresh_deadline_config):
+    """
+    Forward compat: with an old config (farm set, no farm_region), region resolution
+    returns None so the client uses the session/profile/AWS-default region exactly as the
+    single-region client did.
+    """
+    _write_raw_config(fresh_deadline_config, _OLD_FORMAT_CONFIG)
+    assert _resolve_region(config=config_file.read_config()) is None
+
+
+# ---------------------------------------------------------------------------
+# 4. Resolution precedence / fallback matrix
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_region_falls_back_to_none_when_farm_section_absent(fresh_deadline_config):
+    """
+    A default farm_id whose farm section does not exist at all (so it has no farm_region)
+    must resolve to None, not raise.
+    """
+    config.set_setting("defaults.farm_id", "farm-no-section")
+    # No farm_region was ever written for this farm.
+    assert _resolve_region() is None
+
+
+def test_resolve_region_is_per_farm_no_stale_leak(fresh_deadline_config):
+    """
+    farm_region is keyed per farm. Switching the default farm_id must not leak the
+    previous farm's region; a farm without its own region resolves to None.
+    """
+    config.set_setting("defaults.farm_id", "farm-west")
+    config.set_setting("defaults.farm_region", "us-west-2")
+    assert _resolve_region() == "us-west-2"
+
+    # Switch to a farm that has no stored region -> must NOT inherit us-west-2.
+    config.set_setting("defaults.farm_id", "farm-unknown")
+    assert _resolve_region() is None
+
+    # And a third farm with its own region resolves to that region.
+    config.set_setting("defaults.farm_id", "farm-eu")
+    config.set_setting("defaults.farm_region", "eu-west-1")
+    assert _resolve_region() == "eu-west-1"
+
+    # Switching back to the first farm restores its region (no data was lost).
+    config.set_setting("defaults.farm_id", "farm-west")
+    assert _resolve_region() == "us-west-2"
+
+
+def test_explicit_region_overrides_stored_farm_region(fresh_deadline_config):
+    """Explicit region argument beats a stored farm_region beats None."""
+    config.set_setting("defaults.farm_id", "farm-x")
+    config.set_setting("defaults.farm_region", "us-east-1")
+    assert _resolve_region(region="eu-central-1") == "eu-central-1"
+
+
+def test_resolve_region_uses_passed_farm_id_not_default(fresh_deadline_config):
+    """
+    When an explicit farm_id is passed, _resolve_region resolves THAT farm's stored
+    region, not the default farm's. farm_region is keyed per farm, so a programmatic
+    caller working with a non-default farm must get the right region.
+    """
+    # Default farm is in us-west-2; a different (non-default) farm is in eu-west-1.
+    config.set_setting("defaults.farm_id", "farm-default")
+    config.set_setting("defaults.farm_region", "us-west-2")
+    config.set_setting("defaults.farm_id", "farm-other")
+    config.set_setting("defaults.farm_region", "eu-west-1")
+    # Restore the default farm so the default-farm lookup would yield us-west-2.
+    config.set_setting("defaults.farm_id", "farm-default")
+
+    # Resolving for the non-default farm must yield ITS region, not the default's.
+    assert _resolve_region(farm_id="farm-other") == "eu-west-1"
+    # And for a farm with no stored region, None (not the default farm's region).
+    assert _resolve_region(farm_id="farm-no-region") is None
+    # Explicit region still wins over the per-farm lookup.
+    assert _resolve_region(region="ap-south-1", farm_id="farm-other") == "ap-south-1"
+
+
+def test_resolve_region_default_farm_when_no_farm_id_passed(fresh_deadline_config):
+    """With no farm_id passed, _resolve_region falls back to the default farm's region."""
+    config.set_setting("defaults.farm_id", "farm-default")
+    config.set_setting("defaults.farm_region", "us-west-2")
+    assert _resolve_region() == "us-west-2"
+
+
+# ---------------------------------------------------------------------------
+# 5. deadline_regions override hygiene
+# ---------------------------------------------------------------------------
+
+
+def test_deadline_regions_override_blank_and_whitespace(fresh_deadline_config):
+    """
+    A blank or whitespace-only settings.deadline_regions must not be treated as a real
+    override; resolution should fall through to the curated DEADLINE_REGIONS list.
+    """
+    config.set_setting("settings.deadline_regions", "   ")
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("DEADLINE_CLOUD_REGIONS", None)
+        result = config_file.get_deadline_regions()
+    # Falls back to the curated constant, not an empty/garbage list.
+    assert result == config_file.DEADLINE_REGIONS
+
+
+def test_deadline_regions_env_blank_falls_through(fresh_deadline_config):
+    """A blank DEADLINE_CLOUD_REGIONS env var must not zero out the region set."""
+    config.set_setting("settings.deadline_regions", "eu-west-1,us-east-1")
+    with patch.dict(os.environ, {"DEADLINE_CLOUD_REGIONS": "  "}):
+        result = config_file.get_deadline_regions()
+    # Falls through to the config override (not an empty list).
+    assert result == ["eu-west-1", "us-east-1"]
+
+
+# ---------------------------------------------------------------------------
+# 6. AWS_ENDPOINT_URL_DEADLINE interaction with the fan-out
+# ---------------------------------------------------------------------------
+
+
+def test_list_farms_with_endpoint_override_scans_single_region(
+    fresh_deadline_config,
+):
+    """
+    When AWS_ENDPOINT_URL_DEADLINE is set, a multi-region fan-out is meaningless (boto3
+    honors the override verbatim for every client, so N region-scoped clients would all
+    point at the SAME endpoint, querying it N times as N different "regions"). list_farms
+    suppresses the fan-out and scans only the single session/profile default region:
+    get_deadline_regions is NOT consulted, and exactly one client is built.
+    """
+    built_for_regions = []
+
+    def fake_get_boto3_client(service_name, config=None, region=None):
+        built_for_regions.append(region)
+        client = MagicMock()
+        client.list_farms.return_value = {"farms": [{"farmId": "farm-only"}]}
+        return client
+
+    mock_session = MagicMock()
+    mock_session.region_name = "us-east-1"
+
+    with patch.dict(os.environ, {"AWS_ENDPOINT_URL_DEADLINE": "https://override.test/deadline"}):
+        os.environ.pop("DEADLINE_CLOUD_REGIONS", None)
+        with patch.object(
+            _list_apis, "get_boto3_client", side_effect=fake_get_boto3_client
+        ), patch.object(_list_apis, "get_boto3_session", return_value=mock_session), patch.object(
+            _list_apis.config_file, "get_deadline_regions"
+        ) as regions_mock, patch.object(_list_apis, "_apply_principal_id_filter"):
+            result = _list_apis.list_farms()
+
+    # FIXED BEHAVIOR: the override collapses the fan-out to a single-region scan.
+    regions_mock.assert_not_called()
+    assert built_for_regions == ["us-east-1"]
+    # The single region's farm comes back, tagged with the session region.
+    assert [f["region"] for f in result["farms"]] == ["us-east-1"]
+
+
+def test_fanout_queries_each_region_independently(fresh_deadline_config):
+    """
+    The fan-out builds a separate region-scoped client per region (never shares one
+    client across regions), and tags each farm with its origin region. This is the
+    property that makes per-region results meaningful.
+    """
+    regions = ["us-west-2", "eu-west-1"]
+
+    created = []
+
+    def fake_get_boto3_client(service_name, config=None, region=None):
+        created.append(region)
+        client = MagicMock()
+        client.list_farms.return_value = {"farms": [{"farmId": f"farm-{region}"}]}
+        return client
+
+    with patch.object(
+        _list_apis, "get_boto3_client", side_effect=fake_get_boto3_client
+    ), patch.object(_list_apis, "_apply_principal_id_filter"):
+        results = list(_list_apis._iter_farms_by_region(regions=regions))
+
+    # A distinct client was built for each region.
+    assert sorted(created) == sorted(regions)
+    # Each region's farm is tagged with its origin region.
+    by_region = {region: payload for region, payload, exc in results}
+    west = by_region["us-west-2"]
+    east = by_region["eu-west-1"]
+    assert west is not None and east is not None
+    assert west[0]["farmId"] == "farm-us-west-2"
+    assert west[0]["region"] == "us-west-2"
+    assert east[0]["region"] == "eu-west-1"
+
+
+# ---------------------------------------------------------------------------
+# 7. SETTINGS introspection drift
+# ---------------------------------------------------------------------------
+
+
+def test_new_settings_are_registered_and_discoverable(fresh_deadline_config):
+    """
+    Anything that enumerates SETTINGS (config show, external tooling) must see the new
+    settings with their documented metadata so it doesn't choke or mis-render them.
+    """
+    assert "defaults.farm_region" in config_file.SETTINGS
+    assert "settings.deadline_regions" in config_file.SETTINGS
+
+    farm_region = config_file.SETTINGS["defaults.farm_region"]
+    assert farm_region["default"] == ""
+    assert farm_region["depend"] == "defaults.farm_id"
+    assert "description" in farm_region
+
+    deadline_regions = config_file.SETTINGS["settings.deadline_regions"]
+    assert deadline_regions["default"] == ""
+    assert "description" in deadline_regions

--- a/test/unit/deadline_client/ui/controllers/test_async_runner.py
+++ b/test/unit/deadline_client/ui/controllers/test_async_runner.py
@@ -109,6 +109,52 @@ class TestAsyncTaskRunner:
 
         assert result_received[0] == {"data": "test"}
 
+    def test_run_streaming_emits_progress_per_item(self, qtbot):
+        """run_streaming delivers each yielded item to on_progress, then on_finished."""
+        runner = AsyncTaskRunner()
+
+        progress_received = []
+        finished_called = []
+
+        def gen():
+            yield "a"
+            yield "b"
+            yield "c"
+
+        runner.run_streaming(
+            "stream_op",
+            gen,
+            on_progress=lambda item: progress_received.append(item),
+            on_finished=lambda: finished_called.append(True),
+        )
+
+        qtbot.waitUntil(lambda: len(finished_called) > 0, timeout=2000)
+
+        assert progress_received == ["a", "b", "c"]
+        assert finished_called == [True]
+
+    def test_run_streaming_calls_on_error(self, qtbot):
+        """run_streaming routes a generator exception to on_error."""
+        runner = AsyncTaskRunner()
+
+        error_received = []
+        test_error = ValueError("boom")
+
+        def gen():
+            yield "a"
+            raise test_error
+
+        runner.run_streaming(
+            "stream_op",
+            gen,
+            on_progress=lambda item: None,
+            on_error=lambda e: error_received.append(e),
+        )
+
+        qtbot.waitUntil(lambda: len(error_received) > 0, timeout=2000)
+
+        assert error_received[0] is test_error
+
     def test_run_calls_on_error_callback(self, qtbot):
         """Test that on_error callback is called on exception."""
         runner = AsyncTaskRunner()

--- a/test/unit/deadline_client/ui/controllers/test_async_task.py
+++ b/test/unit/deadline_client/ui/controllers/test_async_task.py
@@ -8,7 +8,11 @@ import pytest
 from unittest.mock import Mock
 
 try:
-    from deadline.client.ui.controllers._async_task import AsyncTask, WorkerSignals
+    from deadline.client.ui.controllers._async_task import (
+        AsyncTask,
+        StreamingAsyncTask,
+        WorkerSignals,
+    )
 except ImportError:
     pytest.importorskip("deadline.client.ui.controllers._async_task")
 
@@ -209,3 +213,111 @@ class TestAsyncTask:
         task = AsyncTask(fn)
 
         assert task.autoDelete() is True
+
+
+class TestStreamingAsyncTask:
+    """Tests for StreamingAsyncTask, the progressive-result variant of AsyncTask."""
+
+    def test_run_emits_progress_per_item_then_terminal_result(self, qtbot):
+        """Each yielded item is emitted via progress; a single terminal result follows."""
+        task = StreamingAsyncTask(lambda: iter(["a", "b", "c"]))
+
+        progress = []
+        results = []
+        finished = []
+        task.signals.progress.connect(lambda x: progress.append(x))
+        task.signals.result.connect(lambda x: results.append(x))
+        task.signals.finished.connect(lambda: finished.append(True))
+
+        task.run()
+
+        assert progress == ["a", "b", "c"]
+        # Terminal result carries no aggregate payload (progress already delivered items).
+        assert results == [None]
+        assert finished == [True]
+
+    def test_run_does_not_execute_if_canceled_before_start(self, qtbot):
+        """A task canceled before start emits nothing and does not consume the generator."""
+        consumed = []
+
+        def gen():
+            consumed.append("started")
+            yield "a"
+
+        task = StreamingAsyncTask(gen)
+
+        progress = []
+        task.signals.progress.connect(lambda x: progress.append(x))
+
+        task.cancel()
+        task.run()
+
+        assert consumed == []
+        assert progress == []
+
+    def test_run_stops_emitting_progress_after_cancel_mid_stream(self, qtbot):
+        """
+        The in-loop cancellation guard: once canceled mid-stream, no further progress
+        items and no terminal result are emitted (no stale partial updates after a
+        superseded refresh). This directly exercises the per-item _is_canceled check.
+        """
+        progress = []
+        results = []
+        finished = []
+
+        def gen():
+            yield "a"
+            # Cancel after the first item is yielded; the loop must not emit "b"/"c".
+            task.cancel()
+            yield "b"
+            yield "c"
+
+        task = StreamingAsyncTask(gen)
+        task.signals.progress.connect(lambda x: progress.append(x))
+        task.signals.result.connect(lambda x: results.append(x))
+        task.signals.finished.connect(lambda: finished.append(True))
+
+        task.run()
+
+        # Only the item yielded before cancellation was delivered.
+        assert progress == ["a"]
+        # No terminal result and no finished emission after cancellation.
+        assert results == []
+        assert finished == []
+
+    def test_run_does_not_emit_error_if_canceled_during_execution(self, qtbot):
+        """A generator that raises after cancellation must not emit an error signal."""
+
+        def gen():
+            yield "a"
+            task.cancel()
+            raise ValueError("boom")
+
+        task = StreamingAsyncTask(gen)
+
+        errors = []
+        task.signals.error.connect(lambda e: errors.append(e))
+
+        task.run()
+
+        assert errors == []
+
+    def test_run_emits_error_when_generator_raises(self, qtbot):
+        """A generator that raises (without cancellation) routes to the error signal."""
+        test_error = ValueError("boom")
+
+        def gen():
+            yield "a"
+            raise test_error
+
+        task = StreamingAsyncTask(gen)
+
+        progress = []
+        errors = []
+        task.signals.progress.connect(lambda x: progress.append(x))
+        task.signals.error.connect(lambda e: errors.append(e))
+
+        task.run()
+
+        assert progress == ["a"]
+        assert errors == [test_error]

--- a/test/unit/deadline_client/ui/controllers/test_deadline_controller.py
+++ b/test/unit/deadline_client/ui/controllers/test_deadline_controller.py
@@ -8,6 +8,8 @@ import pytest
 from unittest.mock import patch
 from configparser import ConfigParser
 
+from deadline.client.config import config_file
+
 try:
     from deadline.client.ui.controllers._deadline_controller import DeadlineUIController
     from deadline.client.ui.controllers._thread_pool import DeadlineThreadPool
@@ -91,12 +93,12 @@ class TestDeadlineUIController:
 
         assert controller.current_queue_id == ""
 
-    @patch("deadline.client.ui.controllers._deadline_controller.api")
-    def test_refresh_farms_emits_loading_signal(self, mock_api, qtbot):
+    @patch("deadline.client.ui.controllers._deadline_controller._iter_farms_by_region")
+    def test_refresh_farms_emits_loading_signal(self, mock_iter, qtbot):
         """Test that refresh_farms emits farms_loading signal."""
         controller = DeadlineUIController.getInstance()
 
-        mock_api.list_farms.return_value = {"farms": []}
+        mock_iter.side_effect = lambda config=None: iter([])
 
         loading_states = []
         controller.farms_loading.connect(lambda x: loading_states.append(x), _QueuedConnection)
@@ -109,39 +111,145 @@ class TestDeadlineUIController:
         assert loading_states[0] is True  # Loading started
         assert loading_states[-1] is False  # Loading finished
 
-    @patch("deadline.client.ui.controllers._deadline_controller.api")
-    def test_refresh_farms_emits_farms_updated(self, mock_api, qtbot):
-        """Test that refresh_farms emits farms_updated with farm list."""
+    @patch("deadline.client.ui.controllers._deadline_controller._iter_farms_by_region")
+    def test_refresh_farms_appends_farms_per_region(self, mock_iter, qtbot):
+        """refresh_farms streams farms via farms_appended, one emit per region."""
         controller = DeadlineUIController.getInstance()
 
-        mock_api.list_farms.return_value = {
-            "farms": [
-                {"displayName": "Farm A", "farmId": "farm-a"},
-                {"displayName": "Farm B", "farmId": "farm-b"},
-            ]
-        }
+        # Two regions complete (in this order). Each farm option is a
+        # (label, farm_id, region) tuple with the label region-first.
+        def fake_iter(config=None):
+            yield (
+                "us-west-2",
+                [{"displayName": "Farm A", "farmId": "farm-a", "region": "us-west-2"}],
+                None,
+            )
+            yield (
+                "eu-west-1",
+                [{"displayName": "Farm B", "farmId": "farm-b", "region": "eu-west-1"}],
+                None,
+            )
 
-        farms_received = []
-        controller.farms_updated.connect(lambda x: farms_received.append(x), _QueuedConnection)
+        mock_iter.side_effect = lambda config=None: fake_iter()
+
+        cleared = []
+        appended = []
+        controller.farms_updated.connect(lambda x: cleared.append(x), _QueuedConnection)
+        controller.farms_appended.connect(lambda x: appended.append(x), _QueuedConnection)
 
         controller.refresh_farms()
 
-        qtbot.waitUntil(lambda: len(farms_received) > 0, timeout=2000)
+        # One clear (farms_updated([])) up front, then one append per region.
+        qtbot.waitUntil(lambda: len(appended) >= 2, timeout=2000)
 
-        assert len(farms_received) == 1
-        farms = farms_received[0]
-        assert len(farms) == 2
-        # Should be sorted by name
-        # Note: Qt signals may convert tuples to lists
-        assert list(farms[0]) == ["Farm A", "farm-a"]
-        assert list(farms[1]) == ["Farm B", "farm-b"]
+        assert cleared[0] == []
+        # Each region produced its own append batch (incremental).
+        assert len(appended) == 2
+        all_options = [tuple(opt) for batch in appended for opt in batch]
+        labels = {opt[0] for opt in all_options}
+        assert labels == {"(us-west-2) Farm A", "(eu-west-1) Farm B"}
+        # The selected farm's region can be resolved from the controller map.
+        assert controller.region_for_farm("farm-a") == "us-west-2"
+        assert controller.region_for_farm("farm-b") == "eu-west-1"
 
-    @patch("deadline.client.ui.controllers._deadline_controller.api")
-    def test_refresh_farms_handles_error(self, mock_api, qtbot):
-        """Test that refresh_farms handles API errors gracefully."""
+    @patch("deadline.client.ui.controllers._deadline_controller._iter_farms_by_region")
+    def test_refresh_farms_label_region_first(self, mock_iter, qtbot):
+        """Farm labels are formatted region-first: '(region) displayName'."""
         controller = DeadlineUIController.getInstance()
 
-        mock_api.list_farms.side_effect = Exception("API Error")
+        def fake_iter(config=None):
+            yield (
+                "ap-southeast-2",
+                [{"displayName": "My Farm", "farmId": "farm-x", "region": "ap-southeast-2"}],
+                None,
+            )
+
+        mock_iter.side_effect = lambda config=None: fake_iter()
+
+        appended = []
+        controller.farms_appended.connect(lambda x: appended.append(x), _QueuedConnection)
+
+        controller.refresh_farms()
+        qtbot.waitUntil(lambda: len(appended) >= 1, timeout=2000)
+
+        assert tuple(appended[0][0]) == ("(ap-southeast-2) My Farm", "farm-x", "ap-southeast-2")
+
+    @patch("deadline.client.ui.controllers._deadline_controller._iter_farms_by_region")
+    def test_refresh_farms_failing_region_is_non_blocking(self, mock_iter, qtbot):
+        """A failing region emits a warning; surviving regions' farms still append."""
+        controller = DeadlineUIController.getInstance()
+
+        def fake_iter(config=None):
+            yield ("us-east-1", None, Exception("region opt-in required"))
+            yield (
+                "us-west-2",
+                [{"displayName": "Farm A", "farmId": "farm-a", "region": "us-west-2"}],
+                None,
+            )
+
+        mock_iter.side_effect = lambda config=None: fake_iter()
+
+        appended = []
+        warnings = []
+        errors = []
+        controller.farms_appended.connect(lambda x: appended.append(x), _QueuedConnection)
+        controller.farm_region_warning.connect(
+            lambda region, e: warnings.append((region, e)), _QueuedConnection
+        )
+        controller.operation_failed.connect(
+            lambda key, e: errors.append((key, e)), _QueuedConnection
+        )
+
+        controller.refresh_farms()
+        qtbot.waitUntil(lambda: len(appended) >= 1, timeout=2000)
+        qtbot.waitUntil(lambda: len(warnings) >= 1, timeout=2000)
+        # Let the stream finish so we can assert no hard error fired.
+        qtbot.wait(200)
+
+        # Surviving region's farm was appended.
+        assert tuple(appended[0][0]) == ("(us-west-2) Farm A", "farm-a", "us-west-2")
+        # Non-blocking warning for the failing region.
+        assert warnings[0][0] == "us-east-1"
+        # No hard failure since at least one region succeeded.
+        assert errors == []
+
+    @patch("deadline.client.ui.controllers._deadline_controller._iter_farms_by_region")
+    def test_refresh_farms_all_regions_fail_surfaces_error(self, mock_iter, qtbot):
+        """When every region fails, operation_failed is emitted (hard error)."""
+        controller = DeadlineUIController.getInstance()
+
+        def fake_iter(config=None):
+            yield ("us-east-1", None, Exception("boom"))
+            yield ("us-west-2", None, Exception("boom2"))
+
+        mock_iter.side_effect = lambda config=None: fake_iter()
+
+        warnings = []
+        errors = []
+        controller.farm_region_warning.connect(
+            lambda region, e: warnings.append((region, e)), _QueuedConnection
+        )
+        controller.operation_failed.connect(
+            lambda key, e: errors.append((key, e)), _QueuedConnection
+        )
+
+        controller.refresh_farms()
+        qtbot.waitUntil(lambda: len(errors) >= 1, timeout=2000)
+
+        # A warning per failing region, plus a single terminal hard error.
+        assert len(warnings) == 2
+        assert errors[0][0] == "list_farms"
+
+    @patch("deadline.client.ui.controllers._deadline_controller._iter_farms_by_region")
+    def test_refresh_farms_fatal_error_emits_empty(self, mock_iter, qtbot):
+        """A generator that raises outright routes through the error path."""
+        controller = DeadlineUIController.getInstance()
+
+        def fake_iter(config=None):
+            raise Exception("API Error")
+            yield  # pragma: no cover
+
+        mock_iter.side_effect = lambda config=None: fake_iter()
 
         farms_received = []
         errors_received = []
@@ -152,12 +260,10 @@ class TestDeadlineUIController:
 
         controller.refresh_farms()
 
-        qtbot.waitUntil(lambda: len(farms_received) > 0, timeout=2000)
         qtbot.waitUntil(lambda: len(errors_received) > 0, timeout=2000)
 
-        # Should emit empty list on error
-        assert farms_received[0] == []
-        # Should emit error signal
+        # farms_updated([]) is emitted to clear the box (once up front, once on error).
+        assert farms_received[-1] == []
         assert len(errors_received) == 1
 
     @patch("deadline.client.ui.controllers._deadline_controller.api")
@@ -197,6 +303,86 @@ class TestDeadlineUIController:
         mock_api.list_queues.assert_called_once()
         # Note: Qt signals may convert tuples to lists
         assert list(queues_received[0][0]) == ["Queue 1", "queue-1"]
+
+    @patch("deadline.client.ui.controllers._deadline_controller.api")
+    def test_refresh_queues_uses_selected_farm_region(self, mock_api, qtbot):
+        """refresh_queues passes the farm's discovered region to api.list_queues."""
+        controller = DeadlineUIController.getInstance()
+
+        # Seed the farm->region map as if a multi-region refresh already ran.
+        controller._farm_regions = {"farm-123": "eu-central-1"}
+        mock_api.list_queues.return_value = {"queues": []}
+
+        queues_received = []
+        controller.queues_updated.connect(lambda x: queues_received.append(x), _QueuedConnection)
+
+        controller.refresh_queues(farm_id="farm-123")
+
+        qtbot.waitUntil(lambda: len(queues_received) > 0, timeout=2000)
+
+        _, kwargs = mock_api.list_queues.call_args
+        assert kwargs["farmId"] == "farm-123"
+        assert kwargs["region"] == "eu-central-1"
+
+    @patch("deadline.client.ui.controllers._deadline_controller.api")
+    def test_refresh_storage_profiles_uses_selected_farm_region(self, mock_api, qtbot):
+        """refresh_storage_profiles passes the farm's region to the api call."""
+        controller = DeadlineUIController.getInstance()
+
+        controller._farm_regions = {"farm-123": "ap-northeast-1"}
+        mock_api.list_storage_profiles_for_queue.return_value = {"storageProfiles": []}
+
+        received = []
+        controller.storage_profiles_updated.connect(lambda x: received.append(x), _QueuedConnection)
+
+        controller.refresh_storage_profiles(farm_id="farm-123", queue_id="queue-1")
+
+        qtbot.waitUntil(lambda: len(received) > 0, timeout=2000)
+
+        _, kwargs = mock_api.list_storage_profiles_for_queue.call_args
+        assert kwargs["farmId"] == "farm-123"
+        assert kwargs["queueId"] == "queue-1"
+        assert kwargs["region"] == "ap-northeast-1"
+
+    def test_region_for_farm_returns_observed_region(self, qtbot):
+        """region_for_farm returns the region observed while streaming, if known."""
+        controller = DeadlineUIController.getInstance()
+        controller._farm_regions = {"farm-123": "eu-central-1"}
+
+        assert controller.region_for_farm("farm-123") == "eu-central-1"
+
+    def test_region_for_farm_unknown_farm_resolves_per_farm_not_default(self, qtbot):
+        """
+        When a farm wasn't observed in the current session, region_for_farm must resolve
+        THAT farm's persisted region, not blindly return the default farm's region.
+
+        defaults.farm_region is keyed per-farm (depends on defaults.farm_id), so two farms
+        can have different stored regions. Selecting a non-default farm before a refresh has
+        populated _farm_regions must not leak the default farm's region.
+        """
+        controller = DeadlineUIController.getInstance()
+
+        config = ConfigParser()
+        # Store farm-default in us-west-2, then farm-other in eu-west-1 (per-farm sections).
+        config_file.set_setting("defaults.farm_id", "farm-default", config=config)
+        config_file.set_setting("defaults.farm_region", "us-west-2", config=config)
+        config_file.set_setting("defaults.farm_id", "farm-other", config=config)
+        config_file.set_setting("defaults.farm_region", "eu-west-1", config=config)
+        # Leave farm-default as the active default.
+        config_file.set_setting("defaults.farm_id", "farm-default", config=config)
+        controller.set_config(config)
+
+        # The default farm resolves to its own region.
+        assert controller.region_for_farm("farm-default") == "us-west-2"
+        # A non-default, unobserved farm resolves to ITS region, not the default's.
+        assert controller.region_for_farm("farm-other") == "eu-west-1"
+
+    def test_region_for_farm_unknown_returns_none_when_unset(self, qtbot):
+        """region_for_farm returns None for a farm with no observed or stored region."""
+        controller = DeadlineUIController.getInstance()
+        controller.set_config(ConfigParser())
+
+        assert controller.region_for_farm("farm-nope") is None
 
     @patch("deadline.client.ui.controllers._deadline_controller.api")
     def test_on_farm_selected_updates_current_farm(self, mock_api, qtbot):

--- a/test/unit/deadline_client/ui/dialogs/test_deadline_config_dialog.py
+++ b/test/unit/deadline_client/ui/dialogs/test_deadline_config_dialog.py
@@ -9,6 +9,9 @@ try:
     from deadline.client.ui.widgets._deadline_list_combo_boxes import (
         DeadlineFarmListComboBoxController,
     )
+    from deadline.client.ui.dialogs.deadline_config_dialog import (
+        DeadlineWorkstationConfigWidget,
+    )
 except ImportError:
     pytest.importorskip("deadline.client.ui.widgets._deadline_list_combo_boxes")
 
@@ -56,3 +59,35 @@ class TestDeadlineResourceListComboBoxController:
         widget.refresh_selected_id()
 
         assert widget.box.currentText() == "<none selected>"
+
+
+class TestFarmRegionPersistence:
+    """Tests that selecting a farm persists defaults.farm_region with defaults.farm_id."""
+
+    def test_default_farm_changed_persists_region(self):
+        """default_farm_changed records both farm_id and the farm's region in changes."""
+        # Use a lightweight stand-in (plain MagicMock auto-creates the instance
+        # attributes the method touches) so we don't construct the whole
+        # (boto3-backed) dialog; we only exercise the selection-persistence logic.
+        stub = MagicMock()
+        stub.changes = {}
+        stub.default_farm_box.box.itemData.return_value = "farm-a"
+        stub.default_farm_box.region_for_id.return_value = "us-west-2"
+
+        DeadlineWorkstationConfigWidget.default_farm_changed(stub, 0)
+
+        assert stub.changes["defaults.farm_id"] == "farm-a"
+        assert stub.changes["defaults.farm_region"] == "us-west-2"
+        # The queue id is cleared on farm change.
+        assert stub.changes["defaults.queue_id"] == ""
+        stub.default_farm_box.region_for_id.assert_called_once_with("farm-a")
+
+    def test_aws_profile_changed_clears_region(self):
+        """Switching AWS profile clears the persisted farm region."""
+        stub = MagicMock()
+        stub.changes = {}
+
+        DeadlineWorkstationConfigWidget.aws_profile_changed(stub, "other-profile")
+
+        assert stub.changes["defaults.farm_id"] == ""
+        assert stub.changes["defaults.farm_region"] == ""

--- a/test/unit/deadline_client/ui/gui/test_settings_dialogue.py
+++ b/test/unit/deadline_client/ui/gui/test_settings_dialogue.py
@@ -93,6 +93,22 @@ def mock_api(mock_backend):
                 ),
             )
         )
+
+        # The farm combo box now populates incrementally from the per-region
+        # streaming generator. Yield the mock backend's farms as a single
+        # "us-west-2" region so they surface with a (region) displayName label.
+        def _fake_iter_farms_by_region(config=None, regions=None, **kw):
+            farms = deadline_mock.list_farms(**{k: v for k, v in kw.items() if k != "config"})[
+                "farms"
+            ]
+            yield ("us-west-2", [{**farm, "region": "us-west-2"} for farm in farms], None)
+
+        stack.enter_context(
+            patch(
+                "deadline.client.ui.controllers._deadline_controller._iter_farms_by_region",
+                side_effect=_fake_iter_farms_by_region,
+            )
+        )
         stack.enter_context(
             patch(
                 "deadline.client.api.list_queues",
@@ -255,17 +271,19 @@ class TestSettingsDialogue:
         assert edit.directory_edit.isEnabled()
 
     def test_farm_dropdown_populated_from_backend(self, qtbot, config_widget):
-        """Verify farm dropdown gets populated when list is refreshed."""
+        """Verify farm dropdown gets populated incrementally when list is refreshed."""
         controller = DeadlineUIController.getInstance()
         combo = config_widget.default_farm_box.box
 
-        with qtbot.waitSignal(controller.farms_updated, timeout=5000):
+        # Farms now stream in per region via farms_appended.
+        with qtbot.waitSignal(controller.farms_appended, timeout=5000):
             controller.refresh_farms()
 
         QApplication.processEvents()
 
         items = [combo.itemText(i) for i in range(combo.count())]
-        assert "Test Farm" in items
+        # Label is region-first per the (region, farm_id) convention.
+        assert "(us-west-2) Test Farm" in items
 
     def test_queue_dropdown_populated_from_backend(self, qtbot, config_widget, mock_backend):
         """Verify queue dropdown gets populated for a given farm."""
@@ -363,13 +381,14 @@ class TestSettingsDialogue:
         config_widget.changes["defaults.queue_id"] = ""
         config_widget.refresh()
 
-        controller = DeadlineUIController.getInstance()
-
-        # Simulate the profile-change cascade entry point: farms get refreshed.
+        # Simulate the profile-change cascade entry point: farms get refreshed. Farms now
+        # stream in per region, and auto-select fires once the stream completes, so wait
+        # for the pending change to land rather than the initial clear emit.
         config_widget._awaiting_farms_for_cascade = True
-        with qtbot.waitSignal(controller.farms_updated, timeout=5000):
-            config_widget.default_farm_box.refresh_list()
-        QApplication.processEvents()
+        config_widget.default_farm_box.refresh_list()
+        qtbot.waitUntil(
+            lambda: config_widget.changes.get("defaults.farm_id") == farm_id, timeout=5000
+        )
 
         # The single farm should now be recorded as the pending farm change, which is
         # what gets persisted on Apply. (currentData on the combo can't be asserted
@@ -392,20 +411,21 @@ class TestSettingsDialogue:
         config_widget.changes["defaults.queue_id"] = ""
         config_widget.refresh()
 
-        controller = DeadlineUIController.getInstance()
-
         # Sign-in path: refresh_lists() refreshes the farm list WITHOUT the cascade
         # flags, but only when the API is available - so stub auth as signed in.
         auth_stub = MagicMock()
         auth_stub.api_availability = True
         assert not config_widget._awaiting_farms_for_cascade
+        # Farms stream in per region; auto-select fires once the stream completes, so wait
+        # for the pending change to land rather than the initial clear emit.
         with patch(
             "deadline.client.ui.dialogs.deadline_config_dialog.DeadlineAuthenticationStatus.getInstance",
             return_value=auth_stub,
         ):
-            with qtbot.waitSignal(controller.farms_updated, timeout=5000):
-                config_widget.refresh_lists()
-        QApplication.processEvents()
+            config_widget.refresh_lists()
+            qtbot.waitUntil(
+                lambda: config_widget.changes.get("defaults.farm_id") == farm_id, timeout=5000
+            )
 
         # The lone farm is auto-selected (combo fires currentIndexChanged ->
         # default_farm_changed records it). We assert on the pending change, which is

--- a/test/unit/deadline_client/ui/widgets/test_deadline_list_combo_boxes.py
+++ b/test/unit/deadline_client/ui/widgets/test_deadline_list_combo_boxes.py
@@ -221,6 +221,182 @@ class TestDeadlineFarmListComboBoxController:
 
         assert widget.box.currentData() == "farm-a"
 
+    def test_handle_list_append_adds_incrementally(self, qtbot):
+        """Farm options stream in via append without clearing prior batches."""
+        widget = DeadlineFarmListComboBoxController()
+        qtbot.addWidget(widget)
+
+        config = ConfigParser()
+        config["defaults"] = {"farm_id": "", "farm_region": ""}
+        widget.set_config(config)
+
+        with patch("deadline.client.ui.widgets._deadline_list_combo_boxes.config_file") as mock_cf:
+            mock_cf.get_setting.return_value = ""
+            # First region arrives.
+            widget._handle_list_append([("(us-west-2) Farm A", "farm-a", "us-west-2")])
+            assert widget.box.findData("farm-a") >= 0
+            # Second region arrives; first batch is preserved (not cleared).
+            widget._handle_list_append([("(eu-west-1) Farm B", "farm-b", "eu-west-1")])
+
+        assert widget.box.findData("farm-a") >= 0
+        assert widget.box.findData("farm-b") >= 0
+        # Labels are region-first.
+        idx_a = widget.box.findData("farm-a")
+        assert widget.box.itemText(idx_a) == "(us-west-2) Farm A"
+        # Region is recorded per id for downstream persistence.
+        assert widget.region_for_id("farm-a") == "us-west-2"
+        assert widget.region_for_id("farm-b") == "eu-west-1"
+
+    def test_handle_list_append_keeps_stable_alphabetical_order(self, qtbot):
+        """
+        Regardless of the order regions stream in, the list is alphabetized by label.
+        Labels are region-first, so this orders by region then name.
+        """
+        widget = DeadlineFarmListComboBoxController()
+        qtbot.addWidget(widget)
+
+        config = ConfigParser()
+        config["defaults"] = {"farm_id": "", "farm_region": ""}
+        widget.set_config(config)
+
+        with patch("deadline.client.ui.widgets._deadline_list_combo_boxes.config_file") as mock_cf:
+            mock_cf.get_setting.return_value = ""
+            # Regions arrive out of alphabetical order.
+            widget._handle_list_append([("(us-west-2) Zebra", "farm-z", "us-west-2")])
+            widget._handle_list_append([("(eu-west-1) Apple", "farm-a", "eu-west-1")])
+            widget._handle_list_append(
+                [
+                    ("(us-west-2) Apple", "farm-wa", "us-west-2"),
+                    ("(ap-south-1) Mango", "farm-m", "ap-south-1"),
+                ]
+            )
+
+        labels = [widget.box.itemText(i) for i in range(widget.box.count())]
+        assert labels == [
+            "(ap-south-1) Mango",
+            "(eu-west-1) Apple",
+            "(us-west-2) Apple",
+            "(us-west-2) Zebra",
+        ]
+
+    def test_handle_list_append_preserves_selection(self, qtbot):
+        """Appending more farms must not clobber the user's current selection."""
+        widget = DeadlineFarmListComboBoxController()
+        qtbot.addWidget(widget)
+
+        config = ConfigParser()
+        config["defaults"] = {"farm_id": "", "farm_region": ""}
+        widget.set_config(config)
+
+        with patch("deadline.client.ui.widgets._deadline_list_combo_boxes.config_file") as mock_cf:
+            mock_cf.get_setting.return_value = ""
+            widget._handle_list_append([("(us-west-2) Farm A", "farm-a", "us-west-2")])
+            # User selects Farm A.
+            widget.box.setCurrentIndex(widget.box.findData("farm-a"))
+            assert widget.box.currentData() == "farm-a"
+            # A slower region streams in after the selection.
+            widget._handle_list_append([("(eu-west-1) Farm B", "farm-b", "eu-west-1")])
+
+        # Selection is preserved across the append.
+        assert widget.box.currentData() == "farm-a"
+
+    def test_handle_list_append_replaces_raw_id_placeholder(self, qtbot):
+        """A configured-but-unlisted raw id row is replaced by the labeled row."""
+        widget = DeadlineFarmListComboBoxController()
+        qtbot.addWidget(widget)
+
+        config = ConfigParser()
+        config["defaults"] = {"farm_id": "farm-a", "farm_region": ""}
+        widget.set_config(config)
+
+        with patch("deadline.client.ui.widgets._deadline_list_combo_boxes.config_file") as mock_cf:
+            mock_cf.get_setting.return_value = "farm-a"
+            # Simulate the start-of-refresh clear, which inserts the raw configured id.
+            widget._handle_list_update([])
+            assert widget.box.findData("farm-a") >= 0
+            assert widget.box.itemText(widget.box.findData("farm-a")) == "farm-a"
+            # The labeled farm streams in for the same id.
+            widget._handle_list_append([("(us-west-2) Farm A", "farm-a", "us-west-2")])
+
+        # Only one row for farm-a, now with the labeled text.
+        matches = [i for i in range(widget.box.count()) if widget.box.itemData(i) == "farm-a"]
+        assert len(matches) == 1
+        assert widget.box.itemText(matches[0]) == "(us-west-2) Farm A"
+        # And it stays selected.
+        assert widget.box.currentData() == "farm-a"
+
+    def test_handle_list_append_dedupes_repeated_same_id(self, qtbot):
+        """
+        If the same farm id arrives in two separate append batches (e.g. a duplicated or
+        retried region response), the combo box must not show two rows for it -- the later
+        batch replaces the earlier row rather than adding a duplicate.
+        """
+        widget = DeadlineFarmListComboBoxController()
+        qtbot.addWidget(widget)
+
+        config = ConfigParser()
+        config["defaults"] = {"farm_id": "", "farm_region": ""}
+        widget.set_config(config)
+
+        with patch("deadline.client.ui.widgets._deadline_list_combo_boxes.config_file") as mock_cf:
+            mock_cf.get_setting.return_value = ""
+            widget._handle_list_append([("(us-west-2) Farm A", "farm-a", "us-west-2")])
+            # The same id streams in again (possibly with an updated label).
+            widget._handle_list_append([("(us-west-2) Farm A (updated)", "farm-a", "us-west-2")])
+
+        matches = [i for i in range(widget.box.count()) if widget.box.itemData(i) == "farm-a"]
+        assert len(matches) == 1
+        # The most recent batch's label wins.
+        assert widget.box.itemText(matches[0]) == "(us-west-2) Farm A (updated)"
+        assert widget.region_for_id("farm-a") == "us-west-2"
+
+    def test_handle_list_append_dedupes_within_single_batch(self, qtbot):
+        """A single append batch containing the same id twice yields only one row."""
+        widget = DeadlineFarmListComboBoxController()
+        qtbot.addWidget(widget)
+
+        config = ConfigParser()
+        config["defaults"] = {"farm_id": "", "farm_region": ""}
+        widget.set_config(config)
+
+        with patch("deadline.client.ui.widgets._deadline_list_combo_boxes.config_file") as mock_cf:
+            mock_cf.get_setting.return_value = ""
+            widget._handle_list_append(
+                [
+                    ("(us-west-2) Farm A", "farm-a", "us-west-2"),
+                    ("(us-west-2) Farm A dup", "farm-a", "us-west-2"),
+                ]
+            )
+
+        matches = [i for i in range(widget.box.count()) if widget.box.itemData(i) == "farm-a"]
+        assert len(matches) == 1
+
+    def test_handle_region_warning_is_non_blocking(self, qtbot):
+        """A per-region warning sets a tooltip and does not raise/pop a modal."""
+        widget = DeadlineFarmListComboBoxController()
+        qtbot.addWidget(widget)
+
+        # Should not raise; just records a tooltip.
+        widget._handle_region_warning("us-east-1", Exception("opt-in required"))
+
+        assert "us-east-1" in widget.box.toolTip()
+
+    def test_current_region_reflects_selection(self, qtbot):
+        """current_region returns the region of the selected farm."""
+        widget = DeadlineFarmListComboBoxController()
+        qtbot.addWidget(widget)
+
+        config = ConfigParser()
+        config["defaults"] = {"farm_id": "", "farm_region": ""}
+        widget.set_config(config)
+
+        with patch("deadline.client.ui.widgets._deadline_list_combo_boxes.config_file") as mock_cf:
+            mock_cf.get_setting.return_value = ""
+            widget._handle_list_append([("(us-west-2) Farm A", "farm-a", "us-west-2")])
+            widget.box.setCurrentIndex(widget.box.findData("farm-a"))
+
+        assert widget.current_region() == "us-west-2"
+
 
 class TestDeadlineQueueListComboBoxController:
     """Tests for DeadlineQueueListComboBoxController."""

--- a/test/unit/deadline_client/ui/widgets/test_shared_job_settings_tab.py
+++ b/test/unit/deadline_client/ui/widgets/test_shared_job_settings_tab.py
@@ -3,6 +3,7 @@
 import pytest
 
 try:
+    from deadline.client import api
     from deadline.client.ui.widgets.shared_job_settings_tab import SharedJobSettingsWidget
     from deadline.client.ui.dataclasses import JobBundleSettings
 except ImportError:
@@ -80,3 +81,102 @@ def test_max_worker_count_should_be_integer_within_range(
 ):
     shared_job_settings_tab.shared_job_properties_box.max_worker_count_box.setValue(-1)
     assert shared_job_settings_tab.shared_job_properties_box.max_worker_count_box.value() == 1
+
+
+# ---------------------------------------------------------------------------
+# Region scoping for the read-only resource display widgets.
+#
+# These widgets build their own deadline client to fetch farm/queue/storage-profile
+# names. They must scope that client to the farm's region (defaults.farm_region) so the
+# submitter summary works for a farm in a non-default region.
+# ---------------------------------------------------------------------------
+
+MOCK_FARM_ID = "farm-0123456789abcdefabcdefabcdefabcd"
+MOCK_QUEUE_ID = "queue-0123456789abcdefabcdefabcdefabcd"
+MOCK_STORAGE_PROFILE_ID = "sp-0123456789abcdefabcdefabcdefabcd"
+
+
+def test_farm_display_get_item_scopes_client_to_farm_region(qtbot, fresh_deadline_config):
+    from unittest.mock import MagicMock, patch
+    from deadline.client.config import config_file
+    from deadline.client.ui.widgets.shared_job_settings_tab import DeadlineFarmDisplay
+
+    config_file.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config_file.set_setting("defaults.farm_region", "eu-west-1")
+
+    widget = DeadlineFarmDisplay()
+    qtbot.addWidget(widget)
+
+    with patch.object(api, "get_boto3_client") as mock_get_client:
+        deadline = MagicMock()
+        deadline.get_farm.return_value = {
+            "farmId": MOCK_FARM_ID,
+            "displayName": "F",
+            "description": "d",
+        }
+        mock_get_client.return_value = deadline
+
+        widget.get_item()
+
+        assert mock_get_client.call_args.kwargs.get("region") == "eu-west-1"
+
+
+def test_queue_display_get_item_scopes_client_to_farm_region(qtbot, fresh_deadline_config):
+    from unittest.mock import MagicMock, patch
+    from deadline.client.config import config_file
+    from deadline.client.ui.widgets.shared_job_settings_tab import DeadlineQueueDisplay
+
+    config_file.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config_file.set_setting("defaults.farm_region", "eu-west-1")
+    config_file.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+
+    widget = DeadlineQueueDisplay()
+    qtbot.addWidget(widget)
+
+    with patch.object(api, "get_boto3_client") as mock_get_client:
+        deadline = MagicMock()
+        deadline.get_queue.return_value = {
+            "queueId": MOCK_QUEUE_ID,
+            "displayName": "Q",
+            "description": "d",
+        }
+        mock_get_client.return_value = deadline
+
+        widget.get_item()
+
+        assert mock_get_client.call_args.kwargs.get("region") == "eu-west-1"
+
+
+def test_storage_profile_display_get_item_scopes_client_to_farm_region(
+    qtbot, fresh_deadline_config
+):
+    from unittest.mock import MagicMock, patch
+    from deadline.client.config import config_file
+    from deadline.client.ui.widgets.shared_job_settings_tab import (
+        DeadlineStorageProfileNameDisplay,
+    )
+
+    config_file.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config_file.set_setting("defaults.farm_region", "eu-west-1")
+    config_file.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config_file.set_setting("settings.storage_profile_id", MOCK_STORAGE_PROFILE_ID)
+
+    widget = DeadlineStorageProfileNameDisplay()
+    qtbot.addWidget(widget)
+
+    with patch.object(api, "get_boto3_client") as mock_get_client:
+        deadline = MagicMock()
+        deadline.list_storage_profiles_for_queue.return_value = {
+            "storageProfiles": [
+                {
+                    "storageProfileId": MOCK_STORAGE_PROFILE_ID,
+                    "displayName": "SP",
+                    "osFamily": "linux",
+                }
+            ]
+        }
+        mock_get_client.return_value = deadline
+
+        widget.get_item()
+
+        assert mock_get_client.call_args.kwargs.get("region") == "eu-west-1"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We want to make it easier to work with farms across multiple regions within a single profile.

### What was the solution? (How)
Add `region` as a parameter throughout the library and CLI. Farms are now identified by `(region, farm_id)` instead of assuming a single region. 

### What is the impact of this change?

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests?
- Have you run the integration tests?

### Was this change documented?

- Are relevant docstrings in the code base updated?
- Has the README.md been updated? If you modified CLI arguments, for instance.

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [ ] This PR does not add any new dependencies.

### Is this a breaking change?

A breaking change is one that modifies a public contract in a way that is not backwards compatible. See the 
[Public Contracts](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#public-contracts) section
of the DEVELOPMENT.md for more information on the public contracts.

If so, then please describe the changes that users of this package must make to update their scripts, or Python applications.

### Does this change impact security?

- Does the change need to be threat modeled? For example, does it create or modify files/directories that must only be readable by the process owner?
    - If so, then please label this pull request with the "security" label. We'll work with you to analyze the threats.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
