### PR TITLE
feat: add per-job file counts, error isolation, and retry logic

### DIFF
--- a/src/deadline/client/cli/_download_status_file.py
+++ b/src/deadline/client/cli/_download_status_file.py
@@ -137,12 +137,32 @@ def _determine_job_download_status(
     job_id: str,
     job: dict[str, Any],
     categorized_job_ids: CategorizedJobIds,
+    job_download_results: Optional[dict[str, dict[str, Any]]] = None,
 ) -> dict[str, Any]:
     """
-    Determines the download status entry for a single job based on its category.
+    Determines the download status entry for a single job based on its category
+    and download results.
 
     Returns a dict representing the job's status in the status file.
     """
+    # If we have per-job download results, use them for file counts and error info
+    results = (job_download_results or {}).get(job_id)
+
+    # If download failed for this job, report it immediately
+    if results and results.get("error_code") is not None:
+        return _make_status_entry(
+            "failed",
+            total_files=results["total_files"],
+            downloaded_files=results["downloaded_files"],
+            failed_files=results["failed_files"],
+            error_code=results["error_code"],
+            error_message=results.get("error_message"),
+        )
+
+    # File counts from results (or 0 if no results available)
+    total_files = results["total_files"] if results else 0
+    downloaded_files = results["downloaded_files"] if results else 0
+
     if job_id in categorized_job_ids.attachments_free:
         return _make_status_entry("skipped")
 
