### PR TITLE
test: warm the accessibility bridge + GUI caches once per session

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/test/_common/mock_deadline_backend.py
+++ b/test/_common/mock_deadline_backend.py
@@ -1191,6 +1191,18 @@ def _make_handler(routes, validator, backend):
             self.end_headers()
             self.wfile.write(data)
 
+        def handle_one_request(self):
+            # When a test gives up on a GUI subprocess whose accessibility
+            # bridge never attached, the subprocess is killed mid-request and
+            # the socket write raises BrokenPipeError/ConnectionError. That's an
+            # expected teardown race, not a backend bug — swallow it instead of
+            # letting BaseHTTPRequestHandler dump a traceback that buries the
+            # real (xa11y-side) failure in the CI log.
+            try:
+                super().handle_one_request()
+            except (BrokenPipeError, ConnectionResetError, ConnectionAbortedError):
+                self.close_connection = True
+
         def _dispatch(self, method):
             parsed = _urlparse(self.path)
             for route_method, pattern, handler_fn, op_name in routes:
@@ -1219,11 +1231,19 @@ def _make_handler(routes, validator, backend):
                     code = err.get("Code", "InternalServerException")
                     status = 404 if code == "ResourceNotFoundException" else 400
                     self._send_json(status, {"message": err.get("Message", "")}, error_code=code)
+                except (BrokenPipeError, ConnectionResetError, ConnectionAbortedError):
+                    # Client (GUI subprocess) disconnected mid-response — see
+                    # handle_one_request. Don't try to send a 500 back over a
+                    # dead socket; that just raises again.
+                    self.close_connection = True
                 except Exception as exc:  # noqa: BLE001
                     _traceback.print_exc()
-                    self._send_json(
-                        500, {"message": str(exc)}, error_code="InternalServerException"
-                    )
+                    try:
+                        self._send_json(
+                            500, {"message": str(exc)}, error_code="InternalServerException"
+                        )
+                    except (BrokenPipeError, ConnectionResetError, ConnectionAbortedError):
+                        self.close_connection = True
                 return
             # Log 404s at stderr so a debugging CI run surfaces which path
             # the client hit without going through the mock's HTTP response

--- a/test/ui/conftest.py
+++ b/test/ui/conftest.py
@@ -19,7 +19,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from _common.mock_deadline_backend import MockDeadlineBackend, start_server  # noqa: E402
-from helpers import SAMPLE_TEMPLATE, SubmitterDialog, reap_all  # noqa: E402
+from helpers import SAMPLE_TEMPLATE, SubmitterDialog, reap_all, warm_up_gui  # noqa: E402
 
 
 @pytest.fixture(autouse=True)
@@ -27,6 +27,41 @@ def _reap_ui_subprocesses() -> Iterator[None]:
     """Kill any GUI subprocesses still alive at test end."""
     yield
     reap_all()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _warm_accessibility_bridge(_mock_backend_server, tmp_path_factory) -> None:
+    """Warm the accessibility bridge + GUI process caches once per session.
+
+    Runs before any test (autouse) so the one-time cold-start cost of bringing
+    up the platform a11y bridge and the first PySide6 subprocess is paid in
+    session setup, not absorbed by — and flaking — the first test. See
+    ``helpers.warm_up_gui``.
+    """
+    _, deadline_url = _mock_backend_server
+
+    warm_dir = tmp_path_factory.mktemp("warmup")
+    config_file = warm_dir / "deadline.config"
+    config_file.write_text("")
+    shim_dir = warm_dir / "shim"
+    shim_dir.mkdir()
+    (shim_dir / "sitecustomize.py").write_text(_SITECUSTOMIZE)
+    fake_home = warm_dir / "home"
+    fake_home.mkdir()
+
+    env = {
+        **os.environ,
+        "HOME": str(fake_home),
+        "AWS_ENDPOINT_URL_DEADLINE": deadline_url,
+        "AWS_ACCESS_KEY_ID": "testing",
+        "AWS_SECRET_ACCESS_KEY": "testing",
+        "AWS_DEFAULT_REGION": "us-west-2",
+        "DEADLINE_CONFIG_FILE_PATH": str(config_file),
+        "DEADLINE_CLOUD_TELEMETRY_OPT_OUT": "true",
+        "PYTHONUNBUFFERED": "1",
+        "PYTHONPATH": str(shim_dir) + os.pathsep + os.environ.get("PYTHONPATH", ""),
+    }
+    warm_up_gui(env)
 
 
 # ---------------------------------------------------------------------------

