### PR TITLE
chore: add agent invocation telemetry

### DIFF
--- a/src/deadline/client/api/_agent_detection.py
+++ b/src/deadline/client/api/_agent_detection.py
@@ -1,0 +1,100 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Best-effort detection of an AI agent / harness invoking the CLI.
+
+Kept in its own dependency-free module (imports only the standard library) so
+that both ``_session`` and ``_telemetry`` can import it at module level without
+creating an import cycle between them.
+
+Detection follows the convention implemented by unjs/std-env (the de-facto
+reference) and the AGENT proposal tracked in agentsmd/agents.md#136. No
+personally-identifiable information is read - only the presence/value of
+well-known agent marker variables.
+"""
+
+import os
+import re
+from typing import Optional
+
+# Agents that set a marker env var whose mere presence identifies them. Each
+# entry maps a detection env var to the canonical agent name we report. Checked
+# in order; the first match wins.
+_AGENT_ENV_MARKERS: tuple[tuple[str, str], ...] = (
+    ("CLAUDECODE", "claude-code"),
+    ("CLAUDE_CODE", "claude-code"),
+    ("CODEX_SANDBOX", "codex"),
+    ("CODEX_THREAD_ID", "codex"),
+    ("CURSOR_AGENT", "cursor"),
+    ("REPL_ID", "replit"),
+    ("GEMINI_CLI", "gemini"),
+    ("OPENCODE", "opencode"),
+    ("AUGMENT_AGENT", "auggie"),
+    ("GOOSE_PROVIDER", "goose"),
+)
+
+# Agents detected by matching a substring within the value of an env var
+# (rather than presence alone) - typically IDE/editor integrations. Checked
+# after the presence markers above so a more specific agent running inside the
+# IDE is detected first.
+_AGENT_ENV_VALUE_MARKERS: tuple[tuple[str, str, str], ...] = (
+    ("EDITOR", "devin", "devin"),
+    ("TERM_PROGRAM", "kiro", "kiro"),
+)
+
+# Maximum length of a sanitized agent name. The value flows into the HTTP
+# User-Agent header and telemetry payloads, so cap it to keep those bounded.
+_MAX_AGENT_NAME_LENGTH = 64
+
+# Characters permitted in an agent name. Anything else is stripped so a
+# malformed env value (spaces, slashes, control characters, newlines) can't
+# corrupt the User-Agent header token boundary or the telemetry payload.
+_DISALLOWED_AGENT_NAME_CHARS = re.compile(r"[^A-Za-z0-9._-]")
+
+
+def _sanitize_agent_name(value: str) -> Optional[str]:
+    """Constrains a free-form agent name to a safe charset and length.
+
+    Returns the cleaned name, or ``None`` if nothing usable remains. Used only
+    for the user-controlled ``AI_AGENT``/``AGENT`` override values; the built-in
+    marker tables already return fixed, known-safe names.
+    """
+    cleaned = _DISALLOWED_AGENT_NAME_CHARS.sub("", value.strip())
+    cleaned = cleaned[:_MAX_AGENT_NAME_LENGTH]
+    return cleaned.lower() or None
+
+
+def detect_invoking_agent() -> Optional[str]:
+    """Best-effort detection of an AI agent / harness invoking the CLI.
+
+    Returns the canonical agent name (e.g. ``"claude-code"``) if a known agent
+    environment is detected, otherwise ``None`` (treated as a human / direct
+    invocation). Detection is based purely on environment variables that agents
+    set; no personally-identifiable information is collected.
+    """
+    # ``AGENT`` (proposed standard, agents.md#136) and ``AI_AGENT`` (Vercel
+    # convention) carry the agent name directly and take priority. claude-code
+    # sets a "<name>_<version>_agent" form, so take the leading token to avoid
+    # recording a version-specific value. These values are user-controlled, so
+    # sanitize before returning.
+    for override_var in ("AI_AGENT", "AGENT"):
+        value = os.environ.get(override_var)
+        if value and value not in ("1", "true"):
+            sanitized = _sanitize_agent_name(value.split("_", 1)[0])
+            if sanitized:
+                return sanitized
+
+    for env_var, agent_name in _AGENT_ENV_MARKERS:
+        if os.environ.get(env_var):
+            return agent_name
+
+    for env_var, needle, agent_name in _AGENT_ENV_VALUE_MARKERS:
+        value = os.environ.get(env_var)
+        if value and needle in value.lower():
+            return agent_name
+
+    # Generic AGENT=1/true (proposed standard) with no parseable name.
+    if os.environ.get("AGENT") in ("1", "true"):
+        return "unknown"
+
+    return None

--- a/src/deadline/client/api/_session.py
+++ b/src/deadline/client/api/_session.py
@@ -130,6 +130,14 @@ def get_default_client_config(**kwargs) -> botocore.config.Config:
         user_agent_extra += submitter_extra
     if session_context.get("cli-command-name"):
         user_agent_extra += f" cli-command/{session_context['cli-command-name']}"
+    # Attribute AI-agent-driven invocations on the service-side User-Agent so they
+    # are distinguishable in service logs (complements the RUM telemetry tagging).
+    # Imported locally to avoid a circular import (_telemetry imports from here).
+    from ._telemetry import detect_invoking_agent
+
+    agent_name = detect_invoking_agent()
+    if agent_name:
+        user_agent_extra += f" invoked-by/{agent_name}"
     client_config = botocore.config.Config(user_agent_extra=user_agent_extra, **kwargs)
     return client_config
 

--- a/src/deadline/client/api/_session.py
+++ b/src/deadline/client/api/_session.py
@@ -26,6 +26,7 @@ from botocore.exceptions import (  # type: ignore[import]
 from botocore.session import get_session as get_botocore_session
 
 from .. import version
+from ._agent_detection import detect_invoking_agent
 from ..config import get_setting, set_setting, config_file
 from ..exceptions import DeadlineOperationError
 from ...job_attachments._aws.aws_clients import get_s3_client
@@ -132,9 +133,6 @@ def get_default_client_config(**kwargs) -> botocore.config.Config:
         user_agent_extra += f" cli-command/{session_context['cli-command-name']}"
     # Attribute AI-agent-driven invocations on the service-side User-Agent so they
     # are distinguishable in service logs (complements the RUM telemetry tagging).
-    # Imported locally to avoid a circular import (_telemetry imports from here).
-    from ._telemetry import detect_invoking_agent
-
     agent_name = detect_invoking_agent()
     if agent_name:
         user_agent_extra += f" invoked-by/{agent_name}"

--- a/src/deadline/client/api/_telemetry.py
+++ b/src/deadline/client/api/_telemetry.py
@@ -22,6 +22,7 @@ from urllib import request, error
 
 from ...job_attachments.progress_tracker import SummaryStatistics
 
+from ._agent_detection import detect_invoking_agent
 from ._session import (
     get_monitor_id,
     get_user_and_identity_store_id,
@@ -39,70 +40,6 @@ logger = logging.getLogger(__name__)
 
 # Generic function return type.
 F = TypeVar("F", bound=Callable[..., Any])
-
-
-# Detection of an AI agent / harness invoking the CLI follows the convention
-# implemented by unjs/std-env (the de-facto reference) and the AGENT proposal
-# tracked in agentsmd/agents.md#136. No personally-identifiable information is
-# read - only the presence/value of well-known agent marker variables.
-#
-# Agents that set a marker env var whose mere presence identifies them. Each
-# entry maps a detection env var to the canonical agent name we report. Checked
-# in order; the first match wins.
-_AGENT_ENV_MARKERS: tuple[tuple[str, str], ...] = (
-    ("CLAUDECODE", "claude-code"),
-    ("CLAUDE_CODE", "claude-code"),
-    ("CODEX_SANDBOX", "codex"),
-    ("CODEX_THREAD_ID", "codex"),
-    ("CURSOR_AGENT", "cursor"),
-    ("REPL_ID", "replit"),
-    ("GEMINI_CLI", "gemini"),
-    ("OPENCODE", "opencode"),
-    ("AUGMENT_AGENT", "auggie"),
-    ("GOOSE_PROVIDER", "goose"),
-)
-
-# Agents detected by matching a substring within the value of an env var
-# (rather than presence alone) - typically IDE/editor integrations. Checked
-# after the presence markers above so a more specific agent running inside the
-# IDE is detected first.
-_AGENT_ENV_VALUE_MARKERS: tuple[tuple[str, str, str], ...] = (
-    ("EDITOR", "devin", "devin"),
-    ("TERM_PROGRAM", "kiro", "kiro"),
-)
-
-
-def detect_invoking_agent() -> Optional[str]:
-    """Best-effort detection of an AI agent / harness invoking the CLI.
-
-    Returns the canonical agent name (e.g. ``"claude-code"``) if a known agent
-    environment is detected, otherwise ``None`` (treated as a human / direct
-    invocation). Detection is based purely on environment variables that agents
-    set; no personally-identifiable information is collected.
-    """
-    # ``AGENT`` (proposed standard, agents.md#136) and ``AI_AGENT`` (Vercel
-    # convention) carry the agent name directly and take priority. claude-code
-    # sets a "<name>_<version>_agent" form, so take the leading token to avoid
-    # recording a version-specific value.
-    for override_var in ("AI_AGENT", "AGENT"):
-        value = os.environ.get(override_var)
-        if value and value not in ("1", "true"):
-            return value.split("_", 1)[0].lower()
-
-    for env_var, agent_name in _AGENT_ENV_MARKERS:
-        if os.environ.get(env_var):
-            return agent_name
-
-    for env_var, needle, agent_name in _AGENT_ENV_VALUE_MARKERS:
-        value = os.environ.get(env_var)
-        if value and needle in value.lower():
-            return agent_name
-
-    # Generic AGENT=1/true (proposed standard) with no parseable name.
-    if os.environ.get("AGENT") in ("1", "true"):
-        return "unknown"
-
-    return None
 
 
 def _swallow_exceptions(func: F) -> F:

--- a/src/deadline/client/api/_telemetry.py
+++ b/src/deadline/client/api/_telemetry.py
@@ -41,6 +41,70 @@ logger = logging.getLogger(__name__)
 F = TypeVar("F", bound=Callable[..., Any])
 
 
+# Detection of an AI agent / harness invoking the CLI follows the convention
+# implemented by unjs/std-env (the de-facto reference) and the AGENT proposal
+# tracked in agentsmd/agents.md#136. No personally-identifiable information is
+# read - only the presence/value of well-known agent marker variables.
+#
+# Agents that set a marker env var whose mere presence identifies them. Each
+# entry maps a detection env var to the canonical agent name we report. Checked
+# in order; the first match wins.
+_AGENT_ENV_MARKERS: tuple[tuple[str, str], ...] = (
+    ("CLAUDECODE", "claude-code"),
+    ("CLAUDE_CODE", "claude-code"),
+    ("CODEX_SANDBOX", "codex"),
+    ("CODEX_THREAD_ID", "codex"),
+    ("CURSOR_AGENT", "cursor"),
+    ("REPL_ID", "replit"),
+    ("GEMINI_CLI", "gemini"),
+    ("OPENCODE", "opencode"),
+    ("AUGMENT_AGENT", "auggie"),
+    ("GOOSE_PROVIDER", "goose"),
+)
+
+# Agents detected by matching a substring within the value of an env var
+# (rather than presence alone) - typically IDE/editor integrations. Checked
+# after the presence markers above so a more specific agent running inside the
+# IDE is detected first.
+_AGENT_ENV_VALUE_MARKERS: tuple[tuple[str, str, str], ...] = (
+    ("EDITOR", "devin", "devin"),
+    ("TERM_PROGRAM", "kiro", "kiro"),
+)
+
+
+def detect_invoking_agent() -> Optional[str]:
+    """Best-effort detection of an AI agent / harness invoking the CLI.
+
+    Returns the canonical agent name (e.g. ``"claude-code"``) if a known agent
+    environment is detected, otherwise ``None`` (treated as a human / direct
+    invocation). Detection is based purely on environment variables that agents
+    set; no personally-identifiable information is collected.
+    """
+    # ``AGENT`` (proposed standard, agents.md#136) and ``AI_AGENT`` (Vercel
+    # convention) carry the agent name directly and take priority. claude-code
+    # sets a "<name>_<version>_agent" form, so take the leading token to avoid
+    # recording a version-specific value.
+    for override_var in ("AI_AGENT", "AGENT"):
+        value = os.environ.get(override_var)
+        if value and value not in ("1", "true"):
+            return value.split("_", 1)[0].lower()
+
+    for env_var, agent_name in _AGENT_ENV_MARKERS:
+        if os.environ.get(env_var):
+            return agent_name
+
+    for env_var, needle, agent_name in _AGENT_ENV_VALUE_MARKERS:
+        value = os.environ.get(env_var)
+        if value and needle in value.lower():
+            return agent_name
+
+    # Generic AGENT=1/true (proposed standard) with no parseable name.
+    if os.environ.get("AGENT") in ("1", "true"):
+        return "unknown"
+
+    return None
+
+
 def _swallow_exceptions(func: F) -> F:
     """Decorator that catches all exceptions in telemetry functions to prevent
     telemetry issues from affecting the main application flow."""
@@ -131,6 +195,15 @@ class TelemetryClient:
         # If a different base package is provided, include info from this library as supplementary info
         if package_name != "deadline-cloud-library":
             self._common_details["deadline-cloud-version"] = version
+
+        # Tag every event with whether an AI agent / harness invoked the CLI so
+        # downstream metrics can distinguish agent-driven from human usage.
+        # Recorded in _common_details (not metadata) so it is queryable as an
+        # event_details field in RUM event patterns.
+        agent_name = detect_invoking_agent()
+        self._common_details["invoked_by"] = "AGENT" if agent_name else "HUMAN"
+        if agent_name:
+            self._common_details["agent_name"] = agent_name
         try:
             self._system_metadata = self._get_system_metadata(config=config)
         except Exception:

--- a/test/unit/deadline_client/api/test_api_telemetry.py
+++ b/test/unit/deadline_client/api/test_api_telemetry.py
@@ -12,11 +12,11 @@ from dataclasses import asdict
 from urllib import request
 
 from deadline.client import api, config
+from deadline.client.api._agent_detection import detect_invoking_agent
 from deadline.client.api._telemetry import (
     TelemetryClient,
     TelemetryEvent,
     _swallow_exceptions,
-    detect_invoking_agent,
     get_deadline_cloud_library_telemetry_client,
     get_telemetry_client,
     record_success_fail_telemetry_event,
@@ -1115,6 +1115,26 @@ def test_detect_invoking_agent_ai_agent_override(clean_agent_env):
     clean_agent_env.setenv("AI_AGENT", "Claude-Code_1-2-3_agent")
     clean_agent_env.setenv("CURSOR_AGENT", "1")  # would otherwise win
     assert detect_invoking_agent() == "claude-code"
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        # Spaces/slashes/control chars are stripped so the User-Agent token and
+        # telemetry payload can't be corrupted by a malformed env value.
+        pytest.param("foo bar", "foobar", id="strips-space"),
+        pytest.param("a/b\\c", "abc", id="strips-slashes"),
+        pytest.param("name\nwith\rnewlines", "namewithnewlines", id="strips-control-chars"),
+        pytest.param("keep.this-name_x", "keep.this-name", id="keeps-safe-chars-splits-underscore"),
+        pytest.param("MixedCase", "mixedcase", id="lowercased"),
+        pytest.param("!@#$%", None, id="all-disallowed-falls-through"),
+        pytest.param("x" * 200, "x" * 64, id="length-capped"),
+    ],
+)
+def test_detect_invoking_agent_override_sanitized(clean_agent_env, value, expected):
+    """The user-controlled AI_AGENT/AGENT override is constrained to a safe charset/length."""
+    clean_agent_env.setenv("AI_AGENT", value)
+    assert detect_invoking_agent() == expected
 
 
 def test_detect_invoking_agent_presence_beats_ide(clean_agent_env):

--- a/test/unit/deadline_client/api/test_api_telemetry.py
+++ b/test/unit/deadline_client/api/test_api_telemetry.py
@@ -16,6 +16,7 @@ from deadline.client.api._telemetry import (
     TelemetryClient,
     TelemetryEvent,
     _swallow_exceptions,
+    detect_invoking_agent,
     get_deadline_cloud_library_telemetry_client,
     get_telemetry_client,
     record_success_fail_telemetry_event,
@@ -1023,3 +1024,123 @@ class TestGetMonitorSessionId:
 
         client = make_client()
         assert "monitor_session_id" not in client._common_details
+
+
+# Every env var that detect_invoking_agent() inspects. Cleared before each agent
+# detection test so the host environment (which may itself be an agent, e.g. a
+# developer running pytest inside Claude Code) can't leak into the assertions.
+_ALL_AGENT_ENV_VARS = (
+    "AI_AGENT",
+    "AGENT",
+    "CLAUDECODE",
+    "CLAUDE_CODE",
+    "CODEX_SANDBOX",
+    "CODEX_THREAD_ID",
+    "CURSOR_AGENT",
+    "REPL_ID",
+    "GEMINI_CLI",
+    "OPENCODE",
+    "AUGMENT_AGENT",
+    "GOOSE_PROVIDER",
+    "EDITOR",
+    "TERM_PROGRAM",
+)
+
+
+@pytest.fixture(name="clean_agent_env")
+def fixture_clean_agent_env(monkeypatch):
+    """Removes all agent-detection env vars so tests start from a 'human' baseline."""
+    for var in _ALL_AGENT_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    return monkeypatch
+
+
+def test_detect_invoking_agent_human(clean_agent_env):
+    """With no agent markers set, detection returns None (human / direct invocation)."""
+    assert detect_invoking_agent() is None
+
+
+@pytest.mark.parametrize(
+    "env_var, expected",
+    [
+        pytest.param("CLAUDECODE", "claude-code", id="claude-code"),
+        pytest.param("CLAUDE_CODE", "claude-code", id="claude-code-alt"),
+        pytest.param("CODEX_SANDBOX", "codex", id="codex-sandbox"),
+        pytest.param("CODEX_THREAD_ID", "codex", id="codex-thread"),
+        pytest.param("CURSOR_AGENT", "cursor", id="cursor"),
+        pytest.param("REPL_ID", "replit", id="replit"),
+        pytest.param("GEMINI_CLI", "gemini", id="gemini"),
+        pytest.param("OPENCODE", "opencode", id="opencode"),
+        pytest.param("AUGMENT_AGENT", "auggie", id="auggie"),
+        pytest.param("GOOSE_PROVIDER", "goose", id="goose"),
+    ],
+)
+def test_detect_invoking_agent_presence_markers(clean_agent_env, env_var, expected):
+    """Presence of a known agent marker env var resolves to its canonical name."""
+    clean_agent_env.setenv(env_var, "1")
+    assert detect_invoking_agent() == expected
+
+
+@pytest.mark.parametrize(
+    "env_var, value, expected",
+    [
+        pytest.param("EDITOR", "/usr/local/bin/devin-editor", "devin", id="devin-editor"),
+        pytest.param("TERM_PROGRAM", "kiro", "kiro", id="kiro-term"),
+        pytest.param("EDITOR", "vim", None, id="non-agent-editor"),
+    ],
+)
+def test_detect_invoking_agent_value_markers(clean_agent_env, env_var, value, expected):
+    """Value-substring markers (IDE/editor integrations) match on their value."""
+    clean_agent_env.setenv(env_var, value)
+    assert detect_invoking_agent() == expected
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        pytest.param("goose", "goose", id="named"),
+        pytest.param("claude-code_2-1-177_agent", "claude-code", id="versioned-token"),
+        pytest.param("1", "unknown", id="generic-true-numeric"),
+        pytest.param("true", "unknown", id="generic-true"),
+    ],
+)
+def test_detect_invoking_agent_generic_agent_var(clean_agent_env, value, expected):
+    """The proposed generic AGENT var carries a name, or 1/true -> 'unknown'."""
+    clean_agent_env.setenv("AGENT", value)
+    assert detect_invoking_agent() == expected
+
+
+def test_detect_invoking_agent_ai_agent_override(clean_agent_env):
+    """AI_AGENT takes priority and is lowercased to its leading token."""
+    clean_agent_env.setenv("AI_AGENT", "Claude-Code_1-2-3_agent")
+    clean_agent_env.setenv("CURSOR_AGENT", "1")  # would otherwise win
+    assert detect_invoking_agent() == "claude-code"
+
+
+def test_detect_invoking_agent_presence_beats_ide(clean_agent_env):
+    """A specific presence marker is detected before a host IDE value marker."""
+    clean_agent_env.setenv("TERM_PROGRAM", "kiro")
+    clean_agent_env.setenv("CLAUDECODE", "1")
+    assert detect_invoking_agent() == "claude-code"
+
+
+def test_telemetry_client_tags_human(fresh_deadline_config, clean_agent_env):
+    """A client created with no agent env tags events invoked_by=HUMAN, no agent_name."""
+    # Opt out so __init__ skips network initialize(); _common_details is populated first.
+    config.set_setting("telemetry.opt_out", "true")
+    client = TelemetryClient(
+        "deadline-cloud-library", "test-version", config=config.config_file.read_config()
+    )
+    assert client._common_details["invoked_by"] == "HUMAN"
+    assert "agent_name" not in client._common_details
+
+
+def test_telemetry_client_tags_agent(fresh_deadline_config, clean_agent_env):
+    """A client created under an agent env tags invoked_by=AGENT with the agent_name."""
+    config.set_setting("telemetry.opt_out", "true")
+    clean_agent_env.setenv("CLAUDECODE", "1")
+    client = TelemetryClient(
+        "deadline-cloud-library", "test-version", config=config.config_file.read_config()
+    )
+    assert client._common_details["invoked_by"] == "AGENT"
+    assert client._common_details["agent_name"] == "claude-code"

--- a/test/unit/deadline_client/cli/test_cli.py
+++ b/test/unit/deadline_client/cli/test_cli.py
@@ -247,6 +247,26 @@ def test_submitter_version_in_user_agent():
         session_context.update(original_context)
 
 
+def test_invoked_by_agent_in_user_agent():
+    """
+    Verifies that a detected AI agent is appended to user_agent_extra as
+    invoked-by/<agent>, and omitted entirely for human invocations.
+    """
+    from deadline.client.api import _telemetry
+
+    # get_default_client_config does a local `from ._telemetry import
+    # detect_invoking_agent`, so patch the source module, not _session.
+    # Agent detected -> appended.
+    with patch.object(_telemetry, "detect_invoking_agent", return_value="claude-code"):
+        config = get_default_client_config()
+        assert "invoked-by/claude-code" in config.user_agent_extra
+
+    # No agent (human) -> nothing appended.
+    with patch.object(_telemetry, "detect_invoking_agent", return_value=None):
+        config = get_default_client_config()
+        assert "invoked-by/" not in config.user_agent_extra
+
+
 def _run_deadline(*args: str) -> subprocess.CompletedProcess:
     return subprocess.run(
         ["deadline", *args],

--- a/test/unit/deadline_client/cli/test_cli.py
+++ b/test/unit/deadline_client/cli/test_cli.py
@@ -252,17 +252,17 @@ def test_invoked_by_agent_in_user_agent():
     Verifies that a detected AI agent is appended to user_agent_extra as
     invoked-by/<agent>, and omitted entirely for human invocations.
     """
