### PR TITLE
feat(test): Support DEADLINE_BINARY env var in UI tests

### DIFF
--- a/test/ui/helpers.py
+++ b/test/ui/helpers.py
@@ -62,20 +62,23 @@ SAMPLE_TEMPLATE = {
 # CLI helpers
 # ---------------------------------------------------------------------------
 
-_DEADLINE_CMD = os.environ.get("DEADLINE_BINARY", "deadline")
+
+def _deadline_cmd() -> str:
+    """Return the CLI command, respecting DEADLINE_BINARY if set."""
+    return os.environ.get("DEADLINE_BINARY", "deadline")
 
 
 def cli_get(env: dict, setting: str) -> str:
     """Read a deadline config setting via the CLI subprocess."""
     return subprocess.check_output(
-        [_DEADLINE_CMD, "config", "get", setting], env=env, text=True, stderr=subprocess.DEVNULL
+        [_deadline_cmd(), "config", "get", setting], env=env, text=True, stderr=subprocess.DEVNULL
     ).strip()
 
 
 def cli_set(env: dict, setting: str, value: str) -> None:
     """Write a deadline config setting via the CLI subprocess."""
     subprocess.check_call(
-        [_DEADLINE_CMD, "config", "set", setting, value],
+        [_deadline_cmd(), "config", "set", setting, value],
         env=env,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,

--- a/test/ui/helpers.py
+++ b/test/ui/helpers.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import atexit
 import json
+import os
 import subprocess
 import sys
 import time
@@ -61,18 +62,20 @@ SAMPLE_TEMPLATE = {
 # CLI helpers
 # ---------------------------------------------------------------------------
 
+_DEADLINE_CMD = os.environ.get("DEADLINE_BINARY", "deadline")
+
 
 def cli_get(env: dict, setting: str) -> str:
     """Read a deadline config setting via the CLI subprocess."""
     return subprocess.check_output(
-        ["deadline", "config", "get", setting], env=env, text=True, stderr=subprocess.DEVNULL
+        [_DEADLINE_CMD, "config", "get", setting], env=env, text=True, stderr=subprocess.DEVNULL
     ).strip()
 
 
 def cli_set(env: dict, setting: str, value: str) -> None:
     """Write a deadline config setting via the CLI subprocess."""
     subprocess.check_call(
-        ["deadline", "config", "set", setting, value],
+        [_DEADLINE_CMD, "config", "set", setting, value],
         env=env,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
@@ -306,8 +309,17 @@ class DeadlineApp:
         capture_stdio: bool,
         dialog_name: Optional[str],
     ) -> _T:
-        """Spawn the GUI subprocess once and wait for its dialog to appear."""
-        cmd = [sys.executable, "-m", "deadline", *args]
+        """Spawn the GUI subprocess once and wait for its dialog to appear.
+
+        Set the ``DEADLINE_BINARY`` environment variable to test an alternative
+        CLI implementation (e.g. the Rust binary) instead of the default
+        ``python -m deadline`` invocation.
+        """
+        deadline_bin = os.environ.get("DEADLINE_BINARY")
+        if deadline_bin:
+            cmd = [deadline_bin, *args]
+        else:
+            cmd = [sys.executable, "-m", "deadline", *args]
         baseline = {a.name for a in xa11y.App.list()}
         popen_kwargs: dict = dict(
             env=env,


### PR DESCRIPTION
## Summary

Adds `DEADLINE_BINARY` environment variable support to `test/ui/helpers.py`. When set, UI tests launch the specified binary instead of `python -m deadline`.

## Why

This enables running the UI test suite against alternative CLI implementations (e.g. the Rust binary in `deadline-cloud-rs`) without duplicating tests across repos. The Rust repo currently maintains a copy of these UI tests to validate its GUI — with this change, it can clone this repo and run the tests directly.

## What changes

- `DeadlineApp._launch_once()` checks `DEADLINE_BINARY` env var before falling back to `sys.executable -m deadline`
- `cli_get()` / `cli_set()` helpers use the same override

## Impact

- Test-only change (file is under `test/`, not shipped in the wheel)
- Default behavior is unchanged when `DEADLINE_BINARY` is not set
- No production code affected