### PR TITLE
feat: Append deadline-cloud-v2 to the conda queue environment for migr…

### DIFF
--- a/src/deadline/client/api/_queue_parameters.py
+++ b/src/deadline/client/api/_queue_parameters.py
@@ -20,6 +20,50 @@ from ..job_bundle.parameters import (
 from ..ui._utils import tr
 
 
+# The default Conda channel that Deadline Cloud configures automatically, and its v2 successor.
+_DEADLINE_CLOUD_CHANNEL = "deadline-cloud"
+_DEADLINE_CLOUD_V2_CHANNEL = "deadline-cloud-v2"
+
+
+def _prepend_v2_channel(channels: str) -> str:
+    """
+    Inserts ``deadline-cloud-v2`` immediately ahead of the ``deadline-cloud`` channel in a
+    space-separated channel list, returning the new list.
+
+    Returns the input unchanged when ``deadline-cloud`` is absent, or when
+    ``deadline-cloud-v2`` is already present (so the operation is idempotent across repeated
+    queue-parameter reloads and queues that already list the v2 channel).
+    """
+    tokens = channels.split()
+    if _DEADLINE_CLOUD_CHANNEL not in tokens or _DEADLINE_CLOUD_V2_CHANNEL in tokens:
+        return channels
+    result: list[str] = []
+    for token in tokens:
+        # Insert v2 just before v1 so it takes precedence under Conda's channel priority.
+        if token == _DEADLINE_CLOUD_CHANNEL:
+            result.append(_DEADLINE_CLOUD_V2_CHANNEL)
+        result.append(token)
+    return " ".join(result)
+
+
+def _apply_deadline_cloud_v2_channel_migration(queue_parameters: list[JobParameter]) -> None:
+    """
+    Prepends ``deadline-cloud-v2`` ahead of ``deadline-cloud`` in the ``CondaChannels`` queue
+    parameter (see :func:`_prepend_v2_channel`), rewriting both the ``default`` and ``value``
+    fields in place.
+
+    Args:
+        queue_parameters (list[JobParameter]): The queue parameter definitions to modify.
+    """
+    for parameter in queue_parameters:
+        if parameter.get("name") != "CondaChannels":
+            continue
+        for field in ("default", "value"):
+            channels = parameter.get(field)
+            if isinstance(channels, str):
+                parameter[field] = _prepend_v2_channel(channels)
+
+
 @api.record_function_latency_telemetry_event()
 def get_queue_parameter_definitions(
     *, region: Optional[str] = None, farmId: str, queueId: str, config=None

--- a/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
+++ b/src/deadline/client/ui/dialogs/submit_job_to_deadline_dialog.py
@@ -104,6 +104,10 @@ class SubmitJobToDeadlineDialog(QDialog):
         show_host_requirements_tab: Display the host requirements tab in dialog if set to True. Default
             to False.
         submitter_info (SubmitterInfo): Information related to the submitter window and application it's running in
+        use_deadline_cloud_v2_channel (bool): When True, prepend the "deadline-cloud-v2" Conda
+            channel ahead of the default "deadline-cloud" channel in the CondaChannels queue
+            parameter as it loads from the queue. The "deadline-cloud" channel is kept as a
+            fallback and other channels are left untouched. Defaults to False (no change).
     """
 
     _auto_select_complete = _Signal()
@@ -123,6 +127,7 @@ class SubmitJobToDeadlineDialog(QDialog):
         host_requirements: Optional[HostRequirements] = None,
         submitter_info: Optional[SubmitterInfo] = None,
         known_asset_paths: Optional[list[str]] = None,
+        use_deadline_cloud_v2_channel: bool = False,
     ):
         # The Qt.Tool flag makes sure our widget stays in front of the main application window
         super().__init__(parent=parent, f=f)
@@ -153,6 +158,7 @@ class SubmitJobToDeadlineDialog(QDialog):
         self.deadline_authentication_status = DeadlineAuthenticationStatus.getInstance()
         self.show_host_requirements_tab = show_host_requirements_tab
         self.known_asset_paths = known_asset_paths or []
+        self.use_deadline_cloud_v2_channel = use_deadline_cloud_v2_channel
         self.should_close = False
 
         # Runs the auto-select farm/queue API calls off the Qt event loop. Using a
@@ -423,6 +429,7 @@ class SubmitJobToDeadlineDialog(QDialog):
         self.shared_job_settings = SharedJobSettingsWidget(
             initial_settings=initial_job_settings,
             initial_shared_parameter_values=initial_shared_parameter_values,
+            use_deadline_cloud_v2_channel=self.use_deadline_cloud_v2_channel,
             parent=self,
         )
         self.shared_job_settings.parameter_changed.connect(self.on_shared_job_parameter_changed)

--- a/src/deadline/client/ui/widgets/shared_job_settings_tab.py
+++ b/src/deadline/client/ui/widgets/shared_job_settings_tab.py
@@ -25,6 +25,7 @@ from qtpy.QtWidgets import (  # type: ignore
 from .radio_button_widget import HoverRadioButton
 
 from ... import api
+from ...api._queue_parameters import _apply_deadline_cloud_v2_channel_migration
 from ...api._session import _resolve_region
 from ...config import get_setting
 from .._utils import tr
@@ -47,6 +48,9 @@ class SharedJobSettingsWidget(QWidget):  # pylint: disable=too-few-public-method
             to override default queue parameter values from the queue. For example,
             a Rez queue environment may have a default "" for the RezPackages parameter, but a Maya
             submitter would override that default with "maya-2023" or similar.
+        use_deadline_cloud_v2_channel (bool): When True, prepend the "deadline-cloud-v2" Conda
+            channel ahead of the default "deadline-cloud" channel in the CondaChannels queue
+            parameter as it loads, keeping "deadline-cloud" as a fallback. Defaults to False.
         parent: The parent Qt Widget.
     """
 
@@ -60,6 +64,7 @@ class SharedJobSettingsWidget(QWidget):  # pylint: disable=too-few-public-method
         *,
         initial_settings: Any,
         initial_shared_parameter_values: dict[str, Any],
+        use_deadline_cloud_v2_channel: bool = False,
         parent: Optional[QWidget] = None,
     ):
         super().__init__(parent=parent)
@@ -68,6 +73,8 @@ class SharedJobSettingsWidget(QWidget):  # pylint: disable=too-few-public-method
         # This is a dictionary {<name>: <value>} containing values to
         # override the queue parameter defaults.
         self.initial_shared_parameter_values = initial_shared_parameter_values
+
+        self.use_deadline_cloud_v2_channel = use_deadline_cloud_v2_channel
 
         self.shared_job_properties_box = SharedJobPropertiesWidget(
             initial_settings=initial_settings, parent=self
@@ -180,6 +187,9 @@ class SharedJobSettingsWidget(QWidget):  # pylint: disable=too-few-public-method
         """Handle queue parameters update from the controller."""
         self.__valid_queue = True
         self.valid_parameters.emit(True)
+        # Migrate channels before applying submitter overrides, so an explicit override wins.
+        if self.use_deadline_cloud_v2_channel:
+            _apply_deadline_cloud_v2_channel_migration(queue_parameters)
         # Apply the initial queue parameter values
         for parameter in queue_parameters:
             if parameter["name"] in self.initial_shared_parameter_values:

--- a/test/unit/deadline_client/api/test_queue_parameters_conda_channel.py
+++ b/test/unit/deadline_client/api/test_queue_parameters_conda_channel.py
@@ -1,0 +1,104 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Tests for the deadline-cloud -> deadline-cloud-v2 Conda channel migration applied to the
+CondaChannels queue parameter (see deadline.client.api._queue_parameters).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from deadline.client.api._queue_parameters import (
+    _apply_deadline_cloud_v2_channel_migration,
+    _prepend_v2_channel,
+)
+from deadline.client.job_bundle.parameters import JobParameter
+
+
+@pytest.mark.parametrize(
+    "channels, expected",
+    [
+        # The default queue value: v2 is prepended, v1 kept as fallback.
+        ("deadline-cloud", "deadline-cloud-v2 deadline-cloud"),
+        # Trailing channels keep their order, v2 lands just before v1.
+        ("deadline-cloud conda-forge", "deadline-cloud-v2 deadline-cloud conda-forge"),
+        # Leading channels are preserved; v2 is inserted at the v1 position, not the front.
+        ("conda-forge deadline-cloud", "conda-forge deadline-cloud-v2 deadline-cloud"),
+        # Idempotent: v2 already present means no change, even alongside v1.
+        ("deadline-cloud-v2 deadline-cloud", "deadline-cloud-v2 deadline-cloud"),
+        ("deadline-cloud-v2", "deadline-cloud-v2"),
+        # No deadline-cloud channel: customized channels are left untouched.
+        ("my-private-channel", "my-private-channel"),
+        ("conda-forge defaults", "conda-forge defaults"),
+        # Substring safety: only the exact "deadline-cloud" token migrates.
+        ("deadline-cloud-extra", "deadline-cloud-extra"),
+        (
+            "deadline-cloud-extra deadline-cloud",
+            "deadline-cloud-extra deadline-cloud-v2 deadline-cloud",
+        ),
+        # Empty value is a no-op.
+        ("", ""),
+    ],
+)
+def test_prepend_v2_channel(channels: str, expected: str):
+    assert _prepend_v2_channel(channels) == expected
+
+
+def test_prepend_v2_channel_is_idempotent():
+    """Applying the prepend twice yields the same result as applying it once."""
+    once = _prepend_v2_channel("deadline-cloud conda-forge")
+    twice = _prepend_v2_channel(once)
+    assert once == "deadline-cloud-v2 deadline-cloud conda-forge"
+    assert twice == once
+
+
+def test_migration_rewrites_default_and_value():
+    """Both the default and value fields of the CondaChannels parameter are migrated."""
+    params: list[JobParameter] = [
+        {
+            "name": "CondaChannels",
+            "default": "deadline-cloud",
+            "value": "deadline-cloud conda-forge",
+        },
+    ]
+    _apply_deadline_cloud_v2_channel_migration(params)
+    assert params[0]["default"] == "deadline-cloud-v2 deadline-cloud"
+    assert params[0]["value"] == "deadline-cloud-v2 deadline-cloud conda-forge"
+
+
+def test_migration_only_touches_conda_channels_parameter():
+    """Parameters other than CondaChannels are left untouched."""
+    params: list[JobParameter] = [
+        {"name": "CondaPackages", "value": "cinema4d=2026 deadline-cloud-for-cinema4d"},
+        {"name": "CondaChannels", "value": "deadline-cloud"},
+        {"name": "MyQueueParameter", "value": "deadline-cloud"},
+    ]
+    _apply_deadline_cloud_v2_channel_migration(params)
+    # CondaPackages happens to contain the substring but must not be rewritten.
+    assert params[0]["value"] == "cinema4d=2026 deadline-cloud-for-cinema4d"
+    assert params[1]["value"] == "deadline-cloud-v2 deadline-cloud"
+    # A different parameter that happens to hold the same value is not the conda channels list.
+    assert params[2]["value"] == "deadline-cloud"
+
+
+def test_migration_handles_missing_conda_channels_parameter():
+    """No CondaChannels parameter present is a no-op and does not raise."""
+    params: list[JobParameter] = [{"name": "CondaPackages", "value": "cinema4d=2026"}]
+    _apply_deadline_cloud_v2_channel_migration(params)
+    assert params == [{"name": "CondaPackages", "value": "cinema4d=2026"}]
+
+
+def test_migration_handles_parameter_without_value_or_default():
+    """A CondaChannels parameter missing both string fields is skipped cleanly."""
+    params: list[JobParameter] = [{"name": "CondaChannels"}]
+    _apply_deadline_cloud_v2_channel_migration(params)
+    assert params == [{"name": "CondaChannels"}]
+
+
+def test_migration_is_idempotent_across_repeated_calls():
+    """Re-running the migration (as happens on queue/farm reloads) does not duplicate v2."""
+    params: list[JobParameter] = [{"name": "CondaChannels", "value": "deadline-cloud"}]
+    _apply_deadline_cloud_v2_channel_migration(params)
+    _apply_deadline_cloud_v2_channel_migration(params)
+    assert params[0]["value"] == "deadline-cloud-v2 deadline-cloud"

--- a/test/unit/deadline_client/ui/widgets/test_shared_job_settings_tab.py
+++ b/test/unit/deadline_client/ui/widgets/test_shared_job_settings_tab.py
@@ -1,5 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
+from unittest.mock import patch
+
 import pytest
 
 try:
@@ -20,6 +22,45 @@ def shared_job_settings_tab(qtbot, temp_job_bundle_dir) -> SharedJobSettingsWidg
     )
     qtbot.addWidget(widget)
     return widget
+
+
+@pytest.fixture(scope="function")
+def v2_channel_settings_tab(qtbot, temp_job_bundle_dir) -> SharedJobSettingsWidget:
+    """A SharedJobSettingsWidget opted into the deadline-cloud-v2 Conda channel migration."""
+    initial_settings = JobBundleSettings(input_job_bundle_dir=temp_job_bundle_dir, name="test-name")
+    widget = SharedJobSettingsWidget(
+        initial_settings=initial_settings,
+        initial_shared_parameter_values=dict(),
+        use_deadline_cloud_v2_channel=True,
+    )
+    qtbot.addWidget(widget)
+    return widget
+
+
+def test_v2_channel_migration_applied_when_enabled(
+    v2_channel_settings_tab: SharedJobSettingsWidget,
+):
+    """When use_deadline_cloud_v2_channel is True, the queue's CondaChannels gets v2 prepended."""
+    queue_parameters = [{"name": "CondaChannels", "value": "deadline-cloud conda-forge"}]
+    with patch.object(v2_channel_settings_tab.queue_parameters_box, "rebuild_ui") as mock_rebuild:
+        v2_channel_settings_tab._handle_queue_parameters_update(queue_parameters)
+
+    rebuilt = mock_rebuild.call_args.kwargs["parameter_definitions"]
+    conda_channels = next(p for p in rebuilt if p["name"] == "CondaChannels")
+    assert conda_channels["value"] == "deadline-cloud-v2 deadline-cloud conda-forge"
+
+
+def test_v2_channel_migration_not_applied_when_deactivated(
+    shared_job_settings_tab: SharedJobSettingsWidget,
+):
+    """By default (flag off), the queue's CondaChannels is passed through unchanged."""
+    queue_parameters = [{"name": "CondaChannels", "value": "deadline-cloud conda-forge"}]
+    with patch.object(shared_job_settings_tab.queue_parameters_box, "rebuild_ui") as mock_rebuild:
+        shared_job_settings_tab._handle_queue_parameters_update(queue_parameters)
+
+    rebuilt = mock_rebuild.call_args.kwargs["parameter_definitions"]
+    conda_channels = next(p for p in rebuilt if p["name"] == "CondaChannels")
+    assert conda_channels["value"] == "deadline-cloud conda-forge"
 
 
 def test_name_should_be_truncated_to_openjd_spec_128_chars(


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Deadline Cloud is migrating its service-managed Conda channel from `deadline-cloud` to `deadline-cloud-v2` temporarily. The default `CondaChannels` queue-environment parameter still resolves to `deadline-cloud`, so a submitter that wants to adopt the v2 channel had no supported, shared way to do so. Without a mechanism in this library, each DCC integration would have to re-implement the rewrite itself, duplicating the logic and the literal channel names across every submitter.

### What was the solution? (How)

Added an opt-in flag, `use_deadline_cloud_v2_channel` (default `False`), to `SubmitJobToDeadlineDialog` and `SharedJobSettingsWidget`. When enabled, the widget rewrites the `CondaChannels` queue parameter as it loads, via a new private helper in `deadline.client.api._queue_parameters`:

- **Prepend, not replace** — `deadline-cloud-v2` is inserted immediately *before* `deadline-cloud`, keeping v1 as a fallback so any package not yet hosted on v2 still resolves, while v2 takes precedence under Conda's channel priority.
- **Token-level and order-preserving** — only the exact `deadline-cloud` token is affected; other channels (and their relative order) are left untouched. For example, `deadline-cloud conda-forge` becomes `deadline-cloud-v2 deadline-cloud conda-forge`.
- **Idempotent** — a no-op when `deadline-cloud-v2` is already present or `deadline-cloud` is absent, so the re-fire on every farm/queue switch cannot duplicate the channel.
- **Applied before submitter overrides**, so an explicit `initial_shared_parameter_values["CondaChannels"]` still wins.

The logic lives in the Qt-free `_queue_parameters` module so it is unit-testable without Qt, and it is kept private — it is **not** added to `deadline.client.api.__all__`, so the public API surface is unchanged.

### What is the impact of this change?

- **Opt-in and inert by default.** Submitters that do not pass `use_deadline_cloud_v2_channel=True` (every existing DCC integration) behave exactly as before.
- Submitters that opt in get `deadline-cloud-v2` prepended ahead of `deadline-cloud` in the GUI submission flow.
- **Scope is the GUI submission path only.** CLI/headless bundle submission (consumers of `get_queue_parameter_definitions`) is intentionally unaffected.

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

I also ran it with Cinema 4D changes: 

- If there is deadline-cloud channel present. 

<img width="539" height="581" alt="Screenshot 2026-06-16 at 4 50 21 PM" src="https://github.com/user-attachments/assets/cd23947c-4c69-47bd-a66d-ff1c34e671b1" />

- If there is already a non deadline-cloud channel present
<img width="534" height="522" alt="Screenshot 2026-06-16 at 4 51 03 PM" src="https://github.com/user-attachments/assets/bbc0b84f-f951-4802-98fd-0a540ce45c87" />


- **Have you run the unit tests?** Yes.
  - New `test/unit/deadline_client/api/test_queue_parameters_conda_channel.py` covers the pure rewrite logic: the default value, multi-channel values, leading/trailing channel ordering, idempotency (including repeated application), substring safety (`deadline-cloud-extra` is not migrated), customized channels left untouched, missing/value-less `CondaChannels`, and that only the `CondaChannels` parameter is affected.
  - New widget tests in `test/unit/deadline_client/ui/widgets/test_shared_job_settings_tab.py` verify that `_handle_queue_parameters_update` prepends v2 when the flag is enabled and passes the value through unchanged when it is not.
  - Ran the full `test_shared_job_settings_tab.py` and `test_queue_parameters_conda_channel.py` suites — 28 passed, no regressions.
- **Have you run the integration tests?** No — this change only affects the GUI queue-parameter load path, which is exercised by the unit/widget tests above.

### Was this change documented?

- **Are relevant docstrings in the code base updated?** Yes. The new `use_deadline_cloud_v2_channel` argument is documented in the `SubmitJobToDeadlineDialog` and `SharedJobSettingsWidget` docstrings, and the `_prepend_v2_channel` / `_apply_deadline_cloud_v2_channel_migration` helpers carry docstrings describing the prepend behavior and idempotency.
- **Has the README.md been updated?** No — no CLI arguments or user-facing entry points changed.

### Does this PR introduce new dependencies?

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?

No. The new `use_deadline_cloud_v2_channel` argument is keyword-only with a default of `False`, so existing callers are unaffected and behavior is unchanged unless a submitter explicitly opts in. No public contract is modified — the migration helper is private and not exported via `deadline.client.api.__all__`.

### Does this change impact security?

No. The change only rewrites a Conda channel name string in queue parameters during GUI submission; it does not create or modify files/directories or alter permissions, and does not need to be threat modeled.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
