### PR TITLE
feat: write download status JSON file from sync-output

### DIFF
--- a/src/deadline/client/cli/_download_status_file.py
+++ b/src/deadline/client/cli/_download_status_file.py
@@ -67,8 +67,7 @@ def _determine_job_download_status(
         succeeded = task_counts.get("SUCCEEDED", 0)
         total = sum(task_counts.values()) if task_counts else 0
         active_tasks = sum(
-            task_counts.get(s, 0)
-            for s in ["READY", "RUNNING", "ASSIGNED", "STARTING", "SCHEDULED"]
+            task_counts.get(s, 0) for s in ["READY", "RUNNING", "ASSIGNED", "STARTING", "SCHEDULED"]
         )
         if succeeded == total and total > 0 and active_tasks == 0 and "endedAt" in job:
             status = "downloaded"
@@ -103,8 +102,15 @@ def _determine_job_download_status(
         }
 
     if job_id in categorized_job_ids.inactive:
+        task_counts = job.get("taskRunStatusCounts", {})
+        succeeded = task_counts.get("SUCCEEDED", 0)
+        total = sum(task_counts.values()) if task_counts else 0
+        if succeeded == total and total > 0:
+            status = "downloaded"
+        else:
+            status = "skipped"
         return {
-            "download_status": "downloaded",
+            "download_status": status,
             "total_files": 0,
             "downloaded_files": 0,
             "failed_files": 0,
@@ -203,7 +209,7 @@ def _read_existing_status_file(file_path: str) -> dict[str, Any]:
                 data = json.load(f)
             return data.get("jobs", {})
     except (json.JSONDecodeError, OSError, KeyError):
-        pass
+        pass  # Gracefully handle corrupt or inaccessible status files
     return {}
 
 
@@ -223,7 +229,7 @@ def _atomic_write_json(file_path: str, data: dict[str, Any]) -> None:
         try:
             os.unlink(tmp_path)
         except OSError:
-            pass
+            pass  # Best-effort cleanup of temp file
         raise
 
 

--- a/src/deadline/client/cli/_download_status_file.py
+++ b/src/deadline/client/cli/_download_status_file.py
@@ -101,24 +101,6 @@ def _determine_job_download_status(
             "error_message": None,
         }
 
-    if job_id in categorized_job_ids.inactive:
-        task_counts = job.get("taskRunStatusCounts", {})
-        succeeded = task_counts.get("SUCCEEDED", 0)
-        total = sum(task_counts.values()) if task_counts else 0
-        if succeeded == total and total > 0:
-            status = "downloaded"
-        else:
-            status = "skipped"
-        return {
-            "download_status": status,
-            "total_files": 0,
-            "downloaded_files": 0,
-            "failed_files": 0,
-            "last_updated": datetime.now(timezone.utc).isoformat(),
-            "error_code": None,
-            "error_message": None,
-        }
-
     # unchanged jobs — check if all tasks succeeded to determine if fully downloaded
     if job_id in categorized_job_ids.unchanged:
         task_counts = job.get("taskRunStatusCounts", {})
@@ -169,12 +151,13 @@ def _build_status_file_content(
     jobs_status: dict[str, Any] = dict(existing_jobs) if existing_jobs else {}
 
     # Update/add entries from this run's categorized jobs
+    # Inactive jobs are excluded — they dropped out of download_candidate_jobs so we can't
+    # look up their task counts. Their existing entry from the merge is preserved as-is.
     all_job_ids = (
         categorized_job_ids.completed
         | categorized_job_ids.added
         | categorized_job_ids.updated
         | categorized_job_ids.unchanged
-        | categorized_job_ids.inactive
         | categorized_job_ids.attachments_free
         | categorized_job_ids.missing_storage_profile
     )

--- a/src/deadline/client/cli/_download_status_file.py
+++ b/src/deadline/client/cli/_download_status_file.py
@@ -18,6 +18,40 @@ logger = logging.getLogger(__name__)
 DOWNLOAD_STATUS_FILE_SCHEMA_VERSION = 1
 
 
+def _make_status_entry(
+    status: str,
+    total_files: int = 0,
+    downloaded_files: int = 0,
+    failed_files: int = 0,
+    error_code: Optional[str] = None,
+    error_message: Optional[str] = None,
+) -> dict[str, Any]:
+    """Constructs a per-job status entry for the status file."""
+    return {
+        "download_status": status,
+        "total_files": total_files,
+        "downloaded_files": downloaded_files,
+        "failed_files": failed_files,
+        "last_updated": datetime.now(timezone.utc).isoformat(),
+        "error_code": error_code,
+        "error_message": error_message,
+    }
+
+
+def _is_job_fully_complete(job: dict[str, Any], check_active_tasks: bool = False) -> bool:
+    """Returns True if all tasks succeeded and the job has ended."""
+    task_counts = job.get("taskRunStatusCounts", {})
+    succeeded = task_counts.get("SUCCEEDED", 0)
+    total = sum(task_counts.values()) if task_counts else 0
+    if check_active_tasks:
+        active_tasks = sum(
+            task_counts.get(s, 0) for s in ["READY", "RUNNING", "ASSIGNED", "STARTING", "SCHEDULED"]
+        )
+        if active_tasks > 0:
+            return False
+    return succeeded == total and "endedAt" in job
+
+
 def _determine_job_download_status(
     job_id: str,
     job: dict[str, Any],
@@ -30,106 +64,30 @@ def _determine_job_download_status(
     Returns a dict representing the job's status in the status file.
     """
     if job_id in categorized_job_ids.attachments_free:
-        return {
-            "download_status": "skipped",
-            "total_files": 0,
-            "downloaded_files": 0,
-            "failed_files": 0,
-            "last_updated": datetime.now(timezone.utc).isoformat(),
-            "error_code": None,
-            "error_message": None,
-        }
+        return _make_status_entry("skipped")
 
     if job_id in categorized_job_ids.missing_storage_profile:
-        return {
-            "download_status": "skipped",
-            "total_files": 0,
-            "downloaded_files": 0,
-            "failed_files": 0,
-            "last_updated": datetime.now(timezone.utc).isoformat(),
-            "error_code": None,
-            "error_message": None,
-        }
+        return _make_status_entry("skipped")
 
     if job_id in categorized_job_ids.completed:
-        return {
-            "download_status": "downloaded",
-            "total_files": 0,
-            "downloaded_files": 0,
-            "failed_files": 0,
-            "last_updated": datetime.now(timezone.utc).isoformat(),
-            "error_code": None,
-            "error_message": None,
-        }
+        return _make_status_entry("downloaded")
 
     if job_id in categorized_job_ids.added:
-        task_counts = job.get("taskRunStatusCounts", {})
-        succeeded = task_counts.get("SUCCEEDED", 0)
-        total = sum(task_counts.values()) if task_counts else 0
-        active_tasks = sum(
-            task_counts.get(s, 0) for s in ["READY", "RUNNING", "ASSIGNED", "STARTING", "SCHEDULED"]
-        )
-        if succeeded == total and total > 0 and active_tasks == 0 and "endedAt" in job:
-            status = "downloaded"
-        else:
-            status = "in_progress"
-        return {
-            "download_status": status,
-            "total_files": 0,
-            "downloaded_files": 0,
-            "failed_files": 0,
-            "last_updated": datetime.now(timezone.utc).isoformat(),
-            "error_code": None,
-            "error_message": None,
-        }
+        if _is_job_fully_complete(job, check_active_tasks=True):
+            return _make_status_entry("downloaded")
+        return _make_status_entry("in_progress")
 
     if job_id in categorized_job_ids.updated:
-        task_counts = job.get("taskRunStatusCounts", {})
-        succeeded = task_counts.get("SUCCEEDED", 0)
-        total = sum(task_counts.values()) if task_counts else 0
-        if succeeded == total and total > 0 and "endedAt" in job:
-            status = "downloaded"
-        else:
-            status = "in_progress"
-        return {
-            "download_status": status,
-            "total_files": 0,
-            "downloaded_files": 0,
-            "failed_files": 0,
-            "last_updated": datetime.now(timezone.utc).isoformat(),
-            "error_code": None,
-            "error_message": None,
-        }
+        if _is_job_fully_complete(job):
+            return _make_status_entry("downloaded")
+        return _make_status_entry("in_progress")
 
-    # unchanged jobs — check if all tasks succeeded to determine if fully downloaded
     if job_id in categorized_job_ids.unchanged:
-        task_counts = job.get("taskRunStatusCounts", {})
-        succeeded = task_counts.get("SUCCEEDED", 0)
-        total = sum(task_counts.values()) if task_counts else 0
-        if succeeded == total and total > 0 and "endedAt" in job:
-            status = "downloaded"
-        else:
-            status = "in_progress"
-        return {
-            "download_status": status,
-            "total_files": 0,
-            "downloaded_files": 0,
-            "failed_files": 0,
-            "last_updated": datetime.now(timezone.utc).isoformat(),
-            "error_code": None,
-            "error_message": None,
-        }
+        if _is_job_fully_complete(job):
+            return _make_status_entry("downloaded")
+        return _make_status_entry("in_progress")
 
-    # fallback — should not typically reach here
-    return {
-        "download_status": "in_progress",
-        "total_files": 0,
-        "downloaded_files": 0,
-        "failed_files": 0,
-        "last_updated": datetime.now(timezone.utc).isoformat(),
-        "error_code": None,
-        "error_message": None,
-    }
+    return _make_status_entry("in_progress")
 
 
 def _build_status_file_content(

--- a/src/deadline/client/cli/_download_status_file.py
+++ b/src/deadline/client/cli/_download_status_file.py
@@ -8,14 +8,95 @@ import logging
 import os
 import socket
 import tempfile
+import time
+from contextlib import contextmanager
 from datetime import datetime, timezone
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Generator, Optional
 
 from ._incremental_download import CategorizedJobIds
 
 logger = logging.getLogger(__name__)
 
 DOWNLOAD_STATUS_FILE_SCHEMA_VERSION = 1
+_STATUS_FILE_LOCK_TTL_SECONDS = 60
+_STATUS_FILE_LOCK_RETRY_INTERVAL_SECONDS = 1
+# MAX_WAIT must be >= TTL so a waiter is willing to wait at least as long as a lock
+# can legitimately be held before considering it stale.
+_STATUS_FILE_LOCK_MAX_WAIT_SECONDS = 90
+
+
+@contextmanager
+def _status_file_lock(status_file_path: str) -> Generator[None, None, None]:
+    """Cooperative cross-machine lock for the shared NAS status file.
+
+    Creates a sentinel lock file next to the status file. Both machines agree
+    to check for it before reading/writing, preventing last-writer-wins races
+    when two machines sync the same queue to the same NAS simultaneously.
+    Locks older than _STATUS_FILE_LOCK_TTL_SECONDS are considered stale
+    (e.g. from a crashed process) and overwritten.
+    """
+    lock_path = status_file_path + ".lock"
+    dir_path = os.path.dirname(status_file_path)
+    os.makedirs(dir_path, exist_ok=True)
+
+    acquired = False
+    deadline_time = time.monotonic() + _STATUS_FILE_LOCK_MAX_WAIT_SECONDS
+    while time.monotonic() < deadline_time:
+        # Check if a lock exists and whether it is stale.
+        # Read the timestamp from the lock file content rather than the NAS mtime to avoid
+        # NAS-server-vs-client clock skew. Note: client-to-client clock skew (between the
+        # two sync machines) is still a factor but is bounded by NTP drift (typically <1s),
+        # well within the 60s TTL. Worst case is a stale badge on the next poll, not data loss.
+        try:
+            with open(lock_path, "r") as _lf:
+                _lock_data = json.load(_lf)
+            lock_written_at = float(_lock_data.get("time", 0))
+            if time.time() - lock_written_at < _STATUS_FILE_LOCK_TTL_SECONDS:
+                # Lock is fresh — wait for the holder to release it
+                time.sleep(_STATUS_FILE_LOCK_RETRY_INTERVAL_SECONDS)
+                continue
+            else:
+                # Lock is stale — remove it so we can acquire with O_EXCL
+                try:
+                    os.unlink(lock_path)
+                except OSError:
+                    pass  # Another process may have already removed it
+        except (OSError, json.JSONDecodeError, KeyError, ValueError):
+            pass  # Lock file doesn't exist or is unreadable — proceed to acquire
+
+        # Acquire the lock using O_CREAT|O_EXCL for atomic exclusive create.
+        # Note: O_EXCL over NFS/SMB is best-effort — not guaranteed on all network filesystems,
+        # but substantially better than os.replace which gives no exclusion at all.
+        try:
+            lock_time = time.time()
+            lock_content = json.dumps({"hostname": socket.gethostname(), "time": lock_time})
+            fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+            with os.fdopen(fd, "w") as f:
+                f.write(lock_content)
+            acquired = True
+            break
+        except FileExistsError:
+            time.sleep(_STATUS_FILE_LOCK_RETRY_INTERVAL_SECONDS)
+        except OSError:
+            time.sleep(_STATUS_FILE_LOCK_RETRY_INTERVAL_SECONDS)
+    else:
+        logger.warning(
+            f"Could not acquire status file lock at {lock_path} after {_STATUS_FILE_LOCK_MAX_WAIT_SECONDS}s — proceeding without lock."
+        )
+
+    try:
+        yield
+    finally:
+        if acquired:
+            # Verify we still own the lock before deleting — if our hold exceeded the TTL,
+            # another process may have taken it over. Only unlink if the stored time matches.
+            try:
+                with open(lock_path, "r") as _lf:
+                    _on_disk = json.load(_lf)
+                if _on_disk.get("time") == lock_time:
+                    os.unlink(lock_path)
+            except (OSError, json.JSONDecodeError, KeyError, ValueError):
+                pass  # Lock already gone or unreadable — nothing to clean up
 
 
 def _make_status_entry(
@@ -56,7 +137,6 @@ def _determine_job_download_status(
     job_id: str,
     job: dict[str, Any],
     categorized_job_ids: CategorizedJobIds,
-    local_storage_profile_id: Optional[str],
 ) -> dict[str, Any]:
     """
     Determines the download status entry for a single job based on its category.
@@ -95,7 +175,6 @@ def _build_status_file_content(
     storage_profile_id: Optional[str],
     categorized_job_ids: CategorizedJobIds,
     download_candidate_jobs: dict[str, dict[str, Any]],
-    local_storage_profile_id: Optional[str],
     existing_jobs: Optional[dict[str, Any]] = None,
 ) -> dict[str, Any]:
     """
@@ -122,9 +201,7 @@ def _build_status_file_content(
 
     for job_id in all_job_ids:
         job = download_candidate_jobs.get(job_id, {})
-        jobs_status[job_id] = _determine_job_download_status(
-            job_id, job, categorized_job_ids, local_storage_profile_id
-        )
+        jobs_status[job_id] = _determine_job_download_status(job_id, job, categorized_job_ids)
 
     return {
         "schema_version": DOWNLOAD_STATUS_FILE_SCHEMA_VERSION,
@@ -190,6 +267,10 @@ def _get_status_file_paths(
         paths = []
         for location in local_storage_profile.get("fileSystemLocations", []):
             location_path = location["path"]
+            # Only include paths whose root location already exists — avoids writing
+            # phantom files under an empty mount point when the NAS is unmounted.
+            if not os.path.isdir(location_path):
+                continue
             status_file_path = os.path.join(
                 location_path, ".deadline", f"{queue_id}_download_status.json"
             )
@@ -235,18 +316,18 @@ def write_download_status_file(
 
     for status_file_path in status_file_paths:
         try:
-            existing_jobs = _read_existing_status_file(status_file_path)
+            with _status_file_lock(status_file_path):
+                existing_jobs = _read_existing_status_file(status_file_path)
 
-            status_content = _build_status_file_content(
-                queue_id=queue_id,
-                storage_profile_id=local_storage_profile_id,
-                categorized_job_ids=categorized_job_ids,
-                download_candidate_jobs=download_candidate_jobs,
-                local_storage_profile_id=local_storage_profile_id,
-                existing_jobs=existing_jobs,
-            )
+                status_content = _build_status_file_content(
+                    queue_id=queue_id,
+                    storage_profile_id=local_storage_profile_id,
+                    categorized_job_ids=categorized_job_ids,
+                    download_candidate_jobs=download_candidate_jobs,
+                    existing_jobs=existing_jobs,
+                )
 
-            _atomic_write_json(status_file_path, status_content)
+                _atomic_write_json(status_file_path, status_content)
             print_function_callback(f"Download status file saved: {status_file_path}")
         except Exception as e:
             logger.warning(f"Failed to write download status file to {status_file_path}: {e}")

--- a/src/deadline/client/cli/_download_status_file.py
+++ b/src/deadline/client/cli/_download_status_file.py
@@ -256,7 +256,7 @@ def write_download_status_file(
     """
     Writes the download status JSON file to the shared filesystem (or local default path).
 
-    This is called at the end of each sync-output run, inside the PID lock, after the
+    This is called at the end of each sync-output run, inside the PID lock, before the
     checkpoint is saved. If the write fails, it logs a warning but does not abort.
 
     Args:

--- a/src/deadline/client/cli/_download_status_file.py
+++ b/src/deadline/client/cli/_download_status_file.py
@@ -1,0 +1,308 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+from __future__ import annotations
+
+__all__ = ["write_download_status_file"]
+
+import json
+import logging
+import os
+import socket
+import tempfile
+from datetime import datetime, timezone
+from typing import Any, Callable, Optional
+
+from ._incremental_download import CategorizedJobIds
+
+logger = logging.getLogger(__name__)
+
+DOWNLOAD_STATUS_FILE_SCHEMA_VERSION = 1
+
+
+def _determine_job_download_status(
+    job_id: str,
+    job: dict[str, Any],
+    categorized_job_ids: CategorizedJobIds,
+    local_storage_profile_id: Optional[str],
+) -> dict[str, Any]:
+    """
+    Determines the download status entry for a single job based on its category.
+
+    Returns a dict representing the job's status in the status file.
+    """
+    if job_id in categorized_job_ids.attachments_free:
+        return {
+            "download_status": "skipped",
+            "total_files": 0,
+            "downloaded_files": 0,
+            "failed_files": 0,
+            "last_updated": datetime.now(timezone.utc).isoformat(),
+            "error_code": None,
+            "error_message": None,
+        }
+
+    if job_id in categorized_job_ids.missing_storage_profile:
+        return {
+            "download_status": "skipped",
+            "total_files": 0,
+            "downloaded_files": 0,
+            "failed_files": 0,
+            "last_updated": datetime.now(timezone.utc).isoformat(),
+            "error_code": None,
+            "error_message": None,
+        }
+
+    if job_id in categorized_job_ids.completed:
+        return {
+            "download_status": "downloaded",
+            "total_files": 0,
+            "downloaded_files": 0,
+            "failed_files": 0,
+            "last_updated": datetime.now(timezone.utc).isoformat(),
+            "error_code": None,
+            "error_message": None,
+        }
+
+    if job_id in categorized_job_ids.added:
+        task_counts = job.get("taskRunStatusCounts", {})
+        succeeded = task_counts.get("SUCCEEDED", 0)
+        total = sum(task_counts.values()) if task_counts else 0
+        active_tasks = sum(
+            task_counts.get(s, 0)
+            for s in ["READY", "RUNNING", "ASSIGNED", "STARTING", "SCHEDULED"]
+        )
+        if succeeded == total and total > 0 and active_tasks == 0 and "endedAt" in job:
+            status = "downloaded"
+        else:
+            status = "in_progress"
+        return {
+            "download_status": status,
+            "total_files": 0,
+            "downloaded_files": 0,
+            "failed_files": 0,
+            "last_updated": datetime.now(timezone.utc).isoformat(),
+            "error_code": None,
+            "error_message": None,
+        }
+
+    if job_id in categorized_job_ids.updated:
+        task_counts = job.get("taskRunStatusCounts", {})
+        succeeded = task_counts.get("SUCCEEDED", 0)
+        total = sum(task_counts.values()) if task_counts else 0
+        if succeeded == total and total > 0 and "endedAt" in job:
+            status = "downloaded"
+        else:
+            status = "in_progress"
+        return {
+            "download_status": status,
+            "total_files": 0,
+            "downloaded_files": 0,
+            "failed_files": 0,
+            "last_updated": datetime.now(timezone.utc).isoformat(),
+            "error_code": None,
+            "error_message": None,
+        }
+
+    if job_id in categorized_job_ids.inactive:
+        return {
+            "download_status": "downloaded",
+            "total_files": 0,
+            "downloaded_files": 0,
+            "failed_files": 0,
+            "last_updated": datetime.now(timezone.utc).isoformat(),
+            "error_code": None,
+            "error_message": None,
+        }
+
+    # unchanged jobs — check if all tasks succeeded to determine if fully downloaded
+    if job_id in categorized_job_ids.unchanged:
+        task_counts = job.get("taskRunStatusCounts", {})
+        succeeded = task_counts.get("SUCCEEDED", 0)
+        total = sum(task_counts.values()) if task_counts else 0
+        if succeeded == total and total > 0 and "endedAt" in job:
+            status = "downloaded"
+        else:
+            status = "in_progress"
+        return {
+            "download_status": status,
+            "total_files": 0,
+            "downloaded_files": 0,
+            "failed_files": 0,
+            "last_updated": datetime.now(timezone.utc).isoformat(),
+            "error_code": None,
+            "error_message": None,
+        }
+
+    # fallback — should not typically reach here
+    return {
+        "download_status": "in_progress",
+        "total_files": 0,
+        "downloaded_files": 0,
+        "failed_files": 0,
+        "last_updated": datetime.now(timezone.utc).isoformat(),
+        "error_code": None,
+        "error_message": None,
+    }
+
+
+def _build_status_file_content(
+    queue_id: str,
+    storage_profile_id: Optional[str],
+    categorized_job_ids: CategorizedJobIds,
+    download_candidate_jobs: dict[str, dict[str, Any]],
+    local_storage_profile_id: Optional[str],
+    existing_jobs: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
+    """
+    Builds the full status file JSON structure by merging existing job entries
+    with the current run's categorized job data. Existing entries are preserved;
+    current run entries are added or updated on top.
+    """
+    now = datetime.now(timezone.utc).isoformat()
+
+    # Start with existing jobs (preserves old completed jobs that dropped out of tracking)
+    jobs_status: dict[str, Any] = dict(existing_jobs) if existing_jobs else {}
+
+    # Update/add entries from this run's categorized jobs
+    all_job_ids = (
+        categorized_job_ids.completed
+        | categorized_job_ids.added
+        | categorized_job_ids.updated
+        | categorized_job_ids.unchanged
+        | categorized_job_ids.inactive
+        | categorized_job_ids.attachments_free
+        | categorized_job_ids.missing_storage_profile
+    )
+
+    for job_id in all_job_ids:
+        job = download_candidate_jobs.get(job_id, {})
+        jobs_status[job_id] = _determine_job_download_status(
+            job_id, job, categorized_job_ids, local_storage_profile_id
+        )
+
+    return {
+        "schema_version": DOWNLOAD_STATUS_FILE_SCHEMA_VERSION,
+        "sync_metadata": {
+            "queue_id": queue_id,
+            "storage_profile_id": storage_profile_id,
+            "last_sync_completed_at": now,
+            "last_run_status": "success",
+            "hostname": socket.gethostname(),
+        },
+        "jobs": jobs_status,
+    }
+
+
+def _read_existing_status_file(file_path: str) -> dict[str, Any]:
+    """
+    Reads an existing status file and returns its jobs dict.
+    Returns empty dict if file doesn't exist or is invalid.
+    """
+    try:
+        if os.path.exists(file_path):
+            with open(file_path, "r") as f:
+                data = json.load(f)
+            return data.get("jobs", {})
+    except (json.JSONDecodeError, OSError, KeyError):
+        pass
+    return {}
+
+
+def _atomic_write_json(file_path: str, data: dict[str, Any]) -> None:
+    """
+    Writes JSON data atomically using a temp file + rename to prevent partial reads.
+    """
+    dir_path = os.path.dirname(file_path)
+    os.makedirs(dir_path, exist_ok=True)
+
+    fd, tmp_path = tempfile.mkstemp(dir=dir_path, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2)
+        os.replace(tmp_path, file_path)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _get_status_file_paths(
+    queue_id: str,
+    local_storage_profile_id: Optional[str],
+    local_storage_profile: Optional[dict[str, Any]],
+    checkpoint_dir: str,
+) -> list[str]:
+    """
+    Determines all paths where the status file should be written.
+
+    With storage profile: writes to {each_file_system_location}/.deadline/{queue_id}_download_status.json
+    Without storage profile: writes to ~/.deadline/incremental_download/{queue_id}_ignore-storage-profiles_download_status.json
+    """
+    if local_storage_profile_id and local_storage_profile:
+        paths = []
+        for location in local_storage_profile.get("fileSystemLocations", []):
+            location_path = location["path"]
+            status_file_path = os.path.join(
+                location_path, ".deadline", f"{queue_id}_download_status.json"
+            )
+            paths.append(status_file_path)
+        return paths
+    else:
+        status_file_path = os.path.join(
+            checkpoint_dir, f"{queue_id}_ignore-storage-profiles_download_status.json"
+        )
+        return [status_file_path]
+
+
+def write_download_status_file(
+    queue_id: str,
+    categorized_job_ids: CategorizedJobIds,
+    download_candidate_jobs: dict[str, dict[str, Any]],
+    local_storage_profile_id: Optional[str],
+    local_storage_profile: Optional[dict[str, Any]],
+    checkpoint_dir: str,
+    print_function_callback: Callable[[Any], None] = lambda msg: None,
+) -> None:
+    """
+    Writes the download status JSON file to the shared filesystem (or local default path).
+
+    This is called at the end of each sync-output run, inside the PID lock, after the
+    checkpoint is saved. If the write fails, it logs a warning but does not abort.
+
+    Args:
+        queue_id: The queue ID.
+        categorized_job_ids: The categorized job IDs from the current sync run.
+        download_candidate_jobs: The dict of {job_id: job} from the current sync run.
+        local_storage_profile_id: The local storage profile ID, or None if --ignore-storage-profiles.
+        local_storage_profile: The full storage profile dict (with fileSystemLocations), or None.
+        checkpoint_dir: The checkpoint directory path (used for --ignore-storage-profiles case).
+        print_function_callback: Callback for printing output.
+    """
+    status_file_paths = _get_status_file_paths(
+        queue_id=queue_id,
+        local_storage_profile_id=local_storage_profile_id,
+        local_storage_profile=local_storage_profile,
+        checkpoint_dir=checkpoint_dir,
+    )
+
+    for status_file_path in status_file_paths:
+        try:
+            existing_jobs = _read_existing_status_file(status_file_path)
+
+            status_content = _build_status_file_content(
+                queue_id=queue_id,
+                storage_profile_id=local_storage_profile_id,
+                categorized_job_ids=categorized_job_ids,
+                download_candidate_jobs=download_candidate_jobs,
+                local_storage_profile_id=local_storage_profile_id,
+                existing_jobs=existing_jobs,
+            )
+
+            _atomic_write_json(status_file_path, status_content)
+            print_function_callback(f"Download status file saved: {status_file_path}")
+        except Exception as e:
+            logger.warning(f"Failed to write download status file to {status_file_path}: {e}")
+            print_function_callback(
+                f"WARNING: Failed to write download status file to {status_file_path}: {e}"
+            )

--- a/src/deadline/client/cli/_groups/queue_group.py
+++ b/src/deadline/client/cli/_groups/queue_group.py
@@ -436,26 +436,22 @@ def sync_output(
             logger.echo(f"    {location['name']}: {location['path']}")
         logger.echo()
 
-    # Pre-flight validation: verify all storage profile file system locations are accessible
+    # Pre-flight validation: warn about inaccessible storage profile locations.
+    # Downloads proceed regardless — jobs only map to the locations their outputs fall under,
+    # and the status file writer already tolerates per-location write failures gracefully.
     if local_storage_profile_id and local_storage_profile:
-        inaccessible_locations = []
         for location in local_storage_profile["fileSystemLocations"]:
             location_path = location["path"]
             if not os.path.isdir(location_path):
-                inaccessible_locations.append(
-                    f"  {location['name']}: {location_path} (does not exist)"
+                logger.echo(
+                    f"WARNING: File system location '{location['name']}' does not exist: {location_path}"
+                    " — status file will not be written to this location."
                 )
             elif not os.access(location_path, os.W_OK):
-                inaccessible_locations.append(
-                    f"  {location['name']}: {location_path} (not writable)"
+                logger.echo(
+                    f"WARNING: File system location '{location['name']}' is not writable: {location_path}"
+                    " — status file will not be written to this location."
                 )
-        if inaccessible_locations:
-            raise DeadlineOperationError(
-                "The following file system locations in the storage profile are not accessible:\n"
-                + "\n".join(inaccessible_locations)
-                + "\n\nLocations marked 'does not exist' need to be mounted."
-                + "\nLocations marked 'not writable' need write permissions granted."
-            )
 
     # Perform incremental download while holding a process id lock
 

--- a/src/deadline/client/cli/_groups/queue_group.py
+++ b/src/deadline/client/cli/_groups/queue_group.py
@@ -453,7 +453,8 @@ def sync_output(
             raise DeadlineOperationError(
                 "The following file system locations in the storage profile are not accessible:\n"
                 + "\n".join(inaccessible_locations)
-                + "\n\nEnsure all file system locations are mounted and writable before running sync-output."
+                + "\n\nLocations marked 'does not exist' need to be mounted."
+                + "\nLocations marked 'not writable' need write permissions granted."
             )
 
     # Perform incremental download while holding a process id lock

--- a/src/deadline/client/cli/_groups/queue_group.py
+++ b/src/deadline/client/cli/_groups/queue_group.py
@@ -437,8 +437,7 @@ def sync_output(
         logger.echo()
 
     # Pre-flight validation: verify all storage profile file system locations are accessible
-    # Skipped on dry-run since no files will be written
-    if local_storage_profile_id and local_storage_profile and not dry_run:
+    if local_storage_profile_id and local_storage_profile:
         inaccessible_locations = []
         for location in local_storage_profile["fileSystemLocations"]:
             location_path = location["path"]

--- a/src/deadline/client/cli/_groups/queue_group.py
+++ b/src/deadline/client/cli/_groups/queue_group.py
@@ -29,7 +29,7 @@ from ....job_attachments.models import (
 )
 from .click_logger import ClickLogger
 from .._main import deadline as main
-from .._incremental_download import _incremental_output_download, CategorizedJobIds
+from .._incremental_download import _incremental_output_download
 from .._download_status_file import write_download_status_file
 from .._pid_file_lock import PidFileLock
 from ....job_attachments._incremental_downloads.incremental_download_state import (
@@ -427,6 +427,7 @@ def sync_output(
     logger.echo()
 
     if local_storage_profile_id:
+        assert local_storage_profile is not None
         logger.echo(
             f"Mapping job output paths to the local storage profile {local_storage_profile['displayName']} ({local_storage_profile_id})"
         )
@@ -436,14 +437,19 @@ def sync_output(
         logger.echo()
 
     # Pre-flight validation: verify all storage profile file system locations are accessible
-    if local_storage_profile_id and local_storage_profile:
+    # Skipped on dry-run since no files will be written
+    if local_storage_profile_id and local_storage_profile and not dry_run:
         inaccessible_locations = []
         for location in local_storage_profile["fileSystemLocations"]:
             location_path = location["path"]
             if not os.path.isdir(location_path):
-                inaccessible_locations.append(f"  {location['name']}: {location_path} (does not exist)")
+                inaccessible_locations.append(
+                    f"  {location['name']}: {location_path} (does not exist)"
+                )
             elif not os.access(location_path, os.W_OK):
-                inaccessible_locations.append(f"  {location['name']}: {location_path} (not writable)")
+                inaccessible_locations.append(
+                    f"  {location['name']}: {location_path} (not writable)"
+                )
         if inaccessible_locations:
             raise DeadlineOperationError(
                 "The following file system locations in the storage profile are not accessible:\n"

--- a/src/deadline/client/cli/_groups/queue_group.py
+++ b/src/deadline/client/cli/_groups/queue_group.py
@@ -29,7 +29,8 @@ from ....job_attachments.models import (
 )
 from .click_logger import ClickLogger
 from .._main import deadline as main
-from .._incremental_download import _incremental_output_download
+from .._incremental_download import _incremental_output_download, CategorizedJobIds
+from .._download_status_file import write_download_status_file
 from .._pid_file_lock import PidFileLock
 from ....job_attachments._incremental_downloads.incremental_download_state import (
     IncrementalDownloadState,
@@ -376,6 +377,7 @@ def sync_output(
 
     if ignore_storage_profiles:
         local_storage_profile_id = None
+        local_storage_profile = None
         logger.echo("Ignoring all storage profiles.")
     else:
         local_storage_profile_id = config_file.get_setting(
@@ -433,6 +435,22 @@ def sync_output(
             logger.echo(f"    {location['name']}: {location['path']}")
         logger.echo()
 
+    # Pre-flight validation: verify all storage profile file system locations are accessible
+    if local_storage_profile_id and local_storage_profile:
+        inaccessible_locations = []
+        for location in local_storage_profile["fileSystemLocations"]:
+            location_path = location["path"]
+            if not os.path.isdir(location_path):
+                inaccessible_locations.append(f"  {location['name']}: {location_path} (does not exist)")
+            elif not os.access(location_path, os.W_OK):
+                inaccessible_locations.append(f"  {location['name']}: {location_path} (not writable)")
+        if inaccessible_locations:
+            raise DeadlineOperationError(
+                "The following file system locations in the storage profile are not accessible:\n"
+                + "\n".join(inaccessible_locations)
+                + "\n\nEnsure all file system locations are mounted and writable before running sync-output."
+            )
+
     # Perform incremental download while holding a process id lock
 
     pid_lock_file_path: str = os.path.join(checkpoint_dir, f"{download_checkpoint_file_name}.pid")
@@ -488,19 +506,31 @@ def sync_output(
 
         logger.echo()
 
-        updated_download_state: IncrementalDownloadState = _incremental_output_download(
-            boto3_session=boto3_session,
-            farm_id=farm_id,
-            queue=queue,
-            checkpoint=checkpoint,
-            file_conflict_resolution=FileConflictResolution[conflict_resolution],
-            config=config,
-            print_function_callback=logger.echo,
-            dry_run=dry_run,
+        updated_download_state, categorized_job_ids, download_candidate_jobs = (
+            _incremental_output_download(
+                boto3_session=boto3_session,
+                farm_id=farm_id,
+                queue=queue,
+                checkpoint=checkpoint,
+                file_conflict_resolution=FileConflictResolution[conflict_resolution],
+                config=config,
+                print_function_callback=logger.echo,
+                dry_run=dry_run,
+            )
         )
 
-        # Save the checkpoint file if it's not a dry run
+        # Save status file and checkpoint if it's not a dry run
         if not dry_run:
+            write_download_status_file(
+                queue_id=queue_id,
+                categorized_job_ids=categorized_job_ids,
+                download_candidate_jobs=download_candidate_jobs,
+                local_storage_profile_id=local_storage_profile_id,
+                local_storage_profile=local_storage_profile if local_storage_profile_id else None,
+                checkpoint_dir=checkpoint_dir,
+                print_function_callback=logger.echo,
+            )
+
             updated_download_state.save_file(checkpoint_file_path)
             logger.echo("Checkpoint saved")
         else:

--- a/src/deadline/client/cli/_incremental_download.py
+++ b/src/deadline/client/cli/_incremental_download.py
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 from __future__ import annotations
 
-__all__ = ["_incremental_output_download", "CategorizedJobIds"]
+__all__ = ["CategorizedJobIds", "_incremental_output_download"]
 
 from dataclasses import dataclass, asdict
 from datetime import datetime, timedelta, timezone

--- a/src/deadline/client/cli/_incremental_download.py
+++ b/src/deadline/client/cli/_incremental_download.py
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 from __future__ import annotations
 
-__all__ = ["_incremental_output_download"]
+__all__ = ["_incremental_output_download", "CategorizedJobIds"]
 
 from dataclasses import dataclass, asdict
 from datetime import datetime, timedelta, timezone
@@ -991,7 +991,7 @@ def _incremental_output_download(
     print_function_callback: Callable[[Any], None] = lambda msg: None,
     *,
     dry_run: bool = False,
-) -> IncrementalDownloadState:
+) -> tuple[IncrementalDownloadState, CategorizedJobIds, dict[str, dict[str, Any]]]:
     """
     This function downloads all the task run outputs from the specified queue, that have become
     available since the last time the function was called. The checkpoint object
@@ -1015,7 +1015,7 @@ def _incremental_output_download(
         dry_run: If True, the operation will print out information but not perform any data downloads.
 
     Returns:
-        An updated checkpoint object.
+        A tuple of (updated checkpoint, categorized job IDs, download candidate jobs dict).
     """
     durations = IncrementalOutputDownloadLatencies()
     # Operations here are within a single farm, so scope the deadline client to that
@@ -1294,4 +1294,4 @@ def _incremental_output_download(
     print_function_callback(f"    unchanged: {stats['jobs_without_downloads']['unchanged']}")
     print_function_callback(f"    inactive: {stats['jobs_without_downloads']['inactive']}")
 
-    return checkpoint
+    return checkpoint, categorized_job_ids, download_candidate_jobs

--- a/test/unit/deadline_client/cli/test_cli_download_status_file.py
+++ b/test/unit/deadline_client/cli/test_cli_download_status_file.py
@@ -120,19 +120,6 @@ class TestDetermineJobDownloadStatus:
         result = _determine_job_download_status(MOCK_JOB_ID, job, cjids, MOCK_STORAGE_PROFILE_ID)
         assert result["download_status"] == "in_progress"
 
-    def test_inactive_job_all_succeeded_returns_downloaded(self):
-        cjids = _make_categorized_job_ids(inactive={MOCK_JOB_ID})
-        job = _make_job(MOCK_JOB_ID, succeeded=5, total=5)
-        result = _determine_job_download_status(MOCK_JOB_ID, job, cjids, MOCK_STORAGE_PROFILE_ID)
-        assert result["download_status"] == "downloaded"
-
-    def test_inactive_job_not_all_succeeded_returns_skipped(self):
-        """Canceled/failed inactive jobs should not be marked as downloaded."""
-        cjids = _make_categorized_job_ids(inactive={MOCK_JOB_ID})
-        job = _make_job(MOCK_JOB_ID, succeeded=2, total=5, ended=True)
-        result = _determine_job_download_status(MOCK_JOB_ID, job, cjids, MOCK_STORAGE_PROFILE_ID)
-        assert result["download_status"] == "skipped"
-
     def test_attachments_free_returns_skipped(self):
         cjids = _make_categorized_job_ids(attachments_free={MOCK_JOB_ID})
         job = _make_job(MOCK_JOB_ID, attachments=False)

--- a/test/unit/deadline_client/cli/test_cli_download_status_file.py
+++ b/test/unit/deadline_client/cli/test_cli_download_status_file.py
@@ -6,9 +6,7 @@ Tests for the CLI download status file module.
 
 import json
 import os
-import tempfile
-
-import pytest
+from typing import Any, Optional
 
 from deadline.client.cli._download_status_file import (
     _atomic_write_json,
@@ -45,10 +43,10 @@ def _make_job(
     total: int = 1,
     ended: bool = True,
     attachments: bool = True,
-    storage_profile_id: str = MOCK_STORAGE_PROFILE_ID,
-) -> dict:
+    storage_profile_id: Optional[str] = MOCK_STORAGE_PROFILE_ID,
+) -> dict[str, Any]:
     """Helper to create a fake job dict."""
-    job = {
+    job: dict[str, Any] = {
         "jobId": job_id,
         "name": f"test-job-{job_id[-8:]}",
         "taskRunStatusCounts": {
@@ -122,11 +120,18 @@ class TestDetermineJobDownloadStatus:
         result = _determine_job_download_status(MOCK_JOB_ID, job, cjids, MOCK_STORAGE_PROFILE_ID)
         assert result["download_status"] == "in_progress"
 
-    def test_inactive_job_returns_downloaded(self):
+    def test_inactive_job_all_succeeded_returns_downloaded(self):
         cjids = _make_categorized_job_ids(inactive={MOCK_JOB_ID})
-        job = _make_job(MOCK_JOB_ID)
+        job = _make_job(MOCK_JOB_ID, succeeded=5, total=5)
         result = _determine_job_download_status(MOCK_JOB_ID, job, cjids, MOCK_STORAGE_PROFILE_ID)
         assert result["download_status"] == "downloaded"
+
+    def test_inactive_job_not_all_succeeded_returns_skipped(self):
+        """Canceled/failed inactive jobs should not be marked as downloaded."""
+        cjids = _make_categorized_job_ids(inactive={MOCK_JOB_ID})
+        job = _make_job(MOCK_JOB_ID, succeeded=2, total=5, ended=True)
+        result = _determine_job_download_status(MOCK_JOB_ID, job, cjids, MOCK_STORAGE_PROFILE_ID)
+        assert result["download_status"] == "skipped"
 
     def test_attachments_free_returns_skipped(self):
         cjids = _make_categorized_job_ids(attachments_free={MOCK_JOB_ID})
@@ -181,7 +186,10 @@ class TestGetStatusFilePaths:
             checkpoint_dir="/home/user/.deadline/incremental_download",
         )
         assert len(paths) == 1
-        assert paths[0] == f"/mnt/nas/renders/.deadline/{MOCK_QUEUE_ID}_download_status.json"
+        expected = os.path.join(
+            "/mnt/nas/renders", ".deadline", f"{MOCK_QUEUE_ID}_download_status.json"
+        )
+        assert paths[0] == expected
 
     def test_storage_profile_multiple_locations(self):
         profile = {
@@ -198,9 +206,18 @@ class TestGetStatusFilePaths:
             checkpoint_dir="/home/user/.deadline/incremental_download",
         )
         assert len(paths) == 3
-        assert f"/mnt/nas/renders/.deadline/{MOCK_QUEUE_ID}_download_status.json" in paths
-        assert f"/mnt/nas/projects/.deadline/{MOCK_QUEUE_ID}_download_status.json" in paths
-        assert f"/mnt/nas/tools/.deadline/{MOCK_QUEUE_ID}_download_status.json" in paths
+        assert (
+            os.path.join("/mnt/nas/renders", ".deadline", f"{MOCK_QUEUE_ID}_download_status.json")
+            in paths
+        )
+        assert (
+            os.path.join("/mnt/nas/projects", ".deadline", f"{MOCK_QUEUE_ID}_download_status.json")
+            in paths
+        )
+        assert (
+            os.path.join("/mnt/nas/tools", ".deadline", f"{MOCK_QUEUE_ID}_download_status.json")
+            in paths
+        )
 
 
 class TestBuildStatusFileContent:
@@ -356,7 +373,7 @@ class TestWriteDownloadStatusFile:
         }
         cjids = _make_categorized_job_ids(completed={MOCK_JOB_ID})
         jobs = {MOCK_JOB_ID: _make_job(MOCK_JOB_ID)}
-        messages = []
+        messages: list[str] = []
 
         write_download_status_file(
             queue_id=MOCK_QUEUE_ID,
@@ -380,7 +397,7 @@ class TestWriteDownloadStatusFile:
         checkpoint_dir.mkdir()
         cjids = _make_categorized_job_ids(added={MOCK_JOB_ID})
         jobs = {MOCK_JOB_ID: _make_job(MOCK_JOB_ID, succeeded=3, total=10, ended=False)}
-        messages = []
+        messages: list[str] = []
 
         write_download_status_file(
             queue_id=MOCK_QUEUE_ID,
@@ -392,7 +409,9 @@ class TestWriteDownloadStatusFile:
             print_function_callback=messages.append,
         )
 
-        status_file = checkpoint_dir / f"{MOCK_QUEUE_ID}_ignore-storage-profiles_download_status.json"
+        status_file = (
+            checkpoint_dir / f"{MOCK_QUEUE_ID}_ignore-storage-profiles_download_status.json"
+        )
         assert status_file.exists()
         with open(status_file) as f:
             data = json.load(f)
@@ -425,14 +444,17 @@ class TestWriteDownloadStatusFile:
         assert (projects_dir / ".deadline" / f"{MOCK_QUEUE_ID}_download_status.json").exists()
 
     def test_warns_on_write_failure_does_not_raise(self, tmp_path):
+        # Use a path nested under a file (not a directory) to guarantee failure on all platforms
+        blocker_file = tmp_path / "blocker"
+        blocker_file.write_text("not a directory")
         profile = {
             "fileSystemLocations": [
-                {"name": "renders", "path": "/nonexistent/path/that/cannot/be/created"},
+                {"name": "renders", "path": str(blocker_file / "nested" / "path")},
             ]
         }
         cjids = _make_categorized_job_ids(completed={MOCK_JOB_ID})
         jobs = {MOCK_JOB_ID: _make_job(MOCK_JOB_ID)}
-        messages = []
+        messages: list[str] = []
 
         write_download_status_file(
             queue_id=MOCK_QUEUE_ID,
@@ -469,7 +491,9 @@ class TestWriteDownloadStatusFile:
             checkpoint_dir=str(checkpoint_dir),
         )
 
-        status_file = checkpoint_dir / f"{MOCK_QUEUE_ID}_ignore-storage-profiles_download_status.json"
+        status_file = (
+            checkpoint_dir / f"{MOCK_QUEUE_ID}_ignore-storage-profiles_download_status.json"
+        )
         with open(status_file) as f:
             data = json.load(f)
 

--- a/test/unit/deadline_client/cli/test_cli_download_status_file.py
+++ b/test/unit/deadline_client/cli/test_cli_download_status_file.py
@@ -1,0 +1,480 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Tests for the CLI download status file module.
+"""
+
+import json
+import os
+import tempfile
+
+import pytest
+
+from deadline.client.cli._download_status_file import (
+    _atomic_write_json,
+    _build_status_file_content,
+    _determine_job_download_status,
+    _get_status_file_paths,
+    write_download_status_file,
+)
+from deadline.client.cli._incremental_download import CategorizedJobIds
+
+from ..shared_constants import MOCK_QUEUE_ID, MOCK_STORAGE_PROFILE_ID, MOCK_JOB_ID
+
+
+MOCK_JOB_ID_2 = "job-aaaabbbbccccddddeeeeffffaaaabbbb"
+MOCK_JOB_ID_3 = "job-11112222333344445555666677778888"
+
+
+def _make_categorized_job_ids(**kwargs) -> CategorizedJobIds:
+    """Helper to create a CategorizedJobIds with specified sets."""
+    cjids = CategorizedJobIds()
+    cjids.added = kwargs.get("added", set())
+    cjids.updated = kwargs.get("updated", set())
+    cjids.unchanged = kwargs.get("unchanged", set())
+    cjids.completed = kwargs.get("completed", set())
+    cjids.inactive = kwargs.get("inactive", set())
+    cjids.attachments_free = kwargs.get("attachments_free", set())
+    cjids.missing_storage_profile = kwargs.get("missing_storage_profile", set())
+    return cjids
+
+
+def _make_job(
+    job_id: str,
+    succeeded: int = 1,
+    total: int = 1,
+    ended: bool = True,
+    attachments: bool = True,
+    storage_profile_id: str = MOCK_STORAGE_PROFILE_ID,
+) -> dict:
+    """Helper to create a fake job dict."""
+    job = {
+        "jobId": job_id,
+        "name": f"test-job-{job_id[-8:]}",
+        "taskRunStatusCounts": {
+            "SUCCEEDED": succeeded,
+            "FAILED": 0,
+            "RUNNING": total - succeeded,
+            "READY": 0,
+            "PENDING": 0,
+            "ASSIGNED": 0,
+            "STARTING": 0,
+            "SCHEDULED": 0,
+            "INTERRUPTING": 0,
+            "SUSPENDED": 0,
+            "CANCELED": 0,
+            "NOT_COMPATIBLE": 0,
+        },
+        "attachments": {"manifests": []} if attachments else None,
+        "storageProfileId": storage_profile_id,
+    }
+    if ended:
+        job["endedAt"] = "2026-06-15T12:00:00+00:00"
+    return job
+
+
+class TestDetermineJobDownloadStatus:
+    """Tests for _determine_job_download_status."""
+
+    def test_completed_job_returns_downloaded(self):
+        cjids = _make_categorized_job_ids(completed={MOCK_JOB_ID})
+        job = _make_job(MOCK_JOB_ID)
+        result = _determine_job_download_status(MOCK_JOB_ID, job, cjids, MOCK_STORAGE_PROFILE_ID)
+        assert result["download_status"] == "downloaded"
+
+    def test_added_job_all_tasks_succeeded_no_active_returns_downloaded(self):
+        """Added job with all tasks succeeded and no active tasks is truly done."""
+        cjids = _make_categorized_job_ids(added={MOCK_JOB_ID})
+        job = _make_job(MOCK_JOB_ID, succeeded=5, total=5, ended=True)
+        result = _determine_job_download_status(MOCK_JOB_ID, job, cjids, MOCK_STORAGE_PROFILE_ID)
+        assert result["download_status"] == "downloaded"
+
+    def test_added_job_requeued_with_active_tasks_returns_in_progress(self):
+        """Requeued job has active tasks (READY) so should be in_progress even if endedAt is set."""
+        cjids = _make_categorized_job_ids(added={MOCK_JOB_ID})
+        job = _make_job(MOCK_JOB_ID, succeeded=5, total=5, ended=True)
+        job["taskRunStatusCounts"]["READY"] = 3
+        job["taskRunStatusCounts"]["RUNNING"] = 0
+        result = _determine_job_download_status(MOCK_JOB_ID, job, cjids, MOCK_STORAGE_PROFILE_ID)
+        assert result["download_status"] == "in_progress"
+
+    def test_added_job_partial_tasks_returns_in_progress(self):
+        cjids = _make_categorized_job_ids(added={MOCK_JOB_ID})
+        job = _make_job(MOCK_JOB_ID, succeeded=3, total=10, ended=False)
+        result = _determine_job_download_status(MOCK_JOB_ID, job, cjids, MOCK_STORAGE_PROFILE_ID)
+        assert result["download_status"] == "in_progress"
+
+    def test_updated_job_partial_tasks_returns_in_progress(self):
+        cjids = _make_categorized_job_ids(updated={MOCK_JOB_ID})
+        job = _make_job(MOCK_JOB_ID, succeeded=7, total=10, ended=False)
+        result = _determine_job_download_status(MOCK_JOB_ID, job, cjids, MOCK_STORAGE_PROFILE_ID)
+        assert result["download_status"] == "in_progress"
+
+    def test_unchanged_job_all_succeeded_returns_downloaded(self):
+        cjids = _make_categorized_job_ids(unchanged={MOCK_JOB_ID})
+        job = _make_job(MOCK_JOB_ID, succeeded=10, total=10, ended=True)
+        result = _determine_job_download_status(MOCK_JOB_ID, job, cjids, MOCK_STORAGE_PROFILE_ID)
+        assert result["download_status"] == "downloaded"
+
+    def test_unchanged_job_partial_returns_in_progress(self):
+        cjids = _make_categorized_job_ids(unchanged={MOCK_JOB_ID})
+        job = _make_job(MOCK_JOB_ID, succeeded=5, total=10, ended=False)
+        result = _determine_job_download_status(MOCK_JOB_ID, job, cjids, MOCK_STORAGE_PROFILE_ID)
+        assert result["download_status"] == "in_progress"
+
+    def test_inactive_job_returns_downloaded(self):
+        cjids = _make_categorized_job_ids(inactive={MOCK_JOB_ID})
+        job = _make_job(MOCK_JOB_ID)
+        result = _determine_job_download_status(MOCK_JOB_ID, job, cjids, MOCK_STORAGE_PROFILE_ID)
+        assert result["download_status"] == "downloaded"
+
+    def test_attachments_free_returns_skipped(self):
+        cjids = _make_categorized_job_ids(attachments_free={MOCK_JOB_ID})
+        job = _make_job(MOCK_JOB_ID, attachments=False)
+        result = _determine_job_download_status(MOCK_JOB_ID, job, cjids, MOCK_STORAGE_PROFILE_ID)
+        assert result["download_status"] == "skipped"
+
+    def test_missing_storage_profile_returns_skipped(self):
+        cjids = _make_categorized_job_ids(missing_storage_profile={MOCK_JOB_ID})
+        job = _make_job(MOCK_JOB_ID, storage_profile_id=None)
+        result = _determine_job_download_status(MOCK_JOB_ID, job, cjids, MOCK_STORAGE_PROFILE_ID)
+        assert result["download_status"] == "skipped"
+
+    def test_result_has_all_required_fields(self):
+        cjids = _make_categorized_job_ids(completed={MOCK_JOB_ID})
+        job = _make_job(MOCK_JOB_ID)
+        result = _determine_job_download_status(MOCK_JOB_ID, job, cjids, MOCK_STORAGE_PROFILE_ID)
+        assert "download_status" in result
+        assert "total_files" in result
+        assert "downloaded_files" in result
+        assert "failed_files" in result
+        assert "last_updated" in result
+        assert "error_code" in result
+        assert "error_message" in result
+
+
+class TestGetStatusFilePaths:
+    """Tests for _get_status_file_paths."""
+
+    def test_no_storage_profile_returns_local_path(self):
+        paths = _get_status_file_paths(
+            queue_id=MOCK_QUEUE_ID,
+            local_storage_profile_id=None,
+            local_storage_profile=None,
+            checkpoint_dir="/home/user/.deadline/incremental_download",
+        )
+        assert len(paths) == 1
+        assert "ignore-storage-profiles" in paths[0]
+        assert MOCK_QUEUE_ID in paths[0]
+        assert paths[0].endswith("_download_status.json")
+
+    def test_storage_profile_single_location(self):
+        profile = {
+            "fileSystemLocations": [
+                {"name": "renders", "path": "/mnt/nas/renders"},
+            ]
+        }
+        paths = _get_status_file_paths(
+            queue_id=MOCK_QUEUE_ID,
+            local_storage_profile_id=MOCK_STORAGE_PROFILE_ID,
+            local_storage_profile=profile,
+            checkpoint_dir="/home/user/.deadline/incremental_download",
+        )
+        assert len(paths) == 1
+        assert paths[0] == f"/mnt/nas/renders/.deadline/{MOCK_QUEUE_ID}_download_status.json"
+
+    def test_storage_profile_multiple_locations(self):
+        profile = {
+            "fileSystemLocations": [
+                {"name": "renders", "path": "/mnt/nas/renders"},
+                {"name": "projects", "path": "/mnt/nas/projects"},
+                {"name": "tools", "path": "/mnt/nas/tools"},
+            ]
+        }
+        paths = _get_status_file_paths(
+            queue_id=MOCK_QUEUE_ID,
+            local_storage_profile_id=MOCK_STORAGE_PROFILE_ID,
+            local_storage_profile=profile,
+            checkpoint_dir="/home/user/.deadline/incremental_download",
+        )
+        assert len(paths) == 3
+        assert f"/mnt/nas/renders/.deadline/{MOCK_QUEUE_ID}_download_status.json" in paths
+        assert f"/mnt/nas/projects/.deadline/{MOCK_QUEUE_ID}_download_status.json" in paths
+        assert f"/mnt/nas/tools/.deadline/{MOCK_QUEUE_ID}_download_status.json" in paths
+
+
+class TestBuildStatusFileContent:
+    """Tests for _build_status_file_content."""
+
+    def test_builds_valid_structure(self):
+        cjids = _make_categorized_job_ids(completed={MOCK_JOB_ID})
+        jobs = {MOCK_JOB_ID: _make_job(MOCK_JOB_ID)}
+        result = _build_status_file_content(
+            queue_id=MOCK_QUEUE_ID,
+            storage_profile_id=MOCK_STORAGE_PROFILE_ID,
+            categorized_job_ids=cjids,
+            download_candidate_jobs=jobs,
+            local_storage_profile_id=MOCK_STORAGE_PROFILE_ID,
+        )
+        assert result["schema_version"] == 1
+        assert result["sync_metadata"]["queue_id"] == MOCK_QUEUE_ID
+        assert result["sync_metadata"]["storage_profile_id"] == MOCK_STORAGE_PROFILE_ID
+        assert result["sync_metadata"]["last_run_status"] == "success"
+        assert "hostname" in result["sync_metadata"]
+        assert "last_sync_completed_at" in result["sync_metadata"]
+        assert MOCK_JOB_ID in result["jobs"]
+
+    def test_multiple_jobs_all_included(self):
+        cjids = _make_categorized_job_ids(
+            completed={MOCK_JOB_ID},
+            added={MOCK_JOB_ID_2},
+            attachments_free={MOCK_JOB_ID_3},
+        )
+        jobs = {
+            MOCK_JOB_ID: _make_job(MOCK_JOB_ID),
+            MOCK_JOB_ID_2: _make_job(MOCK_JOB_ID_2, succeeded=3, total=10, ended=False),
+            MOCK_JOB_ID_3: _make_job(MOCK_JOB_ID_3, attachments=False),
+        }
+        result = _build_status_file_content(
+            queue_id=MOCK_QUEUE_ID,
+            storage_profile_id=MOCK_STORAGE_PROFILE_ID,
+            categorized_job_ids=cjids,
+            download_candidate_jobs=jobs,
+            local_storage_profile_id=MOCK_STORAGE_PROFILE_ID,
+        )
+        assert len(result["jobs"]) == 3
+        assert result["jobs"][MOCK_JOB_ID]["download_status"] == "downloaded"
+        assert result["jobs"][MOCK_JOB_ID_2]["download_status"] == "in_progress"
+        assert result["jobs"][MOCK_JOB_ID_3]["download_status"] == "skipped"
+
+    def test_no_storage_profile_sets_null(self):
+        cjids = _make_categorized_job_ids(completed={MOCK_JOB_ID})
+        jobs = {MOCK_JOB_ID: _make_job(MOCK_JOB_ID)}
+        result = _build_status_file_content(
+            queue_id=MOCK_QUEUE_ID,
+            storage_profile_id=None,
+            categorized_job_ids=cjids,
+            download_candidate_jobs=jobs,
+            local_storage_profile_id=None,
+        )
+        assert result["sync_metadata"]["storage_profile_id"] is None
+
+    def test_merges_with_existing_jobs(self):
+        """Old jobs that dropped out of tracking are preserved in the status file."""
+        existing_jobs = {
+            "job-old-completed-aaaaaa": {
+                "download_status": "downloaded",
+                "total_files": 5,
+                "downloaded_files": 5,
+                "failed_files": 0,
+                "last_updated": "2026-06-10T12:00:00+00:00",
+                "error_code": None,
+                "error_message": None,
+            }
+        }
+        cjids = _make_categorized_job_ids(completed={MOCK_JOB_ID})
+        jobs = {MOCK_JOB_ID: _make_job(MOCK_JOB_ID)}
+        result = _build_status_file_content(
+            queue_id=MOCK_QUEUE_ID,
+            storage_profile_id=MOCK_STORAGE_PROFILE_ID,
+            categorized_job_ids=cjids,
+            download_candidate_jobs=jobs,
+            local_storage_profile_id=MOCK_STORAGE_PROFILE_ID,
+            existing_jobs=existing_jobs,
+        )
+        assert len(result["jobs"]) == 2
+        assert "job-old-completed-aaaaaa" in result["jobs"]
+        assert result["jobs"]["job-old-completed-aaaaaa"]["download_status"] == "downloaded"
+        assert result["jobs"][MOCK_JOB_ID]["download_status"] == "downloaded"
+
+    def test_current_run_overwrites_existing_entry(self):
+        """If a job exists in the file and is also in the current run, current run wins."""
+        existing_jobs = {
+            MOCK_JOB_ID: {
+                "download_status": "downloaded",
+                "total_files": 5,
+                "downloaded_files": 5,
+                "failed_files": 0,
+                "last_updated": "2026-06-10T12:00:00+00:00",
+                "error_code": None,
+                "error_message": None,
+            }
+        }
+        cjids = _make_categorized_job_ids(added={MOCK_JOB_ID})
+        jobs = {MOCK_JOB_ID: _make_job(MOCK_JOB_ID, succeeded=2, total=10, ended=False)}
+        result = _build_status_file_content(
+            queue_id=MOCK_QUEUE_ID,
+            storage_profile_id=MOCK_STORAGE_PROFILE_ID,
+            categorized_job_ids=cjids,
+            download_candidate_jobs=jobs,
+            local_storage_profile_id=MOCK_STORAGE_PROFILE_ID,
+            existing_jobs=existing_jobs,
+        )
+        assert result["jobs"][MOCK_JOB_ID]["download_status"] == "in_progress"
+
+
+class TestAtomicWriteJson:
+    """Tests for _atomic_write_json."""
+
+    def test_writes_valid_json(self, tmp_path):
+        file_path = str(tmp_path / "test_status.json")
+        data = {"schema_version": 1, "jobs": {}}
+        _atomic_write_json(file_path, data)
+
+        with open(file_path, "r") as f:
+            loaded = json.load(f)
+        assert loaded == data
+
+    def test_creates_parent_directories(self, tmp_path):
+        file_path = str(tmp_path / "nested" / "dir" / "status.json")
+        data = {"test": True}
+        _atomic_write_json(file_path, data)
+
+        assert os.path.exists(file_path)
+        with open(file_path, "r") as f:
+            assert json.load(f) == data
+
+    def test_overwrites_existing_file(self, tmp_path):
+        file_path = str(tmp_path / "status.json")
+        _atomic_write_json(file_path, {"version": 1})
+        _atomic_write_json(file_path, {"version": 2})
+
+        with open(file_path, "r") as f:
+            assert json.load(f)["version"] == 2
+
+
+class TestWriteDownloadStatusFile:
+    """Tests for the main write_download_status_file function."""
+
+    def test_writes_to_storage_profile_locations(self, tmp_path):
+        renders_dir = tmp_path / "renders"
+        renders_dir.mkdir()
+        profile = {
+            "fileSystemLocations": [
+                {"name": "renders", "path": str(renders_dir)},
+            ]
+        }
+        cjids = _make_categorized_job_ids(completed={MOCK_JOB_ID})
+        jobs = {MOCK_JOB_ID: _make_job(MOCK_JOB_ID)}
+        messages = []
+
+        write_download_status_file(
+            queue_id=MOCK_QUEUE_ID,
+            categorized_job_ids=cjids,
+            download_candidate_jobs=jobs,
+            local_storage_profile_id=MOCK_STORAGE_PROFILE_ID,
+            local_storage_profile=profile,
+            checkpoint_dir=str(tmp_path / "checkpoint"),
+            print_function_callback=messages.append,
+        )
+
+        status_file = renders_dir / ".deadline" / f"{MOCK_QUEUE_ID}_download_status.json"
+        assert status_file.exists()
+        with open(status_file) as f:
+            data = json.load(f)
+        assert data["jobs"][MOCK_JOB_ID]["download_status"] == "downloaded"
+        assert any("saved" in msg for msg in messages)
+
+    def test_writes_to_ignore_storage_profiles_path(self, tmp_path):
+        checkpoint_dir = tmp_path / "checkpoint"
+        checkpoint_dir.mkdir()
+        cjids = _make_categorized_job_ids(added={MOCK_JOB_ID})
+        jobs = {MOCK_JOB_ID: _make_job(MOCK_JOB_ID, succeeded=3, total=10, ended=False)}
+        messages = []
+
+        write_download_status_file(
+            queue_id=MOCK_QUEUE_ID,
+            categorized_job_ids=cjids,
+            download_candidate_jobs=jobs,
+            local_storage_profile_id=None,
+            local_storage_profile=None,
+            checkpoint_dir=str(checkpoint_dir),
+            print_function_callback=messages.append,
+        )
+
+        status_file = checkpoint_dir / f"{MOCK_QUEUE_ID}_ignore-storage-profiles_download_status.json"
+        assert status_file.exists()
+        with open(status_file) as f:
+            data = json.load(f)
+        assert data["jobs"][MOCK_JOB_ID]["download_status"] == "in_progress"
+
+    def test_writes_to_multiple_locations(self, tmp_path):
+        renders_dir = tmp_path / "renders"
+        projects_dir = tmp_path / "projects"
+        renders_dir.mkdir()
+        projects_dir.mkdir()
+        profile = {
+            "fileSystemLocations": [
+                {"name": "renders", "path": str(renders_dir)},
+                {"name": "projects", "path": str(projects_dir)},
+            ]
+        }
+        cjids = _make_categorized_job_ids(completed={MOCK_JOB_ID})
+        jobs = {MOCK_JOB_ID: _make_job(MOCK_JOB_ID)}
+
+        write_download_status_file(
+            queue_id=MOCK_QUEUE_ID,
+            categorized_job_ids=cjids,
+            download_candidate_jobs=jobs,
+            local_storage_profile_id=MOCK_STORAGE_PROFILE_ID,
+            local_storage_profile=profile,
+            checkpoint_dir=str(tmp_path / "checkpoint"),
+        )
+
+        assert (renders_dir / ".deadline" / f"{MOCK_QUEUE_ID}_download_status.json").exists()
+        assert (projects_dir / ".deadline" / f"{MOCK_QUEUE_ID}_download_status.json").exists()
+
+    def test_warns_on_write_failure_does_not_raise(self, tmp_path):
+        profile = {
+            "fileSystemLocations": [
+                {"name": "renders", "path": "/nonexistent/path/that/cannot/be/created"},
+            ]
+        }
+        cjids = _make_categorized_job_ids(completed={MOCK_JOB_ID})
+        jobs = {MOCK_JOB_ID: _make_job(MOCK_JOB_ID)}
+        messages = []
+
+        write_download_status_file(
+            queue_id=MOCK_QUEUE_ID,
+            categorized_job_ids=cjids,
+            download_candidate_jobs=jobs,
+            local_storage_profile_id=MOCK_STORAGE_PROFILE_ID,
+            local_storage_profile=profile,
+            checkpoint_dir=str(tmp_path),
+            print_function_callback=messages.append,
+        )
+
+        assert any("WARNING" in msg for msg in messages)
+
+    def test_json_is_valid_and_parseable(self, tmp_path):
+        checkpoint_dir = tmp_path / "checkpoint"
+        checkpoint_dir.mkdir()
+        cjids = _make_categorized_job_ids(
+            completed={MOCK_JOB_ID},
+            added={MOCK_JOB_ID_2},
+            attachments_free={MOCK_JOB_ID_3},
+        )
+        jobs = {
+            MOCK_JOB_ID: _make_job(MOCK_JOB_ID),
+            MOCK_JOB_ID_2: _make_job(MOCK_JOB_ID_2, succeeded=2, total=5, ended=False),
+            MOCK_JOB_ID_3: _make_job(MOCK_JOB_ID_3, attachments=False),
+        }
+
+        write_download_status_file(
+            queue_id=MOCK_QUEUE_ID,
+            categorized_job_ids=cjids,
+            download_candidate_jobs=jobs,
+            local_storage_profile_id=None,
+            local_storage_profile=None,
+            checkpoint_dir=str(checkpoint_dir),
+        )
+
+        status_file = checkpoint_dir / f"{MOCK_QUEUE_ID}_ignore-storage-profiles_download_status.json"
+        with open(status_file) as f:
+            data = json.load(f)
+
+        assert data["schema_version"] == 1
+        assert len(data["jobs"]) == 3
+        assert data["jobs"][MOCK_JOB_ID]["download_status"] == "downloaded"
+        assert data["jobs"][MOCK_JOB_ID_2]["download_status"] == "in_progress"
+        assert data["jobs"][MOCK_JOB_ID_3]["download_status"] == "skipped"

--- a/test/unit/deadline_client/cli/test_cli_download_status_file.py
+++ b/test/unit/deadline_client/cli/test_cli_download_status_file.py
@@ -13,6 +13,7 @@ from deadline.client.cli._download_status_file import (
     _build_status_file_content,
     _determine_job_download_status,
     _get_status_file_paths,
+    _status_file_lock,
     write_download_status_file,
 )
 from deadline.client.cli._incremental_download import CategorizedJobIds
@@ -77,14 +78,14 @@ class TestDetermineJobDownloadStatus:
     def test_completed_job_returns_downloaded(self):
         cjids = _make_categorized_job_ids(completed={MOCK_JOB_ID})
         job = _make_job(MOCK_JOB_ID)
-        result = _determine_job_download_status(MOCK_JOB_ID, job, cjids, MOCK_STORAGE_PROFILE_ID)
+        result = _determine_job_download_status(MOCK_JOB_ID, job, cjids)
         assert result["download_status"] == "downloaded"
 
     def test_added_job_all_tasks_succeeded_no_active_returns_downloaded(self):
         """Added job with all tasks succeeded and no active tasks is truly done."""
         cjids = _make_categorized_job_ids(added={MOCK_JOB_ID})
         job = _make_job(MOCK_JOB_ID, succeeded=5, total=5, ended=True)
-        result = _determine_job_download_status(MOCK_JOB_ID, job, cjids, MOCK_STORAGE_PROFILE_ID)
+        result = _determine_job_download_status(MOCK_JOB_ID, job, cjids)
         assert result["download_status"] == "downloaded"
 
     def test_added_job_requeued_with_active_tasks_returns_in_progress(self):
@@ -93,49 +94,49 @@ class TestDetermineJobDownloadStatus:
         job = _make_job(MOCK_JOB_ID, succeeded=5, total=5, ended=True)
         job["taskRunStatusCounts"]["READY"] = 3
         job["taskRunStatusCounts"]["RUNNING"] = 0
-        result = _determine_job_download_status(MOCK_JOB_ID, job, cjids, MOCK_STORAGE_PROFILE_ID)
+        result = _determine_job_download_status(MOCK_JOB_ID, job, cjids)
         assert result["download_status"] == "in_progress"
 
     def test_added_job_partial_tasks_returns_in_progress(self):
         cjids = _make_categorized_job_ids(added={MOCK_JOB_ID})
         job = _make_job(MOCK_JOB_ID, succeeded=3, total=10, ended=False)
-        result = _determine_job_download_status(MOCK_JOB_ID, job, cjids, MOCK_STORAGE_PROFILE_ID)
+        result = _determine_job_download_status(MOCK_JOB_ID, job, cjids)
         assert result["download_status"] == "in_progress"
 
     def test_updated_job_partial_tasks_returns_in_progress(self):
         cjids = _make_categorized_job_ids(updated={MOCK_JOB_ID})
         job = _make_job(MOCK_JOB_ID, succeeded=7, total=10, ended=False)
-        result = _determine_job_download_status(MOCK_JOB_ID, job, cjids, MOCK_STORAGE_PROFILE_ID)
+        result = _determine_job_download_status(MOCK_JOB_ID, job, cjids)
         assert result["download_status"] == "in_progress"
 
     def test_unchanged_job_all_succeeded_returns_downloaded(self):
         cjids = _make_categorized_job_ids(unchanged={MOCK_JOB_ID})
         job = _make_job(MOCK_JOB_ID, succeeded=10, total=10, ended=True)
-        result = _determine_job_download_status(MOCK_JOB_ID, job, cjids, MOCK_STORAGE_PROFILE_ID)
+        result = _determine_job_download_status(MOCK_JOB_ID, job, cjids)
         assert result["download_status"] == "downloaded"
 
     def test_unchanged_job_partial_returns_in_progress(self):
         cjids = _make_categorized_job_ids(unchanged={MOCK_JOB_ID})
         job = _make_job(MOCK_JOB_ID, succeeded=5, total=10, ended=False)
-        result = _determine_job_download_status(MOCK_JOB_ID, job, cjids, MOCK_STORAGE_PROFILE_ID)
+        result = _determine_job_download_status(MOCK_JOB_ID, job, cjids)
         assert result["download_status"] == "in_progress"
 
     def test_attachments_free_returns_skipped(self):
         cjids = _make_categorized_job_ids(attachments_free={MOCK_JOB_ID})
         job = _make_job(MOCK_JOB_ID, attachments=False)
-        result = _determine_job_download_status(MOCK_JOB_ID, job, cjids, MOCK_STORAGE_PROFILE_ID)
+        result = _determine_job_download_status(MOCK_JOB_ID, job, cjids)
         assert result["download_status"] == "skipped"
 
     def test_missing_storage_profile_returns_skipped(self):
         cjids = _make_categorized_job_ids(missing_storage_profile={MOCK_JOB_ID})
         job = _make_job(MOCK_JOB_ID, storage_profile_id=None)
-        result = _determine_job_download_status(MOCK_JOB_ID, job, cjids, MOCK_STORAGE_PROFILE_ID)
+        result = _determine_job_download_status(MOCK_JOB_ID, job, cjids)
         assert result["download_status"] == "skipped"
 
     def test_result_has_all_required_fields(self):
         cjids = _make_categorized_job_ids(completed={MOCK_JOB_ID})
         job = _make_job(MOCK_JOB_ID)
-        result = _determine_job_download_status(MOCK_JOB_ID, job, cjids, MOCK_STORAGE_PROFILE_ID)
+        result = _determine_job_download_status(MOCK_JOB_ID, job, cjids)
         assert "download_status" in result
         assert "total_files" in result
         assert "downloaded_files" in result
@@ -160,10 +161,12 @@ class TestGetStatusFilePaths:
         assert MOCK_QUEUE_ID in paths[0]
         assert paths[0].endswith("_download_status.json")
 
-    def test_storage_profile_single_location(self):
+    def test_storage_profile_single_location(self, tmp_path):
+        renders_dir = tmp_path / "renders"
+        renders_dir.mkdir()
         profile = {
             "fileSystemLocations": [
-                {"name": "renders", "path": "/mnt/nas/renders"},
+                {"name": "renders", "path": str(renders_dir)},
             ]
         }
         paths = _get_status_file_paths(
@@ -174,16 +177,21 @@ class TestGetStatusFilePaths:
         )
         assert len(paths) == 1
         expected = os.path.join(
-            "/mnt/nas/renders", ".deadline", f"{MOCK_QUEUE_ID}_download_status.json"
+            str(renders_dir), ".deadline", f"{MOCK_QUEUE_ID}_download_status.json"
         )
         assert paths[0] == expected
 
-    def test_storage_profile_multiple_locations(self):
+    def test_storage_profile_multiple_locations(self, tmp_path):
+        renders_dir = tmp_path / "renders"
+        projects_dir = tmp_path / "projects"
+        tools_dir = tmp_path / "tools"
+        for d in [renders_dir, projects_dir, tools_dir]:
+            d.mkdir()
         profile = {
             "fileSystemLocations": [
-                {"name": "renders", "path": "/mnt/nas/renders"},
-                {"name": "projects", "path": "/mnt/nas/projects"},
-                {"name": "tools", "path": "/mnt/nas/tools"},
+                {"name": "renders", "path": str(renders_dir)},
+                {"name": "projects", "path": str(projects_dir)},
+                {"name": "tools", "path": str(tools_dir)},
             ]
         }
         paths = _get_status_file_paths(
@@ -194,17 +202,36 @@ class TestGetStatusFilePaths:
         )
         assert len(paths) == 3
         assert (
-            os.path.join("/mnt/nas/renders", ".deadline", f"{MOCK_QUEUE_ID}_download_status.json")
+            os.path.join(str(renders_dir), ".deadline", f"{MOCK_QUEUE_ID}_download_status.json")
             in paths
         )
         assert (
-            os.path.join("/mnt/nas/projects", ".deadline", f"{MOCK_QUEUE_ID}_download_status.json")
+            os.path.join(str(projects_dir), ".deadline", f"{MOCK_QUEUE_ID}_download_status.json")
             in paths
         )
         assert (
-            os.path.join("/mnt/nas/tools", ".deadline", f"{MOCK_QUEUE_ID}_download_status.json")
+            os.path.join(str(tools_dir), ".deadline", f"{MOCK_QUEUE_ID}_download_status.json")
             in paths
         )
+
+    def test_unmounted_location_excluded(self, tmp_path):
+        """Locations whose root does not exist are excluded to avoid phantom writes."""
+        renders_dir = tmp_path / "renders"
+        renders_dir.mkdir()
+        profile = {
+            "fileSystemLocations": [
+                {"name": "renders", "path": str(renders_dir)},
+                {"name": "unmounted", "path": "/nonexistent/mount/point"},
+            ]
+        }
+        paths = _get_status_file_paths(
+            queue_id=MOCK_QUEUE_ID,
+            local_storage_profile_id=MOCK_STORAGE_PROFILE_ID,
+            local_storage_profile=profile,
+            checkpoint_dir="/home/user/.deadline/incremental_download",
+        )
+        assert len(paths) == 1
+        assert str(renders_dir) in paths[0]
 
 
 class TestBuildStatusFileContent:
@@ -218,7 +245,6 @@ class TestBuildStatusFileContent:
             storage_profile_id=MOCK_STORAGE_PROFILE_ID,
             categorized_job_ids=cjids,
             download_candidate_jobs=jobs,
-            local_storage_profile_id=MOCK_STORAGE_PROFILE_ID,
         )
         assert result["schema_version"] == 1
         assert result["sync_metadata"]["queue_id"] == MOCK_QUEUE_ID
@@ -244,7 +270,6 @@ class TestBuildStatusFileContent:
             storage_profile_id=MOCK_STORAGE_PROFILE_ID,
             categorized_job_ids=cjids,
             download_candidate_jobs=jobs,
-            local_storage_profile_id=MOCK_STORAGE_PROFILE_ID,
         )
         assert len(result["jobs"]) == 3
         assert result["jobs"][MOCK_JOB_ID]["download_status"] == "downloaded"
@@ -259,7 +284,6 @@ class TestBuildStatusFileContent:
             storage_profile_id=None,
             categorized_job_ids=cjids,
             download_candidate_jobs=jobs,
-            local_storage_profile_id=None,
         )
         assert result["sync_metadata"]["storage_profile_id"] is None
 
@@ -283,7 +307,6 @@ class TestBuildStatusFileContent:
             storage_profile_id=MOCK_STORAGE_PROFILE_ID,
             categorized_job_ids=cjids,
             download_candidate_jobs=jobs,
-            local_storage_profile_id=MOCK_STORAGE_PROFILE_ID,
             existing_jobs=existing_jobs,
         )
         assert len(result["jobs"]) == 2
@@ -311,7 +334,6 @@ class TestBuildStatusFileContent:
             storage_profile_id=MOCK_STORAGE_PROFILE_ID,
             categorized_job_ids=cjids,
             download_candidate_jobs=jobs,
-            local_storage_profile_id=MOCK_STORAGE_PROFILE_ID,
             existing_jobs=existing_jobs,
         )
         assert result["jobs"][MOCK_JOB_ID]["download_status"] == "in_progress"
@@ -431,12 +453,15 @@ class TestWriteDownloadStatusFile:
         assert (projects_dir / ".deadline" / f"{MOCK_QUEUE_ID}_download_status.json").exists()
 
     def test_warns_on_write_failure_does_not_raise(self, tmp_path):
-        # Use a path nested under a file (not a directory) to guarantee failure on all platforms
-        blocker_file = tmp_path / "blocker"
-        blocker_file.write_text("not a directory")
+        # Location root exists (passes the mount check) but .deadline subdir creation fails
+        # because a file with that name already exists.
+        renders_dir = tmp_path / "renders"
+        renders_dir.mkdir()
+        deadline_blocker = renders_dir / ".deadline"
+        deadline_blocker.write_text("not a directory")  # blocks os.makedirs inside the lock
         profile = {
             "fileSystemLocations": [
-                {"name": "renders", "path": str(blocker_file / "nested" / "path")},
+                {"name": "renders", "path": str(renders_dir)},
             ]
         }
         cjids = _make_categorized_job_ids(completed={MOCK_JOB_ID})
@@ -489,3 +514,63 @@ class TestWriteDownloadStatusFile:
         assert data["jobs"][MOCK_JOB_ID]["download_status"] == "downloaded"
         assert data["jobs"][MOCK_JOB_ID_2]["download_status"] == "in_progress"
         assert data["jobs"][MOCK_JOB_ID_3]["download_status"] == "skipped"
+
+
+class TestStatusFileLock:
+    """Tests for _status_file_lock cooperative NAS lock."""
+
+    def test_lock_file_created_and_removed(self, tmp_path):
+        """Lock file exists during context and is removed after."""
+        status_file = str(tmp_path / "status.json")
+        lock_file = status_file + ".lock"
+
+        with _status_file_lock(status_file):
+            assert os.path.exists(lock_file)
+
+        assert not os.path.exists(lock_file)
+
+    def test_lock_file_removed_on_exception(self, tmp_path):
+        """Lock file is cleaned up even if an exception occurs inside the context."""
+        status_file = str(tmp_path / "status.json")
+        lock_file = status_file + ".lock"
+
+        try:
+            with _status_file_lock(status_file):
+                raise RuntimeError("simulated error")
+        except RuntimeError:
+            pass
+
+        assert not os.path.exists(lock_file)
+
+    def test_stale_lock_is_overwritten(self, tmp_path):
+        """A lock file older than TTL is treated as stale and overwritten."""
+        status_file = str(tmp_path / "status.json")
+        lock_file = status_file + ".lock"
+
+        # Write a stale lock file (mtime in the past)
+        os.makedirs(os.path.dirname(lock_file), exist_ok=True)
+        with open(lock_file, "w") as f:
+            f.write('{"hostname": "old-machine", "time": 0}')
+        os.utime(lock_file, (0, 0))  # set mtime to epoch (definitely stale)
+
+        # Should acquire successfully despite stale lock
+        with _status_file_lock(status_file):
+            assert os.path.exists(lock_file)
+            # Verify it's our lock, not the old one
+            with open(lock_file) as f:
+                content = json.load(f)
+            assert content["time"] > 0
+
+        assert not os.path.exists(lock_file)
+
+    def test_lock_contains_hostname(self, tmp_path):
+        """Lock file contains hostname for debugging."""
+        import socket
+
+        status_file = str(tmp_path / "status.json")
+        lock_file = status_file + ".lock"
+
+        with _status_file_lock(status_file):
+            with open(lock_file) as f:
+                content = json.load(f)
+            assert content["hostname"] == socket.gethostname()

--- a/test/unit/deadline_client/cli/test_cli_queue_incremental_download.py
+++ b/test/unit/deadline_client/cli/test_cli_queue_incremental_download.py
@@ -463,6 +463,9 @@ def test_incremental_output_download_storage_profile_path_mapping(
             }
 
     deadline_mock.get_storage_profile_for_queue = mock_get_storage_profile_for_queue
+    # Create the local storage profile directories so pre-flight validation passes
+    (tmp_path / "Location1").mkdir(exist_ok=True)
+    (tmp_path / "Location2").mkdir(exist_ok=True)
     # Mock list_sessions to return one session
     deadline_mock.list_sessions.return_value = {
         "sessions": [

--- a/test/unit/deadline_client/cli/test_cli_region_per_command.py
+++ b/test/unit/deadline_client/cli/test_cli_region_per_command.py
@@ -518,7 +518,9 @@ def test_cli_queue_sync_output_region(fresh_deadline_config, tmp_path):
         patch.object(
             queue_group, "get_session_client", return_value=deadline_client
         ) as mock_get_session_client,
-        patch.object(queue_group, "_incremental_output_download", return_value=MagicMock()),
+        patch.object(
+            queue_group, "_incremental_output_download", return_value=(MagicMock(), MagicMock(), {})
+        ),
     ):
         runner = CliRunner()
         result = runner.invoke(


### PR DESCRIPTION
Note: This is part 1 of 3. PR #1223 builds on top of this with per-job file counts and error isolation. PR #1258 adds per-task tracking and skip_reason.

### What was the problem/requirement? (What/Why)

Customers using the auto-downloader (`deadline queue sync-output`) have no visibility into download status from DCM. Artists must manually browse the filesystem or check cron machine logs to verify if job outputs have landed.

### What was the solution? (How)

`sync-output` now writes a JSON status file after each run containing per-job download status (`downloaded`, `in_progress`, `skipped`).

- New module `_download_status_file.py` handles status determination, atomic write, and path derivation
- Status file written to all storage profile file system locations (`{location}/.deadline/{queue_id}_download_status.json`) or `~/.deadline/incremental_download/` for `--ignore-storage-profiles`
- Cooperative cross-machine NAS lock (`{queue_id}_download_status.json.lock`) prevents concurrent writes from multiple sync machines
- Unmounted NAS locations excluded from `_get_status_file_paths` to prevent phantom files under empty mount points
- Pre-flight warning (not fatal) when storage profile locations are inaccessible — downloads proceed, status file is skipped for that location
- Read-merge-write preserves old job entries across runs
- Modified `_incremental_output_download()` to return categorized job data for status determination

### What is the impact of this change?

- `sync-output` writes one additional small JSON file per run (no performance impact)
- No changes to existing download behavior or checkpoint logic
- Enables DCM desktop app to display download badges by reading the status file from the shared filesystem

### How was this change tested?

- Unit tests (31 tests covering status determination, path derivation, atomic write, merge logic, lock behavior, failure handling)
- Manual test: same-machine with `--ignore-storage-profiles`
- Manual test: shared filesystem with storage profile (Mac + Windows NAS)
- Manual test: cross-OS path mapping (Mac submit → Windows sync, Windows submit → Mac sync)
- Manual test: pre-flight validation with unmounted NAS
- Manual test: requeue status transitions
- Ran full unit test suite (2945 passed)

### Was this change documented?

- Docstrings added to new module and functions
- README.md does not need updating (no CLI argument changes)

### Does this PR introduce new dependencies?

- This PR does not add any new dependencies.

### Is this a breaking change?

No. `_determine_job_download_status` and `_build_status_file_content` had an unused `local_storage_profile_id` parameter removed per reviewer feedback — these are internal functions not part of the public contract.

### Does this change impact security?

No. The status file contains only job IDs and task counts — information already visible via the Deadline Cloud API. No credentials or secrets stored. Written using existing filesystem permissions.
