### PR TITLE
chore: make API change detection use __all__ as the public surface

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,10 @@ show_error_codes = true
 pretty = true
 # Prohibit equality checks, identity checks, and container checks between non-overlapping types.
 strict_equality = true
+# Require names re-exported from a module to be listed in __all__ (or imported with an
+# explicit ``import X as X``). This keeps __all__ the authoritative public surface and
+# prevents incidental imports from leaking into the public API.
+no_implicit_reexport = true
 ignore_missing_imports = true
 # Tell mypy that there's a namespace package at src/deadline
 namespace_packages = true
@@ -116,6 +120,10 @@ disable_error_code = ["attr-defined", "assignment"]
 line-length = 100
 
 [tool.ruff.lint]
+# F822 (undefined name in __all__) is on by default and keeps __all__ entries valid.
+# RUF022 keeps __all__ sorted so the declared public surface stays consistent and
+# diffs stay clean. The default rule set (E, F) is otherwise preserved.
+extend-select = ["RUF022"]
 ignore = ["E501"]
 
 [tool.ruff.lint.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,9 +97,8 @@ show_error_codes = true
 pretty = true
 # Prohibit equality checks, identity checks, and container checks between non-overlapping types.
 strict_equality = true
-# Require names re-exported from a module to be listed in __all__ (or imported with an
-# explicit ``import X as X``). This keeps __all__ the authoritative public surface and
-# prevents incidental imports from leaking into the public API.
+# Re-exports must be declared in __all__ (or use ``import X as X``), so __all__ stays the
+# authoritative public surface and incidental imports don't leak into the API.
 no_implicit_reexport = true
 ignore_missing_imports = true
 # Tell mypy that there's a namespace package at src/deadline
@@ -120,9 +119,7 @@ disable_error_code = ["attr-defined", "assignment"]
 line-length = 100
 
 [tool.ruff.lint]
-# F822 (undefined name in __all__) is on by default and keeps __all__ entries valid.
-# RUF022 keeps __all__ sorted so the declared public surface stays consistent and
-# diffs stay clean. The default rule set (E, F) is otherwise preserved.
+# F822 (undefined name in __all__) is on by default; RUF022 keeps __all__ sorted.
 extend-select = ["RUF022"]
 ignore = ["E501"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,9 +97,6 @@ show_error_codes = true
 pretty = true
 # Prohibit equality checks, identity checks, and container checks between non-overlapping types.
 strict_equality = true
-# Re-exports must be declared in __all__ (or use ``import X as X``), so __all__ stays the
-# authoritative public surface and incidental imports don't leak into the API.
-no_implicit_reexport = true
 ignore_missing_imports = true
 # Tell mypy that there's a namespace package at src/deadline
 namespace_packages = true

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -103,6 +103,39 @@ hatch run docs:validate-api-snapshot /tmp/baseline.json
 - 🗑️ **REMOVED**: Deleted APIs, functions, classes, methods, attributes  
 - 🔄 **MODIFIED**: Changed function signatures, parameters, return types, decorators, class bases, attribute types/values
 
+The snapshot validation reports *all* real API changes (not just breaking ones) so
+reviewers can be aware of the evolving public surface - additions, removals, new or
+changed parameters, and annotation changes such as `Requirements -> Optional[Requirements]`.
+
+The public surface is determined as follows, so the report stays high-signal:
+
+- **`__all__` is authoritative when a module declares it.** A module's `__all__` is the
+  explicit, author-declared public API. When present, only the names it lists are tracked
+  as public (submodules are always traversed and judged by their own `__all__`, since
+  `__all__` governs `from module import *` and does not list submodules by convention).
+  This means imported names, internal helpers, and sub-components left out of `__all__`
+  are correctly treated as non-public.
+- **Heuristic fallback when `__all__` is absent.** For modules without `__all__`, a member
+  is public if it does not start with an underscore and is not merely an imported name
+  (e.g. `from typing import Any` resolves outside the `deadline` package and is dropped;
+  a deliberate re-export like `from deadline.client...import JobParameter` is kept).
+- **Annotations are rendered as readable strings.** Type annotations are compared and
+  displayed in source-like form (`Optional[HardwareRequirements]`) rather than as raw
+  griffe expression dicts, so annotation changes are easy to read in the diff.
+
+#### Keeping `__all__` correct and enforced
+
+Because the public surface is driven by `__all__`, two linters keep it trustworthy:
+
+- **ruff `F822`** (on by default) fails the build if `__all__` lists a name that does not
+  exist in the module - catching stale entries.
+- **ruff `RUF022`** keeps `__all__` sorted so the declared surface stays consistent and
+  diffs stay clean. A small number of `__all__` lists are intentionally grouped by feature
+  with section comments and opt out with `# noqa: RUF022`.
+- **mypy `no_implicit_reexport`** requires names re-exported from a module to be listed in
+  `__all__` (or imported with an explicit `import X as X`), preventing incidental imports
+  from leaking into the public API.
+
 ### Running Tests with Docker for File and Directory Permissions
 
 We have some unit tests that require being run in a specific docker container that is set up for testing with different users. Those unit tests are marked with `docker`, and the `run_sudo_tests.sh` script is provided to facilitate this testing. The script builds the Docker image using the Dockerfile located in `testing_containers/localuser_sudo_environment/`, and then runs the container.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -103,38 +103,23 @@ hatch run docs:validate-api-snapshot /tmp/baseline.json
 - 🗑️ **REMOVED**: Deleted APIs, functions, classes, methods, attributes  
 - 🔄 **MODIFIED**: Changed function signatures, parameters, return types, decorators, class bases, attribute types/values
 
-The snapshot validation reports *all* real API changes (not just breaking ones) so
-reviewers can be aware of the evolving public surface - additions, removals, new or
-changed parameters, and annotation changes such as `Requirements -> Optional[Requirements]`.
+Snapshot validation reports *all* real API changes, not just breaking ones, so reviewers
+see the evolving public surface (additions, removals, parameter changes, and annotation
+changes like `Requirements -> Optional[Requirements]`). The surface is determined by:
 
-The public surface is determined as follows, so the report stays high-signal:
-
-- **`__all__` is authoritative when a module declares it.** A module's `__all__` is the
-  explicit, author-declared public API. When present, only the names it lists are tracked
-  as public (submodules are always traversed and judged by their own `__all__`, since
-  `__all__` governs `from module import *` and does not list submodules by convention).
-  This means imported names, internal helpers, and sub-components left out of `__all__`
-  are correctly treated as non-public.
-- **Heuristic fallback when `__all__` is absent.** For modules without `__all__`, a member
-  is public if it does not start with an underscore and is not merely an imported name
-  (e.g. `from typing import Any` resolves outside the `deadline` package and is dropped;
-  a deliberate re-export like `from deadline.client...import JobParameter` is kept).
-- **Annotations are rendered as readable strings.** Type annotations are compared and
-  displayed in source-like form (`Optional[HardwareRequirements]`) rather than as raw
-  griffe expression dicts, so annotation changes are easy to read in the diff.
+- **`__all__` when a module declares it.** Only listed names are public. Submodules are
+  the exception (they aren't listed in `__all__` by convention) and are judged by their
+  own `__all__`.
+- **Heuristic otherwise:** public if not underscore-prefixed and not an import (e.g.
+  `from typing import Any` is dropped; `from deadline...import JobParameter` is kept).
+- **Annotations rendered as strings** (`Optional[HardwareRequirements]`) rather than raw
+  griffe dicts, so changes are readable.
 
 #### Keeping `__all__` correct and enforced
 
-Because the public surface is driven by `__all__`, two linters keep it trustworthy:
-
-- **ruff `F822`** (on by default) fails the build if `__all__` lists a name that does not
-  exist in the module - catching stale entries.
-- **ruff `RUF022`** keeps `__all__` sorted so the declared surface stays consistent and
-  diffs stay clean. A small number of `__all__` lists are intentionally grouped by feature
-  with section comments and opt out with `# noqa: RUF022`.
-- **mypy `no_implicit_reexport`** requires names re-exported from a module to be listed in
-  `__all__` (or imported with an explicit `import X as X`), preventing incidental imports
-  from leaking into the public API.
+- **ruff `F822`** (default): fails on `__all__` entries that don't exist (stale names).
+- **ruff `RUF022`**: keeps `__all__` sorted. Feature-grouped lists opt out via `# noqa: RUF022`.
+- **mypy `no_implicit_reexport`**: re-exports must be in `__all__` (or use `import X as X`).
 
 ### Running Tests with Docker for File and Directory Permissions
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -119,7 +119,6 @@ changes like `Requirements -> Optional[Requirements]`). The surface is determine
 
 - **ruff `F822`** (default): fails on `__all__` entries that don't exist (stale names).
 - **ruff `RUF022`**: keeps `__all__` sorted. Feature-grouped lists opt out via `# noqa: RUF022`.
-- **mypy `no_implicit_reexport`**: re-exports must be in `__all__` (or use `import X as X`).
 
 ### Running Tests with Docker for File and Directory Permissions
 

--- a/scripts/generate_api_snapshot.py
+++ b/scripts/generate_api_snapshot.py
@@ -14,79 +14,49 @@ import sys
 from pathlib import Path
 
 
-# The package whose API we track. Aliases that resolve outside this package are
-# imported names (e.g. ``from typing import Any``) rather than part of our API.
+# Aliases resolving outside this package are imports (e.g. ``from typing import Any``),
+# not part of our API.
 TRACKED_PACKAGE = "deadline"
 
 
 def is_reexported_import(obj: dict) -> bool:
-    """Return True if a member is an imported name rather than part of our API.
+    """True if a member is an imported name rather than our own API.
 
-    A bare ``from typing import Any`` (or ``import os``) shows up in griffe as an
-    ``alias`` member whose ``target_path`` points outside the tracked package.
-    These are implementation details of the module - not public API - so counting
-    them as "added/removed APIs" produces noise (e.g. adding ``Optional`` to an
-    import line should not register as a new public interface).
-
-    Aliases that resolve *within* the tracked package (e.g. a deliberate
-    re-export like ``from deadline.client...import JobParameter``) are kept,
-    since those genuinely expose our own API surface from a new location.
+    Imports like ``from typing import Any`` appear as ``alias`` members whose
+    ``target_path`` points outside the tracked package; counting them as API is noise.
+    Re-exports of our own package (``from deadline...import JobParameter``) are kept.
     """
     if not isinstance(obj, dict) or obj.get("kind") != "alias":
         return False
 
     target = obj.get("target_path")
     if not isinstance(target, str) or not target:
-        # An alias with no resolvable target is most likely an unresolved import.
-        return True
+        return True  # unresolved alias: most likely an import
 
-    # Keep re-exports of our own package; drop everything else (typing, os, ...).
     return target != TRACKED_PACKAGE and not target.startswith(f"{TRACKED_PACKAGE}.")
 
 
 def is_public_interface(name: str, obj: dict = None, all_names: list = None) -> bool:
-    """Check if an interface is public.
+    """True if a member is public.
 
-    When the containing module declares ``__all__`` (passed in as ``all_names``),
-    that list is authoritative for *named* members - functions, classes, attributes,
-    and re-exported aliases. A member of that kind is public if and only if it is
-    listed in ``__all__``. This is the explicit, author-declared public surface and
-    removes guesswork about imports and underscores.
-
-    Submodules and subpackages are an exception: ``__all__`` governs names imported
-    via ``from module import *``, and by convention it does not list submodules even
-    though they are independently importable public API (e.g. ``deadline.client.api``
-    is public even though it is not in ``deadline.client``'s ``__all__``). Submodules
-    are therefore always traversed and judged by the underscore convention, then
-    evaluated against their own ``__all__`` recursively.
-
-    When ``__all__`` is absent, fall back to a heuristic: a member is public if it
-    does not start with an underscore and is not merely an imported name (e.g.
-    ``from typing import Any``).
+    When the module declares ``__all__`` (``all_names``), it is authoritative for named
+    members. Submodules bypass it: ``__all__`` does not list submodules by convention,
+    yet they are public (e.g. ``deadline.client.api``), so they are judged by their own
+    ``__all__`` recursively. Without ``__all__``, fall back to: not underscore-prefixed
+    and not an import.
     """
     is_module = isinstance(obj, dict) and obj.get("kind") == "module"
 
-    # An explicit __all__ is the source of truth for named members. Submodules are
-    # not listed in __all__ by convention, so they bypass this check.
     if all_names is not None and not is_module:
         return name in all_names
 
-    # Heuristic fallback (modules without __all__, and submodules of any module).
-
-    # Skip private interfaces (starting with _)
+    # Heuristic fallback.
     if name.startswith("_"):
         return False
-
-    # Skip imported names that just happen to live in the module namespace.
     if is_reexported_import(obj):
         return False
-
-    # If we have the object, also check the is_public flag from griffe
-    if obj and isinstance(obj, dict):
-        # Griffe provides is_public flag - use it if available
-        if "is_public" in obj:
-            return obj["is_public"]
-
+    if obj and isinstance(obj, dict) and "is_public" in obj:
+        return obj["is_public"]  # griffe's own flag
     return True
 
 
@@ -94,9 +64,7 @@ def normalize_paths_in_snapshot(snapshot_data, project_root: Path):
     """Recursively normalize absolute paths to relative paths and remove user-specific info."""
     if isinstance(snapshot_data, dict):
         result = {}
-        # ``exports`` is griffe's serialization of a module's ``__all__``. When present
-        # it is the authoritative declaration of the module's public surface, so we use
-        # it to decide which members to keep (see ``is_public_interface``).
+        # ``exports`` is griffe's serialization of ``__all__``; drives member filtering.
         exports = snapshot_data.get("exports")
         all_names = exports if isinstance(exports, list) else None
         for key, value in snapshot_data.items():

--- a/scripts/generate_api_snapshot.py
+++ b/scripts/generate_api_snapshot.py
@@ -14,10 +14,71 @@ import sys
 from pathlib import Path
 
 
-def is_public_interface(name: str, obj: dict = None) -> bool:
-    """Check if an interface is public (doesn't start with underscore)."""
+# The package whose API we track. Aliases that resolve outside this package are
+# imported names (e.g. ``from typing import Any``) rather than part of our API.
+TRACKED_PACKAGE = "deadline"
+
+
+def is_reexported_import(obj: dict) -> bool:
+    """Return True if a member is an imported name rather than part of our API.
+
+    A bare ``from typing import Any`` (or ``import os``) shows up in griffe as an
+    ``alias`` member whose ``target_path`` points outside the tracked package.
+    These are implementation details of the module - not public API - so counting
+    them as "added/removed APIs" produces noise (e.g. adding ``Optional`` to an
+    import line should not register as a new public interface).
+
+    Aliases that resolve *within* the tracked package (e.g. a deliberate
+    re-export like ``from deadline.client...import JobParameter``) are kept,
+    since those genuinely expose our own API surface from a new location.
+    """
+    if not isinstance(obj, dict) or obj.get("kind") != "alias":
+        return False
+
+    target = obj.get("target_path")
+    if not isinstance(target, str) or not target:
+        # An alias with no resolvable target is most likely an unresolved import.
+        return True
+
+    # Keep re-exports of our own package; drop everything else (typing, os, ...).
+    return target != TRACKED_PACKAGE and not target.startswith(f"{TRACKED_PACKAGE}.")
+
+
+def is_public_interface(name: str, obj: dict = None, all_names: list = None) -> bool:
+    """Check if an interface is public.
+
+    When the containing module declares ``__all__`` (passed in as ``all_names``),
+    that list is authoritative for *named* members - functions, classes, attributes,
+    and re-exported aliases. A member of that kind is public if and only if it is
+    listed in ``__all__``. This is the explicit, author-declared public surface and
+    removes guesswork about imports and underscores.
+
+    Submodules and subpackages are an exception: ``__all__`` governs names imported
+    via ``from module import *``, and by convention it does not list submodules even
+    though they are independently importable public API (e.g. ``deadline.client.api``
+    is public even though it is not in ``deadline.client``'s ``__all__``). Submodules
+    are therefore always traversed and judged by the underscore convention, then
+    evaluated against their own ``__all__`` recursively.
+
+    When ``__all__`` is absent, fall back to a heuristic: a member is public if it
+    does not start with an underscore and is not merely an imported name (e.g.
+    ``from typing import Any``).
+    """
+    is_module = isinstance(obj, dict) and obj.get("kind") == "module"
+
+    # An explicit __all__ is the source of truth for named members. Submodules are
+    # not listed in __all__ by convention, so they bypass this check.
+    if all_names is not None and not is_module:
+        return name in all_names
+
+    # Heuristic fallback (modules without __all__, and submodules of any module).
+
     # Skip private interfaces (starting with _)
     if name.startswith("_"):
+        return False
+
+    # Skip imported names that just happen to live in the module namespace.
+    if is_reexported_import(obj):
         return False
 
     # If we have the object, also check the is_public flag from griffe
@@ -33,6 +94,11 @@ def normalize_paths_in_snapshot(snapshot_data, project_root: Path):
     """Recursively normalize absolute paths to relative paths and remove user-specific info."""
     if isinstance(snapshot_data, dict):
         result = {}
+        # ``exports`` is griffe's serialization of a module's ``__all__``. When present
+        # it is the authoritative declaration of the module's public surface, so we use
+        # it to decide which members to keep (see ``is_public_interface``).
+        exports = snapshot_data.get("exports")
+        all_names = exports if isinstance(exports, list) else None
         for key, value in snapshot_data.items():
             if key == "docstring":
                 # Skip docstrings entirely to save space - they're not used in API comparison
@@ -41,7 +107,7 @@ def normalize_paths_in_snapshot(snapshot_data, project_root: Path):
                 # Filter out private members
                 public_members = {}
                 for member_name, member_obj in value.items():
-                    if is_public_interface(member_name, member_obj):
+                    if is_public_interface(member_name, member_obj, all_names):
                         public_members[member_name] = normalize_paths_in_snapshot(
                             member_obj, project_root
                         )

--- a/scripts/validate_api_snapshot.py
+++ b/scripts/validate_api_snapshot.py
@@ -81,18 +81,12 @@ def extract_api_paths(api_data: Dict[str, Any]) -> Set[str]:
 
 
 def render_annotation(ann: Any) -> Any:
-    """Render a griffe annotation/expression into a readable, diff-friendly string.
+    """Render a griffe annotation expression into a readable string.
 
-    Griffe serializes type annotations as nested expression dicts, e.g.
-    ``Optional[HardwareRequirements]`` becomes
-    ``{"left": {"name": "Optional", ...}, "slice": {"name": "HardwareRequirements",
-    ...}, "cls": "ExprSubscript"}``. Diffing those raw dicts produces an unreadable
-    wall of text in the change report. Rendering them back to source-like strings
-    ("HardwareRequirements" -> "Optional[HardwareRequirements]") makes annotation
-    changes - the thing a reviewer actually cares about - obvious at a glance.
-
-    Plain strings and ``None`` pass through unchanged. Any unrecognized shape falls
-    back to the original value so we never lose information.
+    Griffe serializes annotations as nested expression dicts; diffing those raw is
+    unreadable. Rendering them to source-like form (``Optional[HardwareRequirements]``)
+    makes annotation changes obvious in the report. Strings/``None`` pass through;
+    unrecognized shapes fall back to the original value.
     """
     if ann is None or isinstance(ann, str):
         return ann
@@ -108,7 +102,7 @@ def render_annotation(ann: Any) -> Any:
     if cls == "ExprName":
         return ann.get("name", "")
     if cls == "ExprAttribute":
-        # Dotted access like ``typing.Optional`` -> join the parts.
+        # Dotted access, e.g. ``typing.Optional``.
         values = ann.get("values", [])
         return ".".join(render_annotation(v) for v in values)
     if cls == "ExprSubscript":
@@ -135,7 +129,7 @@ def render_annotation(ann: Any) -> Any:
         value = render_annotation(ann.get("value"))
         return f"{name}={value}"
 
-    # Unknown expression shape - fall back to the raw value rather than dropping it.
+    # Unknown shape: fall back rather than drop.
     if "name" in ann:
         return ann["name"]
     return ann

--- a/scripts/validate_api_snapshot.py
+++ b/scripts/validate_api_snapshot.py
@@ -80,6 +80,67 @@ def extract_api_paths(api_data: Dict[str, Any]) -> Set[str]:
     return paths
 
 
+def render_annotation(ann: Any) -> Any:
+    """Render a griffe annotation/expression into a readable, diff-friendly string.
+
+    Griffe serializes type annotations as nested expression dicts, e.g.
+    ``Optional[HardwareRequirements]`` becomes
+    ``{"left": {"name": "Optional", ...}, "slice": {"name": "HardwareRequirements",
+    ...}, "cls": "ExprSubscript"}``. Diffing those raw dicts produces an unreadable
+    wall of text in the change report. Rendering them back to source-like strings
+    ("HardwareRequirements" -> "Optional[HardwareRequirements]") makes annotation
+    changes - the thing a reviewer actually cares about - obvious at a glance.
+
+    Plain strings and ``None`` pass through unchanged. Any unrecognized shape falls
+    back to the original value so we never lose information.
+    """
+    if ann is None or isinstance(ann, str):
+        return ann
+
+    if isinstance(ann, list):
+        return [render_annotation(item) for item in ann]
+
+    if not isinstance(ann, dict):
+        return ann
+
+    cls = ann.get("cls")
+
+    if cls == "ExprName":
+        return ann.get("name", "")
+    if cls == "ExprAttribute":
+        # Dotted access like ``typing.Optional`` -> join the parts.
+        values = ann.get("values", [])
+        return ".".join(render_annotation(v) for v in values)
+    if cls == "ExprSubscript":
+        left = render_annotation(ann.get("left"))
+        sl = render_annotation(ann.get("slice"))
+        return f"{left}[{sl}]"
+    if cls == "ExprTuple":
+        elements = ann.get("elements", [])
+        return ", ".join(render_annotation(e) for e in elements)
+    if cls == "ExprList":
+        elements = ann.get("elements", [])
+        return "[" + ", ".join(render_annotation(e) for e in elements) + "]"
+    if cls == "ExprBinOp":
+        left = render_annotation(ann.get("left"))
+        right = render_annotation(ann.get("right"))
+        op = ann.get("operator", "|")
+        return f"{left} {op} {right}"
+    if cls == "ExprCall":
+        func = render_annotation(ann.get("function"))
+        args = ", ".join(render_annotation(a) for a in ann.get("arguments", []))
+        return f"{func}({args})"
+    if cls == "ExprKeyword":
+        name = ann.get("name", "")
+        value = render_annotation(ann.get("value"))
+        return f"{name}={value}"
+
+    # Unknown expression shape - fall back to the raw value rather than dropping it.
+    if "name" in ann:
+        return ann["name"]
+    return ann
+
+
 def normalize_decorator_info(decorators):
     """Normalize decorator info by removing line numbers to focus on functional changes."""
     if not decorators or not isinstance(decorators, list):
@@ -115,7 +176,7 @@ def extract_functional_signature(obj: Dict[str, Any]) -> Dict[str, Any]:
                     if "default" in p and p["default"] is not None:
                         param_sig["default"] = p["default"]
                     if "annotation" in p and p["annotation"] is not None:
-                        param_sig["annotation"] = p["annotation"]
+                        param_sig["annotation"] = render_annotation(p["annotation"])
 
                     # Only add if we have meaningful data
                     if param_sig:
@@ -125,7 +186,7 @@ def extract_functional_signature(obj: Dict[str, Any]) -> Dict[str, Any]:
 
         # Track return type annotation if present
         if "returns" in obj and obj["returns"] is not None:
-            signature["returns"] = obj["returns"]
+            signature["returns"] = render_annotation(obj["returns"])
 
         # Track decorator names only (ignore line numbers and other metadata)
         if "decorators" in obj and isinstance(obj["decorators"], list):
@@ -139,7 +200,7 @@ def extract_functional_signature(obj: Dict[str, Any]) -> Dict[str, Any]:
     elif kind == "class":
         # Track base classes
         if "bases" in obj and obj["bases"]:
-            signature["bases"] = obj["bases"]
+            signature["bases"] = render_annotation(obj["bases"])
 
         # Track decorator names only
         if "decorators" in obj and isinstance(obj["decorators"], list):
@@ -153,7 +214,7 @@ def extract_functional_signature(obj: Dict[str, Any]) -> Dict[str, Any]:
     elif kind == "attribute":
         # Track type annotation and value if meaningful
         if "annotation" in obj and obj["annotation"] is not None:
-            signature["annotation"] = obj["annotation"]
+            signature["annotation"] = render_annotation(obj["annotation"])
         # Only track simple values, ignore complex ones that might have noise
         if "value" in obj and obj["value"] is not None:
             value = obj["value"]

--- a/src/deadline/client/api/__init__.py
+++ b/src/deadline/client/api/__init__.py
@@ -19,7 +19,7 @@ depending on whether the credentials are from a Deadline Cloud Monitor login or 
 provider.
 """
 
-__all__ = [
+__all__ = [  # noqa: RUF022  intentionally grouped by feature (see section comments), not sorted
     "login",
     "logout",
     "create_job_from_job_bundle",

--- a/src/deadline/client/api/__init__.py
+++ b/src/deadline/client/api/__init__.py
@@ -19,7 +19,7 @@ depending on whether the credentials are from a Deadline Cloud Monitor login or 
 provider.
 """
 
-__all__ = [  # noqa: RUF022  intentionally grouped by feature (see section comments), not sorted
+__all__ = [  # noqa: RUF022  grouped by feature, not sorted
     "login",
     "logout",
     "create_job_from_job_bundle",

--- a/src/deadline/client/api/_submit_job_bundle.py
+++ b/src/deadline/client/api/_submit_job_bundle.py
@@ -53,7 +53,14 @@ from ...job_attachments.models import (
     StorageProfile,
     FileSystemLocationType,
 )
-from ...job_attachments.progress_tracker import ProgressReportMetadata, ProgressStatus
+from ...job_attachments.progress_tracker import (
+    ProgressReportMetadata,
+    ProgressStatus,
+    # SummaryStatistics is defined here; import from its source module rather than
+    # via job_attachments.upload (which only re-imports it) so the public contract
+    # is explicit. Matches the import in api/_telemetry.py.
+    SummaryStatistics,
+)
 from ...job_attachments.upload import S3AssetManager
 from ._session import session_context
 from ...job_attachments._path_summarization import (
@@ -61,7 +68,6 @@ from ...job_attachments._path_summarization import (
     summarize_path_list,
 )
 from ...job_attachments.api._hashing import _hash_attachments
-from ...job_attachments.upload import SummaryStatistics
 
 logger = logging.getLogger(__name__)
 

--- a/src/deadline/client/api/_submit_job_bundle.py
+++ b/src/deadline/client/api/_submit_job_bundle.py
@@ -56,9 +56,7 @@ from ...job_attachments.models import (
 from ...job_attachments.progress_tracker import (
     ProgressReportMetadata,
     ProgressStatus,
-    # SummaryStatistics is defined here; import from its source module rather than
-    # via job_attachments.upload (which only re-imports it) so the public contract
-    # is explicit. Matches the import in api/_telemetry.py.
+    # imported from its source module (not via .upload) for explicit re-export
     SummaryStatistics,
 )
 from ...job_attachments.upload import S3AssetManager

--- a/src/deadline/client/api/_update_checker.py
+++ b/src/deadline/client/api/_update_checker.py
@@ -10,12 +10,12 @@ integration is available by comparing the installed version against a remote man
 from __future__ import annotations
 
 __all__ = [
-    "MANIFEST_URL",
     "DOWNLOAD_BASE_URL",
-    "UpdateCheckStatus",
+    "MANIFEST_URL",
     "UpdateCheckResult",
-    "safe_check_for_updates",
+    "UpdateCheckStatus",
     "get_current_platform",
+    "safe_check_for_updates",
 ]
 
 import json

--- a/src/deadline/client/cli/_common.py
+++ b/src/deadline/client/cli/_common.py
@@ -8,13 +8,13 @@ from __future__ import annotations
 
 __all__ = [
     "_PROMPT_WHEN_COMPLETE",
-    "_prompt_at_completion",
-    "_handle_error",
+    "_ProgressBarCallbackManager",
     "_apply_cli_options_to_config",
     "_cli_object_repr",
-    "_ProgressBarCallbackManager",
+    "_handle_error",
     "_parse_file_parameter",
     "_parse_multi_format_parameters",
+    "_prompt_at_completion",
     "_suggest_resources_on_client_error",
 ]
 

--- a/src/deadline/client/cli/_deadline_web_url.py
+++ b/src/deadline/client/cli/_deadline_web_url.py
@@ -15,10 +15,10 @@ from ..exceptions import DeadlineOperationError
 logger = getLogger(__name__)
 
 __all__ = [
-    "parse_query_string",
-    "install_deadline_web_url_handler",
-    "uninstall_deadline_web_url_handler",
     "DEADLINE_URL_SCHEME_NAME",
+    "install_deadline_web_url_handler",
+    "parse_query_string",
+    "uninstall_deadline_web_url_handler",
 ]
 
 DEADLINE_URL_SCHEME_NAME = "deadline"

--- a/src/deadline/client/cli/_groups/__init__.py
+++ b/src/deadline/client/cli/_groups/__init__.py
@@ -1,18 +1,18 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 __all__ = [
+    "attachment_group",
+    "auth_group",
     "bundle_group",
     "config_group",
-    "auth_group",
     "farm_group",
     "fleet_group",
     "handle_web_url_command",
     "job_group",
-    "queue_group",
-    "worker_group",
-    "attachment_group",
     "manifest_group",
     "mcp_server_command",
+    "queue_group",
+    "worker_group",
 ]
 
 from . import (

--- a/src/deadline/client/config/__init__.py
+++ b/src/deadline/client/config/__init__.py
@@ -11,13 +11,13 @@ file path instead.
 """
 
 __all__ = [
-    "get_setting_default",
-    "get_setting",
-    "set_setting",
+    "DEFAULT_DEADLINE_ENDPOINT_URL",
     "clear_setting",
     "get_best_profile_for_farm",
+    "get_setting",
+    "get_setting_default",
+    "set_setting",
     "str2bool",
-    "DEFAULT_DEADLINE_ENDPOINT_URL",
 ]
 
 from .config_file import (

--- a/src/deadline/client/config/config_file.py
+++ b/src/deadline/client/config/config_file.py
@@ -1,17 +1,17 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 __all__ = [
-    "get_config_file_path",
-    "get_cache_directory",
-    "read_config",
-    "write_config",
-    "get_setting_default",
-    "get_setting",
-    "set_setting",
+    "DEFAULT_QUEUE_INCREMENTAL_DOWNLOAD_DIR",
     "clear_setting",
     "get_best_profile_for_farm",
+    "get_cache_directory",
+    "get_config_file_path",
+    "get_setting",
+    "get_setting_default",
+    "read_config",
+    "set_setting",
     "str2bool",
-    "DEFAULT_QUEUE_INCREMENTAL_DOWNLOAD_DIR",
+    "write_config",
 ]
 
 import getpass

--- a/src/deadline/client/job_bundle/_hooks/__init__.py
+++ b/src/deadline/client/job_bundle/_hooks/__init__.py
@@ -7,9 +7,9 @@ from ._models import HookConfiguration, HookDefinition, HookMetadata, HookResult
 from ._validator import validate_pre_gui_output
 
 __all__ = [
-    "HookManager",
     "HookConfiguration",
     "HookDefinition",
+    "HookManager",
     "HookMetadata",
     "HookResult",
     "_generate_hooks_confirmation_message",

--- a/src/deadline/client/job_bundle/loader.py
+++ b/src/deadline/client/job_bundle/loader.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 __all__ = [
+    "parse_yaml_or_json_content",
     "read_yaml_or_json",
     "read_yaml_or_json_object",
-    "parse_yaml_or_json_content",
     "validate_directory_symlink_containment",
 ]
 

--- a/src/deadline/client/job_bundle/parameters.py
+++ b/src/deadline/client/job_bundle/parameters.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 __all__ = [
+    "JobParameter",
     "apply_job_parameters",
-    "read_job_bundle_parameters",
     "get_ui_control_for_parameter_definition",
     "parameter_definition_difference",
+    "read_job_bundle_parameters",
 ]
 
 import os

--- a/src/deadline/client/ui/__init__.py
+++ b/src/deadline/client/ui/__init__.py
@@ -6,10 +6,10 @@ interfaces that use Deadline Cloud.
 """
 
 __all__ = [
-    "block_signals",
-    "gui_error_handler",
-    "gui_context_for_cli",
     "CancelationFlag",
+    "block_signals",
+    "gui_context_for_cli",
+    "gui_error_handler",
 ]
 
 from ._utils import block_signals, gui_error_handler, gui_context_for_cli, CancelationFlag

--- a/src/deadline/client/ui/dataclasses/__init__.py
+++ b/src/deadline/client/ui/dataclasses/__init__.py
@@ -7,14 +7,14 @@ Contains dataclasses for holding UI parameter values, used by the widgets.
 from __future__ import annotations
 
 __all__ = [
-    "JobBundleSettings",
     "CliJobSettings",
-    "OsRequirements",
-    "HardwareRequirements",
     "CustomAmountRequirement",
     "CustomAttributeRequirement",
     "CustomRequirements",
+    "HardwareRequirements",
     "HostRequirements",
+    "JobBundleSettings",
+    "OsRequirements",
 ]
 
 import os

--- a/src/deadline/client/ui/dialogs/__init__.py
+++ b/src/deadline/client/ui/dialogs/__init__.py
@@ -3,10 +3,10 @@
 __all__ = [
     "DeadlineConfigDialog",
     "DeadlineLoginDialog",
+    "JobBundlePurpose",
     "SubmitJobProgressDialog",
     "SubmitJobToDeadlineDialog",
     "UpdateAvailableDialog",
-    "JobBundlePurpose",
 ]
 
 from ._types import JobBundlePurpose

--- a/src/deadline/client/ui/widgets/__init__.py
+++ b/src/deadline/client/ui/widgets/__init__.py
@@ -1,6 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
-__all__ = [  # noqa: RUF022  intentionally grouped by widget category (see section comments), not sorted
+__all__ = [  # noqa: RUF022  grouped by category, not sorted
     "DirectoryPickerWidget",
     "InputFilePickerWidget",
     "OutputFilePickerWidget",

--- a/src/deadline/client/ui/widgets/__init__.py
+++ b/src/deadline/client/ui/widgets/__init__.py
@@ -1,6 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
-__all__ = [
+__all__ = [  # noqa: RUF022  intentionally grouped by widget category (see section comments), not sorted
     "DirectoryPickerWidget",
     "InputFilePickerWidget",
     "OutputFilePickerWidget",

--- a/src/deadline/client/ui/widgets/path_widgets.py
+++ b/src/deadline/client/ui/widgets/path_widgets.py
@@ -1,6 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
-__all__ = ["InputFilePickerWidget", "OutputFilePickerWidget", "DirectoryPickerWidget"]
+__all__ = ["DirectoryPickerWidget", "InputFilePickerWidget", "OutputFilePickerWidget"]
 
 import os
 from typing import Optional

--- a/src/deadline/common/__init__.py
+++ b/src/deadline/common/__init__.py
@@ -4,8 +4,5 @@
 Common utilities for the Deadline Cloud project.
 """
 
-# This package namespace intentionally exposes no names directly. The only public
-# (deprecated) surface lives in the ``deadline.common.path_utils`` submodule, which
-# declares its own ``__all__``. The empty ``__all__`` here makes that explicit so API
-# tooling does not treat incidental imports as public interface.
+# Nothing public here; the (deprecated) surface lives in the path_utils submodule.
 __all__: list[str] = []

--- a/src/deadline/common/__init__.py
+++ b/src/deadline/common/__init__.py
@@ -3,3 +3,9 @@
 """
 Common utilities for the Deadline Cloud project.
 """
+
+# This package namespace intentionally exposes no names directly. The only public
+# (deprecated) surface lives in the ``deadline.common.path_utils`` submodule, which
+# declares its own ``__all__``. The empty ``__all__`` here makes that explicit so API
+# tooling does not treat incidental imports as public interface.
+__all__: list[str] = []

--- a/src/deadline/common/path_utils.py
+++ b/src/deadline/common/path_utils.py
@@ -18,9 +18,9 @@ warnings.warn(
 )
 
 __all__ = [
+    "PathSummary",
     "human_readable_file_size",
+    "summarize_path_list",
     "summarize_paths_by_nested_directory",
     "summarize_paths_by_sequence",
-    "summarize_path_list",
-    "PathSummary",
 ]


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The snapshot half of API change detection flagged any non-underscore name griffe could see, so adding `from typing import Any` to a module registered as new public API and failed the advisory check (e.g. PR #1198). It also rendered annotation changes as raw griffe AST dicts, which were unreadable.

### What was the solution? (How)
Determine the public surface from `__all__` when a module declares it, and fall back to a heuristic (drop underscore-prefixed names and imports that resolve outside `deadline`) otherwise. Submodules are always traversed and judged by their own `__all__`. Render annotations as readable strings so the report shows real changes like `HardwareRequirements -> Optional[HardwareRequirements]`, new parameters, and new shapes.

Keep `__all__` correct and consistent with linters:
- ruff RUF022 sorts `__all__` (2 feature-grouped lists opt out with noqa)
- mypy no_implicit_reexport requires re-exports to be declared in `__all__` (fixed the one violation by importing SummaryStatistics from its source module, matching api/_telemetry.py)

Add `JobParameter` to job_bundle.parameters `__all__` (it appears in public signatures) and `__all__ = []` to deadline.common (its only public surface is the deprecated path_utils submodule).

### What is the impact of this change?
Less noise in API change detection.

### How was this change tested?
CI actions

### Was this change documented?
Yes

### Does this PR introduce new dependencies?
No

### Is this a breaking change?
No

### Does this change impact security?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