@@ -150,24 +170,24 @@ def _determine_job_download_status(
         return _make_status_entry("skipped")
 
     if job_id in categorized_job_ids.completed:
-        return _make_status_entry("downloaded")
+        return _make_status_entry("downloaded", total_files, downloaded_files)
 
     if job_id in categorized_job_ids.added:
         if _is_job_fully_complete(job, check_active_tasks=True):
-            return _make_status_entry("downloaded")
-        return _make_status_entry("in_progress")
+            return _make_status_entry("downloaded", total_files, downloaded_files)
+        return _make_status_entry("in_progress", total_files, downloaded_files)
 
     if job_id in categorized_job_ids.updated:
         if _is_job_fully_complete(job):
-            return _make_status_entry("downloaded")
-        return _make_status_entry("in_progress")
+            return _make_status_entry("downloaded", total_files, downloaded_files)
+        return _make_status_entry("in_progress", total_files, downloaded_files)
 
     if job_id in categorized_job_ids.unchanged:
         if _is_job_fully_complete(job):
-            return _make_status_entry("downloaded")
-        return _make_status_entry("in_progress")
+            return _make_status_entry("downloaded", total_files, downloaded_files)
+        return _make_status_entry("in_progress", total_files, downloaded_files)
 
-    return _make_status_entry("in_progress")
+    return _make_status_entry("in_progress", total_files, downloaded_files)
 
 
 def _build_status_file_content(
@@ -176,6 +196,7 @@ def _build_status_file_content(
     categorized_job_ids: CategorizedJobIds,
     download_candidate_jobs: dict[str, dict[str, Any]],
     existing_jobs: Optional[dict[str, Any]] = None,
+    job_download_results: Optional[dict[str, dict[str, Any]]] = None,
 ) -> dict[str, Any]:
     """
     Builds the full status file JSON structure by merging existing job entries
@@ -201,7 +222,27 @@ def _build_status_file_content(
 
     for job_id in all_job_ids:
         job = download_candidate_jobs.get(job_id, {})
-        jobs_status[job_id] = _determine_job_download_status(job_id, job, categorized_job_ids)
+        new_entry = _determine_job_download_status(
+            job_id, job, categorized_job_ids, job_download_results
+        )
+        existing_entry = jobs_status.get(job_id)
+        # Don't overwrite an existing entry that has file counts with one that has none
+        if (
+            existing_entry
+            and existing_entry.get("total_files", 0) > 0
+            and new_entry.get("total_files", 0) == 0
+        ):
+            # Preserve existing entry but update the status if it changed
+            if new_entry["download_status"] != existing_entry["download_status"]:
+                existing_entry["download_status"] = new_entry["download_status"]
+                existing_entry["last_updated"] = new_entry["last_updated"]
+        else:
+            jobs_status[job_id] = new_entry
+
+    # Determine run status — "failed" if any job in this run had errors
+    has_failures = any(
+        r.get("error_code") is not None for r in (job_download_results or {}).values()
+    )
 
     return {
         "schema_version": DOWNLOAD_STATUS_FILE_SCHEMA_VERSION,
@@ -209,7 +250,7 @@ def _build_status_file_content(
             "queue_id": queue_id,
             "storage_profile_id": storage_profile_id,
             "last_sync_completed_at": now,
-            "last_run_status": "success",
+            "last_run_status": "failed" if has_failures else "success",
             "hostname": socket.gethostname(),
         },
         "jobs": jobs_status,
@@ -290,6 +331,7 @@ def write_download_status_file(
     local_storage_profile_id: Optional[str],
     local_storage_profile: Optional[dict[str, Any]],
     checkpoint_dir: str,
+    job_download_results: Optional[dict[str, dict[str, Any]]] = None,
     print_function_callback: Callable[[Any], None] = lambda msg: None,
 ) -> None:
     """
@@ -305,6 +347,7 @@ def write_download_status_file(
         local_storage_profile_id: The local storage profile ID, or None if --ignore-storage-profiles.
         local_storage_profile: The full storage profile dict (with fileSystemLocations), or None.
         checkpoint_dir: The checkpoint directory path (used for --ignore-storage-profiles case).
+        job_download_results: Per-job download results with file counts and error info.
         print_function_callback: Callback for printing output.
     """
     status_file_paths = _get_status_file_paths(
@@ -325,6 +368,7 @@ def write_download_status_file(
                     categorized_job_ids=categorized_job_ids,
                     download_candidate_jobs=download_candidate_jobs,
                     existing_jobs=existing_jobs,
+                    job_download_results=job_download_results,
                 )
 
                 _atomic_write_json(status_file_path, status_content)

--- a/src/deadline/client/cli/_download_status_file.py
+++ b/src/deadline/client/cli/_download_status_file.py
@@ -119,18 +119,18 @@ def _make_status_entry(
     }
 
 
-def _is_job_fully_complete(job: dict[str, Any], check_active_tasks: bool = False) -> bool:
-    """Returns True if all tasks succeeded and the job has ended."""
+def _is_job_fully_complete(job: dict[str, Any]) -> bool:
+    """Returns True if the job has ended with no active tasks remaining.
+
+    A job is considered complete when it has ended and no tasks are still
+    active — even if some tasks failed or were canceled. All available
+    outputs from succeeded tasks have been downloaded.
+    """
     task_counts = job.get("taskRunStatusCounts", {})
-    succeeded = task_counts.get("SUCCEEDED", 0)
-    total = sum(task_counts.values()) if task_counts else 0
-    if check_active_tasks:
-        active_tasks = sum(
-            task_counts.get(s, 0) for s in ["READY", "RUNNING", "ASSIGNED", "STARTING", "SCHEDULED"]
-        )
-        if active_tasks > 0:
-            return False
-    return succeeded == total and "endedAt" in job
+    active_tasks = sum(
+        task_counts.get(s, 0) for s in ["READY", "RUNNING", "ASSIGNED", "STARTING", "SCHEDULED"]
+    )
+    return "endedAt" in job and active_tasks == 0
 
 
 def _determine_job_download_status(
@@ -173,7 +173,7 @@ def _determine_job_download_status(
         return _make_status_entry("downloaded", total_files, downloaded_files)
 
     if job_id in categorized_job_ids.added:
-        if _is_job_fully_complete(job, check_active_tasks=True):
+        if _is_job_fully_complete(job):
             return _make_status_entry("downloaded", total_files, downloaded_files)
         return _make_status_entry("in_progress", total_files, downloaded_files)
 
@@ -226,18 +226,29 @@ def _build_status_file_content(
             job_id, job, categorized_job_ids, job_download_results
         )
         existing_entry = jobs_status.get(job_id)
-        # Don't overwrite an existing entry that has file counts with one that has none
         if (
             existing_entry
             and existing_entry.get("total_files", 0) > 0
             and new_entry.get("total_files", 0) == 0
         ):
-            # Preserve existing entry but update the status if it changed
+            # No download this run — preserve existing counts, update status if changed
             if new_entry["download_status"] != existing_entry["download_status"]:
                 existing_entry["download_status"] = new_entry["download_status"]
                 existing_entry["last_updated"] = new_entry["last_updated"]
         else:
             jobs_status[job_id] = new_entry
+
+    # Update inactive jobs with non-terminal status to a terminal state
+    for job_id in categorized_job_ids.inactive:
+        existing_entry = jobs_status.get(job_id)
+        if existing_entry and existing_entry.get("download_status") == "in_progress":
+            if existing_entry.get("downloaded_files", 0) > 0:
+                # Had some downloads — mark as downloaded (all available outputs are on disk)
+                existing_entry["download_status"] = "downloaded"
+            else:
+                # No downloads at all — mark as skipped (job stopped before any output)
+                existing_entry["download_status"] = "skipped"
+            existing_entry["last_updated"] = now
 
     # Determine run status — "failed" if any job in this run had errors
     has_failures = any(

--- a/src/deadline/client/cli/_groups/queue_group.py
+++ b/src/deadline/client/cli/_groups/queue_group.py
@@ -508,17 +508,20 @@ def sync_output(
 
         logger.echo()
 
-        updated_download_state, categorized_job_ids, download_candidate_jobs = (
-            _incremental_output_download(
-                boto3_session=boto3_session,
-                farm_id=farm_id,
-                queue=queue,
-                checkpoint=checkpoint,
-                file_conflict_resolution=FileConflictResolution[conflict_resolution],
-                config=config,
-                print_function_callback=logger.echo,
-                dry_run=dry_run,
-            )
+        (
+            updated_download_state,
+            categorized_job_ids,
+            download_candidate_jobs,
+            job_download_results,
+        ) = _incremental_output_download(
+            boto3_session=boto3_session,
+            farm_id=farm_id,
+            queue=queue,
+            checkpoint=checkpoint,
+            file_conflict_resolution=FileConflictResolution[conflict_resolution],
+            config=config,
+            print_function_callback=logger.echo,
+            dry_run=dry_run,
         )
 
         # Save status file and checkpoint if it's not a dry run
@@ -530,6 +533,7 @@ def sync_output(
                 local_storage_profile_id=local_storage_profile_id,
                 local_storage_profile=local_storage_profile if local_storage_profile_id else None,
                 checkpoint_dir=checkpoint_dir,
+                job_download_results=job_download_results,
                 print_function_callback=logger.echo,
             )
 

--- a/src/deadline/client/cli/_groups/queue_group.py
+++ b/src/deadline/client/cli/_groups/queue_group.py
@@ -476,6 +476,16 @@ def sync_output(
             # Print the bootstrap time in local time
             if force_bootstrap:
                 logger.echo(f"Bootstrap forced, lookback is {bootstrap_lookback_minutes} minutes")
+                # Also clear the failed jobs tracker so abandoned jobs get a fresh start
+                storage_profile_key = local_storage_profile_id or "ignore-storage-profiles"
+                failed_jobs_file = os.path.join(
+                    checkpoint_dir,
+                    f"{queue_id}_{storage_profile_key}_failed_jobs.json",
+                )
+                try:
+                    os.unlink(failed_jobs_file)
+                except OSError:
+                    pass  # File doesn't exist — nothing to clear
             else:
                 logger.echo(
                     f"Checkpoint not found, lookback is {bootstrap_lookback_minutes} minutes"
@@ -519,6 +529,7 @@ def sync_output(
             queue=queue,
             checkpoint=checkpoint,
             file_conflict_resolution=FileConflictResolution[conflict_resolution],
+            checkpoint_dir=checkpoint_dir,
             config=config,
             print_function_callback=logger.echo,
             dry_run=dry_run,

--- a/src/deadline/client/cli/_incremental_download.py
+++ b/src/deadline/client/cli/_incremental_download.py
@@ -1216,6 +1216,8 @@ def _incremental_output_download(
             f"Manifest list length mismatch: {len(manifests_to_download)} vs {len(downloaded_manifests)}"
         )
     job_manifest_paths: dict[str, list[BaseManifestPath]] = {}
+    # Dedup is per-job only. Cross-job path collisions are not expected since each job
+    # writes to its own output path. file_conflict_resolution handles any actual conflicts.
     job_seen_paths: dict[str, set[str]] = {}
     for i, (_, job_id, _, _) in enumerate(manifests_to_download):
         manifest_tuple = downloaded_manifests[i]
@@ -1312,20 +1314,17 @@ def _incremental_output_download(
     else:
         print_function_callback("Skipping downloads due to DRY RUN")
 
-    # Update the timestamp only if all jobs succeeded — if any failed, keep the old timestamp
-    # so the next run's SearchJobs query window still covers the failed jobs
-    has_download_failures = any(
-        r.get("error_code") is not None for r in job_download_results.values()
-    )
-    if not has_download_failures:
-        checkpoint.downloads_completed_timestamp = new_completed_timestamp
-
     # Remove failed jobs from checkpoint entirely so they're treated as new (added) next run
     failed_job_ids = {
         job_id for job_id, r in job_download_results.items() if r.get("error_code") is not None
     }
     if failed_job_ids:
         checkpoint.jobs = [job for job in checkpoint.jobs if job.job_id not in failed_job_ids]
+
+    # Update the timestamp only if all jobs succeeded — if any failed, keep the old timestamp
+    # so the next run's SearchJobs query window still covers the failed jobs
+    if not failed_job_ids:
+        checkpoint.downloads_completed_timestamp = new_completed_timestamp
 
     stats: dict[str, Any] = {
         "downloaded_session_actions": sum(

--- a/src/deadline/client/cli/_incremental_download.py
+++ b/src/deadline/client/cli/_incremental_download.py
@@ -1331,19 +1331,19 @@ def _incremental_output_download(
         job_sessions,
         path_mapping_rule_appliers,
     )
-    # Correlate manifests_to_download with downloaded_manifests by position. Both are produced
-    # from _get_manifests_to_download with identical inputs, so their lengths always match in
-    # practice (downloaded_manifests is a per-index fill of the same list). This guard is
-    # defensive only: if they ever diverge, skip per-job attribution rather than risk a wrong
-    # index correlation. The actual output-file download happens per job in the loop below, so
-    # a skipped-attribution run would download nothing — acceptable only because the mismatch
-    # is unreachable with the current deterministic inputs.
+    # Correlate manifests_to_download with downloaded_manifests by position to attribute each
+    # downloaded manifest to its job. Both lists come from _get_manifests_to_download with
+    # identical inputs, so their lengths match in practice. If they ever diverge we skip only
+    # the per-job attribution — the downloads still proceed via the fallback bucket below, so a
+    # mismatch degrades reporting but never causes a silent zero-download run. (Downloads are
+    # decoupled from attribution: what gets downloaded comes from downloaded_manifests either
+    # way; attribution is best-effort layered on top.)
     skip_attribution = len(manifests_to_download) != len(downloaded_manifests)
     if skip_attribution:
         print_function_callback(
             f"WARNING: Manifest list length mismatch ({len(manifests_to_download)} vs "
             f"{len(downloaded_manifests)}) — per-job download tracking will not be "
-            f"populated for this run."
+            f"populated for this run; files will still be downloaded."
         )
     job_manifest_paths: dict[str, list[BaseManifestPath]] = {}
     # global_seen_paths prevents concurrent writes to the same destination file across jobs.
@@ -1367,6 +1367,23 @@ def _incremental_output_download(
                         seen.add(normcased)
                         global_seen_paths.add(normcased)
                         job_manifest_paths.setdefault(job_id, []).append(manifest_path)
+    else:
+        # Attribution skipped: download everything anyway, decoupled from per-job tracking.
+        # Collect every downloaded path (deduped) under a synthetic bucket keyed by "" so it
+        # never collides with a real job id. Per-job counts aren't populated this run, but no
+        # files are lost; the "" bucket is dropped from results before the status file is built.
+        fallback_seen: set[str] = set()
+        fallback_paths: list[BaseManifestPath] = []
+        for manifest_tuple in downloaded_manifests:
+            if manifest_tuple is not None:
+                _, manifest = manifest_tuple
+                for manifest_path in manifest.paths:
+                    normcased = os.path.normcase(manifest_path.path)
+                    if normcased not in fallback_seen:
+                        fallback_seen.add(normcased)
+                        fallback_paths.append(manifest_path)
+        if fallback_paths:
+            job_manifest_paths[""] = fallback_paths
 
     # Print a summary of all the paths before starting the download
     all_manifest_paths = [path for paths in job_manifest_paths.values() for path in paths]
@@ -1383,6 +1400,9 @@ def _incremental_output_download(
 
     # Download per-job with error isolation, running jobs in parallel to restore throughput.
     job_download_results: dict[str, dict[str, Any]] = {}
+    # Set when the synthetic "" fallback bucket (attribution skipped) failed to download —
+    # gates the timestamp advance below so the lost window is re-attempted next run.
+    fallback_download_failed = False
 
     if not dry_run:
         total_files = sum(len(paths) for paths in job_manifest_paths.values())
@@ -1479,6 +1499,15 @@ def _incremental_output_download(
         if cancelled:
             raise AssetSyncCancelledError("File download cancelled.")
 
+        # The synthetic fallback bucket (used when attribution was skipped) is retained in
+        # job_download_results so the run-level file/byte stats and the success/failure signal are
+        # computed from it — dropping it would report zero downloads (on success) or a false
+        # success (on failure) for a run that actually moved the full window. It is never a real
+        # job id, so it stays out of the per-job status entries (built from categorized_job_ids
+        # only) and the failed-jobs tracker (comprehensions below skip falsy job ids). On failure
+        # the flag also holds the timestamp back so the lost window is re-attempted next run.
+        fallback_download_failed = job_download_results.get("", {}).get("error_code") is not None
+
         durations.download = time.perf_counter_ns() - start_t
         duration = datetime.now(tz=timezone.utc) - start_time
         print_function_callback(f"...downloaded in {duration}")
@@ -1487,11 +1516,18 @@ def _incremental_output_download(
 
     # Remove failed jobs from checkpoint so they're treated as new (added) next run.
     # Track them in the failed jobs file so they're retried even after the timestamp advances.
+    # The synthetic "" fallback bucket (kept above only when it failed) is not a real job, so it
+    # is excluded here — it must never reach the checkpoint filter or the failed-jobs tracker. Its
+    # retry is driven by the held-back timestamp (fallback_download_failed), not per-job tracking.
     failed_job_ids = {
-        job_id for job_id, r in job_download_results.items() if r.get("error_code") is not None
+        job_id
+        for job_id, r in job_download_results.items()
+        if job_id and r.get("error_code") is not None
     }
     succeeded_job_ids = {
-        job_id for job_id, r in job_download_results.items() if r.get("error_code") is None
+        job_id
+        for job_id, r in job_download_results.items()
+        if job_id and r.get("error_code") is None
     }
     # Any previously-tracked job that was in this run's candidate set but produced no result
     # entry (e.g. deleted, attachments_free, missing storage profile, or all paths claimed by
@@ -1507,7 +1543,11 @@ def _incremental_output_download(
 
     # Always advance the timestamp — failed jobs are tracked separately so they don't
     # pin the global window. This prevents a single stuck job from degrading the entire queue.
-    checkpoint.downloads_completed_timestamp = new_completed_timestamp
+    # Exception: when attribution was skipped, there is no per-job tracker entry to carry a
+    # failed download's retry, so the global window is the only retry lever — hold it back on
+    # a fallback failure so the lost outputs are re-attempted next run.
+    if not fallback_download_failed:
+        checkpoint.downloads_completed_timestamp = new_completed_timestamp
 
     stats: dict[str, Any] = {
         "downloaded_session_actions": sum(

--- a/src/deadline/client/cli/_incremental_download.py
+++ b/src/deadline/client/cli/_incremental_download.py
@@ -31,6 +31,7 @@ from ...job_attachments._incremental_downloads._manifest_s3_downloads import (
     _get_manifests_to_download,
     _download_manifest_paths,
 )
+from ...job_attachments.exceptions import AssetSyncCancelledError
 from ...job_attachments._path_mapping import (
     _generate_path_mapping_rules,
     _PathMappingRuleApplier,
@@ -1297,6 +1298,8 @@ def _incremental_output_download(
                     "error_code": None,
                     "error_message": None,
                 }
+            except AssetSyncCancelledError:
+                raise
             except Exception as e:
                 downloaded_count = sum(1 for f in job_files if os.path.exists(f.path))
                 job_download_results[job_id] = {

--- a/src/deadline/client/cli/_incremental_download.py
+++ b/src/deadline/client/cli/_incremental_download.py
@@ -1331,9 +1331,19 @@ def _incremental_output_download(
         job_sessions,
         path_mapping_rule_appliers,
     )
-    if len(manifests_to_download) != len(downloaded_manifests):
-        raise RuntimeError(
-            f"Manifest list length mismatch: {len(manifests_to_download)} vs {len(downloaded_manifests)}"
+    # Correlate manifests_to_download with downloaded_manifests by position. Both are produced
+    # from _get_manifests_to_download with identical inputs, so their lengths always match in
+    # practice (downloaded_manifests is a per-index fill of the same list). This guard is
+    # defensive only: if they ever diverge, skip per-job attribution rather than risk a wrong
+    # index correlation. The actual output-file download happens per job in the loop below, so
+    # a skipped-attribution run would download nothing — acceptable only because the mismatch
+    # is unreachable with the current deterministic inputs.
+    skip_attribution = len(manifests_to_download) != len(downloaded_manifests)
+    if skip_attribution:
+        print_function_callback(
+            f"WARNING: Manifest list length mismatch ({len(manifests_to_download)} vs "
+            f"{len(downloaded_manifests)}) — per-job download tracking will not be "
+            f"populated for this run."
         )
     job_manifest_paths: dict[str, list[BaseManifestPath]] = {}
     # global_seen_paths prevents concurrent writes to the same destination file across jobs.
@@ -1343,19 +1353,20 @@ def _incremental_output_download(
     # since file_conflict_resolution would have picked one winner anyway).
     global_seen_paths: set[str] = set()
     job_seen_paths: dict[str, set[str]] = {}
-    for i, (_, job_id, _, _) in enumerate(manifests_to_download):
-        manifest_tuple = downloaded_manifests[i]
-        if manifest_tuple is not None:
-            _, manifest = manifest_tuple
-            for manifest_path in manifest.paths:
-                normcased = os.path.normcase(manifest_path.path)
-                if normcased in global_seen_paths:
-                    continue  # Another job already claims this path — skip to prevent concurrent writes
-                seen = job_seen_paths.setdefault(job_id, set())
-                if normcased not in seen:
-                    seen.add(normcased)
-                    global_seen_paths.add(normcased)
-                    job_manifest_paths.setdefault(job_id, []).append(manifest_path)
+    if not skip_attribution:
+        for i, (_, job_id, _, _) in enumerate(manifests_to_download):
+            manifest_tuple = downloaded_manifests[i]
+            if manifest_tuple is not None:
+                _, manifest = manifest_tuple
+                for manifest_path in manifest.paths:
+                    normcased = os.path.normcase(manifest_path.path)
+                    if normcased in global_seen_paths:
+                        continue  # Another job already claims this path — skip to prevent concurrent writes
+                    seen = job_seen_paths.setdefault(job_id, set())
+                    if normcased not in seen:
+                        seen.add(normcased)
+                        global_seen_paths.add(normcased)
+                        job_manifest_paths.setdefault(job_id, []).append(manifest_path)
 
     # Print a summary of all the paths before starting the download
     all_manifest_paths = [path for paths in job_manifest_paths.values() for path in paths]

--- a/src/deadline/client/cli/_incremental_download.py
+++ b/src/deadline/client/cli/_incremental_download.py
@@ -1045,7 +1045,7 @@ def _incremental_output_download(
         dry_run: If True, the operation will print out information but not perform any data downloads.
 
     Returns:
-        A tuple of (updated checkpoint, categorized job IDs, download candidate jobs dict).
+        A tuple of (updated checkpoint, categorized job IDs, download candidate jobs dict, per-job download results).
     """
     durations = IncrementalOutputDownloadLatencies()
     # Operations here are within a single farm, so scope the deadline client to that
@@ -1211,13 +1211,22 @@ def _incremental_output_download(
         job_sessions,
         path_mapping_rule_appliers,
     )
+    if len(manifests_to_download) != len(downloaded_manifests):
+        raise RuntimeError(
+            f"Manifest list length mismatch: {len(manifests_to_download)} vs {len(downloaded_manifests)}"
+        )
     job_manifest_paths: dict[str, list[BaseManifestPath]] = {}
+    job_seen_paths: dict[str, set[str]] = {}
     for i, (_, job_id, _, _) in enumerate(manifests_to_download):
         manifest_tuple = downloaded_manifests[i]
         if manifest_tuple is not None:
             _, manifest = manifest_tuple
             for manifest_path in manifest.paths:
-                job_manifest_paths.setdefault(job_id, []).append(manifest_path)
+                normcased = os.path.normcase(manifest_path.path)
+                seen = job_seen_paths.setdefault(job_id, set())
+                if normcased not in seen:
+                    seen.add(normcased)
+                    job_manifest_paths.setdefault(job_id, []).append(manifest_path)
 
     # Print a summary of all the paths before starting the download
     all_manifest_paths = [path for paths in job_manifest_paths.values() for path in paths]
@@ -1305,13 +1314,15 @@ def _incremental_output_download(
 
     # Update the timestamp only if all jobs succeeded — if any failed, keep the old timestamp
     # so the next run's SearchJobs query window still covers the failed jobs
-    has_download_failures = any(r.get("failed_files", 0) > 0 for r in job_download_results.values())
+    has_download_failures = any(
+        r.get("error_code") is not None for r in job_download_results.values()
+    )
     if not has_download_failures:
         checkpoint.downloads_completed_timestamp = new_completed_timestamp
 
     # Remove failed jobs from checkpoint entirely so they're treated as new (added) next run
     failed_job_ids = {
-        job_id for job_id, r in job_download_results.items() if r.get("failed_files", 0) > 0
+        job_id for job_id, r in job_download_results.items() if r.get("error_code") is not None
     }
     if failed_job_ids:
         checkpoint.jobs = [job for job in checkpoint.jobs if job.job_id not in failed_job_ids]

--- a/src/deadline/client/cli/_incremental_download.py
+++ b/src/deadline/client/cli/_incremental_download.py
@@ -6,6 +6,7 @@ __all__ = ["CategorizedJobIds", "_incremental_output_download"]
 from dataclasses import dataclass, asdict
 from datetime import datetime, timedelta, timezone
 import difflib
+import os
 from typing import Optional
 from configparser import ConfigParser
 from typing import Any, Callable
@@ -27,7 +28,7 @@ from ...job_attachments._incremental_downloads.incremental_download_state import
 from ...job_attachments._incremental_downloads._manifest_s3_downloads import (
     _add_output_manifests_from_s3,
     _download_all_manifests_with_absolute_paths,
-    _merge_absolute_path_manifest_list,
+    _get_manifests_to_download,
     _download_manifest_paths,
 )
 from ...job_attachments._path_mapping import (
@@ -52,6 +53,30 @@ from ...job_attachments.progress_tracker import (
 from ._common import _cli_object_repr, sigint_handler
 
 SESSIONS_API_MAX_CONCURRENCY = 3
+
+
+def _classify_error(e: Exception) -> str:
+    """Classifies a download exception into a standard error code."""
+    if isinstance(e, PermissionError):
+        return "PERMISSION_DENIED"
+    if isinstance(e, OSError) and e.errno == 28:
+        return "DISK_FULL"
+    if isinstance(e, FileNotFoundError):
+        return "PATH_NOT_FOUND"
+    if isinstance(e, (ConnectionError, TimeoutError)):
+        return "NETWORK_ERROR"
+
+    # Fallback: check the error message for S3/boto errors
+    error_str = str(e).lower()
+    if "permission" in error_str or "access denied" in error_str:
+        return "PERMISSION_DENIED"
+    elif "no space" in error_str or "disk full" in error_str:
+        return "DISK_FULL"
+    elif "no such file" in error_str or "not found" in error_str:
+        return "PATH_NOT_FOUND"
+    elif "network" in error_str or "connection" in error_str or "timeout" in error_str:
+        return "NETWORK_ERROR"
+    return "UNKNOWN"
 
 
 @dataclass
@@ -991,7 +1016,12 @@ def _incremental_output_download(
     print_function_callback: Callable[[Any], None] = lambda msg: None,
     *,
     dry_run: bool = False,
-) -> tuple[IncrementalDownloadState, CategorizedJobIds, dict[str, dict[str, Any]]]:
+) -> tuple[
+    IncrementalDownloadState,
+    CategorizedJobIds,
+    dict[str, dict[str, Any]],
+    dict[str, dict[str, Any]],
+]:
     """
     This function downloads all the task run outputs from the specified queue, that have become
     available since the last time the function was called. The checkpoint object
@@ -1174,15 +1204,26 @@ def _incremental_output_download(
             )
             print_function_callback(textwrap.indent(paths_summary, "      "))
 
-    # Merge the manifests ordered by the last modified timestamp
-    manifest_paths_to_download: list[BaseManifestPath] = _merge_absolute_path_manifest_list(
-        downloaded_manifests
+    # Build per-job file mapping by correlating downloaded manifests with their job IDs
+    manifests_to_download = _get_manifests_to_download(
+        queue["jobAttachmentSettings"]["rootPrefix"],
+        download_candidate_jobs,
+        job_sessions,
+        path_mapping_rule_appliers,
     )
+    job_manifest_paths: dict[str, list[BaseManifestPath]] = {}
+    for i, (_, job_id, _, _) in enumerate(manifests_to_download):
+        manifest_tuple = downloaded_manifests[i]
+        if manifest_tuple is not None:
+            _, manifest = manifest_tuple
+            for manifest_path in manifest.paths:
+                job_manifest_paths.setdefault(job_id, []).append(manifest_path)
 
     # Print a summary of all the paths before starting the download
-    local_path_list = [manifest_path.path for manifest_path in manifest_paths_to_download]
+    all_manifest_paths = [path for paths in job_manifest_paths.values() for path in paths]
+    local_path_list = [manifest_path.path for manifest_path in all_manifest_paths]
     file_size_by_path = {
-        manifest_path.path: manifest_path.size for manifest_path in manifest_paths_to_download
+        manifest_path.path: manifest_path.size for manifest_path in all_manifest_paths
     }
     print_function_callback("")
     print_function_callback("Summary of paths to download:")
@@ -1191,43 +1232,70 @@ def _incremental_output_download(
     )
     print_function_callback("")
 
+    # Download per-job with error isolation
+    job_download_results: dict[str, dict[str, Any]] = {}
+
     if not dry_run:
-        print_function_callback(f"Downloading {len(manifest_paths_to_download)} files from S3...")
+        total_files = sum(len(paths) for paths in job_manifest_paths.values())
+        print_function_callback(
+            f"Downloading {total_files} files from S3 across {len(job_manifest_paths)} jobs..."
+        )
         start_t = time.perf_counter_ns()
         start_time = datetime.now(tz=timezone.utc)
 
-        # Incremental download is mostly a background thing, so don't print status too often while downloading
-        MIN_DELAY_BETWEEN_PRINTOUTS = 20
-        last_call_time = time.time() - MIN_DELAY_BETWEEN_PRINTOUTS
-        printed_100_percent = False
+        for job_id, job_files in job_manifest_paths.items():
+            job_name = download_candidate_jobs.get(job_id, {}).get("name", job_id)
+            print_function_callback(f"  Downloading {len(job_files)} files for job: {job_name}")
 
-        def _update_download_progress(
-            download_metadata: ProgressReportMetadata,
-        ) -> bool:
-            nonlocal last_call_time, printed_100_percent
+            MIN_DELAY_BETWEEN_PRINTOUTS = 20
+            last_call_time = time.time() - MIN_DELAY_BETWEEN_PRINTOUTS
+            printed_100_percent = False
 
-            if not printed_100_percent and download_metadata.progress == 100:
-                print_function_callback(f"{download_metadata.progressMessage}")
-                last_call_time = time.time()
-                printed_100_percent = True
-            elif (
-                not printed_100_percent
-                and time.time() - last_call_time > MIN_DELAY_BETWEEN_PRINTOUTS
-            ):
-                print_function_callback(f"{download_metadata.progressMessage}")
-                last_call_time = time.time()
+            def _update_download_progress(
+                download_metadata: ProgressReportMetadata,
+            ) -> bool:
+                nonlocal last_call_time, printed_100_percent
 
-            return sigint_handler.continue_operation
+                if not printed_100_percent and download_metadata.progress == 100:
+                    print_function_callback(f"    {download_metadata.progressMessage}")
+                    last_call_time = time.time()
+                    printed_100_percent = True
+                elif (
+                    not printed_100_percent
+                    and time.time() - last_call_time > MIN_DELAY_BETWEEN_PRINTOUTS
+                ):
+                    print_function_callback(f"    {download_metadata.progressMessage}")
+                    last_call_time = time.time()
 
-        _download_manifest_paths(
-            manifest_paths_to_download,
-            HashAlgorithm.XXH128,
-            queue,
-            boto3_session_for_s3,
-            file_conflict_resolution,
-            on_downloading_files=_update_download_progress,
-            print_function_callback=print_function_callback,
-        )
+                return sigint_handler.continue_operation
+
+            try:
+                _download_manifest_paths(
+                    job_files,
+                    HashAlgorithm.XXH128,
+                    queue,
+                    boto3_session_for_s3,
+                    file_conflict_resolution,
+                    on_downloading_files=_update_download_progress,
+                    print_function_callback=print_function_callback,
+                )
+                job_download_results[job_id] = {
+                    "total_files": len(job_files),
+                    "downloaded_files": len(job_files),
+                    "failed_files": 0,
+                    "error_code": None,
+                    "error_message": None,
+                }
+            except Exception as e:
+                downloaded_count = sum(1 for f in job_files if os.path.exists(f.path))
+                job_download_results[job_id] = {
+                    "total_files": len(job_files),
+                    "downloaded_files": downloaded_count,
+                    "failed_files": len(job_files) - downloaded_count,
+                    "error_code": _classify_error(e),
+                    "error_message": str(e),
+                }
+                print_function_callback(f"  ERROR downloading job {job_name} ({job_id}): {e}")
 
         durations.download = time.perf_counter_ns() - start_t
         duration = datetime.now(tz=timezone.utc) - start_time
@@ -1235,8 +1303,18 @@ def _incremental_output_download(
     else:
         print_function_callback("Skipping downloads due to DRY RUN")
 
-    # Update the timestamp in the state object to reflect the downloads that were completed
-    checkpoint.downloads_completed_timestamp = new_completed_timestamp
+    # Update the timestamp only if all jobs succeeded — if any failed, keep the old timestamp
+    # so the next run's SearchJobs query window still covers the failed jobs
+    has_download_failures = any(r.get("failed_files", 0) > 0 for r in job_download_results.values())
+    if not has_download_failures:
+        checkpoint.downloads_completed_timestamp = new_completed_timestamp
+
+    # Remove failed jobs from checkpoint entirely so they're treated as new (added) next run
+    failed_job_ids = {
+        job_id for job_id, r in job_download_results.items() if r.get("failed_files", 0) > 0
+    }
+    if failed_job_ids:
+        checkpoint.jobs = [job for job in checkpoint.jobs if job.job_id not in failed_job_ids]
 
     stats: dict[str, Any] = {
         "downloaded_session_actions": sum(
@@ -1244,8 +1322,8 @@ def _incremental_output_download(
             for session_list in job_sessions.values()
             for session in session_list
         ),
-        "downloaded_files": len(manifest_paths_to_download),
-        "downloaded_bytes": sum(path.size for path in manifest_paths_to_download),
+        "downloaded_files": len(all_manifest_paths),
+        "downloaded_bytes": sum(path.size for path in all_manifest_paths),
         "jobs_with_downloads": {
             "completed": len(categorized_job_ids.completed),
             "added": len(categorized_job_ids.added),
@@ -1294,4 +1372,4 @@ def _incremental_output_download(
     print_function_callback(f"    unchanged: {stats['jobs_without_downloads']['unchanged']}")
     print_function_callback(f"    inactive: {stats['jobs_without_downloads']['inactive']}")
 
-    return checkpoint, categorized_job_ids, download_candidate_jobs
+    return checkpoint, categorized_job_ids, download_candidate_jobs, job_download_results

--- a/src/deadline/client/cli/_incremental_download.py
+++ b/src/deadline/client/cli/_incremental_download.py
@@ -6,7 +6,10 @@ __all__ = ["CategorizedJobIds", "_incremental_output_download"]
 from dataclasses import dataclass, asdict
 from datetime import datetime, timedelta, timezone
 import difflib
+import json
 import os
+import tempfile
+import threading
 from typing import Optional
 from configparser import ConfigParser
 from typing import Any, Callable
@@ -17,9 +20,11 @@ import textwrap
 from .. import api
 import boto3
 from botocore.client import BaseClient  # type: ignore[import]
+from botocore.exceptions import ClientError  # type: ignore[import]
 from ..api._list_jobs_by_filter_expression import _list_jobs_by_filter_expression
 from ..api._session import get_session_client, _resolve_region
 from ...job_attachments.api import summarize_path_list, human_readable_file_size
+from ...job_attachments._aws.aws_clients import get_s3_client as _get_s3_client
 from ...job_attachments._incremental_downloads.incremental_download_state import (
     IncrementalDownloadState,
     IncrementalDownloadJob,
@@ -78,6 +83,76 @@ def _classify_error(e: Exception) -> str:
     elif "network" in error_str or "connection" in error_str or "timeout" in error_str:
         return "NETWORK_ERROR"
     return "UNKNOWN"
+
+
+_MAX_FAILED_JOB_RETRIES = 5
+
+
+class _FailedJobsTracker:
+    """Persists per-job download failure counts so the global timestamp can advance freely.
+
+    When a job fails to download, it is tracked here instead of freezing the checkpoint
+    timestamp. On the next run, failed jobs are fetched individually via GetJob and merged
+    into the download candidates. After _MAX_FAILED_JOB_RETRIES attempts, the job is
+    abandoned and a warning is logged.
+    """
+
+    def __init__(self, file_path: str) -> None:
+        self._file_path = file_path
+        self._counts: dict[str, int] = {}
+        self._load()
+
+    def _load(self) -> None:
+        try:
+            if os.path.exists(self._file_path):
+                with open(self._file_path, "r") as f:
+                    self._counts = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            self._counts = {}
+
+    def save(self) -> None:
+        dir_path = os.path.dirname(self._file_path)
+        tmp_path: Optional[str] = None
+        try:
+            os.makedirs(dir_path, exist_ok=True)
+            fd, tmp_path = tempfile.mkstemp(dir=dir_path, suffix=".tmp")
+            with os.fdopen(fd, "w") as f:
+                json.dump(self._counts, f)
+            os.replace(tmp_path, self._file_path)
+            tmp_path = None  # Rename succeeded — no cleanup needed
+        except OSError:
+            pass  # Best-effort write — if the checkpoint dir is unwritable, skip silently
+        finally:
+            if tmp_path is not None:
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass  # Best-effort cleanup of temp file
+
+    def get_tracked_job_ids(self) -> set[str]:
+        """Returns job IDs that should be retried (below the retry cap)."""
+        return {job_id for job_id, count in self._counts.items() if count < _MAX_FAILED_JOB_RETRIES}
+
+    def is_abandoned(self, job_id: str) -> bool:
+        """Returns True if the job has hit the retry cap and should not be retried."""
+        return self._counts.get(job_id, 0) >= _MAX_FAILED_JOB_RETRIES
+
+    def record_failures(
+        self, failed_job_ids: set[str], print_function_callback: Callable[[Any], None]
+    ) -> None:
+        for job_id in failed_job_ids:
+            self._counts[job_id] = self._counts.get(job_id, 0) + 1
+            if self._counts[job_id] >= _MAX_FAILED_JOB_RETRIES:
+                print_function_callback(
+                    f"WARNING: Job {job_id} has failed to download {_MAX_FAILED_JOB_RETRIES} "
+                    f"times and will no longer be retried automatically."
+                )
+                # Keep in _counts at the cap value so subsequent timestamp-window rediscoveries
+                # are suppressed — do NOT delete here.
+
+    def record_successes(self, succeeded_job_ids: set[str]) -> None:
+        for job_id in succeeded_job_ids:
+            self._counts.pop(job_id, None)
 
 
 @dataclass
@@ -1013,6 +1088,7 @@ def _incremental_output_download(
     boto3_session: boto3.Session,
     checkpoint: IncrementalDownloadState,
     file_conflict_resolution: FileConflictResolution,
+    checkpoint_dir: str,
     config: Optional[ConfigParser] = None,
     print_function_callback: Callable[[Any], None] = lambda msg: None,
     *,
@@ -1094,17 +1170,60 @@ def _incremental_output_download(
         job.job_id: job.session_completed_indexes for job in checkpoint.jobs
     }
 
+    # Load failed jobs tracker — tracks jobs that failed in previous runs so the global
+    # timestamp can advance freely while still retrying failed jobs individually.
+    queue_id = queue["queueId"]
+    storage_profile_key = checkpoint.local_storage_profile_id or "ignore-storage-profiles"
+    failed_jobs_file = os.path.join(
+        checkpoint_dir, f"{queue_id}_{storage_profile_key}_failed_jobs.json"
+    )
+    failed_jobs_tracker = _FailedJobsTracker(failed_jobs_file)
+
     # Call deadline:SearchJobs to get a set of jobs that includes every job with downloads available.
     start_t = time.perf_counter_ns()
     download_candidate_jobs: dict[str, dict[str, Any]] = _get_download_candidate_jobs(
         boto3_session,
         farm_id,
-        queue["queueId"],
+        queue_id,
         checkpoint.downloads_completed_timestamp,
         print_function_callback,
         region=region,
     )
     durations._get_download_candidate_jobs = time.perf_counter_ns() - start_t
+
+    # Inject previously failed jobs that fell outside the timestamp window
+    previously_failed_job_ids = failed_jobs_tracker.get_tracked_job_ids()
+    if previously_failed_job_ids:
+        print_function_callback(
+            f"Retrying {len(previously_failed_job_ids)} previously failed job(s)..."
+        )
+        jobs_not_found: set[str] = set()
+        for job_id in previously_failed_job_ids:
+            if job_id not in download_candidate_jobs:
+                try:
+                    job = deadline.get_job(farmId=farm_id, queueId=queue_id, jobId=job_id)
+                    download_candidate_jobs[job_id] = _datetimes_to_str(job)
+                except ClientError as e:
+                    if e.response.get("Error", {}).get("Code") == "ResourceNotFoundException":
+                        # Job was deleted — remove from tracker to stop retrying
+                        jobs_not_found.add(job_id)
+                    # All other errors (throttling, network, auth) are transient — leave in tracker
+                except Exception:
+                    pass  # Unexpected error — leave in tracker to retry next run
+        if jobs_not_found:
+            failed_jobs_tracker.record_successes(jobs_not_found)
+            if not dry_run:
+                failed_jobs_tracker.save()
+
+    # Remove abandoned jobs (hit retry cap) from download candidates so they are not
+    # re-queued even when rediscovered via the timestamp window.
+    abandoned_job_ids = {
+        job_id
+        for job_id in list(download_candidate_jobs.keys())
+        if failed_jobs_tracker.is_abandoned(job_id)
+    }
+    for job_id in abandoned_job_ids:
+        del download_candidate_jobs[job_id]
 
     print_function_callback("")
 
@@ -1217,8 +1336,12 @@ def _incremental_output_download(
             f"Manifest list length mismatch: {len(manifests_to_download)} vs {len(downloaded_manifests)}"
         )
     job_manifest_paths: dict[str, list[BaseManifestPath]] = {}
-    # Dedup is per-job only. Cross-job path collisions are not expected since each job
-    # writes to its own output path. file_conflict_resolution handles any actual conflicts.
+    # global_seen_paths prevents concurrent writes to the same destination file across jobs.
+    # Without cross-job dedup, parallel threads could write the same path simultaneously
+    # (e.g. two jobs sharing a file-system location), corrupting the file under OVERWRITE.
+    # The first job to claim a path wins; subsequent jobs skip it (same outcome as before
+    # since file_conflict_resolution would have picked one winner anyway).
+    global_seen_paths: set[str] = set()
     job_seen_paths: dict[str, set[str]] = {}
     for i, (_, job_id, _, _) in enumerate(manifests_to_download):
         manifest_tuple = downloaded_manifests[i]
@@ -1226,9 +1349,12 @@ def _incremental_output_download(
             _, manifest = manifest_tuple
             for manifest_path in manifest.paths:
                 normcased = os.path.normcase(manifest_path.path)
+                if normcased in global_seen_paths:
+                    continue  # Another job already claims this path — skip to prevent concurrent writes
                 seen = job_seen_paths.setdefault(job_id, set())
                 if normcased not in seen:
                     seen.add(normcased)
+                    global_seen_paths.add(normcased)
                     job_manifest_paths.setdefault(job_id, []).append(manifest_path)
 
     # Print a summary of all the paths before starting the download
@@ -1244,7 +1370,7 @@ def _incremental_output_download(
     )
     print_function_callback("")
 
-    # Download per-job with error isolation
+    # Download per-job with error isolation, running jobs in parallel to restore throughput.
     job_download_results: dict[str, dict[str, Any]] = {}
 
     if not dry_run:
@@ -1255,9 +1381,16 @@ def _incremental_output_download(
         start_t = time.perf_counter_ns()
         start_time = datetime.now(tz=timezone.utc)
 
-        for job_id, job_files in job_manifest_paths.items():
+        # Pre-warm the S3 client so all threads hit the lru_cache and share one
+        # pre-built client — avoids concurrent session.client() calls across threads.
+        _get_s3_client(session=boto3_session_for_s3)
+
+        print_lock = threading.Lock()
+
+        def _download_job(job_id: str, job_files: list) -> dict[str, Any]:
             job_name = download_candidate_jobs.get(job_id, {}).get("name", job_id)
-            print_function_callback(f"  Downloading {len(job_files)} files for job: {job_name}")
+            with print_lock:
+                print_function_callback(f"  Downloading {len(job_files)} files for job: {job_name}")
 
             MIN_DELAY_BETWEEN_PRINTOUTS = 20
             last_call_time = time.time() - MIN_DELAY_BETWEEN_PRINTOUTS
@@ -1267,18 +1400,18 @@ def _incremental_output_download(
                 download_metadata: ProgressReportMetadata,
             ) -> bool:
                 nonlocal last_call_time, printed_100_percent
-
                 if not printed_100_percent and download_metadata.progress == 100:
-                    print_function_callback(f"    {download_metadata.progressMessage}")
+                    with print_lock:
+                        print_function_callback(f"    {download_metadata.progressMessage}")
                     last_call_time = time.time()
                     printed_100_percent = True
                 elif (
                     not printed_100_percent
                     and time.time() - last_call_time > MIN_DELAY_BETWEEN_PRINTOUTS
                 ):
-                    print_function_callback(f"    {download_metadata.progressMessage}")
+                    with print_lock:
+                        print_function_callback(f"    {download_metadata.progressMessage}")
                     last_call_time = time.time()
-
                 return sigint_handler.continue_operation
 
             try:
@@ -1291,7 +1424,7 @@ def _incremental_output_download(
                     on_downloading_files=_update_download_progress,
                     print_function_callback=print_function_callback,
                 )
-                job_download_results[job_id] = {
+                return {
                     "total_files": len(job_files),
                     "downloaded_files": len(job_files),
                     "failed_files": 0,
@@ -1302,14 +1435,38 @@ def _incremental_output_download(
                 raise
             except Exception as e:
                 downloaded_count = sum(1 for f in job_files if os.path.exists(f.path))
-                job_download_results[job_id] = {
+                with print_lock:
+                    print_function_callback(f"  ERROR downloading job {job_name} ({job_id}): {e}")
+                return {
                     "total_files": len(job_files),
                     "downloaded_files": downloaded_count,
                     "failed_files": len(job_files) - downloaded_count,
                     "error_code": _classify_error(e),
                     "error_message": str(e),
                 }
-                print_function_callback(f"  ERROR downloading job {job_name} ({job_id}): {e}")
+
+        cancelled = False
+        # Bound concurrency to avoid S3 throttling and socket exhaustion — each
+        # _download_manifest_paths call has its own internal thread pool, so total
+        # S3 fan-out is max_workers × per-call threads.
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=SESSIONS_API_MAX_CONCURRENCY
+        ) as executor:
+            future_to_job = {
+                executor.submit(_download_job, job_id, job_files): job_id
+                for job_id, job_files in job_manifest_paths.items()
+            }
+            for future in concurrent.futures.as_completed(future_to_job):
+                job_id = future_to_job[future]
+                try:
+                    job_download_results[job_id] = future.result()
+                except AssetSyncCancelledError:
+                    cancelled = True
+                    executor.shutdown(wait=False, cancel_futures=True)
+                    break
+
+        if cancelled:
+            raise AssetSyncCancelledError("File download cancelled.")
 
         durations.download = time.perf_counter_ns() - start_t
         duration = datetime.now(tz=timezone.utc) - start_time
@@ -1317,17 +1474,29 @@ def _incremental_output_download(
     else:
         print_function_callback("Skipping downloads due to DRY RUN")
 
-    # Remove failed jobs from checkpoint entirely so they're treated as new (added) next run
+    # Remove failed jobs from checkpoint so they're treated as new (added) next run.
+    # Track them in the failed jobs file so they're retried even after the timestamp advances.
     failed_job_ids = {
         job_id for job_id, r in job_download_results.items() if r.get("error_code") is not None
     }
+    succeeded_job_ids = {
+        job_id for job_id, r in job_download_results.items() if r.get("error_code") is None
+    }
+    # Any previously-tracked job that was in this run's candidate set but produced no result
+    # entry (e.g. deleted, attachments_free, missing storage profile, or all paths claimed by
+    # cross-job dedup) should be cleared from the tracker — no retry needed.
+    previously_failed_attempted = previously_failed_job_ids & set(download_candidate_jobs.keys())
+    succeeded_job_ids |= previously_failed_attempted - failed_job_ids
     if failed_job_ids:
         checkpoint.jobs = [job for job in checkpoint.jobs if job.job_id not in failed_job_ids]
+        failed_jobs_tracker.record_failures(failed_job_ids, print_function_callback)
+    failed_jobs_tracker.record_successes(succeeded_job_ids)
+    if not dry_run:
+        failed_jobs_tracker.save()
 
-    # Update the timestamp only if all jobs succeeded — if any failed, keep the old timestamp
-    # so the next run's SearchJobs query window still covers the failed jobs
-    if not failed_job_ids:
-        checkpoint.downloads_completed_timestamp = new_completed_timestamp
+    # Always advance the timestamp — failed jobs are tracked separately so they don't
+    # pin the global window. This prevents a single stuck job from degrading the entire queue.
+    checkpoint.downloads_completed_timestamp = new_completed_timestamp
 
     stats: dict[str, Any] = {
         "downloaded_session_actions": sum(
@@ -1335,8 +1504,22 @@ def _incremental_output_download(
             for session_list in job_sessions.values()
             for session in session_list
         ),
-        "downloaded_files": len(all_manifest_paths),
-        "downloaded_bytes": sum(path.size for path in all_manifest_paths),
+        # On dry runs job_download_results is empty — fall back to job_manifest_paths so the
+        # summary reports the count/size of files that would be downloaded (the preview value).
+        "downloaded_files": sum(
+            r.get("downloaded_files", 0)
+            for r in job_download_results.values()
+            if r.get("error_code") is None
+        )
+        if not dry_run
+        else sum(len(paths) for paths in job_manifest_paths.values()),
+        "downloaded_bytes": sum(
+            path.size
+            for job_id, paths in job_manifest_paths.items()
+            for path in paths
+            if job_id in job_download_results
+            and job_download_results[job_id].get("error_code") is None
+        ),
         "jobs_with_downloads": {
             "completed": len(categorized_job_ids.completed),
             "added": len(categorized_job_ids.added),

--- a/test/unit/deadline_client/cli/test_cli_download_status_file.py
+++ b/test/unit/deadline_client/cli/test_cli_download_status_file.py
@@ -799,6 +799,61 @@ class TestFileCountPreservation:
         assert result["jobs"][MOCK_JOB_ID]["downloaded_files"] == 5
 
 
+class TestFailedJobsTracker:
+    """Tests for _FailedJobsTracker."""
+
+    def test_empty_on_missing_file(self, tmp_path):
+        from deadline.client.cli._incremental_download import _FailedJobsTracker
+
+        tracker = _FailedJobsTracker(str(tmp_path / "failed_jobs.json"))
+        assert tracker.get_tracked_job_ids() == set()
+
+    def test_record_and_retrieve_failure(self, tmp_path):
+        from deadline.client.cli._incremental_download import _FailedJobsTracker
+
+        tracker = _FailedJobsTracker(str(tmp_path / "failed_jobs.json"))
+        messages: list[str] = []
+        tracker.record_failures({MOCK_JOB_ID}, messages.append)
+        assert MOCK_JOB_ID in tracker.get_tracked_job_ids()
+
+    def test_record_success_removes_job(self, tmp_path):
+        from deadline.client.cli._incremental_download import _FailedJobsTracker
+
+        tracker = _FailedJobsTracker(str(tmp_path / "failed_jobs.json"))
+        messages: list[str] = []
+        tracker.record_failures({MOCK_JOB_ID}, messages.append)
+        tracker.record_successes({MOCK_JOB_ID})
+        assert MOCK_JOB_ID not in tracker.get_tracked_job_ids()
+
+    def test_retry_cap_removes_job_and_warns(self, tmp_path):
+        from deadline.client.cli._incremental_download import (
+            _FailedJobsTracker,
+            _MAX_FAILED_JOB_RETRIES,
+        )
+
+        tracker = _FailedJobsTracker(str(tmp_path / "failed_jobs.json"))
+        messages: list[str] = []
+        for _ in range(_MAX_FAILED_JOB_RETRIES):
+            tracker.record_failures({MOCK_JOB_ID}, messages.append)
+        # Abandoned job is excluded from get_tracked_job_ids (not retried)
+        assert MOCK_JOB_ID not in tracker.get_tracked_job_ids()
+        # But is_abandoned returns True so it can be filtered from timestamp window too
+        assert tracker.is_abandoned(MOCK_JOB_ID)
+        assert any("WARNING" in m for m in messages)
+
+    def test_persists_and_reloads(self, tmp_path):
+        from deadline.client.cli._incremental_download import _FailedJobsTracker
+
+        file_path = str(tmp_path / "failed_jobs.json")
+        tracker = _FailedJobsTracker(file_path)
+        messages: list[str] = []
+        tracker.record_failures({MOCK_JOB_ID}, messages.append)
+        tracker.save()
+
+        tracker2 = _FailedJobsTracker(file_path)
+        assert MOCK_JOB_ID in tracker2.get_tracked_job_ids()
+
+
 class TestClassifyError:
     """Tests for _classify_error."""
 

--- a/test/unit/deadline_client/cli/test_cli_download_status_file.py
+++ b/test/unit/deadline_client/cli/test_cli_download_status_file.py
@@ -574,3 +574,281 @@ class TestStatusFileLock:
             with open(lock_file) as f:
                 content = json.load(f)
             assert content["hostname"] == socket.gethostname()
+
+
+class TestPerJobFileCountsAndErrors:
+    """Tests for per-job file counts, error isolation, and failed status."""
+
+    def test_file_counts_populated_from_download_results(self):
+        """Job download results populate total_files and downloaded_files."""
+        cjids = _make_categorized_job_ids(completed={MOCK_JOB_ID})
+        job = _make_job(MOCK_JOB_ID)
+        download_results = {
+            MOCK_JOB_ID: {
+                "total_files": 10,
+                "downloaded_files": 10,
+                "failed_files": 0,
+                "error_code": None,
+                "error_message": None,
+            }
+        }
+        result = _determine_job_download_status(MOCK_JOB_ID, job, cjids, download_results)
+        assert result["download_status"] == "downloaded"
+        assert result["total_files"] == 10
+        assert result["downloaded_files"] == 10
+        assert result["failed_files"] == 0
+
+    def test_failed_job_returns_failed_status(self):
+        """A job with failed files returns 'failed' status with error info."""
+        cjids = _make_categorized_job_ids(completed={MOCK_JOB_ID})
+        job = _make_job(MOCK_JOB_ID)
+        download_results = {
+            MOCK_JOB_ID: {
+                "total_files": 5,
+                "downloaded_files": 0,
+                "failed_files": 5,
+                "error_code": "PERMISSION_DENIED",
+                "error_message": "Access denied to S3 object",
+            }
+        }
+        result = _determine_job_download_status(MOCK_JOB_ID, job, cjids, download_results)
+        assert result["download_status"] == "failed"
+        assert result["total_files"] == 5
+        assert result["failed_files"] == 5
+        assert result["error_code"] == "PERMISSION_DENIED"
+        assert result["error_message"] == "Access denied to S3 object"
+
+    def test_failed_status_overrides_category(self):
+        """Even if categorized as 'completed', a failed download shows 'failed'."""
+        cjids = _make_categorized_job_ids(added={MOCK_JOB_ID})
+        job = _make_job(MOCK_JOB_ID, succeeded=3, total=10, ended=False)
+        download_results = {
+            MOCK_JOB_ID: {
+                "total_files": 8,
+                "downloaded_files": 0,
+                "failed_files": 8,
+                "error_code": "DISK_FULL",
+                "error_message": "No space left on device",
+            }
+        }
+        result = _determine_job_download_status(MOCK_JOB_ID, job, cjids, download_results)
+        assert result["download_status"] == "failed"
+        assert result["error_code"] == "DISK_FULL"
+
+    def test_no_download_results_defaults_to_zero(self):
+        """Without download results, file counts default to 0."""
+        cjids = _make_categorized_job_ids(completed={MOCK_JOB_ID})
+        job = _make_job(MOCK_JOB_ID)
+        result = _determine_job_download_status(MOCK_JOB_ID, job, cjids, None)
+        assert result["total_files"] == 0
+        assert result["downloaded_files"] == 0
+        assert result["failed_files"] == 0
+
+    def test_last_run_status_failed_when_any_job_fails(self):
+        """sync_metadata.last_run_status is 'failed' when any job has errors."""
+        cjids = _make_categorized_job_ids(
+            completed={MOCK_JOB_ID},
+            added={MOCK_JOB_ID_2},
+        )
+        jobs = {
+            MOCK_JOB_ID: _make_job(MOCK_JOB_ID),
+            MOCK_JOB_ID_2: _make_job(MOCK_JOB_ID_2, succeeded=3, total=5, ended=False),
+        }
+        download_results: dict[str, dict[str, Any]] = {
+            MOCK_JOB_ID: {
+                "total_files": 3,
+                "downloaded_files": 3,
+                "failed_files": 0,
+                "error_code": None,
+                "error_message": None,
+            },
+            MOCK_JOB_ID_2: {
+                "total_files": 5,
+                "downloaded_files": 0,
+                "failed_files": 5,
+                "error_code": "NETWORK_ERROR",
+                "error_message": "Connection timeout",
+            },
+        }
+        result = _build_status_file_content(
+            queue_id=MOCK_QUEUE_ID,
+            storage_profile_id=MOCK_STORAGE_PROFILE_ID,
+            categorized_job_ids=cjids,
+            download_candidate_jobs=jobs,
+            job_download_results=download_results,
+        )
+        assert result["sync_metadata"]["last_run_status"] == "failed"
+        assert result["jobs"][MOCK_JOB_ID]["download_status"] == "downloaded"
+        assert result["jobs"][MOCK_JOB_ID_2]["download_status"] == "failed"
+
+    def test_last_run_status_success_when_all_jobs_succeed(self):
+        """sync_metadata.last_run_status is 'success' when no errors."""
+        cjids = _make_categorized_job_ids(completed={MOCK_JOB_ID})
+        jobs = {MOCK_JOB_ID: _make_job(MOCK_JOB_ID)}
+        download_results = {
+            MOCK_JOB_ID: {
+                "total_files": 3,
+                "downloaded_files": 3,
+                "failed_files": 0,
+                "error_code": None,
+                "error_message": None,
+            },
+        }
+        result = _build_status_file_content(
+            queue_id=MOCK_QUEUE_ID,
+            storage_profile_id=MOCK_STORAGE_PROFILE_ID,
+            categorized_job_ids=cjids,
+            download_candidate_jobs=jobs,
+            job_download_results=download_results,
+        )
+        assert result["sync_metadata"]["last_run_status"] == "success"
+        assert result["jobs"][MOCK_JOB_ID]["total_files"] == 3
+        assert result["jobs"][MOCK_JOB_ID]["downloaded_files"] == 3
+
+
+class TestFileCountPreservation:
+    """Tests for preserving file counts when new entry has no download results."""
+
+    def test_existing_file_counts_not_zeroed_by_inactive_job(self):
+        """An inactive job without download results should not zero out existing file counts."""
+        existing_jobs = {
+            MOCK_JOB_ID: {
+                "download_status": "downloaded",
+                "total_files": 4,
+                "downloaded_files": 4,
+                "failed_files": 0,
+                "last_updated": "2026-06-18T12:00:00+00:00",
+                "error_code": None,
+                "error_message": None,
+            }
+        }
+        cjids = _make_categorized_job_ids(inactive={MOCK_JOB_ID})
+        jobs = {MOCK_JOB_ID: _make_job(MOCK_JOB_ID)}
+        result = _build_status_file_content(
+            queue_id=MOCK_QUEUE_ID,
+            storage_profile_id=MOCK_STORAGE_PROFILE_ID,
+            categorized_job_ids=cjids,
+            download_candidate_jobs=jobs,
+            existing_jobs=existing_jobs,
+            job_download_results={},
+        )
+        assert result["jobs"][MOCK_JOB_ID]["total_files"] == 4
+        assert result["jobs"][MOCK_JOB_ID]["downloaded_files"] == 4
+
+    def test_status_update_preserved_when_file_counts_kept(self):
+        """If status changes but no file counts, update status but keep counts."""
+        existing_jobs = {
+            MOCK_JOB_ID: {
+                "download_status": "downloaded",
+                "total_files": 3,
+                "downloaded_files": 3,
+                "failed_files": 0,
+                "last_updated": "2026-06-18T12:00:00+00:00",
+                "error_code": None,
+                "error_message": None,
+            }
+        }
+        cjids = _make_categorized_job_ids(added={MOCK_JOB_ID})
+        job = _make_job(MOCK_JOB_ID, succeeded=2, total=5, ended=False)
+        jobs = {MOCK_JOB_ID: job}
+        result = _build_status_file_content(
+            queue_id=MOCK_QUEUE_ID,
+            storage_profile_id=MOCK_STORAGE_PROFILE_ID,
+            categorized_job_ids=cjids,
+            download_candidate_jobs=jobs,
+            existing_jobs=existing_jobs,
+            job_download_results={},
+        )
+        assert result["jobs"][MOCK_JOB_ID]["download_status"] == "in_progress"
+        assert result["jobs"][MOCK_JOB_ID]["total_files"] == 3
+
+    def test_new_download_results_overwrite_existing(self):
+        """When new download results have real counts, they overwrite existing."""
+        existing_jobs = {
+            MOCK_JOB_ID: {
+                "download_status": "downloaded",
+                "total_files": 3,
+                "downloaded_files": 3,
+                "failed_files": 0,
+                "last_updated": "2026-06-18T12:00:00+00:00",
+                "error_code": None,
+                "error_message": None,
+            }
+        }
+        cjids = _make_categorized_job_ids(added={MOCK_JOB_ID})
+        job = _make_job(MOCK_JOB_ID, succeeded=5, total=5, ended=True)
+        jobs = {MOCK_JOB_ID: job}
+        download_results = {
+            MOCK_JOB_ID: {
+                "total_files": 5,
+                "downloaded_files": 5,
+                "failed_files": 0,
+                "error_code": None,
+                "error_message": None,
+            }
+        }
+        result = _build_status_file_content(
+            queue_id=MOCK_QUEUE_ID,
+            storage_profile_id=MOCK_STORAGE_PROFILE_ID,
+            categorized_job_ids=cjids,
+            download_candidate_jobs=jobs,
+            existing_jobs=existing_jobs,
+            job_download_results=download_results,
+        )
+        assert result["jobs"][MOCK_JOB_ID]["total_files"] == 5
+        assert result["jobs"][MOCK_JOB_ID]["downloaded_files"] == 5
+
+
+class TestClassifyError:
+    """Tests for _classify_error."""
+
+    def test_permission_denied_by_type(self):
+        from deadline.client.cli._incremental_download import _classify_error
+
+        assert _classify_error(PermissionError("cannot write")) == "PERMISSION_DENIED"
+
+    def test_disk_full_by_type(self):
+        from deadline.client.cli._incremental_download import _classify_error
+
+        e = OSError(28, "No space left on device")
+        assert _classify_error(e) == "DISK_FULL"
+
+    def test_path_not_found_by_type(self):
+        from deadline.client.cli._incremental_download import _classify_error
+
+        assert _classify_error(FileNotFoundError("missing")) == "PATH_NOT_FOUND"
+
+    def test_network_error_by_type(self):
+        from deadline.client.cli._incremental_download import _classify_error
+
+        assert _classify_error(ConnectionError("reset")) == "NETWORK_ERROR"
+        assert _classify_error(TimeoutError("timed out")) == "NETWORK_ERROR"
+
+    def test_permission_denied_by_message(self):
+        from deadline.client.cli._incremental_download import _classify_error
+
+        assert _classify_error(Exception("Access Denied")) == "PERMISSION_DENIED"
+        assert _classify_error(Exception("permission error")) == "PERMISSION_DENIED"
+
+    def test_disk_full_by_message(self):
+        from deadline.client.cli._incremental_download import _classify_error
+
+        assert _classify_error(Exception("No space left on device")) == "DISK_FULL"
+        assert _classify_error(Exception("disk full")) == "DISK_FULL"
+
+    def test_path_not_found_by_message(self):
+        from deadline.client.cli._incremental_download import _classify_error
+
+        assert _classify_error(Exception("No such file or directory")) == "PATH_NOT_FOUND"
+        assert _classify_error(Exception("path not found")) == "PATH_NOT_FOUND"
+
+    def test_network_error_by_message(self):
+        from deadline.client.cli._incremental_download import _classify_error
+
+        assert _classify_error(Exception("Connection timeout")) == "NETWORK_ERROR"
+        assert _classify_error(Exception("network unreachable")) == "NETWORK_ERROR"
+
+    def test_unknown_error(self):
+        from deadline.client.cli._incremental_download import _classify_error
+
+        assert _classify_error(Exception("something unexpected")) == "UNKNOWN"

--- a/test/unit/deadline_client/cli/test_cli_download_status_file.py
+++ b/test/unit/deadline_client/cli/test_cli_download_status_file.py
@@ -748,7 +748,7 @@ class TestFileCountPreservation:
                 "error_message": None,
             }
         }
-        cjids = _make_categorized_job_ids(added={MOCK_JOB_ID})
+        cjids = _make_categorized_job_ids(updated={MOCK_JOB_ID})
         job = _make_job(MOCK_JOB_ID, succeeded=2, total=5, ended=False)
         jobs = {MOCK_JOB_ID: job}
         result = _build_status_file_content(

--- a/test/unit/deadline_client/cli/test_cli_queue_incremental_download.py
+++ b/test/unit/deadline_client/cli/test_cli_queue_incremental_download.py
@@ -4,6 +4,7 @@
 Tests for the CLI queue incremental output download command.
 """
 
+import json
 import os
 import sys
 import pytest
@@ -30,6 +31,7 @@ from ..mock_deadline_job_apis import (
 )
 from deadline.job_attachments._incremental_downloads.incremental_download_state import (
     EVENTUAL_CONSISTENCY_MAX_SECONDS,
+    IncrementalDownloadState,
 )
 from deadline.job_attachments.models import StorageProfileOperatingSystemFamily
 import deadline.client.api
@@ -1295,3 +1297,314 @@ def test_incremental_output_download_unmapped_paths_without_storage_profile(
     assert result.exit_code == 0, result.output
     assert "WARNING: THE FOLLOWING FILES WILL NOT BE DOWNLOADED" in result.output, result.output
     assert "/etc/cron.d/evil" in result.output, result.output
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
+)
+def test_incremental_output_download_manifest_mismatch_still_downloads(
+    fresh_deadline_config, deadline_mock, checkpoint_dir
+):
+    """Decouple guard: if the manifest lists ever diverge in length (skip_attribution),
+    downloads must still proceed — the files are downloaded from downloaded_manifests via a
+    fallback bucket, and per-job attribution is skipped only for reporting. Previously a
+    mismatch left job_manifest_paths empty and silently downloaded nothing."""
+    from deadline.job_attachments.asset_manifests.v2023_03_03.asset_manifest import (
+        AssetManifest,
+        ManifestPath,
+    )
+    from deadline.job_attachments.asset_manifests import HashAlgorithm
+
+    mock_jobs = create_fake_job_list(1)
+    mock_jobs[0]["name"] = "Mock Job"
+    mock_jobs[0]["jobId"] = MOCK_JOB_ID
+    mock_jobs[0]["taskRunStatus"] = "SUCCEEDED"
+    mock_jobs[0]["taskRunStatusCounts"] = {"SUCCEEDED": 1, "READY": 0}
+    mock_jobs[0]["attachments"] = {
+        "manifests": [
+            {"rootPath": "/", "rootPathFormat": "posix", "outputRelativeDirectories": ["."]}
+        ],
+        "fileSystem": "COPIED",
+    }
+    mock_jobs[0]["endedAt"] = datetime.fromisoformat(ISO_FREEZE_TIME)
+    deadline_mock.search_jobs = mock_search_jobs_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+    deadline_mock.get_job = mock_get_job_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+
+    deadline_mock.list_sessions.return_value = {
+        "sessions": [
+            {
+                "sessionId": MOCK_SESSION_ID,
+                "fleetId": MOCK_FLEET_ID,
+                "workerId": MOCK_WORKER_ID,
+                "startedAt": datetime.fromisoformat("2025-08-06T00:15:45.712000+00:00"),
+                "endedAt": datetime.fromisoformat("2025-08-06T00:20:59.992000+00:00"),
+                "lifecycleStatus": "ENDED",
+            }
+        ]
+    }
+    deadline_mock.list_session_actions.return_value = {
+        "sessionActions": [
+            {
+                "sessionActionId": MOCK_SESSION_ACTION_ID_1,
+                "status": "SUCCEEDED",
+                "startedAt": "2025-08-06T00:20:58.454000+00:00",
+                "endedAt": "2025-08-06T00:20:59.992000+00:00",
+                "progressPercent": 100.0,
+                "definition": {
+                    "taskRun": {
+                        "taskId": "task-b1764261dff54214aace3932bde8ae7e-0",
+                        "stepId": "step-b1764261dff54214aace3932bde8ae7e",
+                    }
+                },
+                "manifests": [{"outputManifestPath": "task-0/manifest"}],
+            },
+        ]
+    }
+
+    downloaded_file = "/tmp/mismatch_test_output.exr"
+    downloaded_manifests = [
+        (
+            datetime.fromisoformat(ISO_FREEZE_TIME),
+            AssetManifest(
+                hash_alg=HashAlgorithm.XXH128,
+                total_size=1,
+                paths=[ManifestPath(path=downloaded_file, hash="h", size=1, mtime=1)],
+            ),
+        )
+    ]
+
+    def fake_download_all_manifests(
+        queue,
+        download_candidate_jobs,
+        job_sessions,
+        path_mapping_rule_appliers,
+        output_unmapped_paths,
+        boto3_session_for_s3,
+        print_function_callback=lambda msg: None,
+    ):
+        return downloaded_manifests  # length 1
+
+    # Force a length mismatch: return 2 tuples here vs 1 downloaded manifest -> skip_attribution.
+    def fake_get_manifests_to_download(*args, **kwargs):
+        return [
+            (None, MOCK_JOB_ID, "/", "prefix/step/task-0/manifest"),
+            (None, MOCK_JOB_ID, "/", "prefix/step/task-1/manifest"),
+        ]
+
+    downloaded_files_seen: list = []
+
+    def fake_download_manifest_paths(
+        files,
+        hash_algorithm,
+        queue,
+        session,
+        conflict,
+        on_downloading_files,
+        print_function_callback,
+    ):
+        # Record what got handed to the downloader — proves downloads proceed despite the mismatch.
+        downloaded_files_seen.extend(f.path for f in files)
+
+    runner = CliRunner()
+    with (
+        patch(
+            "deadline.client.cli._incremental_download._download_all_manifests_with_absolute_paths",
+            side_effect=fake_download_all_manifests,
+        ),
+        patch(
+            "deadline.client.cli._incremental_download._get_manifests_to_download",
+            side_effect=fake_get_manifests_to_download,
+        ),
+        patch(
+            "deadline.client.cli._incremental_download._download_manifest_paths",
+            side_effect=fake_download_manifest_paths,
+        ),
+        freeze_time(ISO_FREEZE_TIME),
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "queue",
+                "sync-output",
+                "--ignore-storage-profiles",
+                "--force-bootstrap",
+                "--bootstrap-lookback-minutes",
+                "120",
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--checkpoint-dir",
+                checkpoint_dir,
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    # The mismatch warning fired, but the file was STILL downloaded (via the fallback bucket).
+    assert "Manifest list length mismatch" in result.output, result.output
+    assert downloaded_file in downloaded_files_seen, (
+        f"Expected {downloaded_file} to be downloaded despite skip_attribution; "
+        f"got {downloaded_files_seen}"
+    )
+    # A successful fallback run must still report what it downloaded — the retained "" bucket
+    # feeds the run-level stats, so a real download never reports "0 files downloaded".
+    assert "Downloaded files: 1" in result.output, result.output
+    # ...and the run is reported successful, with no synthetic "" job leaking into the entries.
+    status_path = os.path.join(
+        checkpoint_dir, f"{MOCK_QUEUE_ID}_ignore-storage-profiles_download_status.json"
+    )
+    with open(status_path) as f:
+        status = json.load(f)
+    assert status["sync_metadata"]["last_run_status"] == "success", status
+    assert "" not in status["jobs"], status["jobs"]
+
+
+def test_incremental_output_download_fallback_failure_marks_run_failed(
+    fresh_deadline_config, deadline_mock, checkpoint_dir
+):
+    """When attribution is skipped (manifest mismatch) AND the fallback download fails, the
+    failure must not be silently swallowed with the synthetic "" bucket: the run is reported
+    failed and the checkpoint timestamp is held back so the lost window is retried next run."""
+    from deadline.job_attachments.asset_manifests.v2023_03_03.asset_manifest import (
+        AssetManifest,
+        ManifestPath,
+    )
+    from deadline.job_attachments.asset_manifests import HashAlgorithm
+
+    mock_jobs = create_fake_job_list(1)
+    mock_jobs[0]["name"] = "Mock Job"
+    mock_jobs[0]["jobId"] = MOCK_JOB_ID
+    mock_jobs[0]["taskRunStatus"] = "SUCCEEDED"
+    mock_jobs[0]["taskRunStatusCounts"] = {"SUCCEEDED": 1, "READY": 0}
+    mock_jobs[0]["attachments"] = {
+        "manifests": [
+            {"rootPath": "/", "rootPathFormat": "posix", "outputRelativeDirectories": ["."]}
+        ],
+        "fileSystem": "COPIED",
+    }
+    mock_jobs[0]["endedAt"] = datetime.fromisoformat(ISO_FREEZE_TIME)
+    deadline_mock.search_jobs = mock_search_jobs_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+    deadline_mock.get_job = mock_get_job_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+
+    deadline_mock.list_sessions.return_value = {
+        "sessions": [
+            {
+                "sessionId": MOCK_SESSION_ID,
+                "fleetId": MOCK_FLEET_ID,
+                "workerId": MOCK_WORKER_ID,
+                "startedAt": datetime.fromisoformat("2025-08-06T00:15:45.712000+00:00"),
+                "endedAt": datetime.fromisoformat("2025-08-06T00:20:59.992000+00:00"),
+                "lifecycleStatus": "ENDED",
+            }
+        ]
+    }
+    deadline_mock.list_session_actions.return_value = {
+        "sessionActions": [
+            {
+                "sessionActionId": MOCK_SESSION_ACTION_ID_1,
+                "status": "SUCCEEDED",
+                "startedAt": "2025-08-06T00:20:58.454000+00:00",
+                "endedAt": "2025-08-06T00:20:59.992000+00:00",
+                "progressPercent": 100.0,
+                "definition": {
+                    "taskRun": {
+                        "taskId": "task-b1764261dff54214aace3932bde8ae7e-0",
+                        "stepId": "step-b1764261dff54214aace3932bde8ae7e",
+                    }
+                },
+                "manifests": [{"outputManifestPath": "task-0/manifest"}],
+            },
+        ]
+    }
+
+    downloaded_file = "/tmp/mismatch_fail_output.exr"
+    downloaded_manifests = [
+        (
+            datetime.fromisoformat(ISO_FREEZE_TIME),
+            AssetManifest(
+                hash_alg=HashAlgorithm.XXH128,
+                total_size=1,
+                paths=[ManifestPath(path=downloaded_file, hash="h", size=1, mtime=1)],
+            ),
+        )
+    ]
+
+    def fake_download_all_manifests(
+        queue,
+        download_candidate_jobs,
+        job_sessions,
+        path_mapping_rule_appliers,
+        output_unmapped_paths,
+        boto3_session_for_s3,
+        print_function_callback=lambda msg: None,
+    ):
+        return downloaded_manifests
+
+    # Force a length mismatch (2 vs 1) so attribution is skipped -> fallback bucket.
+    def fake_get_manifests_to_download(*args, **kwargs):
+        return [
+            (None, MOCK_JOB_ID, "/", "prefix/step/task-0/manifest"),
+            (None, MOCK_JOB_ID, "/", "prefix/step/task-1/manifest"),
+        ]
+
+    def fake_download_manifest_paths(*args, **kwargs):
+        raise PermissionError("Access is denied")  # fallback download fails
+
+    runner = CliRunner()
+    with (
+        patch(
+            "deadline.client.cli._incremental_download._download_all_manifests_with_absolute_paths",
+            side_effect=fake_download_all_manifests,
+        ),
+        patch(
+            "deadline.client.cli._incremental_download._get_manifests_to_download",
+            side_effect=fake_get_manifests_to_download,
+        ),
+        patch(
+            "deadline.client.cli._incremental_download._download_manifest_paths",
+            side_effect=fake_download_manifest_paths,
+        ),
+        freeze_time(ISO_FREEZE_TIME),
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "queue",
+                "sync-output",
+                "--ignore-storage-profiles",
+                "--force-bootstrap",
+                "--bootstrap-lookback-minutes",
+                "120",
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--checkpoint-dir",
+                checkpoint_dir,
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+
+    # The run is reported failed — not silently swallowed with the "" bucket.
+    status_path = os.path.join(
+        checkpoint_dir, f"{MOCK_QUEUE_ID}_ignore-storage-profiles_download_status.json"
+    )
+    with open(status_path) as f:
+        status = json.load(f)
+    assert status["sync_metadata"]["last_run_status"] == "failed", status
+    # The synthetic "" bucket never leaks into the per-job entries.
+    assert "" not in status["jobs"], status["jobs"]
+
+    # The checkpoint timestamp is held back to the bootstrap start (completed == started), not
+    # advanced, so the lost window is re-attempted on the next run. A successful run would have
+    # advanced completed to (now - eventual_consistency), strictly after started.
+    checkpoint_path = os.path.join(
+        checkpoint_dir, f"{MOCK_QUEUE_ID}_ignore-storage-profiles_download_checkpoint.json"
+    )
+    saved = IncrementalDownloadState.from_file(checkpoint_path)
+    assert saved.downloads_completed_timestamp == saved.downloads_started_timestamp, (
+        f"Expected timestamp held back to bootstrap start for retry, got "
+        f"completed={saved.downloads_completed_timestamp.isoformat()} "
+        f"started={saved.downloads_started_timestamp.isoformat()}"
+    )

--- a/test/unit/deadline_client/cli/test_cli_region_per_command.py
+++ b/test/unit/deadline_client/cli/test_cli_region_per_command.py
@@ -519,7 +519,9 @@ def test_cli_queue_sync_output_region(fresh_deadline_config, tmp_path):
             queue_group, "get_session_client", return_value=deadline_client
         ) as mock_get_session_client,
         patch.object(
-            queue_group, "_incremental_output_download", return_value=(MagicMock(), MagicMock(), {})
+            queue_group,
+            "_incremental_output_download",
+            return_value=(MagicMock(), MagicMock(), {}, {}),
         ),
     ):
         runner = CliRunner()


### PR DESCRIPTION
Note: This is part 2 of 3. Depends on PR #1220. Once that merges, the duplicate commits here will be gone. PR #1258 adds per-task tracking on top of this.

### What was the problem/requirement? (What/Why)

PR #1220 writes a status file with per-job download status but lacks file count detail and has no error isolation. If any file fails to download, the entire sync-output run crashes — all jobs fail together with no per-job error information. Artists can't see how many files were downloaded or what specifically went wrong.

### What was the solution? (How)

- Refactored download from a flat batch to per-job parallel download via `ThreadPoolExecutor` with try/except error isolation — one job failing no longer affects others
- Track `total_files`, `downloaded_files`, `failed_files` per job using a manifest-to-job mapping rebuilt from `_get_manifests_to_download()`
- After a failure, count files on disk via `os.path.exists()` for best-effort partial progress (informational only — `error_code` is the authoritative failure signal)
- Added `_classify_error()` that identifies errors by exception type first, then falls back to message string matching (`PERMISSION_DENIED`, `DISK_FULL`, `PATH_NOT_FOUND`, `NETWORK_ERROR`, `UNKNOWN`)
- `sync_metadata.last_run_status` set to `"failed"` when any job has download errors
- Failed jobs tracked separately in `{queue_id}_{storage_profile}_failed_jobs.json` so the global timestamp always advances
- Retry cap of 5 attempts — abandoned jobs show a WARNING and are suppressed from future runs
- `--force-bootstrap` clears the failed jobs file so abandoned jobs get a fresh retry
- `downloaded_files` and `downloaded_bytes` stats now derive from `job_download_results` (succeeded jobs only) for consistency
- File counts represent the last run only, not cumulative totals
- Cross-job path dedup via `global_seen_paths` prevents concurrent writes to the same destination file under parallel downloads — newest-manifest-wins semantics preserved
- S3 client pre-warmed before thread pool to avoid concurrent `session.client()` races
- `AssetSyncCancelledError` re-raised before generic `except Exception` so Ctrl+C still stops the run

### What is the impact of this change?

- One job failing no longer crashes the entire sync-output run — other jobs download successfully
- Failed downloads automatically retry on subsequent runs with a 5-attempt cap
- `last_run_status` signals to DCM when something went wrong in the last sync
- Parallel downloads restore throughput for queues with many jobs

### How was this change tested?

- Unit tests (54 total — new tests covering file counts, error classification, failed status, retry cap, `_FailedJobsTracker` lifecycle, `is_abandoned`, force-bootstrap)
- Manual test: multiple jobs with correct file counts in JSON
- Manual test: simulated permission failure — failed job shows `"failed"` with `PERMISSION_DENIED`, other jobs succeed
- Manual test: fixed permissions → failed job retries and succeeds
- Manual test: retry cap — failed job shows WARNING after 5 attempts and is suppressed
- Manual test: `--force-bootstrap` clears abandoned job and retries successfully
- Manual test: cross-OS (Mac submit → Windows sync with file counts)
- Ran full unit test suite (2945 passed)

### Was this change documented?

- Docstrings added to new functions (`_classify_error`, `_FailedJobsTracker`)
- README.md does not need updating

### Does this PR introduce new dependencies?

- This PR does not add any new dependencies.

### Is this a breaking change?

No. The return tuple from `_incremental_output_download()` expanded from 3 to 4 elements, but this is an internal function (prefixed with `_`), not a public contract. Existing test mocks updated accordingly.

### Does this change impact security?

No. Same security posture as PR #1220 — status file contains only job IDs, file counts, and error messages. No credentials or secrets.