--- a/test/ui/helpers.py
+++ b/test/ui/helpers.py
@@ -211,6 +211,36 @@ def _find_app(pid: int, baseline_names: set, timeout: float) -> xa11y.App:
     raise TimeoutError(f"No accessibility app found for PID {pid}")
 
 
+# Time to wait for the accessibility bridge to start responding to queries
+# before launching the first GUI. Only paid once per session (see the
+# ``_warm_accessibility_bridge`` fixture in conftest.py).
+BRIDGE_READY_TIMEOUT = 30.0
+
+
+def wait_for_accessibility_bridge(timeout: float = BRIDGE_READY_TIMEOUT) -> None:
+    """Block until the platform accessibility bridge answers a query.
+
+    ``xa11y.App.list()`` raises (or the bridge wedges) until the AT-SPI registry
+    (Linux), UIA (Windows), or AX (macOS) is actually serving requests. The CI
+    workflow only ``sleep``s a fixed amount after starting the bridge, which is
+    a guess; polling here turns that guess into a real readiness signal so the
+    first test isn't the one that discovers the bridge wasn't up yet.
+    """
+    end = time.monotonic() + timeout
+    last_exc: Optional[BaseException] = None
+    while time.monotonic() < end:
+        try:
+            xa11y.App.list()
+            return
+        except Exception as exc:  # noqa: BLE001 — any bridge error means "not ready"
+            last_exc = exc
+        time.sleep(0.25)
+    raise TimeoutError(
+        f"Accessibility bridge did not become queryable within {timeout}s"
+        + (f" (last error: {last_exc})" if last_exc is not None else "")
+    )
+
+
 # ---------------------------------------------------------------------------
 # Page objects
 # ---------------------------------------------------------------------------
@@ -410,6 +440,28 @@ class ConfigDialog(DeadlineApp):
         """Return the visible text of the Nth combo box in a group."""
         combo = self.locator(f'group[name="{group}"] combo_box').elements()[index]
         return combo.value or combo.name or ""
+
+
+def warm_up_gui(env: dict) -> None:
+    """Launch and close one real GUI to warm the session before tests run.
+
+    Two cold-start costs dominate the startup-time flakiness on hosted CI
+    runners, and both are one-time:
+
+    1. The accessibility bridge often only fully initialises when its first
+       client attaches; the very first test otherwise absorbs that latency.
+    2. The first GUI subprocess pays uncached Python ``.pyc`` and Qt-plugin
+       load costs that later launches don't.
+
+    Launching one ``deadline config gui`` here (after the bridge-readiness
+    probe) pays both up front, so steady-state launches are warm and land well
+    inside the existing ``STARTUP_TIMEOUT``. A failure here is surfaced as a
+    session-setup error with a clear message rather than a confusing first-test
+    failure.
+    """
+    wait_for_accessibility_bridge()
+    with ConfigDialog.open(env=env) as app:
+        app.dialog().wait_visible(timeout=STARTUP_TIMEOUT)
 
 
 class SubmitterDialog(DeadlineApp):


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
UI tests have been flaky. Root cause is that on cold workers, the UI and accessibility bridge take extra time to start which causes assertions to time out.

### What was the solution? (How)
Warm up the GUI and bridge at the start of the test session.

### What is the impact of this change?
Should fix test flakes.

### How was this change tested?
CI

### Was this change documented?
n/a

### Does this PR introduce new dependencies?
No

### Is this a breaking change?
No

### Does this change impact security?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
