### PR TITLE
fix: regionalize endpoint URL for cross-region API calls

### DIFF
--- a/src/deadline/client/api/_session.py
+++ b/src/deadline/client/api/_session.py
@@ -173,12 +173,16 @@ def _resolve_cross_region_endpoint_url(
             scoped_config = session._session.get_scoped_config()
             services_name = scoped_config.get("services")
             if services_name and isinstance(services_name, str):
-                services_defs = session._session.full_config.get("services", {})
-                service_config = services_defs.get(services_name, {}).get(service_name, {})
-                if isinstance(service_config, dict):
-                    endpoint_url = service_config.get("endpoint_url")
-        except (ProfileNotFound, KeyError):
-            # Profile may not exist or config structure may be unexpected; fall through.
+                full_config = session._session.full_config
+                if isinstance(full_config, dict):
+                    services_defs = full_config.get("services", {})
+                    if isinstance(services_defs, dict):
+                        service_config = services_defs.get(services_name, {}).get(service_name, {})
+                        if isinstance(service_config, dict):
+                            endpoint_url = service_config.get("endpoint_url")
+        except Exception:
+            # Session internals may not be accessible (e.g. profile doesn't exist,
+            # unexpected config structure, or test mocks). Fall through safely.
             pass
 
     if not endpoint_url:

--- a/src/deadline/client/api/_session.py
+++ b/src/deadline/client/api/_session.py
@@ -8,6 +8,7 @@ of the Deadline-configured IAM credentials.
 from __future__ import annotations
 
 import logging
+import os
 from configparser import ConfigParser
 from contextlib import contextmanager
 from enum import Enum
@@ -158,26 +159,25 @@ def _resolve_cross_region_endpoint_url(
     if not session_region or target_region == session_region:
         return None
 
-    # Inspect the botocore session config for a service endpoint override.
-    # The profile's scoped config has a ``services`` key that names a services definition
-    # (e.g. "deadline-gamma-us-west-2"), and the actual endpoint URLs live in
-    # ``full_config['services'][<name>][<service>]['endpoint_url']``.
-    endpoint_url = None
-    try:
-        scoped_config = session._session.get_scoped_config()
-        services_name = scoped_config.get("services")
-        if services_name and isinstance(services_name, str):
-            services_defs = session._session.full_config.get("services", {})
-            service_config = services_defs.get(services_name, {}).get(service_name, {})
-            if isinstance(service_config, dict):
-                endpoint_url = service_config.get("endpoint_url")
-    except Exception:
-        pass
+    # Resolve the effective endpoint override using botocore's precedence:
+    # env var (AWS_ENDPOINT_URL_<SERVICE>) > profile [services] section.
+    endpoint_url = os.environ.get(f"AWS_ENDPOINT_URL_{service_name.upper()}")
 
     if not endpoint_url:
-        import os
-
-        endpoint_url = os.environ.get(f"AWS_ENDPOINT_URL_{service_name.upper()}")
+        # Fall back to the profile's [services] section. The scoped config has a ``services``
+        # key naming a services definition (e.g. "deadline-gamma-us-west-2"), and the actual
+        # endpoint URLs live in ``full_config['services'][<name>][<service>]['endpoint_url']``.
+        try:
+            scoped_config = session._session.get_scoped_config()
+            services_name = scoped_config.get("services")
+            if services_name and isinstance(services_name, str):
+                services_defs = session._session.full_config.get("services", {})
+                service_config = services_defs.get(services_name, {}).get(service_name, {})
+                if isinstance(service_config, dict):
+                    endpoint_url = service_config.get("endpoint_url")
+        except (ProfileNotFound, KeyError):
+            # Profile may not exist or config structure may be unexpected; fall through.
+            pass
 
     if not endpoint_url:
         return None

--- a/src/deadline/client/api/_session.py
+++ b/src/deadline/client/api/_session.py
@@ -158,20 +158,33 @@ def _resolve_cross_region_endpoint_url(
     if not session_region or target_region == session_region:
         return None
 
-    # Build a client using the session defaults to discover the effective endpoint.
-    default_client = session.client(service_name, config=get_default_client_config())
-    default_endpoint = default_client.meta.endpoint_url
+    # Inspect the botocore session config for a service endpoint override.
+    # The profile's scoped config has a ``services`` key that names a services definition
+    # (e.g. "deadline-gamma-us-west-2"), and the actual endpoint URLs live in
+    # ``full_config['services'][<name>][<service>]['endpoint_url']``.
+    endpoint_url = None
+    try:
+        scoped_config = session._session.get_scoped_config()
+        services_name = scoped_config.get("services")
+        if services_name and isinstance(services_name, str):
+            services_defs = session._session.full_config.get("services", {})
+            service_config = services_defs.get(services_name, {}).get(service_name, {})
+            if isinstance(service_config, dict):
+                endpoint_url = service_config.get("endpoint_url")
+    except Exception:
+        pass
 
-    # Standard endpoints follow the pattern ``https://{service}.{region}.amazonaws.com``.
-    # If the endpoint matches that pattern for the session region, boto3 will resolve the
-    # target region's endpoint natively — no fixup needed.
-    standard_endpoint = f"https://{service_name}.{session_region}.amazonaws.com"
-    if default_endpoint == standard_endpoint:
+    if not endpoint_url:
+        import os
+
+        endpoint_url = os.environ.get(f"AWS_ENDPOINT_URL_{service_name.upper()}")
+
+    if not endpoint_url:
         return None
 
     # Non-standard endpoint (gamma, beta, custom): replace the session region with the target.
-    if session_region in default_endpoint:
-        return default_endpoint.replace(session_region, target_region)
+    if session_region in endpoint_url:
+        return endpoint_url.replace(session_region, target_region)
 
     return None
 

--- a/src/deadline/client/api/_session.py
+++ b/src/deadline/client/api/_session.py
@@ -156,12 +156,14 @@ def _resolve_cross_region_endpoint_url(
     region matches the session's default region (no fixup needed).
     """
     session_region = session.region_name
-    if not session_region or target_region == session_region:
+    if not isinstance(session_region, str) or not session_region or target_region == session_region:
         return None
 
     # Resolve the effective endpoint override using botocore's precedence:
-    # env var (AWS_ENDPOINT_URL_<SERVICE>) > profile [services] section.
-    endpoint_url = os.environ.get(f"AWS_ENDPOINT_URL_{service_name.upper()}")
+    # AWS_ENDPOINT_URL_<SERVICE> > AWS_ENDPOINT_URL (global) > profile [services] section.
+    endpoint_url = os.environ.get(
+        f"AWS_ENDPOINT_URL_{service_name.upper()}", os.environ.get("AWS_ENDPOINT_URL")
+    )
 
     if not endpoint_url:
         # Fall back to the profile's [services] section. The scoped config has a ``services``

--- a/src/deadline/client/api/_session.py
+++ b/src/deadline/client/api/_session.py
@@ -8,7 +8,6 @@ of the Deadline-configured IAM credentials.
 from __future__ import annotations
 
 import logging
-import os
 from configparser import ConfigParser
 from contextlib import contextmanager
 from enum import Enum
@@ -141,60 +140,6 @@ def get_default_client_config(**kwargs) -> botocore.config.Config:
     return client_config
 
 
-def _resolve_cross_region_endpoint_url(
-    session: boto3.Session, service_name: str, target_region: str
-) -> Optional[str]:
-    """
-    When the session has a profile-level endpoint override (e.g. via the ``[services ...]``
-    section in ``~/.aws/config``), boto3 applies it regardless of the ``region_name`` passed
-    to ``.client()``. This causes SigV4 credential-scope mismatches for cross-region calls.
-
-    This function detects the override and replaces the session's default region in the URL
-    with the target region so that the endpoint and signing region stay consistent.
-
-    Returns the regionalized endpoint URL, or None if no override is active or the target
-    region matches the session's default region (no fixup needed).
-    """
-    session_region = session.region_name
-    if not isinstance(session_region, str) or not session_region or target_region == session_region:
-        return None
-
-    # Resolve the effective endpoint override using botocore's precedence:
-    # AWS_ENDPOINT_URL_<SERVICE> > AWS_ENDPOINT_URL (global) > profile [services] section.
-    endpoint_url = os.environ.get(
-        f"AWS_ENDPOINT_URL_{service_name.upper()}", os.environ.get("AWS_ENDPOINT_URL")
-    )
-
-    if not endpoint_url:
-        # Fall back to the profile's [services] section. The scoped config has a ``services``
-        # key naming a services definition (e.g. "deadline-gamma-us-west-2"), and the actual
-        # endpoint URLs live in ``full_config['services'][<name>][<service>]['endpoint_url']``.
-        try:
-            scoped_config = session._session.get_scoped_config()
-            services_name = scoped_config.get("services")
-            if services_name and isinstance(services_name, str):
-                full_config = session._session.full_config
-                if isinstance(full_config, dict):
-                    services_defs = full_config.get("services", {})
-                    if isinstance(services_defs, dict):
-                        service_config = services_defs.get(services_name, {}).get(service_name, {})
-                        if isinstance(service_config, dict):
-                            endpoint_url = service_config.get("endpoint_url")
-        except Exception:
-            # Session internals may not be accessible (e.g. profile doesn't exist,
-            # unexpected config structure, or test mocks). Fall through safely.
-            pass
-
-    if not endpoint_url:
-        return None
-
-    # Non-standard endpoint (gamma, beta, custom): replace the session region with the target.
-    if session_region in endpoint_url:
-        return endpoint_url.replace(session_region, target_region)
-
-    return None
-
-
 @lru_cache
 def get_session_client(session: boto3.Session, service_name: str, region: Optional[str] = None):
     """
@@ -204,6 +149,12 @@ def get_session_client(session: boto3.Session, service_name: str, region: Option
     with the same session, service name, and region return the cached client to
     avoid repeating initialization where possible. The ``region`` argument is part
     of the cache key so clients for different regions are never reused for each other.
+
+    When a profile has a non-standard endpoint override (e.g. via the ``[services ...]``
+    section or ``AWS_ENDPOINT_URL*`` env vars), boto3 applies it regardless of the
+    ``region_name`` passed to ``.client()``. This causes SigV4 credential-scope mismatches
+    for cross-region calls. We detect this by inspecting the resolved endpoint and
+    re-creating the client with the regionalized URL if needed.
 
     Args:
         session: The boto3 Session to use for creating the client
@@ -217,15 +168,18 @@ def get_session_client(session: boto3.Session, service_name: str, region: Option
     if region is None:
         return session.client(service_name, config=get_default_client_config())
 
-    endpoint_url = _resolve_cross_region_endpoint_url(session, service_name, region)
-    if endpoint_url:
+    client = session.client(service_name, config=get_default_client_config(), region_name=region)
+    resolved = client.meta.endpoint_url
+    session_region = session.region_name
+    # An override leaked the session's region into a cross-region endpoint.
+    if region not in resolved and session_region and session_region in resolved:
         return session.client(
             service_name,
             config=get_default_client_config(),
             region_name=region,
-            endpoint_url=endpoint_url,
+            endpoint_url=resolved.replace(session_region, region, 1),
         )
-    return session.client(service_name, config=get_default_client_config(), region_name=region)
+    return client
 
 
 def _resolve_region(

--- a/src/deadline/client/api/_session.py
+++ b/src/deadline/client/api/_session.py
@@ -140,6 +140,42 @@ def get_default_client_config(**kwargs) -> botocore.config.Config:
     return client_config
 
 
+def _resolve_cross_region_endpoint_url(
+    session: boto3.Session, service_name: str, target_region: str
+) -> Optional[str]:
+    """
+    When the session has a profile-level endpoint override (e.g. via the ``[services ...]``
+    section in ``~/.aws/config``), boto3 applies it regardless of the ``region_name`` passed
+    to ``.client()``. This causes SigV4 credential-scope mismatches for cross-region calls.
+
+    This function detects the override and replaces the session's default region in the URL
+    with the target region so that the endpoint and signing region stay consistent.
+
+    Returns the regionalized endpoint URL, or None if no override is active or the target
+    region matches the session's default region (no fixup needed).
+    """
+    session_region = session.region_name
+    if not session_region or target_region == session_region:
+        return None
+
+    # Build a client using the session defaults to discover the effective endpoint.
+    default_client = session.client(service_name, config=get_default_client_config())
+    default_endpoint = default_client.meta.endpoint_url
+
+    # Standard endpoints follow the pattern ``https://{service}.{region}.amazonaws.com``.
+    # If the endpoint matches that pattern for the session region, boto3 will resolve the
+    # target region's endpoint natively — no fixup needed.
+    standard_endpoint = f"https://{service_name}.{session_region}.amazonaws.com"
+    if default_endpoint == standard_endpoint:
+        return None
+
+    # Non-standard endpoint (gamma, beta, custom): replace the session region with the target.
+    if session_region in default_endpoint:
+        return default_endpoint.replace(session_region, target_region)
+
+    return None
+
+
 @lru_cache
 def get_session_client(session: boto3.Session, service_name: str, region: Optional[str] = None):
     """
@@ -161,6 +197,15 @@ def get_session_client(session: boto3.Session, service_name: str, region: Option
     """
     if region is None:
         return session.client(service_name, config=get_default_client_config())
+
+    endpoint_url = _resolve_cross_region_endpoint_url(session, service_name, region)
+    if endpoint_url:
+        return session.client(
+            service_name,
+            config=get_default_client_config(),
+            region_name=region,
+            endpoint_url=endpoint_url,
+        )
     return session.client(service_name, config=get_default_client_config(), region_name=region)
 
 

--- a/test/unit/deadline_client/api/test_api_session.py
+++ b/test/unit/deadline_client/api/test_api_session.py
@@ -355,13 +355,18 @@ class TestResolveCrossRegionEndpointUrl:
         - scoped_config["services"] is the *name* of the services definition (a string)
         - full_config["services"][name] holds the actual endpoint URLs
         """
-        session = MagicMock()
-        session.region_name = region
+        # Use a concrete inner mock to avoid MagicMock attribute-access instability
+        # across Python versions when setting dict attributes on child mocks.
+        inner_session = MagicMock()
         scoped_config = {}
         if services_name is not None:
             scoped_config["services"] = services_name
-        session._session.get_scoped_config.return_value = scoped_config
-        session._session.full_config = {"services": services_defs or {}}
+        inner_session.get_scoped_config.return_value = scoped_config
+        inner_session.full_config = {"services": services_defs or {}}
+
+        session = MagicMock()
+        session.region_name = region
+        session._session = inner_session
         return session
 
     def test_returns_none_when_target_matches_session_region(self):
@@ -432,16 +437,20 @@ def test_get_session_client_cross_region_overrides_endpoint():
     SigV4 signing region matches the endpoint.
     """
     get_session_client.cache_clear()
-    session = MagicMock()
-    session.region_name = "us-west-2"
-    session._session.get_scoped_config.return_value = {"services": "deadline-gamma-us-west-2"}
-    session._session.full_config = {
+
+    inner_session = MagicMock()
+    inner_session.get_scoped_config.return_value = {"services": "deadline-gamma-us-west-2"}
+    inner_session.full_config = {
         "services": {
             "deadline-gamma-us-west-2": {
                 "deadline": {"endpoint_url": "https://gamma.bealine-dev.us-west-2.amazonaws.com"}
             }
         }
     }
+
+    session = MagicMock()
+    session.region_name = "us-west-2"
+    session._session = inner_session
 
     cross_region_client = MagicMock()
     session.client.return_value = cross_region_client

--- a/test/unit/deadline_client/api/test_api_session.py
+++ b/test/unit/deadline_client/api/test_api_session.py
@@ -396,9 +396,7 @@ class TestResolveCrossRegionEndpointUrl:
             "us-west-2",
             services_name="custom-svc",
             services_defs={
-                "custom-svc": {
-                    "deadline": {"endpoint_url": "https://custom-endpoint.example.com"}
-                }
+                "custom-svc": {"deadline": {"endpoint_url": "https://custom-endpoint.example.com"}}
             },
         )
         assert _resolve_cross_region_endpoint_url(session, "deadline", "us-east-1") is None
@@ -425,9 +423,7 @@ def test_get_session_client_cross_region_overrides_endpoint():
     session._session.full_config = {
         "services": {
             "deadline-gamma-us-west-2": {
-                "deadline": {
-                    "endpoint_url": "https://gamma.bealine-dev.us-west-2.amazonaws.com"
-                }
+                "deadline": {"endpoint_url": "https://gamma.bealine-dev.us-west-2.amazonaws.com"}
             }
         }
     }

--- a/test/unit/deadline_client/api/test_api_session.py
+++ b/test/unit/deadline_client/api/test_api_session.py
@@ -15,6 +15,7 @@ from deadline.client.api._session import (
     get_session_client,
     precache_clients,
     _resolve_region,
+    _resolve_cross_region_endpoint_url,
 )
 
 
@@ -343,6 +344,80 @@ def test_get_session_client_same_region_cached():
     client2 = get_session_client(session, "s3", region="eu-west-1")
 
     assert client1 is client2
+
+
+class TestResolveCrossRegionEndpointUrl:
+    """Tests for _resolve_cross_region_endpoint_url."""
+
+    def test_returns_none_when_target_matches_session_region(self):
+        session = MagicMock()
+        session.region_name = "us-west-2"
+        assert _resolve_cross_region_endpoint_url(session, "deadline", "us-west-2") is None
+
+    def test_returns_none_when_session_has_no_region(self):
+        session = MagicMock()
+        session.region_name = None
+        assert _resolve_cross_region_endpoint_url(session, "deadline", "us-east-1") is None
+
+    def test_returns_none_for_standard_endpoint(self):
+        session = MagicMock()
+        session.region_name = "us-west-2"
+        mock_client = MagicMock()
+        mock_client.meta.endpoint_url = "https://deadline.us-west-2.amazonaws.com"
+        session.client.return_value = mock_client
+
+        assert _resolve_cross_region_endpoint_url(session, "deadline", "us-east-1") is None
+
+    def test_replaces_region_in_custom_endpoint(self):
+        session = MagicMock()
+        session.region_name = "us-west-2"
+        mock_client = MagicMock()
+        mock_client.meta.endpoint_url = "https://gamma.bealine-dev.us-west-2.amazonaws.com"
+        session.client.return_value = mock_client
+
+        result = _resolve_cross_region_endpoint_url(session, "deadline", "us-east-1")
+        assert result == "https://gamma.bealine-dev.us-east-1.amazonaws.com"
+
+    def test_returns_none_when_session_region_not_in_endpoint(self):
+        session = MagicMock()
+        session.region_name = "us-west-2"
+        mock_client = MagicMock()
+        mock_client.meta.endpoint_url = "https://custom-endpoint.example.com"
+        session.client.return_value = mock_client
+
+        assert _resolve_cross_region_endpoint_url(session, "deadline", "us-east-1") is None
+
+
+def test_get_session_client_cross_region_overrides_endpoint():
+    """
+    When a profile has a non-standard endpoint override (e.g. gamma), creating a
+    client for a different region must regionalize the endpoint URL so that the
+    SigV4 signing region matches the endpoint.
+    """
+    get_session_client.cache_clear()
+    session = MagicMock()
+    session.region_name = "us-west-2"
+
+    default_client = MagicMock()
+    default_client.meta.endpoint_url = "https://gamma.bealine-dev.us-west-2.amazonaws.com"
+
+    cross_region_client = MagicMock()
+
+    def mock_client_factory(service_name, config=None, region_name=None, endpoint_url=None):
+        if endpoint_url and "us-east-1" in endpoint_url:
+            return cross_region_client
+        return default_client
+
+    session.client.side_effect = mock_client_factory
+
+    result = get_session_client(session, "deadline", "us-east-1")
+    assert result is cross_region_client
+    session.client.assert_any_call(
+        "deadline",
+        config=ANY,
+        region_name="us-east-1",
+        endpoint_url="https://gamma.bealine-dev.us-east-1.amazonaws.com",
+    )
 
 
 def test_get_queue_user_boto3_session_uses_resolved_farm_region(fresh_deadline_config):

--- a/test/unit/deadline_client/api/test_api_session.py
+++ b/test/unit/deadline_client/api/test_api_session.py
@@ -401,11 +401,26 @@ class TestResolveCrossRegionEndpointUrl:
         )
         assert _resolve_cross_region_endpoint_url(session, "deadline", "us-east-1") is None
 
-    def test_falls_back_to_env_var(self, monkeypatch):
+    def test_falls_back_to_service_env_var(self, monkeypatch):
         session = self._make_session("us-west-2")
         monkeypatch.setenv(
             "AWS_ENDPOINT_URL_DEADLINE", "https://gamma.bealine-dev.us-west-2.amazonaws.com"
         )
+        result = _resolve_cross_region_endpoint_url(session, "deadline", "us-east-1")
+        assert result == "https://gamma.bealine-dev.us-east-1.amazonaws.com"
+
+    def test_falls_back_to_global_env_var(self, monkeypatch):
+        session = self._make_session("us-west-2")
+        monkeypatch.setenv("AWS_ENDPOINT_URL", "https://gamma.bealine-dev.us-west-2.amazonaws.com")
+        result = _resolve_cross_region_endpoint_url(session, "deadline", "us-east-1")
+        assert result == "https://gamma.bealine-dev.us-east-1.amazonaws.com"
+
+    def test_service_env_var_takes_precedence_over_global(self, monkeypatch):
+        session = self._make_session("us-west-2")
+        monkeypatch.setenv(
+            "AWS_ENDPOINT_URL_DEADLINE", "https://gamma.bealine-dev.us-west-2.amazonaws.com"
+        )
+        monkeypatch.setenv("AWS_ENDPOINT_URL", "https://wrong.us-west-2.amazonaws.com")
         result = _resolve_cross_region_endpoint_url(session, "deadline", "us-east-1")
         assert result == "https://gamma.bealine-dev.us-east-1.amazonaws.com"
 

--- a/test/unit/deadline_client/api/test_api_session.py
+++ b/test/unit/deadline_client/api/test_api_session.py
@@ -15,7 +15,6 @@ from deadline.client.api._session import (
     get_session_client,
     precache_clients,
     _resolve_region,
-    _resolve_cross_region_endpoint_url,
 )
 
 
@@ -346,123 +345,91 @@ def test_get_session_client_same_region_cached():
     assert client1 is client2
 
 
-class TestResolveCrossRegionEndpointUrl:
-    """Tests for _resolve_cross_region_endpoint_url."""
+class TestGetSessionClientCrossRegion:
+    """Tests for cross-region endpoint override handling in get_session_client."""
 
-    def _make_session(self, region, services_name=None, services_defs=None):
+    def _make_session(self, region, endpoint_url):
         """
-        Build a mock session that mimics botocore's config structure:
-        - scoped_config["services"] is the *name* of the services definition (a string)
-        - full_config["services"][name] holds the actual endpoint URLs
+        Build a mock session whose .client() returns a mock with the given endpoint_url
+        on meta.endpoint_url, simulating boto3's endpoint resolution behavior.
         """
-        # Use a concrete inner mock to avoid MagicMock attribute-access instability
-        # across Python versions when setting dict attributes on child mocks.
-        inner_session = MagicMock()
-        scoped_config = {}
-        if services_name is not None:
-            scoped_config["services"] = services_name
-        inner_session.get_scoped_config.return_value = scoped_config
-        inner_session.full_config = {"services": services_defs or {}}
-
         session = MagicMock()
         session.region_name = region
-        session._session = inner_session
+
+        client_mock = MagicMock()
+        client_mock.meta.endpoint_url = endpoint_url
+        session.client.return_value = client_mock
         return session
 
-    def test_returns_none_when_target_matches_session_region(self):
-        session = self._make_session("us-west-2")
-        assert _resolve_cross_region_endpoint_url(session, "deadline", "us-west-2") is None
+    def test_cross_region_regionalizes_override(self):
+        """
+        When the resolved endpoint contains the session region but not the target
+        region, get_session_client recreates the client with a regionalized URL.
+        """
+        get_session_client.cache_clear()
+        session = self._make_session("us-west-2", "https://custom.deadline.us-west-2.example.com")
 
-    def test_returns_none_when_session_has_no_region(self):
-        session = self._make_session(None)
-        assert _resolve_cross_region_endpoint_url(session, "deadline", "us-east-1") is None
+        cross_region_client = MagicMock()
+        # First call returns the client with the wrong region; second returns the fixed one.
+        session.client.side_effect = [
+            session.client.return_value,
+            cross_region_client,
+        ]
 
-    def test_returns_none_when_no_endpoint_override(self):
-        session = self._make_session("us-west-2", services_name="my-services", services_defs={})
-        assert _resolve_cross_region_endpoint_url(session, "deadline", "us-east-1") is None
-
-    def test_replaces_region_in_custom_endpoint(self):
-        session = self._make_session(
-            "us-west-2",
-            services_name="deadline-gamma-us-west-2",
-            services_defs={
-                "deadline-gamma-us-west-2": {
-                    "deadline": {
-                        "endpoint_url": "https://gamma.bealine-dev.us-west-2.amazonaws.com"
-                    }
-                }
-            },
+        result = get_session_client(session, "deadline", "us-east-1")
+        assert result is cross_region_client
+        assert session.client.call_count == 2
+        second_call = session.client.call_args_list[1]
+        assert second_call == call(
+            "deadline",
+            config=ANY,
+            region_name="us-east-1",
+            endpoint_url="https://custom.deadline.us-east-1.example.com",
         )
-        result = _resolve_cross_region_endpoint_url(session, "deadline", "us-east-1")
-        assert result == "https://gamma.bealine-dev.us-east-1.amazonaws.com"
 
-    def test_returns_none_when_session_region_not_in_endpoint(self):
-        session = self._make_session(
-            "us-west-2",
-            services_name="custom-svc",
-            services_defs={
-                "custom-svc": {"deadline": {"endpoint_url": "https://custom-endpoint.example.com"}}
-            },
-        )
-        assert _resolve_cross_region_endpoint_url(session, "deadline", "us-east-1") is None
+    def test_cross_region_no_override_needed(self):
+        """
+        When the resolved endpoint already contains the target region, no
+        recreation is needed.
+        """
+        get_session_client.cache_clear()
+        session = self._make_session("us-west-2", "https://deadline.us-east-1.amazonaws.com")
 
-    def test_falls_back_to_service_env_var(self, monkeypatch):
-        session = self._make_session("us-west-2")
-        monkeypatch.setenv(
-            "AWS_ENDPOINT_URL_DEADLINE", "https://gamma.bealine-dev.us-west-2.amazonaws.com"
-        )
-        result = _resolve_cross_region_endpoint_url(session, "deadline", "us-east-1")
-        assert result == "https://gamma.bealine-dev.us-east-1.amazonaws.com"
+        result = get_session_client(session, "deadline", "us-east-1")
+        assert result is session.client.return_value
+        session.client.assert_called_once()
 
-    def test_falls_back_to_global_env_var(self, monkeypatch):
-        session = self._make_session("us-west-2")
-        monkeypatch.setenv("AWS_ENDPOINT_URL", "https://gamma.bealine-dev.us-west-2.amazonaws.com")
-        result = _resolve_cross_region_endpoint_url(session, "deadline", "us-east-1")
-        assert result == "https://gamma.bealine-dev.us-east-1.amazonaws.com"
+    def test_cross_region_no_session_region(self):
+        """
+        When the session has no region_name, the initial client is returned as-is.
+        """
+        get_session_client.cache_clear()
+        session = self._make_session(None, "https://deadline.us-east-1.amazonaws.com")
 
-    def test_service_env_var_takes_precedence_over_global(self, monkeypatch):
-        session = self._make_session("us-west-2")
-        monkeypatch.setenv(
-            "AWS_ENDPOINT_URL_DEADLINE", "https://gamma.bealine-dev.us-west-2.amazonaws.com"
-        )
-        monkeypatch.setenv("AWS_ENDPOINT_URL", "https://wrong.us-west-2.amazonaws.com")
-        result = _resolve_cross_region_endpoint_url(session, "deadline", "us-east-1")
-        assert result == "https://gamma.bealine-dev.us-east-1.amazonaws.com"
+        result = get_session_client(session, "deadline", "us-east-1")
+        assert result is session.client.return_value
+        session.client.assert_called_once()
 
+    def test_cross_region_session_region_not_in_endpoint(self):
+        """
+        When the resolved endpoint doesn't contain the session region at all,
+        no regionalization is attempted.
+        """
+        get_session_client.cache_clear()
+        session = self._make_session("us-west-2", "https://custom-endpoint.example.com")
 
-def test_get_session_client_cross_region_overrides_endpoint():
-    """
-    When a profile has a non-standard endpoint override (e.g. gamma), creating a
-    client for a different region must regionalize the endpoint URL so that the
-    SigV4 signing region matches the endpoint.
-    """
-    get_session_client.cache_clear()
+        result = get_session_client(session, "deadline", "us-east-1")
+        assert result is session.client.return_value
+        session.client.assert_called_once()
 
-    inner_session = MagicMock()
-    inner_session.get_scoped_config.return_value = {"services": "deadline-gamma-us-west-2"}
-    inner_session.full_config = {
-        "services": {
-            "deadline-gamma-us-west-2": {
-                "deadline": {"endpoint_url": "https://gamma.bealine-dev.us-west-2.amazonaws.com"}
-            }
-        }
-    }
+    def test_no_region_uses_session_default(self):
+        """When region is None, a simple client with session defaults is returned."""
+        get_session_client.cache_clear()
+        session = self._make_session("us-west-2", "https://deadline.us-west-2.amazonaws.com")
 
-    session = MagicMock()
-    session.region_name = "us-west-2"
-    session._session = inner_session
-
-    cross_region_client = MagicMock()
-    session.client.return_value = cross_region_client
-
-    result = get_session_client(session, "deadline", "us-east-1")
-    assert result is cross_region_client
-    session.client.assert_called_once_with(
-        "deadline",
-        config=ANY,
-        region_name="us-east-1",
-        endpoint_url="https://gamma.bealine-dev.us-east-1.amazonaws.com",
-    )
+        result = get_session_client(session, "deadline", None)
+        assert result is session.client.return_value
+        session.client.assert_called_once_with("deadline", config=ANY)
 
 
 def test_get_queue_user_boto3_session_uses_resolved_farm_region(fresh_deadline_config):

--- a/test/unit/deadline_client/api/test_api_session.py
+++ b/test/unit/deadline_client/api/test_api_session.py
@@ -349,43 +349,67 @@ def test_get_session_client_same_region_cached():
 class TestResolveCrossRegionEndpointUrl:
     """Tests for _resolve_cross_region_endpoint_url."""
 
-    def test_returns_none_when_target_matches_session_region(self):
+    def _make_session(self, region, services_name=None, services_defs=None):
+        """
+        Build a mock session that mimics botocore's config structure:
+        - scoped_config["services"] is the *name* of the services definition (a string)
+        - full_config["services"][name] holds the actual endpoint URLs
+        """
         session = MagicMock()
-        session.region_name = "us-west-2"
+        session.region_name = region
+        scoped_config = {}
+        if services_name is not None:
+            scoped_config["services"] = services_name
+        session._session.get_scoped_config.return_value = scoped_config
+        session._session.full_config = {"services": services_defs or {}}
+        return session
+
+    def test_returns_none_when_target_matches_session_region(self):
+        session = self._make_session("us-west-2")
         assert _resolve_cross_region_endpoint_url(session, "deadline", "us-west-2") is None
 
     def test_returns_none_when_session_has_no_region(self):
-        session = MagicMock()
-        session.region_name = None
+        session = self._make_session(None)
         assert _resolve_cross_region_endpoint_url(session, "deadline", "us-east-1") is None
 
-    def test_returns_none_for_standard_endpoint(self):
-        session = MagicMock()
-        session.region_name = "us-west-2"
-        mock_client = MagicMock()
-        mock_client.meta.endpoint_url = "https://deadline.us-west-2.amazonaws.com"
-        session.client.return_value = mock_client
-
+    def test_returns_none_when_no_endpoint_override(self):
+        session = self._make_session("us-west-2", services_name="my-services", services_defs={})
         assert _resolve_cross_region_endpoint_url(session, "deadline", "us-east-1") is None
 
     def test_replaces_region_in_custom_endpoint(self):
-        session = MagicMock()
-        session.region_name = "us-west-2"
-        mock_client = MagicMock()
-        mock_client.meta.endpoint_url = "https://gamma.bealine-dev.us-west-2.amazonaws.com"
-        session.client.return_value = mock_client
-
+        session = self._make_session(
+            "us-west-2",
+            services_name="deadline-gamma-us-west-2",
+            services_defs={
+                "deadline-gamma-us-west-2": {
+                    "deadline": {
+                        "endpoint_url": "https://gamma.bealine-dev.us-west-2.amazonaws.com"
+                    }
+                }
+            },
+        )
         result = _resolve_cross_region_endpoint_url(session, "deadline", "us-east-1")
         assert result == "https://gamma.bealine-dev.us-east-1.amazonaws.com"
 
     def test_returns_none_when_session_region_not_in_endpoint(self):
-        session = MagicMock()
-        session.region_name = "us-west-2"
-        mock_client = MagicMock()
-        mock_client.meta.endpoint_url = "https://custom-endpoint.example.com"
-        session.client.return_value = mock_client
-
+        session = self._make_session(
+            "us-west-2",
+            services_name="custom-svc",
+            services_defs={
+                "custom-svc": {
+                    "deadline": {"endpoint_url": "https://custom-endpoint.example.com"}
+                }
+            },
+        )
         assert _resolve_cross_region_endpoint_url(session, "deadline", "us-east-1") is None
+
+    def test_falls_back_to_env_var(self, monkeypatch):
+        session = self._make_session("us-west-2")
+        monkeypatch.setenv(
+            "AWS_ENDPOINT_URL_DEADLINE", "https://gamma.bealine-dev.us-west-2.amazonaws.com"
+        )
+        result = _resolve_cross_region_endpoint_url(session, "deadline", "us-east-1")
+        assert result == "https://gamma.bealine-dev.us-east-1.amazonaws.com"
 
 
 def test_get_session_client_cross_region_overrides_endpoint():
@@ -397,22 +421,23 @@ def test_get_session_client_cross_region_overrides_endpoint():
     get_session_client.cache_clear()
     session = MagicMock()
     session.region_name = "us-west-2"
-
-    default_client = MagicMock()
-    default_client.meta.endpoint_url = "https://gamma.bealine-dev.us-west-2.amazonaws.com"
+    session._session.get_scoped_config.return_value = {"services": "deadline-gamma-us-west-2"}
+    session._session.full_config = {
+        "services": {
+            "deadline-gamma-us-west-2": {
+                "deadline": {
+                    "endpoint_url": "https://gamma.bealine-dev.us-west-2.amazonaws.com"
+                }
+            }
+        }
+    }
 
     cross_region_client = MagicMock()
-
-    def mock_client_factory(service_name, config=None, region_name=None, endpoint_url=None):
-        if endpoint_url and "us-east-1" in endpoint_url:
-            return cross_region_client
-        return default_client
-
-    session.client.side_effect = mock_client_factory
+    session.client.return_value = cross_region_client
 
     result = get_session_client(session, "deadline", "us-east-1")
     assert result is cross_region_client
-    session.client.assert_any_call(
+    session.client.assert_called_once_with(
         "deadline",
         config=ANY,
         region_name="us-east-1",


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

When a profile has a non-standard endpoint override (e.g. via the [services] section in ~/.aws/config for gamma/beta environments), boto3 applies it regardless of the region_name passed to .client(). This causes SigV4 credential-scope mismatches when submitting jobs to a farm in a different region than the profile's default.

### What was the solution? (How)

Detect the override in get_session_client and replace the session's default region in the URL with the target region so that the signing region and endpoint stay consistent.

### What is the impact of this change?

Makes sure that cross region resource interactions work when an endpoint override is present (such as when using a DCM gamma profile).

### How was this change tested?

- Ran (and added new) unit tests
- Ran integration tests
- Manually tested by submitting a job to a farm in us-east-1 using a DCM profile for a monitor based in us-west-2 with the `services` override pointing to the gamma us-west-2 endpoint.

### Was this change documented?

- Added doc strings to new functions

### Does this PR introduce new dependencies?


*   This PR does not add any new dependencies.

### Is this a breaking change?

Not a breaking change. 

### Does this change impact security?

No change to security posture.
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
