### PR TITLE
fix(test): update integ test assertions for multi-region farm list output

### DIFF
--- a/test/integ/cli/test_cli_farm.py
+++ b/test/integ/cli/test_cli_farm.py
@@ -36,7 +36,8 @@ def test_farm_list(deadline_cli_test: DeadlineCliTest) -> None:
 
     assert result.exit_code == 0
 
-    assert f"- farmId: {deadline_cli_test.farm_id}" in result.output
+    assert f"farmId: {deadline_cli_test.farm_id}" in result.output
     # The following vary from farm to farm, so just make sure the general layout is there.
     # Unit tests are able to test the output more throughly. We'll only look for the required fields.
     assert "displayName:" in result.output
+    assert "region:" in result.output

--- a/test/integ/deadline_mcp/test_mcp_server_integration.py
+++ b/test/integ/deadline_mcp/test_mcp_server_integration.py
@@ -146,7 +146,7 @@ async def test_tool_description_extraction(get_boto_session):
         f"Got: {list_farms_tool.description}"
     )
 
-    assert "Calls the [deadline:ListFarms] API call" in list_farms_tool.description, (
+    assert "Calls the [deadline:ListFarms] API" in list_farms_tool.description, (
         "Tool description should come from the function's doc string"
     )
 


### PR DESCRIPTION
## Summary

Fixes the 2 integration test failures introduced by #1202 (multi-region farm support) that are causing the `Prod-deadline-cloud-Mainline-Windows-Integ-Test-Failure-Count-Sev3` alarm ([P451852954](https://t.corp.amazon.com/P451852954)).

**test_cli_farm.py::test_farm_list** — The `farm list` CLI output now includes `region` as the first field in each list item. The assertion `"- farmId: ..."` fails because `farmId` is no longer the first field. Fixed by removing the `- ` prefix assumption and adding a `region:` assertion.

**test_mcp_server_integration.py::test_tool_description_extraction** — The `list_farms` docstring was updated from `"Calls the [deadline:ListFarms] API call"` to `"Calls the [deadline:ListFarms] API, paginating to return all farms..."`. Fixed by matching on the shorter common prefix `"Calls the [deadline:ListFarms] API"`.

## Test plan

- [ ] Verify the Windows and Linux mainline integration tests pass with these changes
- [ ] Confirm the CloudWatch alarm returns to OK state after the fix is deployed