-    from deadline.client.api import _telemetry
+    from deadline.client.api import _session
 
-    # get_default_client_config does a local `from ._telemetry import
-    # detect_invoking_agent`, so patch the source module, not _session.
+    # get_default_client_config calls _session's imported detect_invoking_agent,
+    # so patch it where it is used.
     # Agent detected -> appended.
-    with patch.object(_telemetry, "detect_invoking_agent", return_value="claude-code"):
+    with patch.object(_session, "detect_invoking_agent", return_value="claude-code"):
         config = get_default_client_config()
         assert "invoked-by/claude-code" in config.user_agent_extra
 
     # No agent (human) -> nothing appended.
-    with patch.object(_telemetry, "detect_invoking_agent", return_value=None):
+    with patch.object(_session, "detect_invoking_agent", return_value=None):
         config = get_default_client_config()
         assert "invoked-by/" not in config.user_agent_extra
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Deadline Cloud telemetry could not distinguish CLI invocations driven by an AI coding agent / harness (e.g. Claude Code, Codex, Cursor) from those run directly by a human. All such usage was indistinguishable in both the RUM telemetry pipeline and service-side logs, so we had no way to measure how much of our CLI traffic is agent-driven.

### What was the solution? (How)

Added best-effort detection of an invoking AI agent based on well-known environment variables, following the de-facto convention implemented by `unjs/std-env` and the `AGENT` proposal tracked in `agentsmd/agents.md#136`.

