### PR TITLE
Revert "chore(release): 0.59.0 (#1209)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 0.59.0 (2026-06-15)
-
-### BREAKING CHANGES
-* Farms are now identified by (region, farm_id) rather than just farm_id. List operations like `list_farms` fan out across all Deadline Cloud regions and return results annotated with their region. The `farm list` CLI output now includes a `region` field before `farmId`. Users who parse CLI output or rely on the previous single-region behavior will need to update their workflows. (#1202)
 ## 0.58.0 (2026-06-10)
 
 ### BREAKING CHANGES


### PR DESCRIPTION
This reverts commit c6f2a53c517d45f336bf9497d95dee59386ba5f3.

  ### What was the problem/requirement? (What/Why)

  The 0.59.0 release failed in the upstream release pipeline. We need to revert the release commit to unblock the
  release process and prevent the pipeline from re-triggering on this failed version.

  ### What was the solution? (How)

  Revert commit c6f2a53c517d45f336bf9497d95dee59386ba5f3 which added the 0.59.0 changelog entry to CHANGELOG.md.

  ### What is the impact of this change?

  Removes the 0.59.0 release changelog entry. The next release bump will re-create the release with the same (or
  updated) content.

  ### How was this change tested?

  - N/A — this is a revert of a changelog-only commit.

  ### Was this change documented?

  - N/A

  ### Does this PR introduce new dependencies?

  *   [x] This PR does not add any new dependencies.

  ### Is this a breaking change?

  No.

  ### Does this change impact security?

  No.

  ----

  *By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution,
  under the terms of your choice.*