### PR TITLE
feat!: auto-detect --output format from whether stdout is a  TTY

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,14 @@ Use [conventional commits](https://www.conventionalcommits.org/):
 - `perf:` - Performance improvements
 - `feat!:` or `fix!:` - Breaking changes (Also include `BREAKING CHANGES:` section in message body)
 
+### CLI `--output` format auto-detection
+
+Commands that take `--output verbose|json` auto-detect the format when the
+option is omitted: `verbose` at an interactive terminal, `json` otherwise
+(pipes, redirection, CI, agents). An explicit `--output` always wins. Resolve
+this with the shared `_resolve_output_format()` helper and the
+`_OUTPUT_FORMAT_HELP` text rather than hand-rolling the default per command.
+
 ### CHANGELOG.md is auto-generated — do not edit it
 
 `CHANGELOG.md` is generated automatically from conventional commit messages

--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ api.list_farms()
 # {'farms': [{'farmId': 'farm-1234567890abcdefg', 'displayName': 'my-first-farm', ...},]}
 ```
 
+### Output format
+
+The commands that accept an `--output` option (`auth status`, `config show`, `bundle gui-submit`, `job download-output`, `job download-input`, `job wait`, and `job logs`) choose their default format based on whether stdout is an interactive terminal. When you run them in a terminal you get the human-readable (`verbose`) output; when the output is piped, redirected, or has no TTY (for example in CI or when invoked by an agent) the default switches to `json`. Pass `--output` explicitly to override the detection — for example `--output verbose` to force human-readable output in a script, or `--output json` to force JSON in a terminal.
+
 The `deadlinew` command can be used from GUIs to avoid displaying a terminal window in the background when on Windows.
 You can use the `--redirect-output` option to write the terminal output to a file.
 ```sh

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,6 +58,10 @@ api.list_farms()
 # {'farms': [{'farmId': 'farm-1234567890abcdefg', 'displayName': 'my-first-farm', ...},]}
 ```
 
+### Output format
+
+The commands that accept an `--output` option (`auth status`, `config show`, `bundle gui-submit`, `job download-output`, `job download-input`, `job wait`, and `job logs`) choose their default format based on whether stdout is an interactive terminal. When you run them in a terminal you get the human-readable (`verbose`) output; when the output is piped, redirected, or has no TTY (for example in CI or when invoked by an agent) the default switches to `json`. Pass `--output` explicitly to override the detection — for example `--output verbose` to force human-readable output in a script, or `--output json` to force JSON in a terminal.
+
 The `deadlinew` command can be used from GUIs to avoid displaying a terminal window in the background when on Windows.
 You can use the `--redirect-output` option to write the terminal output to a file.
 ```sh

--- a/src/deadline/client/cli/_common.py
+++ b/src/deadline/client/cli/_common.py
@@ -7,6 +7,7 @@ Functionality common to all the CLI groups.
 from __future__ import annotations
 
 __all__ = [
+    "_OUTPUT_FORMAT_HELP",
     "_PROMPT_WHEN_COMPLETE",
     "_ProgressBarCallbackManager",
     "_apply_cli_options_to_config",
@@ -15,6 +16,7 @@ __all__ = [
     "_parse_file_parameter",
     "_parse_multi_format_parameters",
     "_prompt_at_completion",
+    "_resolve_output_format",
     "_suggest_resources_on_client_error",
 ]
 
@@ -43,6 +45,54 @@ from ._groups._sigint_handler import SigIntHandler
 logger = logging.getLogger("deadline.client.cli")
 
 _PROMPT_WHEN_COMPLETE = "PROMPT_WHEN_COMPLETE"
+
+# Shared help text for the `--output` option, documenting the TTY-aware default.
+_OUTPUT_FORMAT_HELP = (
+    "Specifies the output format of the messages printed to stdout.\n"
+    "VERBOSE: Displays messages in a human-readable text format.\n"
+    "JSON: Displays messages in JSON line format, so that the info can be easily "
+    "parsed/consumed by custom scripts.\n"
+    "When this option is not specified, the format is chosen automatically: "
+    "VERBOSE when stdout is an interactive terminal, and JSON otherwise (for example "
+    "when the output is piped, redirected, or run without a TTY such as in CI or by an agent)."
+)
+
+
+def _stdout_is_tty() -> bool:
+    """
+    Returns whether stdout is connected to an interactive terminal.
+
+    A missing or non-TTY stdout (e.g. a closed or redirected stream) is treated as
+    non-interactive. ``isatty()`` can raise on unusual streams, so this is defensive.
+    """
+    try:
+        return bool(sys.stdout.isatty())
+    except (AttributeError, ValueError):
+        return False
+
+
+def _resolve_output_format(output: Optional[str]) -> str:
+    """
+    Resolves the effective ``--output`` format for a CLI command.
+
+    An explicit value always wins. When ``output`` is ``None`` (the option was not
+    provided), the format is auto-detected from whether stdout is an interactive
+    terminal: ``"verbose"`` for a TTY (a human reader) and ``"json"`` otherwise
+    (pipes, redirection, CI, or agents), matching the behavior of tools like the
+    AWS CLI and kubectl.
+
+    Args:
+        output (Optional[str]): The value of the ``--output`` option, or ``None`` if
+            it was not specified. Comparison is case-insensitive.
+
+    Returns:
+        str: The resolved format, either ``"verbose"`` or ``"json"`` (lowercased).
+    """
+    if output is not None:
+        return output.lower()
+
+    return "verbose" if _stdout_is_tty() else "json"
+
 
 # Set up the signal handler for handling Ctrl + C interruptions.
 sigint_handler = SigIntHandler()

--- a/src/deadline/client/cli/_groups/auth_group.py
+++ b/src/deadline/client/cli/_groups/auth_group.py
@@ -15,7 +15,12 @@ from ... import api
 from .._main import deadline as main
 from ...api._session import _modified_logging_level, AwsCredentialsSource
 from ...config import config_file, get_setting
-from .._common import _apply_cli_options_to_config, _handle_error
+from .._common import (
+    _OUTPUT_FORMAT_HELP,
+    _apply_cli_options_to_config,
+    _handle_error,
+    _resolve_output_format,
+)
 
 JSON_FIELD_PROFILE_NAME = "profile_name"
 JSON_FIELD_AUTH_STATUS = "status"
@@ -81,17 +86,15 @@ def auth_logout():
         ["verbose", "json"],
         case_sensitive=False,
     ),
-    default="verbose",
-    help="Specifies the output format of the messages printed to stdout.\n"
-    "VERBOSE: Displays messages in a human-readable text format.\n"
-    "JSON: Displays messages in JSON line format, so that the info can be easily "
-    "parsed/consumed by custom scripts.",
+    default=None,
+    help=_OUTPUT_FORMAT_HELP,
 )
 @_handle_error
 def auth_status(output, **args):
     """Gets the status of the selected AWS profile, including its name, whether it was created by
     Deadline Cloud monitor, and whether Deadline Cloud APIs are accessible.
     """