- New `detect_invoking_agent()` in `_telemetry.py` resolves a canonical agent name from `AI_AGENT` / `AGENT` overrides, then presence markers (claude-code, codex, cursor, replit, gemini, opencode, auggie, goose) and value/IDE markers (devin, kiro), returning `None` for human/direct invocations.
- The result is recorded once in `TelemetryClient._common_details` as `invoked_by` (`AGENT`|`HUMAN`) plus `agent_name`. Because `_common_details` is merged into every event's details at send time, all telemetry events (CLI, GUI, and MCP) are tagged without touching any call site.
- `get_default_client_config()` additionally appends `invoked-by/<agent>` to the boto `user_agent_extra`, surfacing the same attribution on the service-side User-Agent header (CloudTrail) as a second, independent evidence channel.

Detection is environment-variable only — no personally-identifiable information is collected.

### What is the impact of this change?

- RUM telemetry events gain `invoked_by` / `agent_name` fields in `event_details`, enabling dashboards/metrics to break usage down by agent vs. human.
- Service-side requests include `invoked-by/<agent>` in their User-Agent when an agent is detected.
- No behavioral change for end users; telemetry remains opt-out-able via the existing `telemetry.opt_out` setting / `DEADLINE_CLOUD_TELEMETRY_OPT_OUT` env var.

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests? **Yes.** Added 22 unit tests covering `detect_invoking_agent()` (override priority, presence markers, IDE/value markers, generic `AGENT`, human baseline) and the `_common_details` tagging, plus a test asserting `invoked-by/<agent>` is appended to (and absent from) `user_agent_extra`. Full affected suites pass (`test_api_telemetry.py`, `test_cli.py`, `test_mcp_telemetry.py` — 125 tests). `ruff` and `mypy` are clean.
- Have you run the integration tests? **No.** This change does not affect any service-calling integration path; the detection is local and the User-Agent addition is non-functional metadata.

### Was this change documented?

- Are relevant docstrings in the code base updated? **Yes** — `detect_invoking_agent()` and the new logic carry docstrings/comments explaining the convention and the no-PII guarantee.
- Has the README.md been updated? If you modified CLI arguments, for instance. **N/A** — no CLI arguments or user-facing surface changed.

### Does this PR introduce new dependencies?

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?

No. This is purely additive telemetry metadata. No public contract is modified, and no action is required by users of this package.

### Does this change impact security?

The change reads only well-known agent-marker environment variables (no PII) and adds non-sensitive metadata to telemetry and the User-Agent header. It does not create or modify files/directories or change permissions, so it does not require threat modeling.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
