### PR TITLE
Revert "chore(deps): update openjd-model requirement from >=0.9.0

### DIFF
--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -16,7 +16,7 @@ pyinstrument == 5.*
 # MCP (Model Context Protocol) library for MCP unit tests
 mcp >= 1.13.0; python_version >= '3.10'
 # OpenJD model library for job template parsing in mock backend
-openjd-model >= 0.10.0
+openjd-model >= 0.9.0
 
 # GUI testing dependencies
 pytest-qt == 4.*

--- a/requirements-ui-testing.txt
+++ b/requirements-ui-testing.txt
@@ -8,4 +8,4 @@ xa11y >= 0.9.1, < 0.10
 # realistic step/task structure for the submitter to poll. Without it
 # CreateJob returns a 500 InternalServerException and the submission
 # progress dialog hangs on "Preparing files..."
-openjd-model >= 0.10.0
+openjd-model >= 0.9.0


### PR DESCRIPTION
This reverts commit 3619db081939ec25320e9c64a7e90941ea3c5535.

### What was the problem/requirement? (What/Why)

The `openjd-model` dependency was bumped to `>=0.10.0`, but the integration test environment is unable to resolve this version. Reverting to unblock the release while the issue is investigated.

### What was the solution? (How)
Revert the version bump to restore the previous working constraint.

### What is the impact of this change?
Integration tests will pass again. No functional change since openjd-model 0.10.0 doesn't exist yet.

### How was this change tested?
Just changing back to the working version. 
CI will validate that the dependency resolves correctly.

### Was this change documented?

No documentation changes needed — this is a revert of a dependency version bump.

### Does this PR introduce new dependencies?

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x ] This PR does not add any new dependencies.

### Is this a breaking change?

No. This restores the previous state.


### Does this change impact security?

No. 
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