+    output = _resolve_output_format(output)
     # Get a temporary config object with the standard options handled
     config = _apply_cli_options_to_config(**args)
     profile_name = get_setting("defaults.aws_profile_name", config=config)

--- a/src/deadline/client/cli/_groups/bundle_group.py
+++ b/src/deadline/client/cli/_groups/bundle_group.py
@@ -31,10 +31,12 @@ from ....job_attachments.models import JobAttachmentsFileSystem
 
 from ...exceptions import DeadlineOperationError, CreateJobWaiterCanceled
 from .._common import (
+    _OUTPUT_FORMAT_HELP,
     _apply_cli_options_to_config,
     _handle_error,
     _ProgressBarCallbackManager,
     _parse_multi_format_parameters,
+    _resolve_output_format,
     _suggest_resources_on_client_error,
 )
 from .._main import deadline as main
@@ -405,11 +407,8 @@ def bundle_submit(
         ["verbose", "json"],
         case_sensitive=False,
     ),
-    default="verbose",
-    help="Specifies the output format of the messages printed to stdout.\n"
-    "VERBOSE: Displays messages in a human-readable text format.\n"
-    "JSON: Displays messages in JSON line format, so that the info can be easily "
-    "parsed/consumed by custom scripts.",
+    default=None,
+    help=_OUTPUT_FORMAT_HELP,
 )
 @click.option(
     "--known-asset-path",
@@ -476,7 +475,7 @@ def bundle_gui_submit(
                     "Specify a job bundle directory or run the bundle command with the --browse flag"
                 )
             )
-        output = output.lower()
+        output = _resolve_output_format(output)
 
         submitter = show_job_bundle_submitter(
             input_job_bundle_dir=job_bundle_dir,

--- a/src/deadline/client/cli/_groups/config_group.py
+++ b/src/deadline/client/cli/_groups/config_group.py
@@ -9,7 +9,7 @@ import json
 import textwrap
 
 from ...config import config_file
-from .._common import _handle_error
+from .._common import _OUTPUT_FORMAT_HELP, _handle_error, _resolve_output_format
 from .._main import deadline as main
 
 
@@ -29,14 +29,15 @@ def cli_config():
 @click.option(
     "--output",
     type=click.Choice(["verbose", "json"], case_sensitive=False),
-    default="verbose",
-    help="Output format of the command",
+    default=None,
+    help=_OUTPUT_FORMAT_HELP,
 )
 @_handle_error
 def config_show(output):
     """
     Show all workstation configuration settings and current values.
     """
+    output = _resolve_output_format(output)
     settings_json = {}
     if output == "verbose":
         click.echo(

--- a/src/deadline/client/cli/_groups/job_group.py
+++ b/src/deadline/client/cli/_groups/job_group.py
@@ -43,9 +43,11 @@ from ... import api
 from ...config import config_file
 from ...exceptions import DeadlineOperationError, DeadlineOperationTimedOut
 from .._common import (
+    _OUTPUT_FORMAT_HELP,
     _apply_cli_options_to_config,
     _cli_object_repr,
     _handle_error,
+    _resolve_output_format,
     _suggest_resources_on_client_error,
 )
 from .._main import deadline as main
@@ -1076,10 +1078,8 @@ def _assert_valid_path(path: str) -> None:
         ["verbose", "json"],
         case_sensitive=False,
     ),
-    help="Specifies the output format of the messages printed to stdout.\n"
-    "VERBOSE: Displays messages in a human-readable text format.\n"
-    "JSON: Displays messages in JSON line format, so that the info can be easily "
-    "parsed/consumed by custom scripts.",
+    default=None,
+    help=_OUTPUT_FORMAT_HELP,
 )
 @_handle_error
 def job_download_output(
@@ -1101,6 +1101,7 @@ def job_download_output(
     if task_id and not step_id:
         raise click.UsageError("Missing option '--step-id' required with '--task-id'")
 
+    is_json_output = _resolve_output_format(output) == "json"
     include_patterns = _normalize_filters(list(include)) or None
 
     # Get a temporary config object with the standard options handled
@@ -1119,13 +1120,13 @@ def job_download_output(
             job_id=job_id,
             step_id=step_id,
             task_id=task_id,
-            is_json_format=output == "json",
+            is_json_format=is_json_output,
             ignore_storage_profiles=ignore_storage_profiles,
             include_patterns=include_patterns,
             match_paths_by=MatchPathsBy(match_paths_by),
         )
     except Exception as e:
-        if output == "json":
+        if is_json_output:
             error_one_liner = str(e).replace("\n", ". ")
             click.echo(_get_json_line(JSON_MSG_TYPE_ERROR, error_one_liner))
             sys.exit(1)
@@ -1350,10 +1351,8 @@ def _download_job_input(
         ["verbose", "json"],
         case_sensitive=False,
     ),
-    help="Specifies the output format of the messages printed to stdout.\n"
-    "VERBOSE: Displays messages in a human-readable text format.\n"
-    "JSON: Displays messages in JSON line format, so that the info can be easily "
-    "parsed/consumed by custom scripts.",
+    default=None,
+    help=_OUTPUT_FORMAT_HELP,
 )
 @_handle_error
 def job_download_input(include, match_paths_by, output, ignore_storage_profiles, **args):
@@ -1375,6 +1374,7 @@ def job_download_input(include, match_paths_by, output, ignore_storage_profiles,
     farm_id = config_file.get_setting("defaults.farm_id", config=config)
     queue_id = config_file.get_setting("defaults.queue_id", config=config)
     job_id = config_file.get_setting("defaults.job_id", config=config)
+    is_json_output = _resolve_output_format(output) == "json"
     include_patterns = _normalize_filters(list(include)) or None
 
     try:
@@ -1383,13 +1383,13 @@ def job_download_input(include, match_paths_by, output, ignore_storage_profiles,
             farm_id=farm_id,
             queue_id=queue_id,
             job_id=job_id,
-            is_json_format=output == "json",
+            is_json_format=is_json_output,
             ignore_storage_profiles=ignore_storage_profiles,
             include_patterns=include_patterns,
             match_paths_by=MatchPathsBy(match_paths_by),
         )
     except Exception as e:
-        if output == "json":
+        if is_json_output:
             error_one_liner = str(e).replace("\n", ". ")
             click.echo(_get_json_line(JSON_MSG_TYPE_ERROR, error_one_liner))
             sys.exit(1)
@@ -1410,8 +1410,8 @@ def job_download_input(include, match_paths_by, output, ignore_storage_profiles,
 @click.option(
     "--output",
     type=click.Choice(["verbose", "json"], case_sensitive=False),
-    default="verbose",
-    help="Output format (verbose or json).",
+    default=None,
+    help=_OUTPUT_FORMAT_HELP,
 )
 @_handle_error
 def job_wait_for_completion(max_poll_interval, timeout, output, **args):
@@ -1448,7 +1448,7 @@ def job_wait_for_completion(max_poll_interval, timeout, output, **args):
     queue_id = config_file.get_setting("defaults.queue_id", config=config)
     job_id = config_file.get_setting("defaults.job_id", config=config)
 
-    is_json_output = output.lower() == "json"
+    is_json_output = _resolve_output_format(output) == "json"
 
     # Get job name for output
     deadline = api.get_boto3_client("deadline", config=config)
@@ -1605,8 +1605,8 @@ def job_wait_for_completion(max_poll_interval, timeout, output, **args):
 @click.option(
     "--output",
     type=click.Choice(["verbose", "json"], case_sensitive=False),
-    default="verbose",
-    help="Output format (verbose or json).",
+    default=None,
+    help=_OUTPUT_FORMAT_HELP,
 )
 @click.option(
     "--timestamp-format",
@@ -1659,7 +1659,7 @@ def job_logs(
     queue_id = config_file.get_setting("defaults.queue_id", config=config)
     job_id = config_file.get_setting("defaults.job_id", config=config)
 
-    is_json_output = output.lower() == "json"
+    is_json_output = _resolve_output_format(output) == "json"
 
     # Check if --timestamp-format was explicitly provided by the user
     timestamp_format_provided = (

--- a/test/cli_e2e/test_auth.py
+++ b/test/cli_e2e/test_auth.py
@@ -7,7 +7,9 @@ import json
 def test_cli_auth_status_verbose(deadline_env, run_cli, configure_cli_defaults):
     _, env = deadline_env
     configure_cli_defaults(env)
-    r = run_cli(env, "auth", "status")
+    # run_cli executes the CLI in a subprocess (no TTY), where --output now
+    # auto-detects to json, so request verbose explicitly to assert its format.
+    r = run_cli(env, "auth", "status", "--output", "verbose")
     assert r.returncode == 0, r.stderr or r.stdout
     assert "Profile Name:" in r.stdout
     assert "Source:" in r.stdout

--- a/test/unit/deadline_client/cli/conftest.py
+++ b/test/unit/deadline_client/cli/conftest.py
@@ -1,0 +1,42 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Shared fixtures for the `deadline` CLI unit tests."""
+
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def stdout_is_tty(request):
+    """
+    Forces the CLI to treat stdout as an interactive terminal for all CLI tests.
+
+    Several commands auto-detect their default ``--output`` format from whether
+    stdout is a TTY: verbose for an interactive terminal, json otherwise. The click
+    ``CliRunner`` used by these tests captures stdout into a non-TTY buffer, which
+    would flip the default to json. Most of the existing CLI tests predate that
+    auto-detection and assert the human-readable (verbose) output, so this autouse
+    fixture pins stdout to a TTY to preserve that baseline.
+
+    This does not weaken coverage of the auto-detection: tests that pass an explicit
+    ``--output`` value are unaffected (an explicit value always wins), and the tests
+    in ``test_cli_output_format.py`` patch ``_stdout_is_tty`` directly to exercise
+    both the TTY and non-TTY default-resolution paths.
+
+    A test can opt out of the patch (e.g. to test ``_stdout_is_tty`` itself) with the
+    ``@pytest.mark.real_stdout_isatty`` marker.
+    """
+    if request.node.get_closest_marker("real_stdout_isatty"):
+        yield
+        return
+    with patch("deadline.client.cli._common._stdout_is_tty", return_value=True):
+        yield
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "real_stdout_isatty: do not patch _stdout_is_tty for this test "
+        "(lets a test exercise the real TTY-detection helper).",
+    )

--- a/test/unit/deadline_client/cli/test_cli_output_format.py
+++ b/test/unit/deadline_client/cli/test_cli_output_format.py
@@ -1,0 +1,382 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Tests for the TTY-aware ``--output`` default that is shared across the CLI
+commands accepting an ``--output`` option.
+
+The format auto-detection lives in ``deadline.client.cli._common``:
+
+  * ``_stdout_is_tty()`` reports whether stdout is an interactive terminal.
+  * ``_resolve_output_format()`` returns an explicit value when one is given, and
+    otherwise picks ``verbose`` for a TTY and ``json`` for a non-TTY.
+
+These tests cover the helpers directly and then verify that each in-scope command
+honors the resolved default end-to-end. The non-TTY path is exercised by patching
+``_stdout_is_tty`` to ``False`` (which overrides the autouse ``stdout_is_tty``
+fixture from ``conftest.py``), since the click ``CliRunner`` captures stdout into a
+non-TTY buffer.
+"""
+
+import json
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+import deadline.client.ui
+from deadline.client import api, config
+from deadline.client.cli import main
+from deadline.client.cli import _common
+
+from ..shared_constants import MOCK_FARM_ID, MOCK_QUEUE_ID
+
+MOCK_JOB_ID = "job-0123456789abcdefabcdefabcdefabcd"
+
+
+def _non_tty():
+    """Patches the CLI to behave as though stdout is not a terminal."""
+    return patch.object(_common, "_stdout_is_tty", return_value=False)
+
+
+def _tty():
+    """Patches the CLI to behave as though stdout is an interactive terminal."""
+    return patch.object(_common, "_stdout_is_tty", return_value=True)
+
+
+# ---------------------------------------------------------------------------
+# _resolve_output_format / _stdout_is_tty unit tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "explicit,expected",
+    [
+        ("json", "json"),
+        ("verbose", "verbose"),
+        ("JSON", "json"),
+        ("Verbose", "verbose"),
+    ],
+)
+def test_resolve_output_format_explicit_value_wins(explicit, expected):
+    """An explicit --output value is returned (lowercased) regardless of TTY state."""
+    # Even when stdout looks like a non-TTY, an explicit value takes precedence...
+    with _non_tty():
+        assert _common._resolve_output_format(explicit) == expected
+    # ...and the same is true when stdout is a TTY.
+    with _tty():
+        assert _common._resolve_output_format(explicit) == expected
+
+
+def test_resolve_output_format_defaults_to_verbose_for_tty():
+    with _tty():
+        assert _common._resolve_output_format(None) == "verbose"
+
+
+def test_resolve_output_format_defaults_to_json_for_non_tty():
+    with _non_tty():
+        assert _common._resolve_output_format(None) == "json"
+
+
+@pytest.mark.real_stdout_isatty
+def test_stdout_is_tty_reports_underlying_isatty():
+    class FakeStdout:
+        def __init__(self, isatty_result):
+            self._isatty_result = isatty_result
+
+        def isatty(self):
+            return self._isatty_result
+
+    with patch.object(_common.sys, "stdout", FakeStdout(True)):
+        assert _common._stdout_is_tty() is True
+    with patch.object(_common.sys, "stdout", FakeStdout(False)):
+        assert _common._stdout_is_tty() is False
+
+
+@pytest.mark.real_stdout_isatty
+def test_stdout_is_tty_is_defensive_against_broken_streams():
+    class NoIsatty:
+        pass
+
+    class RaisingIsatty:
+        def isatty(self):
+            raise ValueError("I/O operation on closed file")
+
+    # A stream without isatty() (AttributeError) is treated as non-interactive.
+    with patch.object(_common.sys, "stdout", NoIsatty()):
+        assert _common._stdout_is_tty() is False
+    # A stream whose isatty() raises (e.g. closed) is treated as non-interactive.
+    with patch.object(_common.sys, "stdout", RaisingIsatty()):
+        assert _common._stdout_is_tty() is False
+
+
+# ---------------------------------------------------------------------------
+# config show
+# ---------------------------------------------------------------------------
+
+
+def test_config_show_non_tty_defaults_to_json(fresh_deadline_config):
+    with _non_tty():
+        result = CliRunner().invoke(main, ["config", "show"])
+
+    assert result.exit_code == 0, result.output
+    # Output parses as JSON rather than the human-readable listing.
+    parsed = json.loads(result.output)
+    assert "settings.config_file_path" in parsed
+
+
+def test_config_show_tty_defaults_to_verbose(fresh_deadline_config):
+    with _tty():
+        result = CliRunner().invoke(main, ["config", "show"])
+
+    assert result.exit_code == 0, result.output
+    assert "AWS Deadline Cloud configuration file:" in result.output
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(result.output)
+
+
+def test_config_show_explicit_verbose_wins_over_non_tty(fresh_deadline_config):
+    with _non_tty():
+        result = CliRunner().invoke(main, ["config", "show", "--output", "verbose"])
+
+    assert result.exit_code == 0, result.output
+    assert "AWS Deadline Cloud configuration file:" in result.output
+
+
+def test_config_show_explicit_json_wins_over_tty(fresh_deadline_config):
+    with _tty():
+        result = CliRunner().invoke(main, ["config", "show", "--output", "json"])
+
+    assert result.exit_code == 0, result.output
+    json.loads(result.output)  # must be valid JSON
+
+
+# ---------------------------------------------------------------------------
+# auth status
+# ---------------------------------------------------------------------------
+
+
+def _invoke_auth_status(args):
+    profile_name = "sandbox-us-west-2"
+    config.set_setting("defaults.aws_profile_name", profile_name)
+    with (
+        patch.object(api._session, "get_boto3_session") as session_mock,
+        patch.object(api, "get_boto3_session", new=session_mock),
+        patch.object(
+            api,
+            "check_authentication_status",
+            return_value=api.AwsAuthenticationStatus.AUTHENTICATED,
+        ),
+    ):
+        session_mock().profile_name = profile_name
+        return CliRunner().invoke(main, ["auth", "status", *args])
+
+
+def test_auth_status_non_tty_defaults_to_json(fresh_deadline_config):
+    with _non_tty():
+        result = _invoke_auth_status([])
+
+    assert result.exit_code == 0, result.output
+    parsed = json.loads(result.output)
+    assert "profile_name" in parsed
+    assert "status" in parsed
+
+
+def test_auth_status_tty_defaults_to_verbose(fresh_deadline_config):
+    with _tty():
+        result = _invoke_auth_status([])
+
+    assert result.exit_code == 0, result.output
+    assert "Profile Name: " in result.output
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(result.output)
+
+
+def test_auth_status_explicit_verbose_wins_over_non_tty(fresh_deadline_config):
+    with _non_tty():
+        result = _invoke_auth_status(["--output", "verbose"])
+
+    assert result.exit_code == 0, result.output
+    assert "Profile Name: " in result.output
+
+
+# ---------------------------------------------------------------------------
+# job wait
+# ---------------------------------------------------------------------------
+
+
+def _invoke_job_wait(args):
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
+    with (
+        patch.object(api, "wait_for_job_completion") as mock_wait,
+        patch.object(api, "get_boto3_client") as boto3_client_mock,
+    ):
+        mock_wait.return_value = api.JobCompletionResult(
+            status="SUCCEEDED", failed_tasks=[], elapsed_time=10.5
+        )
+        boto3_client_mock().get_job.return_value = {"name": "Test Job Name"}
+        return CliRunner().invoke(main, ["job", "wait", *args])
+
+
+def test_job_wait_non_tty_defaults_to_json(fresh_deadline_config):
+    with _non_tty():
+        result = _invoke_job_wait([])
+
+    assert result.exit_code == 0, result.output
+    parsed = json.loads(result.output)
+    assert parsed["jobId"] == MOCK_JOB_ID
+    assert parsed["status"] == "SUCCEEDED"
+
+
+def test_job_wait_tty_defaults_to_verbose(fresh_deadline_config):
+    with _tty():
+        result = _invoke_job_wait([])
+
+    assert result.exit_code == 0, result.output
+    assert "Job completed with status: SUCCEEDED" in result.output
+
+
+def test_job_wait_explicit_verbose_wins_over_non_tty(fresh_deadline_config):
+    with _non_tty():
+        result = _invoke_job_wait(["--output", "verbose"])
+
+    assert result.exit_code == 0, result.output
+    assert "Job completed with status: SUCCEEDED" in result.output
+
+
+# ---------------------------------------------------------------------------
+# job logs
+# ---------------------------------------------------------------------------
+
+
+def _invoke_job_logs(args):
+    from deadline.client.api._job_monitoring import SessionLogResult, LogEvent
+    import datetime
+
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("defaults.job_id", MOCK_JOB_ID)
+
+    log_result = SessionLogResult(
+        events=[
+            LogEvent(
+                timestamp=datetime.datetime(
+                    2023, 1, 1, 12, 0, 0, 123456, tzinfo=datetime.timezone.utc
+                ),
+                message="Log message 1",
+                ingestion_time=datetime.datetime(
+                    2023, 1, 1, 12, 0, 10, 654321, tzinfo=datetime.timezone.utc
+                ),
+                event_id="event-1",
+            ),
+        ],
+        next_token=None,
+        log_group=f"/aws/deadline/{MOCK_FARM_ID}/{MOCK_QUEUE_ID}",
+        log_stream="session-test-session",
+        count=1,
+    )
+
+    with (
+        patch("deadline.client.api.get_session_logs") as mock_get_logs,
+        patch(
+            "deadline.client.api._job_monitoring.get_user_and_identity_store_id"
+        ) as mock_get_user,
+        patch("deadline.client.api.get_boto3_client") as boto3_client_mock,
+    ):
+        mock_get_user.return_value = (None, None)
+        mock_get_logs.return_value = log_result
+        boto3_client_mock().get_job.return_value = {"name": "Test Job Name"}
+        return CliRunner().invoke(main, ["job", "logs", "--session-id", "test-session", *args])
+
+
+def test_job_logs_non_tty_defaults_to_json(fresh_deadline_config):
+    with _non_tty():
+        result = _invoke_job_logs([])
+
+    assert result.exit_code == 0, result.output
+    parsed = json.loads(result.output)
+    assert parsed["jobId"] == MOCK_JOB_ID
+    assert any(event["message"] == "Log message 1" for event in parsed["events"])
+
+
+def test_job_logs_tty_defaults_to_verbose(fresh_deadline_config):
+    with _tty():
+        result = _invoke_job_logs([])
+
+    assert result.exit_code == 0, result.output
+    assert "Log message 1" in result.output
+    # The verbose form prefixes the message with a bracketed timestamp.
+    assert "[2023-01-01T12:00:00.123456+00:00] Log message 1" in result.output
+
+
+def test_job_logs_explicit_json_wins_over_tty(fresh_deadline_config):
+    with _tty():
+        result = _invoke_job_logs(["--output", "json"])
+
+    assert result.exit_code == 0, result.output
+    parsed = json.loads(result.output)
+    assert any(event["message"] == "Log message 1" for event in parsed["events"])
+
+
+# ---------------------------------------------------------------------------
+# bundle gui-submit
+# ---------------------------------------------------------------------------
+
+
+def _invoke_bundle_gui_submit(args):
+    submitter_module = MagicMock()
+    # The submitter returned by show_job_bundle_submitter reports a submitted job id.
+    submitter = submitter_module.show_job_bundle_submitter.return_value
+    submitter.job_id = MOCK_JOB_ID
+    submitter.job_history_bundle_dir = "/tmp/history"
+
+    with (
+        patch.object(deadline.client.ui, "gui_context_for_cli"),
+        patch.dict(
+            sys.modules,
+            {"deadline.client.ui.job_bundle_submitter": submitter_module},
+        ),
+    ):
+        return CliRunner().invoke(main, ["bundle", "gui-submit", "--browse", *args])
+
+
+def test_bundle_gui_submit_non_tty_defaults_to_json(fresh_deadline_config):
+    with _non_tty():
+        result = _invoke_bundle_gui_submit([])
+
+    assert result.exit_code == 0, result.output
+    parsed = json.loads(result.output)
+    assert parsed["status"] == "SUBMITTED"
+    assert parsed["jobId"] == MOCK_JOB_ID
+
+
+def test_bundle_gui_submit_tty_defaults_to_verbose(fresh_deadline_config):
+    with _tty():
+        result = _invoke_bundle_gui_submit([])
+
+    assert result.exit_code == 0, result.output
+    assert "Submitted job bundle:" in result.output
+    assert f"Job ID: {MOCK_JOB_ID}" in result.output
+
+
+def test_bundle_gui_submit_explicit_json_wins_over_tty(fresh_deadline_config):
+    with _tty():
+        result = _invoke_bundle_gui_submit(["--output", "json"])
+
+    assert result.exit_code == 0, result.output
+    parsed = json.loads(result.output)
+    assert parsed["jobId"] == MOCK_JOB_ID
+
+
+# ---------------------------------------------------------------------------
+# option help text
+# ---------------------------------------------------------------------------
+
+
+def test_output_help_text_documents_auto_detection(fresh_deadline_config):
+    """The --output help should explain the TTY-aware default for discoverability."""
+    result = CliRunner().invoke(main, ["job", "wait", "--help"])
+    assert result.exit_code == 0, result.output
+    assert "terminal" in result.output.lower()


### PR DESCRIPTION
Fixes:  #1130

### What was the problem/requirement? (What/Why)
`--output` defaults to human-formatted text even when used in automated scripts. We can make the default smarter.

Prior art:
- AWS CLI switches its pager and output behavior based on whether stdout is a terminal. See [Using the AWS CLI pager](https://docs.aws.amazon.com/cli/latest/userguide/cli-usage-pagination.html#cli-usage-pagination-clientside) and the [cli_auto_prompt / output configuration](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html).
- kubectl drives color and table-vs-machine output off TTY detection via its [IOStreams abstraction](https://github.com/kubernetes/cli-runtime/blob/master/pkg/genericiooptions/iooptions.go) and documents the machine-output shift in [kubectl get output formats](https://kubernetes.io/docs/reference/kubectl/#output-options).

### What was the solution? (How)
Default the --output format from whether stdout is an interactive terminal: verbose for a TTY (a human reader), json otherwise (pipes, redirection, CI, agents). An explicit --output always wins. This removes the boilerplate of passing --output json on every call from scripts and agents.

### What is the impact of this change?
Nicer default for `--output`

### How was this change tested?
Unit tests

### Was this change documented?
Yes

### Does this PR introduce new dependencies?
No

### Is this a breaking change?
It is a breaking change because it changes a default behavior. It's unlikely to be disruptive because the previous default was human readable text that was not intended for machine parsing, automated processes should not depend on its format. Automated scripts would have set `--output json` if they wanted structured data from its responses.

### Does this change impact security?
No.
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
