### PR TITLE
fix: honor pre-submission parameter changes and load pre-GUI env hooks

### DIFF
--- a/docs/submission-hooks.md
+++ b/docs/submission-hooks.md
@@ -290,6 +290,13 @@ Parameter keys are job template parameter names. Values from a hook are applied 
 the bundle's parameter values, but CLI-supplied `--parameter` values still take precedence
 over hook-supplied ones.
 
+> **`PATH` parameter values differ by channel.** A relative `PATH` value written to
+> `parameter_values.yaml` on disk is resolved against the **job bundle directory**, while a
+> relative `PATH` value emitted on stdout is resolved against the **current working
+> directory** (the same rule as CLI `--parameter`). To avoid this ambiguity, **use absolute
+> paths for `PATH` parameters emitted on stdout** (or write them to `parameter_values.yaml`
+> instead).
+
 ### Post-Submission Hooks
 
 Output is logged but does not modify anything.

--- a/docs/submission-hooks.md
+++ b/docs/submission-hooks.md
@@ -40,6 +40,10 @@ export DEADLINE_HOOKS_DIR=/studio/pipeline/hooks/maya
 
 Requires `settings.allow_environment_hooks` to be enabled. Both sources can be active simultaneously — environment hooks run first, then bundle hooks.
 
+> **Note:** In DCC submitters, environment hooks apply to the **pre-submission** and
+> **post-submission** phases only. The pre-GUI phase is not run by in-application
+> submitters — see [Pre-GUI Hooks](#pre-gui-hooks).
+
 ## Hook Types
 
 ### Pre-GUI Hooks
@@ -50,6 +54,13 @@ Run **before** the submission dialog opens. Use these to:
 - Query a project management system for task metadata
 
 Pre-GUI hooks **block the dialog from opening** if they fail (non-zero exit code or timeout).
+
+> **Supported only by `deadline bundle gui-submit`.** Pre-GUI hooks run on the standalone
+> GUI submitter. They do **not** run in in-application (DCC) submitters such as Maya,
+> Nuke, or Blender — those build their submission dialog directly and do not invoke the
+> pre-GUI phase. Pre-submission and post-submission hooks are unaffected and work across
+> all submission methods. (CLI `deadline bundle submit` has no GUI phase, so pre-GUI hooks
+> do not apply there either.)
 
 Output JSON to stdout to modify the initial dialog state:
 
@@ -472,13 +483,16 @@ Submission is blocked until the issue is resolved.
 
 Failures are logged as warnings but don't affect the submitted job.
 
-## CLI vs GUI
+## Submission methods
 
-Hooks work with both submission methods:
-- `deadline bundle submit` (CLI)
-- `deadline bundle gui-submit` (GUI)
+Hooks work with these submission methods:
+- `deadline bundle submit` (CLI) — pre-submission and post-submission hooks.
+- `deadline bundle gui-submit` (standalone GUI) — all phases, including pre-GUI.
+- In-application (DCC) submitters — pre-submission and post-submission hooks. The pre-GUI
+  phase is not run by DCC submitters (see [Pre-GUI Hooks](#pre-gui-hooks)).
 
-The GUI copies `hooks.yaml` to the job history bundle and resolves script paths back to your original bundle directory.
+The standalone GUI copies `hooks.yaml` to the job history bundle and resolves script paths
+back to your original bundle directory.
 
 ## Best Practices
 

--- a/docs/submission-hooks.md
+++ b/docs/submission-hooks.md
@@ -290,12 +290,12 @@ Parameter keys are job template parameter names. Values from a hook are applied 
 the bundle's parameter values, but CLI-supplied `--parameter` values still take precedence
 over hook-supplied ones.
 
-> **`PATH` parameter values differ by channel.** A relative `PATH` value written to
-> `parameter_values.yaml` on disk is resolved against the **job bundle directory**, while a
-> relative `PATH` value emitted on stdout is resolved against the **current working
-> directory** (the same rule as CLI `--parameter`). To avoid this ambiguity, **use absolute
-> paths for `PATH` parameters emitted on stdout** (or write them to `parameter_values.yaml`
-> instead).
+> **`PATH` parameters emitted on stdout must be absolute.** A hook does not run from — and
+> does not control — the submitting shell's working directory, so a relative `PATH` value on
+> stdout would be ambiguous. Emitting a relative `PATH` value on stdout is **rejected** with
+> an error. Emit an absolute path (for example, join with `DEADLINE_JOB_BUNDLE_DIR`), or
+> write the value to `parameter_values.yaml`/`.json` on disk instead, where a relative `PATH`
+> is resolved against the **job bundle directory**.
 
 ### Post-Submission Hooks
 

--- a/docs/submission-hooks.md
+++ b/docs/submission-hooks.md
@@ -268,6 +268,17 @@ You can also modify other submission parameters:
 print(json.dumps({"priority": 100}))
 ```
 
+Pre-submission hooks can also change job template parameter values, either by rewriting
+`parameter_values.yaml`/`.json` on disk or by emitting a `parameters` map on stdout:
+
+```python
+print(json.dumps({"parameters": {"SceneFile": "/resolved/scene.ma", "Quality": "high"}}))
+```
+
+Parameter keys are job template parameter names. Values from a hook are applied on top of
+the bundle's parameter values, but CLI-supplied `--parameter` values still take precedence
+over hook-supplied ones.
+
 ### Post-Submission Hooks
 
 Output is logged but does not modify anything.

--- a/src/deadline/client/api/_submit_job_bundle.py
+++ b/src/deadline/client/api/_submit_job_bundle.py
@@ -641,21 +641,28 @@ def create_job_from_job_bundle(
         queue_parameter_definitions = api.get_queue_parameter_definitions(
             farmId=farm_id, queueId=queue_id
         )
+    # Bind to a non-Optional local so the nested helper's closure keeps the narrowed type.
+    resolved_queue_parameter_definitions = queue_parameter_definitions
 
-    parameters = merge_queue_job_parameters(
-        queue_id=queue_id,
-        job_parameters=job_bundle_parameters,
-        queue_parameters=queue_parameter_definitions,
-    )
+    def _resolve_parameters(bundle_parameters, extra_overrides=None):
+        """Merge queue + bundle parameters, apply CLI (and any hook) overrides, and format
+        for CreateJob. ``extra_overrides`` are applied beneath the CLI ``job_parameters``.
+        Mutates ``asset_references`` with any PATH parameters, matching prior behavior."""
+        resolved = merge_queue_job_parameters(
+            queue_id=queue_id,
+            job_parameters=bundle_parameters,
+            queue_parameters=resolved_queue_parameter_definitions,
+        )
+        apply_job_parameters(
+            (extra_overrides or []) + job_parameters,
+            job_bundle_dir,
+            resolved,
+            asset_references,
+        )
+        return resolved, split_parameter_args(resolved, job_bundle_dir)
 
-    apply_job_parameters(
-        job_parameters,
-        job_bundle_dir,
-        parameters,
-        asset_references,
-    )
-    app_parameters_formatted, job_parameters_formatted = split_parameter_args(
-        parameters, job_bundle_dir
+    parameters, (app_parameters_formatted, job_parameters_formatted) = _resolve_parameters(
+        job_bundle_parameters
     )
 
     # Extend known_asset_paths with all paths that are treated as known. These are
@@ -740,6 +747,31 @@ def create_job_from_job_bundle(
         if "priority" in hook_result:
             priority = hook_result["priority"]
             create_job_args["priority"] = priority
+
+        # Apply parameter modifications from hooks. A hook may change parameter values
+        # two ways, both of which are honored here:
+        #   1. Rewriting parameter_values.yaml/.json on disk (re-read below).
+        #   2. Emitting a "parameters" map on stdout (applied on top of the disk values).
+        # CLI-supplied job_parameters still take precedence, matching pre-GUI behavior.
+        #
+        # The bundle parameters read earlier (before the hook block) reflect the state of
+        # parameter_values.yaml *before* the hook ran, so they cannot capture an on-disk
+        # rewrite. Re-read here — after the hook has executed — to pick up any change, then
+        # re-resolve. This is only extra work when a hook actually modified parameters.
+        hook_stdout_parameters = hook_result.get("parameters") or {}
+        updated_bundle_parameters = read_job_bundle_parameters(job_bundle_dir)
+        if updated_bundle_parameters != job_bundle_parameters or hook_stdout_parameters:
+            job_bundle_parameters = updated_bundle_parameters
+            # Layer hook stdout parameters beneath the CLI-supplied job_parameters so the
+            # CLI keeps the final say, then re-resolve with the same logic as the initial pass.
+            hook_parameter_overrides = [
+                {"name": name, "value": value}
+                for name, value in hook_stdout_parameters.items()
+                if name not in {p.get("name") for p in job_parameters}
+            ]
+            parameters, (app_parameters_formatted, job_parameters_formatted) = _resolve_parameters(
+                job_bundle_parameters, hook_parameter_overrides
+            )
 
         # Merge any asset references from hooks into asset_references
         if "attachments" in hook_result and "assetReferences" in hook_result["attachments"]:

--- a/src/deadline/client/api/_submit_job_bundle.py
+++ b/src/deadline/client/api/_submit_job_bundle.py
@@ -779,6 +779,10 @@ def create_job_from_job_bundle(
             job_bundle_parameters = updated_bundle_parameters
             # Layer hook stdout parameters beneath the CLI-supplied job_parameters so the
             # CLI keeps the final say, then re-resolve with the same logic as the initial pass.
+            # NOTE: as job_parameters overrides these follow CLI --parameter semantics, so a
+            # relative PATH value here is resolved against the current working directory (not
+            # the bundle dir, as an on-disk parameter_values.yaml rewrite would be). Hooks
+            # should emit absolute paths for PATH parameters on stdout; see docs.
             hook_parameter_overrides = [
                 {"name": name, "value": value}
                 for name, value in hook_stdout_parameters.items()

--- a/src/deadline/client/api/_submit_job_bundle.py
+++ b/src/deadline/client/api/_submit_job_bundle.py
@@ -779,10 +779,30 @@ def create_job_from_job_bundle(
             job_bundle_parameters = updated_bundle_parameters
             # Layer hook stdout parameters beneath the CLI-supplied job_parameters so the
             # CLI keeps the final say, then re-resolve with the same logic as the initial pass.
-            # NOTE: as job_parameters overrides these follow CLI --parameter semantics, so a
-            # relative PATH value here is resolved against the current working directory (not
-            # the bundle dir, as an on-disk parameter_values.yaml rewrite would be). Hooks
-            # should emit absolute paths for PATH parameters on stdout; see docs.
+            #
+            # A hook's stdout parameters are layered as job_parameters overrides, which follow
+            # CLI --parameter semantics: a relative PATH would be resolved against the current
+            # working directory. But a hook does not run from — and does not control — the
+            # submitting shell's cwd, so a relative PATH from a hook is ambiguous (unlike an
+            # on-disk parameter_values.yaml rewrite, which resolves against the bundle dir).
+            # Reject relative PATH values here and require hooks to emit absolute paths.
+            bundle_parameter_types = {
+                p.get("name"): p.get("type") for p in job_bundle_parameters if "name" in p
+            }
+            for name, value in hook_stdout_parameters.items():
+                if (
+                    bundle_parameter_types.get(name) == "PATH"
+                    and isinstance(value, str)
+                    and value != ""
+                    and not os.path.isabs(value)
+                ):
+                    raise DeadlineOperationError(
+                        f"Pre-submission hook emitted a relative PATH value for parameter "
+                        f"'{name}': '{value}'. Hooks must emit absolute paths for PATH "
+                        f"parameters on stdout, since a hook does not run from the submitting "
+                        f"working directory. Use an absolute path (e.g. join with "
+                        f"DEADLINE_JOB_BUNDLE_DIR) or rewrite parameter_values.yaml on disk."
+                    )
             hook_parameter_overrides = [
                 {"name": name, "value": value}
                 for name, value in hook_stdout_parameters.items()

--- a/src/deadline/client/api/_submit_job_bundle.py
+++ b/src/deadline/client/api/_submit_job_bundle.py
@@ -644,10 +644,12 @@ def create_job_from_job_bundle(
     # Bind to a non-Optional local so the nested helper's closure keeps the narrowed type.
     resolved_queue_parameter_definitions = queue_parameter_definitions
 
-    def _resolve_parameters(bundle_parameters, extra_overrides=None):
+    def _resolve_parameters(bundle_parameters, target_asset_references, extra_overrides=None):
         """Merge queue + bundle parameters, apply CLI (and any hook) overrides, and format
         for CreateJob. ``extra_overrides`` are applied beneath the CLI ``job_parameters``.
-        Mutates ``asset_references`` with any PATH parameters, matching prior behavior."""
+        Mutates ``target_asset_references`` with any PATH parameters, matching prior
+        behavior. Callers that re-resolve pass a freshly-derived AssetReferences so stale
+        PATH values from an earlier pass are not carried over."""
         resolved = merge_queue_job_parameters(
             queue_id=queue_id,
             job_parameters=bundle_parameters,
@@ -657,12 +659,12 @@ def create_job_from_job_bundle(
             (extra_overrides or []) + job_parameters,
             job_bundle_dir,
             resolved,
-            asset_references,
+            target_asset_references,
         )
         return resolved, split_parameter_args(resolved, job_bundle_dir)
 
     parameters, (app_parameters_formatted, job_parameters_formatted) = _resolve_parameters(
-        job_bundle_parameters
+        job_bundle_parameters, asset_references
     )
 
     # Extend known_asset_paths with all paths that are treated as known. These are
@@ -769,8 +771,14 @@ def create_job_from_job_bundle(
                 for name, value in hook_stdout_parameters.items()
                 if name not in {p.get("name") for p in job_parameters}
             ]
+            # Re-derive asset_references from the original bundle refs so PATH values from
+            # the first pass are not retained. Otherwise a hook that *changes* a PATH
+            # parameter would leave both the stale and the new path in asset_references and
+            # upload both. The initial-pass object is replaced here; hook-supplied
+            # attachments (merged below) are applied to this fresh object.
+            asset_references = AssetReferences.from_dict(asset_references_obj)
             parameters, (app_parameters_formatted, job_parameters_formatted) = _resolve_parameters(
-                job_bundle_parameters, hook_parameter_overrides
+                job_bundle_parameters, asset_references, hook_parameter_overrides
             )
 
         # Merge any asset references from hooks into asset_references

--- a/src/deadline/client/api/_submit_job_bundle.py
+++ b/src/deadline/client/api/_submit_job_bundle.py
@@ -699,16 +699,29 @@ def create_job_from_job_bundle(
     # Use the parameter names from job_parameters, but the values from parameters. If a value was provided
     # in job_parameters, it has been applied into parameters and normalized as necessary.
     known_parameter_names = {job_param.get("name") for job_param in job_parameters}
-    for job_param in parameters:
-        if job_param.get("type") == "PATH" and job_param.get("name") in known_parameter_names:
-            job_param_value = job_param.get("value")
-            if job_param_value:
-                if job_param.get("objectType") == "FILE":
-                    # If the job parameter is a file, use its directory as the known path. When collecting
-                    # outputs for upload, only that directory is used, not the file path.
-                    known_asset_paths.append(os.path.dirname(job_param_value))
-                else:
-                    known_asset_paths.append(job_param_value)
+
+    def _path_parameter_known_paths(resolved_parameters):
+        """Return the known-asset-path contributions from PATH parameters in
+        ``resolved_parameters`` (values that were explicitly provided in job_parameters)."""
+        contributed: list[str] = []
+        for job_param in resolved_parameters:
+            if job_param.get("type") == "PATH" and job_param.get("name") in known_parameter_names:
+                job_param_value = job_param.get("value")
+                if job_param_value:
+                    if job_param.get("objectType") == "FILE":
+                        # If the job parameter is a file, use its directory as the known
+                        # path. When collecting outputs for upload, only that directory is
+                        # used, not the file path.
+                        contributed.append(os.path.dirname(job_param_value))
+                    else:
+                        contributed.append(job_param_value)
+        return contributed
+
+    # Base known paths (call args, bundle, storage profile, config) without PATH-parameter
+    # contributions — those are folded in per parameter resolution so they can be recomputed
+    # if a pre-submission hook changes a PATH parameter.
+    base_known_asset_paths = list(known_asset_paths)
+    known_asset_paths.extend(_path_parameter_known_paths(parameters))
 
     # Filter known_asset_paths to remove any paths that have another one as a prefix. This can
     # reduce the amount of processing needed later, and produces a shorter warning message when presenting
@@ -779,6 +792,16 @@ def create_job_from_job_bundle(
             asset_references = AssetReferences.from_dict(asset_references_obj)
             parameters, (app_parameters_formatted, job_parameters_formatted) = _resolve_parameters(
                 job_bundle_parameters, asset_references, hook_parameter_overrides
+            )
+            # Recompute known_asset_paths from the re-resolved parameters so a hook that
+            # redirected a PATH parameter keeps its new location recognized as known (rather
+            # than triggering the unknown-path warning / cancellation). Hook-supplied
+            # parameter names count as known here, alongside the original job_parameters.
+            known_parameter_names = known_parameter_names | {
+                o["name"] for o in hook_parameter_overrides
+            }
+            known_asset_paths = _filter_redundant_known_paths(
+                base_known_asset_paths + _path_parameter_known_paths(parameters)
             )
 
         # Merge any asset references from hooks into asset_references

--- a/src/deadline/client/job_bundle/_hooks/__init__.py
+++ b/src/deadline/client/job_bundle/_hooks/__init__.py
@@ -2,7 +2,11 @@
 
 """Submission hooks for job bundles."""
 
-from ._manager import HookManager, _generate_hooks_confirmation_message
+from ._manager import (
+    HookManager,
+    _generate_hooks_confirmation_message,
+    collect_pre_gui_hook_sources,
+)
 from ._models import HookConfiguration, HookDefinition, HookMetadata, HookResult
 from ._validator import validate_pre_gui_output
 
@@ -13,5 +17,6 @@ __all__ = [
     "HookMetadata",
     "HookResult",
     "_generate_hooks_confirmation_message",
+    "collect_pre_gui_hook_sources",
     "validate_pre_gui_output",
 ]

--- a/src/deadline/client/job_bundle/_hooks/_manager.py
+++ b/src/deadline/client/job_bundle/_hooks/_manager.py
@@ -83,8 +83,17 @@ def collect_pre_gui_hook_sources(
     warn = warning_callback or print_callback
     sources: _List["HookManager"] = []
 
+    # If DEADLINE_HOOKS_DIR resolves to the job bundle directory, the two sources are the
+    # same hooks.yaml. Treat it as the bundle source only (skip the env source) so hooks are
+    # not loaded and run twice — matching the pre/post-submission path's dedup.
+    env_is_bundle = (
+        bool(env_hooks_dir)
+        and bool(bundle_dir)
+        and (_os.path.realpath(env_hooks_dir or "") == _os.path.realpath(bundle_dir or ""))
+    )
+
     # Environment hooks first.
-    if env_hooks_dir:
+    if env_hooks_dir and not env_is_bundle:
         if not _os.path.isdir(env_hooks_dir):
             warn(f"Warning: DEADLINE_HOOKS_DIR '{env_hooks_dir}' is not a valid directory")
         else:
@@ -100,11 +109,12 @@ def collect_pre_gui_hook_sources(
                         "Enable with: deadline config set settings.allow_environment_hooks true"
                     )
 
-    # Bundle hooks second.
+    # Bundle hooks second. When env_is_bundle, this single source covers both; it is gated
+    # by allow_bundle_hooks OR allow_environment_hooks (either grant permits the shared dir).
     bundle_manager = HookManager(bundle_dir, print_callback)
     bundle_hooks = bundle_manager.load_hooks()
     if bundle_hooks and bundle_hooks.pre_gui:
-        if allow_bundle_hooks:
+        if allow_bundle_hooks or (env_is_bundle and allow_environment_hooks):
             sources.append(bundle_manager)
         else:
             warn(

--- a/src/deadline/client/job_bundle/_hooks/_manager.py
+++ b/src/deadline/client/job_bundle/_hooks/_manager.py
@@ -6,7 +6,14 @@ from __future__ import annotations
 
 import json as _json
 import logging as _logging
-from typing import Any as _Any, Callable as _Callable, Dict as _Dict, Optional as _Optional
+import os as _os
+from typing import (
+    Any as _Any,
+    Callable as _Callable,
+    Dict as _Dict,
+    List as _List,
+    Optional as _Optional,
+)
 
 from deadline.client.exceptions import DeadlineOperationError as _DeadlineOperationError
 from deadline.client.job_bundle.loader import read_yaml_or_json_object as _read_yaml_or_json_object
@@ -49,6 +56,59 @@ def _generate_hooks_confirmation_message(hooks: _HookConfiguration, bundle_dir: 
 
     lines.append(f"  Bundle: {bundle_dir}\n")
     return "\n".join(lines)
+
+
+def collect_pre_gui_hook_sources(
+    bundle_dir: str,
+    env_hooks_dir: _Optional[str],
+    allow_bundle_hooks: bool,
+    allow_environment_hooks: bool,
+    print_callback: _Callable[[str], None],
+) -> _List["HookManager"]:
+    """Return the HookManagers whose preGUI hooks should run, in execution order.
+
+    PreGUI hooks may come from the directory named by ``DEADLINE_HOOKS_DIR`` (gated by
+    ``allow_environment_hooks``) and/or the job bundle (gated by ``allow_bundle_hooks``).
+    Environment hooks run before bundle hooks. Sources without preGUI hooks are omitted,
+    and disabled-but-present sources emit a guidance message via ``print_callback``.
+
+    This is deliberately Qt-free so it can be unit-tested without a GUI binding; the caller
+    (the submitter) handles the confirmation prompt and execution.
+    """
+    sources: _List["HookManager"] = []
+
+    # Environment hooks first.
+    if env_hooks_dir:
+        if not _os.path.isdir(env_hooks_dir):
+            print_callback(
+                f"Warning: DEADLINE_HOOKS_DIR '{env_hooks_dir}' is not a valid directory"
+            )
+        else:
+            env_manager = HookManager(env_hooks_dir, print_callback)
+            env_hooks = env_manager.load_hooks()
+            if env_hooks and env_hooks.pre_gui:
+                if allow_environment_hooks:
+                    sources.append(env_manager)
+                else:
+                    print_callback(
+                        "Note: DEADLINE_HOOKS_DIR contains preGUI hooks but environment "
+                        "hooks are disabled.\n"
+                        "Enable with: deadline config set settings.allow_environment_hooks true"
+                    )
+
+    # Bundle hooks second.
+    bundle_manager = HookManager(bundle_dir, print_callback)
+    bundle_hooks = bundle_manager.load_hooks()
+    if bundle_hooks and bundle_hooks.pre_gui:
+        if allow_bundle_hooks:
+            sources.append(bundle_manager)
+        else:
+            print_callback(
+                "Note: Job bundle contains preGUI hooks but bundle hooks are disabled.\n"
+                "Enable with: deadline config set settings.allow_bundle_hooks true"
+            )
+
+    return sources
 
 
 class HookManager:

--- a/src/deadline/client/job_bundle/_hooks/_manager.py
+++ b/src/deadline/client/job_bundle/_hooks/_manager.py
@@ -65,6 +65,7 @@ def collect_pre_gui_hook_sources(
     allow_environment_hooks: bool,
     print_callback: _Callable[[str], None],
     warning_callback: _Optional[_Callable[[str], None]] = None,
+    hook_manager_cls: _Optional[type] = None,
 ) -> _List["HookManager"]:
     """Return the HookManagers whose preGUI hooks should run, in execution order.
 
@@ -76,11 +77,14 @@ def collect_pre_gui_hook_sources(
     messages. ``warning_callback`` (defaults to ``print_callback``) receives guidance
     notes — a hooks source that is present but disabled, or an invalid DEADLINE_HOOKS_DIR —
     so callers can log those at a higher severity than routine execution output.
+    ``hook_manager_cls`` (defaults to ``HookManager``) is the class used to construct each
+    source; callers may pass their own reference so it remains a patchable seam.
 
     This is deliberately Qt-free so it can be unit-tested without a GUI binding; the caller
     (the submitter) handles the confirmation prompt and execution.
     """
     warn = warning_callback or print_callback
+    manager_cls = hook_manager_cls or HookManager
     sources: _List["HookManager"] = []
 
     # If DEADLINE_HOOKS_DIR resolves to the job bundle directory, the two sources are the
@@ -97,7 +101,7 @@ def collect_pre_gui_hook_sources(
         if not _os.path.isdir(env_hooks_dir):
             warn(f"Warning: DEADLINE_HOOKS_DIR '{env_hooks_dir}' is not a valid directory")
         else:
-            env_manager = HookManager(env_hooks_dir, print_callback)
+            env_manager = manager_cls(env_hooks_dir, print_callback)
             env_hooks = env_manager.load_hooks()
             if env_hooks and env_hooks.pre_gui:
                 if allow_environment_hooks:
@@ -111,7 +115,7 @@ def collect_pre_gui_hook_sources(
 
     # Bundle hooks second. When env_is_bundle, this single source covers both; it is gated
     # by allow_bundle_hooks OR allow_environment_hooks (either grant permits the shared dir).
-    bundle_manager = HookManager(bundle_dir, print_callback)
+    bundle_manager = manager_cls(bundle_dir, print_callback)
     bundle_hooks = bundle_manager.load_hooks()
     if bundle_hooks and bundle_hooks.pre_gui:
         if allow_bundle_hooks or (env_is_bundle and allow_environment_hooks):

--- a/src/deadline/client/job_bundle/_hooks/_manager.py
+++ b/src/deadline/client/job_bundle/_hooks/_manager.py
@@ -145,11 +145,14 @@ class HookManager:
         Runs before the submission dialog opens. Hooks may output JSON to pre-populate
         dialog fields: parameters, priority, farmId, queueId, name, description.
         Failures block the dialog from opening.
+
+        The caller sets ``metadata.job_bundle_dir`` to the job bundle being submitted; it is
+        respected as-is so environment hooks receive the real bundle dir (not the
+        environment hooks directory), matching the pre/post-submission contract. Relative
+        hook *script* paths are still resolved against this manager's own directory.
         """
         if not self.hooks or not self.hooks.pre_gui:
             return {}
-
-        metadata.job_bundle_dir = self._original_bundle_dir
 
         merged: _Dict[str, _Any] = {}
         for i, hook in enumerate(self.hooks.pre_gui):

--- a/src/deadline/client/job_bundle/_hooks/_manager.py
+++ b/src/deadline/client/job_bundle/_hooks/_manager.py
@@ -64,25 +64,29 @@ def collect_pre_gui_hook_sources(
     allow_bundle_hooks: bool,
     allow_environment_hooks: bool,
     print_callback: _Callable[[str], None],
+    warning_callback: _Optional[_Callable[[str], None]] = None,
 ) -> _List["HookManager"]:
     """Return the HookManagers whose preGUI hooks should run, in execution order.
 
     PreGUI hooks may come from the directory named by ``DEADLINE_HOOKS_DIR`` (gated by
     ``allow_environment_hooks``) and/or the job bundle (gated by ``allow_bundle_hooks``).
-    Environment hooks run before bundle hooks. Sources without preGUI hooks are omitted,
-    and disabled-but-present sources emit a guidance message via ``print_callback``.
+    Environment hooks run before bundle hooks. Sources without preGUI hooks are omitted.
+
+    ``print_callback`` is attached to each returned HookManager for its execution-time
+    messages. ``warning_callback`` (defaults to ``print_callback``) receives guidance
+    notes — a hooks source that is present but disabled, or an invalid DEADLINE_HOOKS_DIR —
+    so callers can log those at a higher severity than routine execution output.
 
     This is deliberately Qt-free so it can be unit-tested without a GUI binding; the caller
     (the submitter) handles the confirmation prompt and execution.
     """
+    warn = warning_callback or print_callback
     sources: _List["HookManager"] = []
 
     # Environment hooks first.
     if env_hooks_dir:
         if not _os.path.isdir(env_hooks_dir):
-            print_callback(
-                f"Warning: DEADLINE_HOOKS_DIR '{env_hooks_dir}' is not a valid directory"
-            )
+            warn(f"Warning: DEADLINE_HOOKS_DIR '{env_hooks_dir}' is not a valid directory")
         else:
             env_manager = HookManager(env_hooks_dir, print_callback)
             env_hooks = env_manager.load_hooks()
@@ -90,7 +94,7 @@ def collect_pre_gui_hook_sources(
                 if allow_environment_hooks:
                     sources.append(env_manager)
                 else:
-                    print_callback(
+                    warn(
                         "Note: DEADLINE_HOOKS_DIR contains preGUI hooks but environment "
                         "hooks are disabled.\n"
                         "Enable with: deadline config set settings.allow_environment_hooks true"
@@ -103,7 +107,7 @@ def collect_pre_gui_hook_sources(
         if allow_bundle_hooks:
             sources.append(bundle_manager)
         else:
-            print_callback(
+            warn(
                 "Note: Job bundle contains preGUI hooks but bundle hooks are disabled.\n"
                 "Enable with: deadline config set settings.allow_bundle_hooks true"
             )

--- a/src/deadline/client/job_bundle/_hooks/_merger.py
+++ b/src/deadline/client/job_bundle/_hooks/_merger.py
@@ -37,6 +37,12 @@ def merge_payload(original: _Dict[str, _Any], modified: _Dict[str, _Any]) -> _Di
             for k, v in value.items():
                 if k != "assetReferences":
                     result["attachments"][k] = v
+        elif key == "parameters" and isinstance(value, dict):
+            # Merge parameter maps per-key so later hooks override earlier ones without
+            # discarding parameters set by a previous hook.
+            merged_params = dict(result.get("parameters", {}))
+            merged_params.update(value)
+            result["parameters"] = merged_params
         else:
             result[key] = value
 

--- a/src/deadline/client/job_bundle/_hooks/_validator.py
+++ b/src/deadline/client/job_bundle/_hooks/_validator.py
@@ -70,6 +70,11 @@ def validate_modified_payload(payload: _Dict[str, _Any], hook_name: str) -> None
         if "assetReferences" in attachments:
             _validate_asset_references(attachments["assetReferences"], hook_name)
 
+    if "parameters" in payload and not isinstance(payload["parameters"], dict):
+        raise _DeadlineOperationError(
+            f"Hook '{hook_name}' 'parameters' must be an object mapping parameter names to values"
+        )
+
 
 _PRE_GUI_ALLOWED_KEYS = {"parameters", "name", "description"}
 

--- a/src/deadline/client/ui/job_bundle_submitter.py
+++ b/src/deadline/client/ui/job_bundle_submitter.py
@@ -95,7 +95,10 @@ def _run_pre_gui_hooks(
         allow_environment_hooks=_config_file.str2bool(
             _get_setting("settings.allow_environment_hooks")
         ),
+        # Hook execution messages ("Running pre-GUI hook…") log at info; the
+        # "hooks present but disabled" guidance logs at warning (its pre-refactor severity).
         print_callback=logger.info,
+        warning_callback=logger.warning,
     )
 
     if not sources:

--- a/src/deadline/client/ui/job_bundle_submitter.py
+++ b/src/deadline/client/ui/job_bundle_submitter.py
@@ -123,7 +123,10 @@ def _run_pre_gui_hooks(
 
     merged: dict[str, Any] = {}
     for manager in sources:
-        metadata = _make_pre_gui_metadata(initial_settings, manager._original_bundle_dir)
+        # Every hook — bundle or environment — receives the job bundle being submitted as
+        # its job_bundle_dir, matching the pre/post-submission contract. (The manager still
+        # resolves relative hook script paths against its own directory.)
+        metadata = _make_pre_gui_metadata(initial_settings, input_job_bundle_dir)
         output = manager.execute_pre_gui_hooks(metadata)
         # Later sources (bundle) override earlier (env) for scalars; parameters merge.
         params = merged.pop("parameters", {})

--- a/src/deadline/client/ui/job_bundle_submitter.py
+++ b/src/deadline/client/ui/job_bundle_submitter.py
@@ -21,9 +21,9 @@ from ..config.config_file import get_setting as _get_setting
 from ..exceptions import DeadlineOperationCanceled as _DeadlineOperationCanceled
 from ..exceptions import DeadlineOperationError
 from ..job_bundle._hooks import (
-    HookManager as _HookManager,
     HookMetadata as _HookMetadata,
     _generate_hooks_confirmation_message,
+    collect_pre_gui_hook_sources as _collect_pre_gui_hook_sources,
 )
 from ..job_bundle.loader import (
     parse_yaml_or_json_content,
@@ -74,6 +74,64 @@ def _make_pre_gui_metadata(initial_settings: Any, job_bundle_dir: str) -> _HookM
         submission_payload={},
         storage_profile_id=storage_profile_id,
     )
+
+
+def _run_pre_gui_hooks(
+    input_job_bundle_dir: str, initial_settings: Any, parent: Any
+) -> dict[str, Any]:
+    """Load and execute pre-GUI hooks from all allowed sources.
+
+    Pre-GUI hooks may be defined in the job bundle (gated by ``allow_bundle_hooks``) and/or
+    in the directory named by ``DEADLINE_HOOKS_DIR`` (gated by ``allow_environment_hooks``).
+    Environment hooks run before bundle hooks. Returns the merged pre-GUI output, or an
+    empty dict if no pre-GUI hooks run.
+    """
+    # Source selection (which bundle/env HookManagers have runnable preGUI hooks) is
+    # Qt-free logic extracted into the hooks package so it can be unit-tested without a GUI.
+    sources = _collect_pre_gui_hook_sources(
+        bundle_dir=input_job_bundle_dir,
+        env_hooks_dir=os.environ.get("DEADLINE_HOOKS_DIR"),
+        allow_bundle_hooks=_config_file.str2bool(_get_setting("settings.allow_bundle_hooks")),
+        allow_environment_hooks=_config_file.str2bool(
+            _get_setting("settings.allow_environment_hooks")
+        ),
+        print_callback=logger.info,
+    )
+
+    if not sources:
+        return {}
+
+    # Confirmation prompt (once), unless auto_accept. Show every source's hooks.
+    if not _config_file.str2bool(_get_setting("settings.auto_accept")):
+        confirmation_msg = (
+            "".join(
+                _generate_hooks_confirmation_message(m.hooks, m._original_bundle_dir)
+                for m in sources
+                if m.hooks
+            )
+            + "Do you want to run these hooks?"
+        )
+        reply = QMessageBox.question(
+            parent,
+            tr("Job Submission Confirmation"),
+            confirmation_msg,
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.No,
+        )
+        if reply != QMessageBox.Yes:
+            raise _DeadlineOperationCanceled("Job submission canceled (user declined hooks).")
+
+    merged: dict[str, Any] = {}
+    for manager in sources:
+        metadata = _make_pre_gui_metadata(initial_settings, manager._original_bundle_dir)
+        output = manager.execute_pre_gui_hooks(metadata)
+        # Later sources (bundle) override earlier (env) for scalars; parameters merge.
+        params = merged.pop("parameters", {})
+        params.update(output.pop("parameters", {}))
+        merged.update(output)
+        if params:
+            merged["parameters"] = params
+    return merged
 
 
 def _resolve_template_host_requirements(template: dict[str, Any]) -> Optional[Dict[str, Any]]:
@@ -337,35 +395,11 @@ def show_job_bundle_submitter(
     initial_settings.parameters = read_job_bundle_parameters(input_job_bundle_dir)
     initial_settings.browse_enabled = browse
 
-    # Run pre-GUI hooks to allow studios to pre-populate dialog fields.
-    pre_gui_output: dict[str, Any] = {}
-    allow_bundle_hooks = _config_file.str2bool(_get_setting("settings.allow_bundle_hooks"))
-    hook_manager = _HookManager(input_job_bundle_dir, logger.info)
-    hooks = hook_manager.load_hooks()
-
-    if hooks and hooks.pre_gui and not allow_bundle_hooks:
-        logger.warning(
-            "Note: Job bundle contains preGUI hooks but bundle hooks are disabled.\n"
-            "Enable with: deadline config set settings.allow_bundle_hooks true"
-        )
-
-    if hooks and hooks.pre_gui and allow_bundle_hooks:
-        if not _config_file.str2bool(_get_setting("settings.auto_accept")):
-            confirmation_msg = (
-                _generate_hooks_confirmation_message(hooks, input_job_bundle_dir)
-                + "Do you want to run these hooks?"
-            )
-            reply = QMessageBox.question(
-                parent,
-                tr("Job Submission Confirmation"),
-                confirmation_msg,
-                QMessageBox.Yes | QMessageBox.No,
-                QMessageBox.No,
-            )
-            if reply != QMessageBox.Yes:
-                raise _DeadlineOperationCanceled("Job submission canceled (user declined hooks).")
-        hook_metadata = _make_pre_gui_metadata(initial_settings, input_job_bundle_dir)
-        pre_gui_output = hook_manager.execute_pre_gui_hooks(hook_metadata)
+    # Run pre-GUI hooks to allow studios to pre-populate dialog fields. Pre-GUI hooks may
+    # come from the job bundle (gated by allow_bundle_hooks) and/or the directory named by
+    # DEADLINE_HOOKS_DIR (gated by allow_environment_hooks). Environment hooks run first,
+    # then bundle hooks — matching the pre/post-submission ordering.
+    pre_gui_output = _run_pre_gui_hooks(input_job_bundle_dir, initial_settings, parent)
 
     initial_shared_parameter_values = {}
 

--- a/src/deadline/client/ui/job_bundle_submitter.py
+++ b/src/deadline/client/ui/job_bundle_submitter.py
@@ -413,6 +413,12 @@ def show_job_bundle_submitter(
     initial_shared_parameter_values = {}
 
     job_parameters_dict = {param["name"]: param for param in (job_parameters or [])}
+    # Capture the CLI-provided parameter names up front. The pop loop below removes template
+    # parameters from job_parameters_dict as it applies them, so the dict alone can no longer
+    # tell us which parameters the CLI supplied when the hook merge runs. Use this set to keep
+    # CLI --parameter values winning over hook-supplied values for both template and shared
+    # parameters.
+    cli_provided_param_names = set(job_parameters_dict)
     for parameter in initial_settings.parameters:
         # Overwrite the parameter values from the job bundle with values provided by job_parameters,
         # e.g. from the CLI when this is called by the 'deadline bundle gui-submit' command.
@@ -443,7 +449,10 @@ def show_job_bundle_submitter(
         hook_params = pre_gui_output.get("parameters", {})
         template_param_names = {p["name"] for p in initial_settings.parameters}
         for param_name, param_value in hook_params.items():
-            if param_name in (job_parameters_dict or {}):
+            # CLI --parameter values take precedence over hook values. Check the up-front
+            # set rather than job_parameters_dict, whose template entries were already popped
+            # above — otherwise a hook could silently override a CLI-supplied template param.
+            if param_name in cli_provided_param_names:
                 continue
             if param_name in template_param_names:
                 # Job template parameter — update initial_settings.parameters in-place

--- a/src/deadline/client/ui/job_bundle_submitter.py
+++ b/src/deadline/client/ui/job_bundle_submitter.py
@@ -21,6 +21,7 @@ from ..config.config_file import get_setting as _get_setting
 from ..exceptions import DeadlineOperationCanceled as _DeadlineOperationCanceled
 from ..exceptions import DeadlineOperationError
 from ..job_bundle._hooks import (
+    HookManager as _HookManager,
     HookMetadata as _HookMetadata,
     _generate_hooks_confirmation_message,
     collect_pre_gui_hook_sources as _collect_pre_gui_hook_sources,
@@ -99,6 +100,8 @@ def _run_pre_gui_hooks(
         # "hooks present but disabled" guidance logs at warning (its pre-refactor severity).
         print_callback=logger.info,
         warning_callback=logger.warning,
+        # Pass our reference so tests can patch `{MODULE}._HookManager` as a behavior seam.
+        hook_manager_cls=_HookManager,
     )
 
     if not sources:

--- a/test/cli_e2e/test_bundle_hooks.py
+++ b/test/cli_e2e/test_bundle_hooks.py
@@ -1,0 +1,136 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""End-to-end tests for submission hooks through ``deadline bundle submit``.
+
+These invoke the real ``deadline`` CLI as a subprocess against the in-process mock
+Deadline backend + moto S3 (see conftest). Real hook subprocesses execute, so we assert
+on their observable effects: a hook writes a sentinel file, a hook-supplied priority
+reaches the created job, and disabled hooks do not run.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_TEMPLATE = """\
+specificationVersion: 'jobtemplate-2023-09'
+name: hook-e2e
+parameterDefinitions:
+- name: Message
+  type: STRING
+  default: original_message
+steps:
+- name: step1
+  script:
+    actions:
+      onRun:
+        command: "echo"
+        args: ["hi"]
+"""
+
+_PARAM_VALUES = "parameterValues:\n- name: Message\n  value: original_message\n"
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (3, 9),
+    reason="MockDeadlineBackend.create_job requires openjd-model (py>=3.9)",
+)
+
+
+def _write_bundle(bundle_dir: Path, hooks_yaml: str, scripts: dict) -> None:
+    bundle_dir.mkdir(parents=True, exist_ok=True)
+    (bundle_dir / "template.yaml").write_text(_TEMPLATE)
+    (bundle_dir / "parameter_values.yaml").write_text(_PARAM_VALUES)
+    (bundle_dir / "hooks.yaml").write_text(hooks_yaml)
+    for name, contents in scripts.items():
+        (bundle_dir / name).write_text(contents)
+
+
+def _enable_bundle_hooks(env, run_cli):
+    assert run_cli(env, "config", "set", "settings.allow_bundle_hooks", "true").returncode == 0
+    assert run_cli(env, "config", "set", "settings.auto_accept", "true").returncode == 0
+
+
+def test_e2e_pre_submission_hook_writes_file(seeded_farm_queue, run_cli, tmp_path):
+    """A pre-submission hook runs during a real ``deadline bundle submit`` and writes a
+    file, and the job is created on the backend."""
+    backend, farm_id, queue_id, env = seeded_farm_queue
+    _enable_bundle_hooks(env, run_cli)
+
+    sentinel = tmp_path / "pre_submission_ran.txt"
+    bundle = tmp_path / "bundle"
+    _write_bundle(
+        bundle,
+        "version: '1.0'\npreSubmission:\n  - command: python3\n    args: [touch.py]\n",
+        {"touch.py": f"open({str(sentinel)!r}, 'w').write('ran')\n"},
+    )
+
+    r = run_cli(env, "bundle", "submit", str(bundle), "--yes")
+
+    assert r.returncode == 0, r.stderr or r.stdout
+    assert sentinel.exists(), "pre-submission hook did not run"
+    jobs = [j for (f, q, _), j in backend.jobs.items() if f == farm_id and q == queue_id]
+    assert len(jobs) == 1
+
+
+def test_e2e_pre_submission_hook_priority_reaches_backend(seeded_farm_queue, run_cli, tmp_path):
+    """A pre-submission hook that emits a priority override on stdout changes the priority
+    of the job recorded by the backend."""
+    backend, farm_id, queue_id, env = seeded_farm_queue
+    _enable_bundle_hooks(env, run_cli)
+
+    bundle = tmp_path / "bundle"
+    _write_bundle(
+        bundle,
+        "version: '1.0'\npreSubmission:\n  - command: python3\n    args: [prio.py]\n",
+        {"prio.py": "import json; print(json.dumps({'priority': 77}))\n"},
+    )
+
+    r = run_cli(env, "bundle", "submit", str(bundle), "--yes")
+
+    assert r.returncode == 0, r.stderr or r.stdout
+    jobs = [j for (f, q, _), j in backend.jobs.items() if f == farm_id and q == queue_id]
+    assert len(jobs) == 1
+    assert jobs[0]["priority"] == 77
+
+
+def test_e2e_post_submission_hook_runs(seeded_farm_queue, run_cli, tmp_path):
+    """A post-submission hook runs after the job is created."""
+    backend, farm_id, queue_id, env = seeded_farm_queue
+    _enable_bundle_hooks(env, run_cli)
+
+    sentinel = tmp_path / "post_submission_ran.txt"
+    bundle = tmp_path / "bundle"
+    _write_bundle(
+        bundle,
+        "version: '1.0'\npostSubmission:\n  - command: python3\n    args: [post.py]\n",
+        {"post.py": f"open({str(sentinel)!r}, 'w').write('post')\n"},
+    )
+
+    r = run_cli(env, "bundle", "submit", str(bundle), "--yes")
+
+    assert r.returncode == 0, r.stderr or r.stdout
+    jobs = [j for (f, q, _), j in backend.jobs.items() if f == farm_id and q == queue_id]
+    assert len(jobs) == 1
+    assert sentinel.exists(), "post-submission hook did not run"
+
+
+def test_e2e_bundle_hooks_disabled_by_default(seeded_farm_queue, run_cli, tmp_path):
+    """With allow_bundle_hooks unset, a bundle hook does not run (security default)."""
+    backend, farm_id, queue_id, env = seeded_farm_queue
+    # Only auto_accept; deliberately do NOT enable allow_bundle_hooks.
+    assert run_cli(env, "config", "set", "settings.auto_accept", "true").returncode == 0
+
+    sentinel = tmp_path / "should_not_exist.txt"
+    bundle = tmp_path / "bundle"
+    _write_bundle(
+        bundle,
+        "version: '1.0'\npreSubmission:\n  - command: python3\n    args: [touch.py]\n",
+        {"touch.py": f"open({str(sentinel)!r}, 'w').write('ran')\n"},
+    )
+
+    r = run_cli(env, "bundle", "submit", str(bundle), "--yes")
+
+    assert r.returncode == 0, r.stderr or r.stdout
+    assert not sentinel.exists(), "bundle hook ran despite allow_bundle_hooks not set"

--- a/test/ui/test_bundle_gui_submit_hooks.py
+++ b/test/ui/test_bundle_gui_submit_hooks.py
@@ -1,0 +1,56 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""UI e2e tests for preGUI submission hooks in ``deadline bundle gui-submit``.
+
+These launch the real GUI submitter as a subprocess and drive it through the OS
+accessibility tree (xa11y), against the in-process mock Deadline backend. A preGUI hook
+runs before the dialog opens and pre-fills the job name; the tests assert on the rendered
+``Name`` field to confirm the hook ran (or, when hooks are disabled, that it did not).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from helpers import SAMPLE_TEMPLATE, SubmitterDialog, cli_set
+
+# A preGUI hook that pre-fills the job name field before the dialog opens.
+_PRE_GUI_HOOKS_YAML = "version: '1.0'\npreGUI:\n  - command: python3\n    args: [prefill.py]\n"
+_PRE_GUI_SCRIPT = 'import json; print(json.dumps({"name": "PREGUI_RAN"}))\n'
+
+
+@pytest.fixture
+def hook_bundle_dir(tmp_path) -> str:
+    """A job bundle whose preGUI hook pre-fills the job name."""
+    d = tmp_path / "bundle"
+    d.mkdir()
+    (d / "template.json").write_text(json.dumps(SAMPLE_TEMPLATE))
+    (d / "hooks.yaml").write_text(_PRE_GUI_HOOKS_YAML)
+    (d / "prefill.py").write_text(_PRE_GUI_SCRIPT)
+    return str(d)
+
+
+def test_pre_gui_hook_prefills_job_name(hook_bundle_dir, submitter_env):
+    """With bundle hooks enabled, the preGUI hook runs before the dialog opens and
+    pre-fills the Name field with its output."""
+    env = submitter_env
+    cli_set(env, "settings.allow_bundle_hooks", "true")
+    cli_set(env, "settings.auto_accept", "true")
+
+    with SubmitterDialog.open(hook_bundle_dir, env=env) as app:
+        app.wait_farm_resolved()
+        assert app.job_name == "PREGUI_RAN"
+
+
+def test_pre_gui_hook_not_run_when_disabled(hook_bundle_dir, submitter_env):
+    """With bundle hooks disabled (default), the preGUI hook does not run and the Name
+    field keeps the job template's name."""
+    env = submitter_env
+    cli_set(env, "settings.auto_accept", "true")
+    # deliberately do NOT enable allow_bundle_hooks
+
+    with SubmitterDialog.open(hook_bundle_dir, env=env) as app:
+        app.wait_farm_resolved()
+        assert app.job_name == SAMPLE_TEMPLATE["name"]  # "Test Render Job", unchanged

--- a/test/unit/deadline_client/api/test_job_bundle_submission_asset_refs.py
+++ b/test/unit/deadline_client/api/test_job_bundle_submission_asset_refs.py
@@ -501,15 +501,17 @@ def test_pre_submission_hook_redirecting_path_param_drops_stale_path(
     bundle = tmp_path / "bundle"
     bundle.mkdir()
     (bundle / "template.yaml").write_text(_PATH_REDIRECT_TEMPLATE)
+    # Use POSIX-style paths so backslashes on Windows do not break YAML or the generated
+    # hook script's Python string literal.
     (bundle / "parameter_values.yaml").write_text(
-        f"parameterValues:\n- name: InDir\n  value: {str(old_dir)}\n"
+        f"parameterValues:\n- name: InDir\n  value: {old_dir.as_posix()}\n"
     )
     # Hook redirects InDir from old_dir to new_dir on disk.
     (bundle / "redirect.py").write_text(
         "import os\n"
         "b = os.environ['DEADLINE_JOB_BUNDLE_DIR']\n"
         "open(os.path.join(b, 'parameter_values.yaml'), 'w').write("
-        f"'parameterValues:\\n- name: InDir\\n  value: {str(new_dir)}\\n')\n"
+        f"'parameterValues:\\n- name: InDir\\n  value: {new_dir.as_posix()}\\n')\n"
     )
     (bundle / "hooks.yaml").write_text(
         "version: '1.0'\npreSubmission:\n  - command: python3\n    args: [redirect.py]\n"

--- a/test/unit/deadline_client/api/test_job_bundle_submission_asset_refs.py
+++ b/test/unit/deadline_client/api/test_job_bundle_submission_asset_refs.py
@@ -562,3 +562,78 @@ def test_pre_submission_hook_redirecting_path_param_drops_stale_path(
     inputs = captured.get("inputs", set())
     assert any("new_inputs" in p for p in inputs), "redirected (new) path should be uploaded"
     assert not any("old_inputs" in p for p in inputs), "stale (old) path must be dropped"
+
+
+def test_pre_submission_hook_redirected_path_stays_known(fresh_deadline_config, tmp_path):
+    """A hook that redirects a PATH parameter (which was supplied as a known job parameter)
+    must keep the redirected location in known_asset_paths, so it is not flagged as an
+    unknown path — which, with no interactive confirmation callback, would raise
+    DeadlineOperationCanceled. known_asset_paths must be recomputed after the hook
+    re-resolve, including the hook's stdout ``parameters`` override name.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("settings.allow_bundle_hooks", "true")
+    config.set_setting("settings.auto_accept", "true")
+
+    old_dir = tmp_path / "old_inputs"
+    new_dir = tmp_path / "redirected_inputs"
+    old_dir.mkdir()
+    new_dir.mkdir()
+    (old_dir / "a.txt").write_text("old")
+    (new_dir / "b.txt").write_text("new")
+
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    (bundle / "template.yaml").write_text(_PATH_REDIRECT_TEMPLATE)
+    (bundle / "parameter_values.yaml").write_text(
+        f"parameterValues:\n- name: InDir\n  value: {old_dir.as_posix()}\n"
+    )
+    # Hook redirects InDir to new_dir via a stdout parameters override.
+    (bundle / "redirect.py").write_text(
+        f"import json\nprint(json.dumps({{'parameters': {{'InDir': {new_dir.as_posix()!r}}}}}))\n"
+    )
+    (bundle / "hooks.yaml").write_text(
+        "version: '1.0'\npreSubmission:\n  - command: python3\n    args: [redirect.py]\n"
+    )
+
+    with (
+        patch.object(_submit_job_bundle.api, "get_boto3_session"),
+        patch.object(_submit_job_bundle.api, "get_boto3_client") as client_mock,
+        patch.object(_submit_job_bundle.api, "get_queue_user_boto3_session"),
+        patch.object(S3AssetManager, "hash_assets_and_create_manifest") as mock_hash_assets,
+        patch.object(S3AssetManager, "upload_assets") as mock_upload_assets,
+        patch.object(_submit_job_bundle.api, "get_deadline_cloud_library_telemetry_client"),
+    ):
+        client_mock().create_job.side_effect = [MOCK_CREATE_JOB_RESPONSE]
+        client_mock().get_queue.side_effect = [MOCK_GET_QUEUE_RESPONSE]
+        mock_hash_assets.return_value = [SummaryStatistics(), AssetRootManifest()]
+        mock_upload_assets.return_value = [
+            SummaryStatistics(),
+            Attachments(
+                [
+                    ManifestProperties(
+                        rootPath=str(tmp_path),
+                        rootPathFormat=PathFormat.POSIX,
+                        inputManifestPath="m",
+                        inputManifestHash="h",
+                        outputRelativeDirectories=["."],
+                    )
+                ]
+            ),
+        ]
+
+        # InDir is supplied as a known job parameter (old_dir is marked known). The hook
+        # then redirects it to new_dir, which is NOT pre-marked known and has no confirmation
+        # callback. If known_asset_paths were not recomputed after the hook, the redirected
+        # path would be treated as unknown and raise DeadlineOperationCanceled. It must
+        # submit successfully instead.
+        api.create_job_from_job_bundle(
+            job_bundle_dir=str(bundle),
+            job_parameters=[{"name": "InDir", "value": str(old_dir)}],
+            known_asset_paths=[str(old_dir)],
+            queue_parameter_definitions=[],
+            require_paths_exist=False,
+        )
+
+    client_mock().create_job.assert_called_once()

--- a/test/unit/deadline_client/api/test_job_bundle_submission_asset_refs.py
+++ b/test/unit/deadline_client/api/test_job_bundle_submission_asset_refs.py
@@ -460,3 +460,103 @@ def test_create_job_from_job_bundle_with_all_asset_ref_variants(
             maxFailedTasksCount=20,
             maxRetriesPerTask=5,
         )
+
+
+_PATH_REDIRECT_TEMPLATE = """specificationVersion: 'jobtemplate-2023-09'
+name: PathRedirect
+parameterDefinitions:
+- name: InDir
+  type: PATH
+  objectType: DIRECTORY
+  dataFlow: IN
+steps:
+- name: S
+  script:
+    actions:
+      onRun:
+        command: echo
+"""
+
+
+def test_pre_submission_hook_redirecting_path_param_drops_stale_path(
+    fresh_deadline_config, tmp_path
+):
+    """A pre-submission hook that redirects a PATH parameter (by rewriting
+    parameter_values.yaml on disk) must upload only the NEW directory. Regression test for
+    the parameter re-resolve carrying over the stale first-pass path — previously both the
+    old and new directories were hashed/uploaded.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("settings.allow_bundle_hooks", "true")
+    config.set_setting("settings.auto_accept", "true")
+
+    old_dir = tmp_path / "old_inputs"
+    new_dir = tmp_path / "new_inputs"
+    old_dir.mkdir()
+    new_dir.mkdir()
+    (old_dir / "a.txt").write_text("old")
+    (new_dir / "b.txt").write_text("new")
+
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    (bundle / "template.yaml").write_text(_PATH_REDIRECT_TEMPLATE)
+    (bundle / "parameter_values.yaml").write_text(
+        f"parameterValues:\n- name: InDir\n  value: {str(old_dir)}\n"
+    )
+    # Hook redirects InDir from old_dir to new_dir on disk.
+    (bundle / "redirect.py").write_text(
+        "import os\n"
+        "b = os.environ['DEADLINE_JOB_BUNDLE_DIR']\n"
+        "open(os.path.join(b, 'parameter_values.yaml'), 'w').write("
+        f"'parameterValues:\\n- name: InDir\\n  value: {str(new_dir)}\\n')\n"
+    )
+    (bundle / "hooks.yaml").write_text(
+        "version: '1.0'\npreSubmission:\n  - command: python3\n    args: [redirect.py]\n"
+    )
+
+    captured: dict = {}
+
+    def fake_hash(*args, **kwargs):
+        groups = kwargs.get("asset_groups", args[0] if args else [])
+        inputs: set = set()
+        for group in groups:
+            inputs |= {str(p) for p in getattr(group, "inputs", set())}
+        captured["inputs"] = inputs
+        return [SummaryStatistics(), AssetRootManifest()]
+
+    with (
+        patch.object(_submit_job_bundle.api, "get_boto3_session"),
+        patch.object(_submit_job_bundle.api, "get_boto3_client") as client_mock,
+        patch.object(_submit_job_bundle.api, "get_queue_user_boto3_session"),
+        patch.object(S3AssetManager, "hash_assets_and_create_manifest", side_effect=fake_hash),
+        patch.object(S3AssetManager, "upload_assets") as mock_upload_assets,
+        patch.object(_submit_job_bundle.api, "get_deadline_cloud_library_telemetry_client"),
+    ):
+        client_mock().create_job.side_effect = [MOCK_CREATE_JOB_RESPONSE]
+        client_mock().get_queue.side_effect = [MOCK_GET_QUEUE_RESPONSE]
+        mock_upload_assets.return_value = [
+            SummaryStatistics(),
+            Attachments(
+                [
+                    ManifestProperties(
+                        rootPath=str(tmp_path),
+                        rootPathFormat=PathFormat.POSIX,
+                        inputManifestPath="m",
+                        inputManifestHash="h",
+                        outputRelativeDirectories=["."],
+                    )
+                ]
+            ),
+        ]
+
+        api.create_job_from_job_bundle(
+            job_bundle_dir=str(bundle),
+            queue_parameter_definitions=[],
+            known_asset_paths=[str(tmp_path)],
+            require_paths_exist=False,
+        )
+
+    inputs = captured.get("inputs", set())
+    assert any("new_inputs" in p for p in inputs), "redirected (new) path should be uploaded"
+    assert not any("old_inputs" in p for p in inputs), "stale (old) path must be dropped"

--- a/test/unit/deadline_client/cli/test_cli_bundle_submit_hooks.py
+++ b/test/unit/deadline_client/cli/test_cli_bundle_submit_hooks.py
@@ -1,12 +1,12 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
-"""End-to-end tests for submission hooks through the ``deadline bundle submit`` CLI.
+"""CLI-level tests that a pre-submission hook's parameter changes reach CreateJob.
 
-These drive the real CLI entry point (via ``CliRunner``) against the moto-backed
-``deadline_mock`` fixture — so the full submission pipeline runs, real hook subprocesses
-execute, and we assert on the observable effects (a hook writes a file, rewrites a
-parameter that reaches CreateJob, or fires post-submission). This complements the
-lower-level unit tests in ``test/unit/deadline_client/job_bundle/test_hooks.py``.
+These drive the CLI entry point (via ``CliRunner``) against the moto-backed
+``deadline_mock`` fixture and assert on the exact ``parameters`` sent to CreateJob — which
+the subprocess-based ``test/cli_e2e`` mock backend does not record. The broader "hook runs
+end to end" behaviors (a hook writes a file, post-submission fires, disabled-by-default)
+are covered as true subprocess e2e tests in ``test/cli_e2e/test_bundle_hooks.py``.
 """
 
 import os
@@ -21,7 +21,7 @@ from ..api.test_job_bundle_submission import MOCK_FARM_ID, MOCK_QUEUE_ID
 from ..testing_utilities import MOCK_CREATE_JOB_RESPONSE, MOCK_GET_JOB_RESPONSE
 
 _TEMPLATE = """specificationVersion: 'jobtemplate-2023-09'
-name: HookE2E
+name: HookParamTest
 parameterDefinitions:
 - name: Message
   type: STRING
@@ -58,31 +58,7 @@ def _enable_hooks():
     config.set_setting("settings.auto_accept", "true")
 
 
-def test_e2e_pre_submission_hook_runs_and_writes_file(
-    fresh_deadline_config, deadline_mock, temp_job_bundle_dir, tmp_path
-):
-    """A pre-submission hook executes during ``deadline bundle submit`` and can write a
-    file — proving the hook actually ran in the full CLI pipeline."""
-    _enable_hooks()
-    deadline_mock.create_job.return_value = MOCK_CREATE_JOB_RESPONSE
-    deadline_mock.get_job.return_value = MOCK_GET_JOB_RESPONSE
-
-    sentinel = tmp_path / "hook_ran.txt"
-    _write_hook_bundle(
-        temp_job_bundle_dir,
-        "version: '1.0'\npreSubmission:\n  - command: python3\n    args: [touch.py]\n",
-        ("touch.py", f"open({str(sentinel)!r}, 'w').write('ran')\n"),
-    )
-
-    result = CliRunner().invoke(main, ["bundle", "submit", temp_job_bundle_dir])
-
-    assert result.exit_code == 0, result.output
-    assert sentinel.exists(), "pre-submission hook did not run"
-    assert sentinel.read_text() == "ran"
-    deadline_mock.create_job.assert_called_once()
-
-
-def test_e2e_pre_submission_hook_rewrites_parameter_reaches_create_job(
+def test_pre_submission_hook_rewrites_parameter_reaches_create_job(
     fresh_deadline_config, deadline_mock, temp_job_bundle_dir
 ):
     """A pre-submission hook that rewrites parameter_values.yaml on disk changes the
@@ -112,7 +88,7 @@ def test_e2e_pre_submission_hook_rewrites_parameter_reaches_create_job(
     assert kwargs["parameters"]["Message"] == {"string": "changed_by_hook"}
 
 
-def test_e2e_pre_submission_hook_stdout_parameter_reaches_create_job(
+def test_pre_submission_hook_stdout_parameter_reaches_create_job(
     fresh_deadline_config, deadline_mock, temp_job_bundle_dir
 ):
     """A pre-submission hook that emits a ``parameters`` map on stdout changes the
@@ -137,7 +113,7 @@ def test_e2e_pre_submission_hook_stdout_parameter_reaches_create_job(
     assert kwargs["parameters"]["Message"] == {"string": "changed_via_stdout"}
 
 
-def test_e2e_cli_parameter_takes_precedence_over_hook(
+def test_cli_parameter_takes_precedence_over_hook(
     fresh_deadline_config, deadline_mock, temp_job_bundle_dir
 ):
     """A CLI ``--parameter`` value wins over a hook-supplied value for the same parameter."""
@@ -162,49 +138,3 @@ def test_e2e_cli_parameter_takes_precedence_over_hook(
     assert result.exit_code == 0, result.output
     kwargs = deadline_mock.create_job.call_args.kwargs
     assert kwargs["parameters"]["Message"] == {"string": "from_cli"}
-
-
-def test_e2e_post_submission_hook_runs_after_create_job(
-    fresh_deadline_config, deadline_mock, temp_job_bundle_dir, tmp_path
-):
-    """A post-submission hook runs after the job is created."""
-    _enable_hooks()
-    deadline_mock.create_job.return_value = MOCK_CREATE_JOB_RESPONSE
-    deadline_mock.get_job.return_value = MOCK_GET_JOB_RESPONSE
-
-    sentinel = tmp_path / "post_ran.txt"
-    _write_hook_bundle(
-        temp_job_bundle_dir,
-        "version: '1.0'\npostSubmission:\n  - command: python3\n    args: [post.py]\n",
-        ("post.py", f"open({str(sentinel)!r}, 'w').write('post')\n"),
-    )
-
-    result = CliRunner().invoke(main, ["bundle", "submit", temp_job_bundle_dir])
-
-    assert result.exit_code == 0, result.output
-    deadline_mock.create_job.assert_called_once()
-    assert sentinel.exists(), "post-submission hook did not run"
-
-
-def test_e2e_bundle_hooks_disabled_by_default_does_not_run(
-    fresh_deadline_config, deadline_mock, temp_job_bundle_dir, tmp_path
-):
-    """With allow_bundle_hooks unset, a bundle hook does not run (security default)."""
-    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
-    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
-    config.set_setting("settings.auto_accept", "true")
-    # deliberately NOT enabling allow_bundle_hooks
-    deadline_mock.create_job.return_value = MOCK_CREATE_JOB_RESPONSE
-    deadline_mock.get_job.return_value = MOCK_GET_JOB_RESPONSE
-
-    sentinel = tmp_path / "should_not_exist.txt"
-    _write_hook_bundle(
-        temp_job_bundle_dir,
-        "version: '1.0'\npreSubmission:\n  - command: python3\n    args: [touch.py]\n",
-        ("touch.py", f"open({str(sentinel)!r}, 'w').write('ran')\n"),
-    )
-
-    result = CliRunner().invoke(main, ["bundle", "submit", temp_job_bundle_dir])
-
-    assert result.exit_code == 0, result.output
-    assert not sentinel.exists(), "bundle hook ran despite allow_bundle_hooks not being set"

--- a/test/unit/deadline_client/cli/test_cli_bundle_submit_hooks.py
+++ b/test/unit/deadline_client/cli/test_cli_bundle_submit_hooks.py
@@ -1,0 +1,210 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""End-to-end tests for submission hooks through the ``deadline bundle submit`` CLI.
+
+These drive the real CLI entry point (via ``CliRunner``) against the moto-backed
+``deadline_mock`` fixture — so the full submission pipeline runs, real hook subprocesses
+execute, and we assert on the observable effects (a hook writes a file, rewrites a
+parameter that reaches CreateJob, or fires post-submission). This complements the
+lower-level unit tests in ``test/unit/deadline_client/job_bundle/test_hooks.py``.
+"""
+
+import os
+import textwrap
+
+from click.testing import CliRunner
+
+from deadline.client import config
+from deadline.client.cli import main
+
+from ..api.test_job_bundle_submission import MOCK_FARM_ID, MOCK_QUEUE_ID
+from ..testing_utilities import MOCK_CREATE_JOB_RESPONSE, MOCK_GET_JOB_RESPONSE
+
+_TEMPLATE = """specificationVersion: 'jobtemplate-2023-09'
+name: HookE2E
+parameterDefinitions:
+- name: Message
+  type: STRING
+  default: original_message
+steps:
+- name: S
+  script:
+    actions:
+      onRun:
+        command: echo
+"""
+
+_PARAM_VALUES = "parameterValues:\n- name: Message\n  value: original_message\n"
+
+
+def _write(path, contents):
+    with open(path, "w", encoding="utf8") as f:
+        f.write(contents)
+
+
+def _write_hook_bundle(bundle_dir, hooks_yaml, *scripts):
+    """Write template, parameter_values, hooks.yaml, and any (name, contents) scripts."""
+    _write(os.path.join(bundle_dir, "template.yaml"), _TEMPLATE)
+    _write(os.path.join(bundle_dir, "parameter_values.yaml"), _PARAM_VALUES)
+    _write(os.path.join(bundle_dir, "hooks.yaml"), hooks_yaml)
+    for name, contents in scripts:
+        _write(os.path.join(bundle_dir, name), textwrap.dedent(contents))
+
+
+def _enable_hooks():
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("settings.allow_bundle_hooks", "true")
+    config.set_setting("settings.auto_accept", "true")
+
+
+def test_e2e_pre_submission_hook_runs_and_writes_file(
+    fresh_deadline_config, deadline_mock, temp_job_bundle_dir, tmp_path
+):
+    """A pre-submission hook executes during ``deadline bundle submit`` and can write a
+    file — proving the hook actually ran in the full CLI pipeline."""
+    _enable_hooks()
+    deadline_mock.create_job.return_value = MOCK_CREATE_JOB_RESPONSE
+    deadline_mock.get_job.return_value = MOCK_GET_JOB_RESPONSE
+
+    sentinel = tmp_path / "hook_ran.txt"
+    _write_hook_bundle(
+        temp_job_bundle_dir,
+        "version: '1.0'\npreSubmission:\n  - command: python3\n    args: [touch.py]\n",
+        ("touch.py", f"open({str(sentinel)!r}, 'w').write('ran')\n"),
+    )
+
+    result = CliRunner().invoke(main, ["bundle", "submit", temp_job_bundle_dir])
+
+    assert result.exit_code == 0, result.output
+    assert sentinel.exists(), "pre-submission hook did not run"
+    assert sentinel.read_text() == "ran"
+    deadline_mock.create_job.assert_called_once()
+
+
+def test_e2e_pre_submission_hook_rewrites_parameter_reaches_create_job(
+    fresh_deadline_config, deadline_mock, temp_job_bundle_dir
+):
+    """A pre-submission hook that rewrites parameter_values.yaml on disk changes the
+    parameter value sent to CreateJob."""
+    _enable_hooks()
+    deadline_mock.create_job.return_value = MOCK_CREATE_JOB_RESPONSE
+    deadline_mock.get_job.return_value = MOCK_GET_JOB_RESPONSE
+
+    _write_hook_bundle(
+        temp_job_bundle_dir,
+        "version: '1.0'\npreSubmission:\n  - command: python3\n    args: [rewrite.py]\n",
+        (
+            "rewrite.py",
+            """
+            import os
+            b = os.environ['DEADLINE_JOB_BUNDLE_DIR']
+            open(os.path.join(b, 'parameter_values.yaml'), 'w').write(
+                'parameterValues:\\n- name: Message\\n  value: changed_by_hook\\n')
+            """,
+        ),
+    )
+
+    result = CliRunner().invoke(main, ["bundle", "submit", temp_job_bundle_dir])
+
+    assert result.exit_code == 0, result.output
+    kwargs = deadline_mock.create_job.call_args.kwargs
+    assert kwargs["parameters"]["Message"] == {"string": "changed_by_hook"}
+
+
+def test_e2e_pre_submission_hook_stdout_parameter_reaches_create_job(
+    fresh_deadline_config, deadline_mock, temp_job_bundle_dir
+):
+    """A pre-submission hook that emits a ``parameters`` map on stdout changes the
+    parameter value sent to CreateJob."""
+    _enable_hooks()
+    deadline_mock.create_job.return_value = MOCK_CREATE_JOB_RESPONSE
+    deadline_mock.get_job.return_value = MOCK_GET_JOB_RESPONSE
+
+    _write_hook_bundle(
+        temp_job_bundle_dir,
+        "version: '1.0'\npreSubmission:\n  - command: python3\n    args: [emit.py]\n",
+        (
+            "emit.py",
+            "import json; print(json.dumps({'parameters': {'Message': 'changed_via_stdout'}}))\n",
+        ),
+    )
+
+    result = CliRunner().invoke(main, ["bundle", "submit", temp_job_bundle_dir])
+
+    assert result.exit_code == 0, result.output
+    kwargs = deadline_mock.create_job.call_args.kwargs
+    assert kwargs["parameters"]["Message"] == {"string": "changed_via_stdout"}
+
+
+def test_e2e_cli_parameter_takes_precedence_over_hook(
+    fresh_deadline_config, deadline_mock, temp_job_bundle_dir
+):
+    """A CLI ``--parameter`` value wins over a hook-supplied value for the same parameter."""
+    _enable_hooks()
+    deadline_mock.create_job.return_value = MOCK_CREATE_JOB_RESPONSE
+    deadline_mock.get_job.return_value = MOCK_GET_JOB_RESPONSE
+
+    _write_hook_bundle(
+        temp_job_bundle_dir,
+        "version: '1.0'\npreSubmission:\n  - command: python3\n    args: [emit.py]\n",
+        (
+            "emit.py",
+            "import json; print(json.dumps({'parameters': {'Message': 'from_hook'}}))\n",
+        ),
+    )
+
+    result = CliRunner().invoke(
+        main,
+        ["bundle", "submit", temp_job_bundle_dir, "--parameter", "Message=from_cli"],
+    )
+
+    assert result.exit_code == 0, result.output
+    kwargs = deadline_mock.create_job.call_args.kwargs
+    assert kwargs["parameters"]["Message"] == {"string": "from_cli"}
+
+
+def test_e2e_post_submission_hook_runs_after_create_job(
+    fresh_deadline_config, deadline_mock, temp_job_bundle_dir, tmp_path
+):
+    """A post-submission hook runs after the job is created."""
+    _enable_hooks()
+    deadline_mock.create_job.return_value = MOCK_CREATE_JOB_RESPONSE
+    deadline_mock.get_job.return_value = MOCK_GET_JOB_RESPONSE
+
+    sentinel = tmp_path / "post_ran.txt"
+    _write_hook_bundle(
+        temp_job_bundle_dir,
+        "version: '1.0'\npostSubmission:\n  - command: python3\n    args: [post.py]\n",
+        ("post.py", f"open({str(sentinel)!r}, 'w').write('post')\n"),
+    )
+
+    result = CliRunner().invoke(main, ["bundle", "submit", temp_job_bundle_dir])
+
+    assert result.exit_code == 0, result.output
+    deadline_mock.create_job.assert_called_once()
+    assert sentinel.exists(), "post-submission hook did not run"
+
+
+def test_e2e_bundle_hooks_disabled_by_default_does_not_run(
+    fresh_deadline_config, deadline_mock, temp_job_bundle_dir, tmp_path
+):
+    """With allow_bundle_hooks unset, a bundle hook does not run (security default)."""
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+    config.set_setting("settings.auto_accept", "true")
+    # deliberately NOT enabling allow_bundle_hooks
+    deadline_mock.create_job.return_value = MOCK_CREATE_JOB_RESPONSE
+    deadline_mock.get_job.return_value = MOCK_GET_JOB_RESPONSE
+
+    sentinel = tmp_path / "should_not_exist.txt"
+    _write_hook_bundle(
+        temp_job_bundle_dir,
+        "version: '1.0'\npreSubmission:\n  - command: python3\n    args: [touch.py]\n",
+        ("touch.py", f"open({str(sentinel)!r}, 'w').write('ran')\n"),
+    )
+
+    result = CliRunner().invoke(main, ["bundle", "submit", temp_job_bundle_dir])
+
+    assert result.exit_code == 0, result.output
+    assert not sentinel.exists(), "bundle hook ran despite allow_bundle_hooks not being set"

--- a/test/unit/deadline_client/job_bundle/test_hooks.py
+++ b/test/unit/deadline_client/job_bundle/test_hooks.py
@@ -1451,6 +1451,89 @@ class TestPreSubmissionHooks:
 
         assert "StepAddedByHook" in template_sent
 
+    def test_stdout_relative_path_parameter_is_rejected(self, fresh_deadline_config, tmp_path):
+        """A hook emitting a relative PATH value on stdout is rejected — a hook does not run
+        from the submitting working directory, so a relative PATH would be ambiguous. Hooks
+        must emit absolute paths (or rewrite parameter_values.yaml on disk)."""
+        bundle = str(tmp_path / "bundle")
+        os.makedirs(bundle)
+        self._configure()
+        template = (
+            "specificationVersion: 'jobtemplate-2023-09'\n"
+            "name: PathHookTest\n"
+            "parameterDefinitions:\n"
+            "- name: ScenePath\n"
+            "  type: PATH\n"
+            "  dataFlow: NONE\n"
+            "  default: placeholder.ma\n"
+            "steps:\n"
+            "- name: StepOriginal\n"
+            "  script:\n"
+            "    actions:\n"
+            "      onRun:\n"
+            "        command: echo\n"
+        )
+        with open(os.path.join(bundle, "template.yaml"), "w", encoding="utf8") as f:
+            f.write(template)
+        with open(os.path.join(bundle, "emit.py"), "w", encoding="utf8") as f:
+            f.write(
+                "import json\n"
+                "print(json.dumps({'parameters': {'ScenePath': 'relative/scene.ma'}}))\n"
+            )
+        with open(os.path.join(bundle, "hooks.yaml"), "w", encoding="utf8") as f:
+            f.write("version: '1.0'\npreSubmission:\n  - command: python3\n    args: [emit.py]\n")
+
+        with patch_calls_for_create_job_from_job_bundle():
+            with pytest.raises(DeadlineOperationError, match="relative PATH"):
+                api.create_job_from_job_bundle(
+                    job_bundle_dir=bundle, queue_parameter_definitions=[]
+                )
+
+    def test_stdout_absolute_path_parameter_is_respected(self, fresh_deadline_config, tmp_path):
+        """An absolute PATH value emitted on stdout is accepted and reaches CreateJob."""
+        bundle = str(tmp_path / "bundle")
+        os.makedirs(bundle)
+        self._configure()
+        abs_scene = os.path.abspath(os.path.join(str(tmp_path), "scene.ma"))
+        template = (
+            "specificationVersion: 'jobtemplate-2023-09'\n"
+            "name: PathHookTest\n"
+            "parameterDefinitions:\n"
+            "- name: ScenePath\n"
+            "  type: PATH\n"
+            "  dataFlow: NONE\n"
+            "  default: placeholder.ma\n"
+            "steps:\n"
+            "- name: StepOriginal\n"
+            "  script:\n"
+            "    actions:\n"
+            "      onRun:\n"
+            "        command: echo\n"
+        )
+        with open(os.path.join(bundle, "template.yaml"), "w", encoding="utf8") as f:
+            f.write(template)
+        with open(os.path.join(bundle, "emit.py"), "w", encoding="utf8") as f:
+            f.write(
+                "import json\n"
+                f"print(json.dumps({{'parameters': {{'ScenePath': {abs_scene!r}}}}}))\n"
+            )
+        with open(os.path.join(bundle, "hooks.yaml"), "w", encoding="utf8") as f:
+            f.write("version: '1.0'\npreSubmission:\n  - command: python3\n    args: [emit.py]\n")
+
+        with patch_calls_for_create_job_from_job_bundle() as mock:
+            api.create_job_from_job_bundle(job_bundle_dir=bundle, queue_parameter_definitions=[])
+            kwargs = mock.get_boto3_client().create_job.call_args.kwargs
+            params = kwargs.get("parameters")
+
+        scene_value = None
+        if isinstance(params, list):
+            for p in params:
+                if p.get("name") == "ScenePath":
+                    scene_value = p.get("value")
+        elif isinstance(params, dict) and "ScenePath" in params:
+            scene_value = next(iter(params["ScenePath"].values()))
+        assert scene_value == abs_scene
+
 
 class TestPreGuiHooks:
     """Tests for pre-GUI hooks."""

--- a/test/unit/deadline_client/job_bundle/test_hooks.py
+++ b/test/unit/deadline_client/job_bundle/test_hooks.py
@@ -12,6 +12,7 @@ import yaml
 
 from typing import List
 
+from deadline.client import api, config
 from deadline.client.exceptions import DeadlineOperationError
 from deadline.client.job_bundle._hooks import (
     HookConfiguration,
@@ -19,6 +20,7 @@ from deadline.client.job_bundle._hooks import (
     HookManager,
     HookMetadata,
     HookResult,
+    collect_pre_gui_hook_sources,
 )
 from deadline.client.job_bundle._hooks._merger import merge_asset_references, merge_payload
 from deadline.client.job_bundle._hooks._validator import (
@@ -26,6 +28,8 @@ from deadline.client.job_bundle._hooks._validator import (
     validate_configuration,
     validate_modified_payload,
 )
+
+from ..testing_utilities import patch_calls_for_create_job_from_job_bundle
 
 
 class TestHookDefinition:
@@ -277,6 +281,15 @@ class TestValidateModifiedPayload:
                 {"attachments": {"assetReferences": {"inputFilenames": "not list"}}}, "test_hook"
             )
 
+    def test_valid_parameters_object(self):
+        """A 'parameters' object is accepted."""
+        validate_modified_payload({"parameters": {"Foo": "bar"}}, "test_hook")
+
+    def test_invalid_parameters_not_dict(self):
+        """A 'parameters' value that is not an object is rejected with a clear error."""
+        with pytest.raises(DeadlineOperationError, match="'parameters' must be an object"):
+            validate_modified_payload({"parameters": "not a dict"}, "test_hook")
+
 
 class TestMergeAssetReferences:
     """Tests for asset reference merging."""
@@ -357,6 +370,20 @@ class TestMergePayload:
         result = merge_payload(original, modified)
         assert result["attachments"]["assetReferences"]["inputFilenames"] == ["/b.txt"]
         assert result["attachments"]["fileSystem"] == "COPIED"
+
+    def test_merge_parameters_per_key(self):
+        """Parameters merge per-key across sequential merges (multiple pre-submission
+        hooks) so a later hook does not discard parameters set by an earlier one."""
+        # Simulates hook #1 then hook #2 each emitting a parameters map.
+        after_hook_1 = merge_payload({}, {"parameters": {"A": "1"}})
+        after_hook_2 = merge_payload(after_hook_1, {"parameters": {"B": "2"}})
+        assert after_hook_2["parameters"] == {"A": "1", "B": "2"}
+
+    def test_merge_parameters_later_overrides_same_key(self):
+        """On a key conflict, the later hook wins."""
+        after_hook_1 = merge_payload({}, {"parameters": {"A": "1"}})
+        after_hook_2 = merge_payload(after_hook_1, {"parameters": {"A": "2"}})
+        assert after_hook_2["parameters"] == {"A": "2"}
 
 
 class TestHookManager:
@@ -1261,3 +1288,215 @@ class TestExecuteBeforeGUIHooks:
         message = _generate_hooks_confirmation_message(hooks, "/bundle")
         assert "Pre-GUI hooks:" in message
         assert "python prefill.py" in message
+
+
+_PARAM_MOCK_FARM_ID = "farm-0123456789abcdef0123456789abcdef"
+_PARAM_MOCK_QUEUE_ID = "queue-0123456789abcdef0123456789abcdef"
+
+_PARAM_TEMPLATE = """specificationVersion: 'jobtemplate-2023-09'
+name: ParamHookTest
+parameterDefinitions:
+- name: Foo
+  type: STRING
+  default: original_value
+steps:
+- name: StepOriginal
+  script:
+    actions:
+      onRun:
+        command: echo
+"""
+
+
+def _write_param_bundle(bundle_dir):
+    with open(os.path.join(bundle_dir, "template.yaml"), "w", encoding="utf8") as f:
+        f.write(_PARAM_TEMPLATE)
+    with open(os.path.join(bundle_dir, "parameter_values.yaml"), "w", encoding="utf8") as f:
+        f.write("parameterValues:\n- name: Foo\n  value: original_value\n")
+
+
+def _foo_value_sent_to_create_job(mock):
+    kwargs = mock.get_boto3_client().create_job.call_args.kwargs
+    params = kwargs.get("parameters")
+    if isinstance(params, list):
+        for p in params:
+            if p.get("name") == "Foo":
+                return p.get("value")
+    elif isinstance(params, dict) and "Foo" in params:
+        return next(iter(params["Foo"].values()))
+    return None
+
+
+class TestPreSubmissionHooks:
+    """Tests for pre-submission hooks.
+
+    A pre-submission hook changing a parameter value should reach CreateJob via both
+    channels: rewriting parameter_values.yaml on disk, and emitting a ``parameters`` map on
+    stdout. A template edit on disk is also honored (template test).
+    """
+
+    def _configure(self):
+        config.set_setting("defaults.farm_id", _PARAM_MOCK_FARM_ID)
+        config.set_setting("defaults.queue_id", _PARAM_MOCK_QUEUE_ID)
+        config.set_setting("settings.allow_bundle_hooks", "true")
+        config.set_setting("settings.auto_accept", "true")
+
+    def test_ondisk_param_change_is_respected(self, fresh_deadline_config, tmp_path):
+        """A hook that rewrites parameter_values.yaml on disk should change the value
+        sent to CreateJob."""
+        bundle = str(tmp_path / "bundle")
+        os.makedirs(bundle)
+        self._configure()
+        _write_param_bundle(bundle)
+        with open(os.path.join(bundle, "rewrite.py"), "w", encoding="utf8") as f:
+            f.write(
+                "import os\n"
+                "b = os.environ['DEADLINE_JOB_BUNDLE_DIR']\n"
+                "open(os.path.join(b, 'parameter_values.yaml'), 'w').write("
+                "'parameterValues:\\n- name: Foo\\n  value: CHANGED_ON_DISK\\n')\n"
+            )
+        with open(os.path.join(bundle, "hooks.yaml"), "w", encoding="utf8") as f:
+            f.write(
+                "version: '1.0'\npreSubmission:\n  - command: python3\n    args: [rewrite.py]\n"
+            )
+
+        with patch_calls_for_create_job_from_job_bundle() as mock:
+            api.create_job_from_job_bundle(job_bundle_dir=bundle, queue_parameter_definitions=[])
+            foo = _foo_value_sent_to_create_job(mock)
+
+        assert foo == "CHANGED_ON_DISK"
+
+    def test_stdout_parameters_are_respected(self, fresh_deadline_config, tmp_path):
+        """A hook emitting {"parameters": {"Foo": "..."}} on stdout should change the value
+        sent to CreateJob."""
+        bundle = str(tmp_path / "bundle")
+        os.makedirs(bundle)
+        self._configure()
+        _write_param_bundle(bundle)
+        with open(os.path.join(bundle, "emit.py"), "w", encoding="utf8") as f:
+            f.write(
+                "import json\nprint(json.dumps({'parameters': {'Foo': 'CHANGED_VIA_STDOUT'}}))\n"
+            )
+        with open(os.path.join(bundle, "hooks.yaml"), "w", encoding="utf8") as f:
+            f.write("version: '1.0'\npreSubmission:\n  - command: python3\n    args: [emit.py]\n")
+
+        with patch_calls_for_create_job_from_job_bundle() as mock:
+            api.create_job_from_job_bundle(job_bundle_dir=bundle, queue_parameter_definitions=[])
+            foo = _foo_value_sent_to_create_job(mock)
+
+        assert foo == "CHANGED_VIA_STDOUT"
+
+    def test_ondisk_template_change_is_respected(self, fresh_deadline_config, tmp_path):
+        """An on-disk TEMPLATE edit IS honored (template re-read from disk after hooks).
+        Confirms the template-vs-parameter difference and that the hook ran."""
+        bundle = str(tmp_path / "bundle")
+        os.makedirs(bundle)
+        self._configure()
+        _write_param_bundle(bundle)
+        new_template = _PARAM_TEMPLATE + (
+            "- name: StepAddedByHook\n"
+            "  script:\n"
+            "    actions:\n"
+            "      onRun:\n"
+            "        command: echo\n"
+        )
+        with open(os.path.join(bundle, "addstep.py"), "w", encoding="utf8") as f:
+            f.write(
+                "import os\n"
+                "b = os.environ['DEADLINE_JOB_BUNDLE_DIR']\n"
+                f"open(os.path.join(b, 'template.yaml'), 'w').write({new_template!r})\n"
+            )
+        with open(os.path.join(bundle, "hooks.yaml"), "w", encoding="utf8") as f:
+            f.write(
+                "version: '1.0'\npreSubmission:\n  - command: python3\n    args: [addstep.py]\n"
+            )
+
+        with patch_calls_for_create_job_from_job_bundle() as mock:
+            api.create_job_from_job_bundle(job_bundle_dir=bundle, queue_parameter_definitions=[])
+            template_sent = mock.get_boto3_client().create_job.call_args.kwargs.get("template", "")
+
+        assert "StepAddedByHook" in template_sent
+
+
+class TestPreGuiHooks:
+    """Tests for pre-GUI hooks."""
+
+    @staticmethod
+    def _write_pre_gui_hooks(directory):
+        """Write a hooks.yaml with a single preGUI hook into ``directory``."""
+        with open(os.path.join(directory, "hooks.yaml"), "w", encoding="utf8") as f:
+            f.write("version: '1.0'\npreGUI:\n  - command: python3\n    args: [x.py]\n")
+
+    def test_env_dir_pregui_hooks_are_collected(self, tmp_path):
+        """A DEADLINE_HOOKS_DIR with preGUI hooks (and no bundle hooks) is collected as a
+        source when environment hooks are allowed. This is the #2 fix — the loader must
+        consult DEADLINE_HOOKS_DIR, not just the bundle dir."""
+        bundle = str(tmp_path / "bundle")
+        studio = str(tmp_path / "studio")
+        os.makedirs(bundle)
+        os.makedirs(studio)
+        self._write_pre_gui_hooks(studio)  # bundle has no hooks.yaml
+
+        sources = collect_pre_gui_hook_sources(
+            bundle_dir=bundle,
+            env_hooks_dir=studio,
+            allow_bundle_hooks=True,
+            allow_environment_hooks=True,
+            print_callback=lambda _msg: None,
+        )
+
+        assert [m.job_bundle_dir for m in sources] == [studio]
+
+    def test_env_dir_ignored_when_env_hooks_disabled(self, tmp_path):
+        """With environment hooks disabled, a DEADLINE_HOOKS_DIR preGUI hook is not run."""
+        bundle = str(tmp_path / "bundle")
+        studio = str(tmp_path / "studio")
+        os.makedirs(bundle)
+        os.makedirs(studio)
+        self._write_pre_gui_hooks(studio)
+
+        sources = collect_pre_gui_hook_sources(
+            bundle_dir=bundle,
+            env_hooks_dir=studio,
+            allow_bundle_hooks=True,
+            allow_environment_hooks=False,
+            print_callback=lambda _msg: None,
+        )
+
+        assert sources == []
+
+    def test_env_and_bundle_ordering(self, tmp_path):
+        """When both sources have preGUI hooks and are enabled, environment hooks come
+        first, then bundle hooks."""
+        bundle = str(tmp_path / "bundle")
+        studio = str(tmp_path / "studio")
+        os.makedirs(bundle)
+        os.makedirs(studio)
+        self._write_pre_gui_hooks(bundle)
+        self._write_pre_gui_hooks(studio)
+
+        sources = collect_pre_gui_hook_sources(
+            bundle_dir=bundle,
+            env_hooks_dir=studio,
+            allow_bundle_hooks=True,
+            allow_environment_hooks=True,
+            print_callback=lambda _msg: None,
+        )
+
+        assert [m.job_bundle_dir for m in sources] == [studio, bundle]
+
+    def test_bundle_hooks_ignored_when_bundle_hooks_disabled(self, tmp_path):
+        """With bundle hooks disabled, a bundle preGUI hook is not run."""
+        bundle = str(tmp_path / "bundle")
+        os.makedirs(bundle)
+        self._write_pre_gui_hooks(bundle)
+
+        sources = collect_pre_gui_hook_sources(
+            bundle_dir=bundle,
+            env_hooks_dir=None,
+            allow_bundle_hooks=False,
+            allow_environment_hooks=True,
+            print_callback=lambda _msg: None,
+        )
+
+        assert sources == []

--- a/test/unit/deadline_client/job_bundle/test_hooks.py
+++ b/test/unit/deadline_client/job_bundle/test_hooks.py
@@ -1139,6 +1139,40 @@ class TestExecuteBeforeGUIHooks:
             assert result["name"] == "Prefilled Job"
             assert result["parameters"] == {"deadline:priority": 80, "Foo": "bar"}
 
+    def test_metadata_job_bundle_dir_is_respected(self):
+        """execute_pre_gui_hooks must NOT override metadata.job_bundle_dir with the
+        manager's own directory. The hook should receive the job_bundle_dir the caller set
+        (the real bundle), even when the hooks live in a different directory (e.g. an
+        environment DEADLINE_HOOKS_DIR). Relative script paths still resolve against the
+        manager's directory."""
+        with (
+            tempfile.TemporaryDirectory() as hooks_dir,
+            tempfile.TemporaryDirectory() as bundle_dir,
+        ):
+            hooks_file = os.path.join(hooks_dir, "hooks.yaml")
+            # The hook echoes the DEADLINE_JOB_BUNDLE_DIR it was given as the job name.
+            with open(hooks_file, "w") as f:
+                yaml.dump(
+                    {
+                        "preGUI": [
+                            {
+                                "command": sys.executable,
+                                "args": [
+                                    "-c",
+                                    "import os, json; "
+                                    "print(json.dumps({'name': os.environ['DEADLINE_JOB_BUNDLE_DIR']}))",
+                                ],
+                            }
+                        ]
+                    },
+                    f,
+                )
+            manager = HookManager(hooks_dir, lambda x: None)
+            manager.load_hooks()
+            # Caller sets job_bundle_dir to the real bundle, distinct from hooks_dir.
+            result = manager.execute_pre_gui_hooks(self._make_metadata(bundle_dir))
+            assert result["name"] == bundle_dir  # not hooks_dir
+
     def test_later_hook_overrides_scalar(self):
         """Later hooks override earlier hooks for scalar fields like name."""
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/test/unit/deadline_client/job_bundle/test_hooks.py
+++ b/test/unit/deadline_client/job_bundle/test_hooks.py
@@ -1159,8 +1159,8 @@ class TestExecuteBeforeGUIHooks:
                                 "command": sys.executable,
                                 "args": [
                                     "-c",
-                                    "import os, json; "
-                                    "print(json.dumps({'name': os.environ['DEADLINE_JOB_BUNDLE_DIR']}))",
+                                    "import os, json; print(json.dumps("
+                                    + "{'name': os.environ['DEADLINE_JOB_BUNDLE_DIR']}))",
                                 ],
                             }
                         ]
@@ -1534,3 +1534,37 @@ class TestPreGuiHooks:
         )
 
         assert sources == []
+
+    def test_env_dir_equal_to_bundle_dir_is_not_duplicated(self, tmp_path):
+        """If DEADLINE_HOOKS_DIR points at the job bundle, the shared hooks.yaml yields a
+        single source (not two) so preGUI hooks do not run twice."""
+        bundle = str(tmp_path / "bundle")
+        os.makedirs(bundle)
+        self._write_pre_gui_hooks(bundle)
+
+        sources = collect_pre_gui_hook_sources(
+            bundle_dir=bundle,
+            env_hooks_dir=bundle,  # same directory
+            allow_bundle_hooks=True,
+            allow_environment_hooks=True,
+            print_callback=lambda _msg: None,
+        )
+
+        assert [m.job_bundle_dir for m in sources] == [bundle]
+
+    def test_env_dir_equal_to_bundle_dir_runs_when_only_env_hooks_enabled(self, tmp_path):
+        """When env dir == bundle dir, enabling only environment hooks still permits the
+        shared source to run (the single source is gated by either grant)."""
+        bundle = str(tmp_path / "bundle")
+        os.makedirs(bundle)
+        self._write_pre_gui_hooks(bundle)
+
+        sources = collect_pre_gui_hook_sources(
+            bundle_dir=bundle,
+            env_hooks_dir=bundle,
+            allow_bundle_hooks=False,
+            allow_environment_hooks=True,
+            print_callback=lambda _msg: None,
+        )
+
+        assert [m.job_bundle_dir for m in sources] == [bundle]

--- a/test/unit/deadline_client/ui/test_pregui_hooks.py
+++ b/test/unit/deadline_client/ui/test_pregui_hooks.py
@@ -1,0 +1,239 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Tests that preGUI submission hooks work as expected on the gui-submit path.
+
+These exercise ``show_job_bundle_submitter`` with the Qt-heavy dependencies patched (no
+GUI binding required), focusing on hook *behavior*: environment (DEADLINE_HOOKS_DIR) hooks
+are loaded in addition to bundle hooks, and a preGUI hook's output (name, description,
+parameters) is applied to the dialog's initial settings. The gating rules (allow_bundle_hooks)
+are covered separately in ``test_pregui_hooks_permission.py``.
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+from deadline.client.job_bundle._hooks import HookConfiguration, HookDefinition
+from deadline.client.ui.job_bundle_submitter import show_job_bundle_submitter
+
+MODULE = "deadline.client.ui.job_bundle_submitter"
+
+
+def _pre_gui_config(pre_gui=True):
+    return HookConfiguration(
+        version="1.0",
+        pre_gui=[HookDefinition(command="python", args=["prefill.py"])] if pre_gui else [],
+        pre_submission=[],
+        post_submission=[],
+    )
+
+
+def _run_submitter(bundle_dir, settings_map, hook_manager, *, env=None):
+    """Drive show_job_bundle_submitter with Qt/deps patched, returning the constructed
+    SubmitJobToDeadlineDialog mock so callers can inspect the initial settings passed to it."""
+
+    def fake_get_setting(name, config=None):
+        return settings_map.get(name, "false")
+
+    template = {"name": "Bundle Job", "steps": []}
+    with (
+        patch(f"{MODULE}.validate_directory_symlink_containment"),
+        patch(
+            f"{MODULE}.read_yaml_or_json_object",
+            side_effect=lambda _dir, name, *a, **k: template if name == "template" else None,
+        ),
+        patch(f"{MODULE}.read_job_bundle_parameters", return_value=[]),
+        patch(f"{MODULE}._HookManager", return_value=hook_manager),
+        patch(f"{MODULE}.SubmitJobToDeadlineDialog") as dialog_cls,
+        patch(f"{MODULE}.QApplication"),
+        patch(f"{MODULE}.QMessageBox"),
+        patch(f"{MODULE}._get_setting", side_effect=fake_get_setting),
+        patch(f"{MODULE}._config_file") as mock_config_file,
+        patch.dict(os.environ, env or {}, clear=False),
+    ):
+        mock_config_file.str2bool.side_effect = lambda v: str(v).lower() == "true"
+        show_job_bundle_submitter(input_job_bundle_dir=bundle_dir)
+    return dialog_cls
+
+
+def _make_bundle(tmp_path):
+    bundle_dir = str(tmp_path / "bundle")
+    os.makedirs(bundle_dir)
+    with open(os.path.join(bundle_dir, "template.yaml"), "w") as f:
+        f.write("name: Bundle Job\nsteps: []\n")
+    return bundle_dir
+
+
+class TestPreGuiHookOutputApplied:
+    """A preGUI hook's output is applied to the dialog's initial settings."""
+
+    def test_hook_name_applied_to_initial_settings(self, tmp_path):
+        bundle_dir = _make_bundle(tmp_path)
+        hook_manager = MagicMock()
+        hook_manager.hooks = _pre_gui_config()
+        hook_manager.load_hooks.return_value = hook_manager.hooks
+        hook_manager._original_bundle_dir = bundle_dir
+        hook_manager.execute_pre_gui_hooks.return_value = {"name": "PREGUI_RAN"}
+
+        dialog_cls = _run_submitter(
+            bundle_dir,
+            {"settings.allow_bundle_hooks": "true", "settings.auto_accept": "true"},
+            hook_manager,
+        )
+
+        hook_manager.execute_pre_gui_hooks.assert_called_once()
+        initial_settings = dialog_cls.call_args.kwargs["initial_job_settings"]
+        assert initial_settings.name == "PREGUI_RAN"
+
+    def test_hook_description_applied_to_initial_settings(self, tmp_path):
+        bundle_dir = _make_bundle(tmp_path)
+        hook_manager = MagicMock()
+        hook_manager.hooks = _pre_gui_config()
+        hook_manager.load_hooks.return_value = hook_manager.hooks
+        hook_manager._original_bundle_dir = bundle_dir
+        hook_manager.execute_pre_gui_hooks.return_value = {"description": "from pipeline"}
+
+        dialog_cls = _run_submitter(
+            bundle_dir,
+            {"settings.allow_bundle_hooks": "true", "settings.auto_accept": "true"},
+            hook_manager,
+        )
+
+        initial_settings = dialog_cls.call_args.kwargs["initial_job_settings"]
+        assert initial_settings.description == "from pipeline"
+
+    def test_hook_shared_parameter_applied(self, tmp_path):
+        """A deadline: shared job property from the hook flows into the initial shared
+        parameter values passed to the dialog."""
+        bundle_dir = _make_bundle(tmp_path)
+        hook_manager = MagicMock()
+        hook_manager.hooks = _pre_gui_config()
+        hook_manager.load_hooks.return_value = hook_manager.hooks
+        hook_manager._original_bundle_dir = bundle_dir
+        hook_manager.execute_pre_gui_hooks.return_value = {"parameters": {"deadline:priority": 90}}
+
+        dialog_cls = _run_submitter(
+            bundle_dir,
+            {"settings.allow_bundle_hooks": "true", "settings.auto_accept": "true"},
+            hook_manager,
+        )
+
+        shared = dialog_cls.call_args.kwargs["initial_shared_parameter_values"]
+        assert shared.get("deadline:priority") == 90
+
+    def test_no_pre_gui_hooks_no_execution(self, tmp_path):
+        """A bundle without preGUI hooks does not invoke execute_pre_gui_hooks."""
+        bundle_dir = _make_bundle(tmp_path)
+        hook_manager = MagicMock()
+        hook_manager.hooks = _pre_gui_config(pre_gui=False)
+        hook_manager.load_hooks.return_value = hook_manager.hooks
+        hook_manager._original_bundle_dir = bundle_dir
+
+        _run_submitter(
+            bundle_dir,
+            {"settings.allow_bundle_hooks": "true", "settings.auto_accept": "true"},
+            hook_manager,
+        )
+
+        hook_manager.execute_pre_gui_hooks.assert_not_called()
+
+
+class TestPreGuiEnvironmentHooksLoaded:
+    """PreGUI hooks are loaded from DEADLINE_HOOKS_DIR, not just the job bundle."""
+
+    def test_env_hooks_dir_is_used_as_a_source(self, tmp_path):
+        """With DEADLINE_HOOKS_DIR set and environment hooks enabled, a _HookManager is
+        constructed for the env dir (the #2 fix — the loader must consult it)."""
+        bundle_dir = _make_bundle(tmp_path)
+        studio = str(tmp_path / "studio")
+        os.makedirs(studio)
+
+        constructed_with = []
+
+        def factory(job_bundle_dir, *a, **k):
+            constructed_with.append(job_bundle_dir)
+            m = MagicMock()
+            m.hooks = _pre_gui_config()
+            m.load_hooks.return_value = m.hooks
+            m._original_bundle_dir = job_bundle_dir
+            m.execute_pre_gui_hooks.return_value = {}
+            return m
+
+        def fake_get_setting(name, config=None):
+            return {
+                "settings.allow_bundle_hooks": "true",
+                "settings.allow_environment_hooks": "true",
+                "settings.auto_accept": "true",
+            }.get(name, "false")
+
+        template = {"name": "Bundle Job", "steps": []}
+        with (
+            patch(f"{MODULE}.validate_directory_symlink_containment"),
+            patch(
+                f"{MODULE}.read_yaml_or_json_object",
+                side_effect=lambda _dir, name, *a, **k: template if name == "template" else None,
+            ),
+            patch(f"{MODULE}.read_job_bundle_parameters", return_value=[]),
+            patch(f"{MODULE}._HookManager", side_effect=factory),
+            patch(f"{MODULE}.SubmitJobToDeadlineDialog"),
+            patch(f"{MODULE}.QApplication"),
+            patch(f"{MODULE}.QMessageBox"),
+            patch(f"{MODULE}._get_setting", side_effect=fake_get_setting),
+            patch(f"{MODULE}._config_file") as mock_config_file,
+            patch.dict(os.environ, {"DEADLINE_HOOKS_DIR": studio}, clear=False),
+        ):
+            mock_config_file.str2bool.side_effect = lambda v: str(v).lower() == "true"
+            show_job_bundle_submitter(input_job_bundle_dir=bundle_dir)
+
+        assert studio in constructed_with  # env dir was consulted
+        assert bundle_dir in constructed_with
+
+    def test_env_hooks_dir_ignored_when_env_hooks_disabled(self, tmp_path):
+        """A preGUI hook in DEADLINE_HOOKS_DIR does not run when environment hooks are
+        disabled (only the bundle source, which here has none, is considered)."""
+        bundle_dir = _make_bundle(tmp_path)
+        studio = str(tmp_path / "studio")
+        os.makedirs(studio)
+
+        executed = []
+
+        def factory(job_bundle_dir, *a, **k):
+            m = MagicMock()
+            # Only the env dir has preGUI hooks; the bundle has none.
+            m.hooks = _pre_gui_config(pre_gui=(job_bundle_dir == studio))
+            m.load_hooks.return_value = m.hooks
+            m._original_bundle_dir = job_bundle_dir
+
+            def _exec(_meta):
+                executed.append(job_bundle_dir)
+                return {}
+
+            m.execute_pre_gui_hooks.side_effect = _exec
+            return m
+
+        def fake_get_setting(name, config=None):
+            return {
+                "settings.allow_bundle_hooks": "true",
+                "settings.allow_environment_hooks": "false",
+                "settings.auto_accept": "true",
+            }.get(name, "false")
+
+        template = {"name": "Bundle Job", "steps": []}
+        with (
+            patch(f"{MODULE}.validate_directory_symlink_containment"),
+            patch(
+                f"{MODULE}.read_yaml_or_json_object",
+                side_effect=lambda _dir, name, *a, **k: template if name == "template" else None,
+            ),
+            patch(f"{MODULE}.read_job_bundle_parameters", return_value=[]),
+            patch(f"{MODULE}._HookManager", side_effect=factory),
+            patch(f"{MODULE}.SubmitJobToDeadlineDialog"),
+            patch(f"{MODULE}.QApplication"),
+            patch(f"{MODULE}.QMessageBox"),
+            patch(f"{MODULE}._get_setting", side_effect=fake_get_setting),
+            patch(f"{MODULE}._config_file") as mock_config_file,
+            patch.dict(os.environ, {"DEADLINE_HOOKS_DIR": studio}, clear=False),
+        ):
+            mock_config_file.str2bool.side_effect = lambda v: str(v).lower() == "true"
+            show_job_bundle_submitter(input_job_bundle_dir=bundle_dir)
+
+        assert executed == []  # env preGUI hook did not run (env hooks disabled)

--- a/test/unit/deadline_client/ui/test_pregui_hooks.py
+++ b/test/unit/deadline_client/ui/test_pregui_hooks.py
@@ -237,3 +237,79 @@ class TestPreGuiEnvironmentHooksLoaded:
             show_job_bundle_submitter(input_job_bundle_dir=bundle_dir)
 
         assert executed == []  # env preGUI hook did not run (env hooks disabled)
+
+
+class TestPreGuiHookCliPrecedence:
+    """CLI --parameter values take precedence over preGUI hook parameters, for both template
+    and shared parameters. Regression for a bug where template CLI params were popped out of
+    the working dict before the hook merge ran, letting a hook silently override them."""
+
+    def _run(self, bundle_dir, hook_manager, bundle_parameters, job_parameters):
+        def fake_get_setting(name, config=None):
+            return {
+                "settings.allow_bundle_hooks": "true",
+                "settings.auto_accept": "true",
+            }.get(name, "false")
+
+        template = {"name": "Bundle Job", "steps": []}
+        with (
+            patch(f"{MODULE}.validate_directory_symlink_containment"),
+            patch(
+                f"{MODULE}.read_yaml_or_json_object",
+                side_effect=lambda _dir, name, *a, **k: template if name == "template" else None,
+            ),
+            patch(f"{MODULE}.read_job_bundle_parameters", return_value=bundle_parameters),
+            patch(f"{MODULE}._HookManager", return_value=hook_manager),
+            patch(f"{MODULE}.SubmitJobToDeadlineDialog") as dialog_cls,
+            patch(f"{MODULE}.QApplication"),
+            patch(f"{MODULE}.QMessageBox"),
+            patch(f"{MODULE}._get_setting", side_effect=fake_get_setting),
+            patch(f"{MODULE}._config_file") as mock_config_file,
+        ):
+            mock_config_file.str2bool.side_effect = lambda v: str(v).lower() == "true"
+            show_job_bundle_submitter(
+                input_job_bundle_dir=bundle_dir, job_parameters=job_parameters
+            )
+        return dialog_cls
+
+    def test_cli_template_parameter_wins_over_hook(self, tmp_path):
+        """A CLI --parameter value for a *template* parameter is not overridden by a preGUI
+        hook emitting the same parameter name."""
+        bundle_dir = _make_bundle(tmp_path)
+        hook_manager = MagicMock()
+        hook_manager.hooks = _pre_gui_config()
+        hook_manager.load_hooks.return_value = hook_manager.hooks
+        hook_manager._original_bundle_dir = bundle_dir
+        hook_manager.execute_pre_gui_hooks.return_value = {"parameters": {"Foo": "hook_value"}}
+
+        dialog_cls = self._run(
+            bundle_dir,
+            hook_manager,
+            bundle_parameters=[{"name": "Foo", "type": "STRING", "default": "bundle_value"}],
+            job_parameters=[{"name": "Foo", "value": "cli_value"}],
+        )
+
+        initial_settings = dialog_cls.call_args.kwargs["initial_job_settings"]
+        foo = next(p for p in initial_settings.parameters if p["name"] == "Foo")
+        assert foo["value"] == "cli_value"
+
+    def test_hook_template_parameter_applied_when_no_cli_value(self, tmp_path):
+        """Without a CLI value, the preGUI hook's template parameter is applied (the guard
+        does not block hook values for parameters the CLI did not supply)."""
+        bundle_dir = _make_bundle(tmp_path)
+        hook_manager = MagicMock()
+        hook_manager.hooks = _pre_gui_config()
+        hook_manager.load_hooks.return_value = hook_manager.hooks
+        hook_manager._original_bundle_dir = bundle_dir
+        hook_manager.execute_pre_gui_hooks.return_value = {"parameters": {"Foo": "hook_value"}}
+
+        dialog_cls = self._run(
+            bundle_dir,
+            hook_manager,
+            bundle_parameters=[{"name": "Foo", "type": "STRING", "default": "bundle_value"}],
+            job_parameters=[],
+        )
+
+        initial_settings = dialog_cls.call_args.kwargs["initial_job_settings"]
+        foo = next(p for p in initial_settings.parameters if p["name"] == "Foo")
+        assert foo["value"] == "hook_value"

--- a/test/unit/deadline_client/ui/test_pregui_hooks_permission.py
+++ b/test/unit/deadline_client/ui/test_pregui_hooks_permission.py
@@ -3,32 +3,38 @@
 """Tests that preGUI bundle hooks are gated solely by allow_bundle_hooks."""
 
 import logging
-import os
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+from deadline.client.job_bundle._hooks import HookConfiguration, HookDefinition
 from deadline.client.ui.job_bundle_submitter import show_job_bundle_submitter
 
 MODULE = "deadline.client.ui.job_bundle_submitter"
 
 
 @pytest.fixture
-def _patch_submitter_deps(tmp_path):
-    """Set up a bundle with a real preGUI hook and patch only the Qt-heavy dependencies of
-    show_job_bundle_submitter. The real pre-GUI source-selection and hook execution run, so
-    a hook that fires writes a sentinel file; the tests assert on its presence."""
-    bundle_dir = str(tmp_path / "bundle")
-    os.makedirs(bundle_dir)
-    with open(os.path.join(bundle_dir, "template.yaml"), "w") as f:
-        f.write("name: Test\nsteps: []\n")
+def hooks_with_pre_gui():
+    """A HookConfiguration that has a preGUI hook defined."""
+    return HookConfiguration(
+        version="1.0",
+        pre_gui=[HookDefinition(command="python", args=["prefill.py"])],
+        pre_submission=[],
+        post_submission=[],
+    )
 
-    # A real preGUI hook that writes a sentinel when it runs.
-    sentinel = str(tmp_path / "pre_gui_ran.txt")
-    with open(os.path.join(bundle_dir, "prefill.py"), "w") as f:
-        f.write(f"open({sentinel!r}, 'w').write('ran')\n")
-    with open(os.path.join(bundle_dir, "hooks.yaml"), "w") as f:
-        f.write("version: '1.0'\npreGUI:\n  - command: python3\n    args: [prefill.py]\n")
+
+@pytest.fixture
+def _patch_submitter_deps(tmp_path, hooks_with_pre_gui):
+    """Patch all heavy dependencies of show_job_bundle_submitter so we can
+    exercise the hooks permission logic without Qt or real file I/O."""
+    bundle_dir = str(tmp_path / "bundle")
+    (tmp_path / "bundle").mkdir()
+    (tmp_path / "bundle" / "template.yaml").write_text("name: Test\nsteps: []\n")
+
+    mock_hook_manager = MagicMock()
+    mock_hook_manager.load_hooks.return_value = hooks_with_pre_gui
+    mock_hook_manager.execute_pre_gui_hooks.return_value = {}
 
     patches = {
         "validate_directory_symlink_containment": patch(
@@ -43,6 +49,7 @@ def _patch_submitter_deps(tmp_path):
         "read_job_bundle_parameters": patch(
             f"{MODULE}.read_job_bundle_parameters", return_value=[]
         ),
+        "HookManager": patch(f"{MODULE}._HookManager", return_value=mock_hook_manager),
         "SubmitJobToDeadlineDialog": patch(f"{MODULE}.SubmitJobToDeadlineDialog"),
         "QApplication": patch(f"{MODULE}.QApplication"),
         "QMessageBox": patch(f"{MODULE}.QMessageBox"),
@@ -54,7 +61,7 @@ def _patch_submitter_deps(tmp_path):
 
     yield {
         "bundle_dir": bundle_dir,
-        "sentinel": sentinel,
+        "hook_manager": mock_hook_manager,
         **started,
     }
 
@@ -91,14 +98,14 @@ class TestPreGuiHooksPermissionGating:
                 },
             )
 
-        assert not os.path.exists(ctx["sentinel"]), "preGUI hook ran despite being disabled"
+        ctx["hook_manager"].execute_pre_gui_hooks.assert_not_called()
         assert "bundle hooks are disabled" in caplog.text
 
     def test_hooks_blocked_even_when_env_hooks_enabled(self, _patch_submitter_deps, caplog):
-        """preGUI bundle hooks must NOT run when only allow_environment_hooks is true.
+        """preGUI hooks must NOT run when only allow_environment_hooks is true.
 
         This is the core security fix: allow_environment_hooks must not bypass
-        the allow_bundle_hooks gate for preGUI bundle hooks.
+        the allow_bundle_hooks gate for preGUI hooks.
         """
         ctx = _patch_submitter_deps
         with caplog.at_level(logging.WARNING):
@@ -110,7 +117,7 @@ class TestPreGuiHooksPermissionGating:
                 },
             )
 
-        assert not os.path.exists(ctx["sentinel"]), "preGUI bundle hook ran despite being disabled"
+        ctx["hook_manager"].execute_pre_gui_hooks.assert_not_called()
         assert "bundle hooks are disabled" in caplog.text
 
     def test_hooks_execute_when_bundle_hooks_enabled(self, _patch_submitter_deps, caplog):
@@ -125,7 +132,7 @@ class TestPreGuiHooksPermissionGating:
                 },
             )
 
-        assert os.path.exists(ctx["sentinel"]), "preGUI hook did not run when enabled"
+        ctx["hook_manager"].execute_pre_gui_hooks.assert_called_once()
         assert "bundle hooks are disabled" not in caplog.text
 
     def test_hooks_execute_without_env_hooks(self, _patch_submitter_deps, caplog):
@@ -142,5 +149,5 @@ class TestPreGuiHooksPermissionGating:
                 },
             )
 
-        assert os.path.exists(ctx["sentinel"]), "preGUI hook did not run when enabled"
+        ctx["hook_manager"].execute_pre_gui_hooks.assert_called_once()
         assert "bundle hooks are disabled" not in caplog.text

--- a/test/unit/deadline_client/ui/test_pregui_hooks_permission.py
+++ b/test/unit/deadline_client/ui/test_pregui_hooks_permission.py
@@ -3,38 +3,32 @@
 """Tests that preGUI bundle hooks are gated solely by allow_bundle_hooks."""
 
 import logging
-from unittest.mock import MagicMock, patch
+import os
+from unittest.mock import patch
 
 import pytest
 
-from deadline.client.job_bundle._hooks import HookConfiguration, HookDefinition
 from deadline.client.ui.job_bundle_submitter import show_job_bundle_submitter
 
 MODULE = "deadline.client.ui.job_bundle_submitter"
 
 
 @pytest.fixture
-def hooks_with_pre_gui():
-    """A HookConfiguration that has a preGUI hook defined."""
-    return HookConfiguration(
-        version="1.0",
-        pre_gui=[HookDefinition(command="python", args=["prefill.py"])],
-        pre_submission=[],
-        post_submission=[],
-    )
-
-
-@pytest.fixture
-def _patch_submitter_deps(tmp_path, hooks_with_pre_gui):
-    """Patch all heavy dependencies of show_job_bundle_submitter so we can
-    exercise the hooks permission logic without Qt or real file I/O."""
+def _patch_submitter_deps(tmp_path):
+    """Set up a bundle with a real preGUI hook and patch only the Qt-heavy dependencies of
+    show_job_bundle_submitter. The real pre-GUI source-selection and hook execution run, so
+    a hook that fires writes a sentinel file; the tests assert on its presence."""
     bundle_dir = str(tmp_path / "bundle")
-    (tmp_path / "bundle").mkdir()
-    (tmp_path / "bundle" / "template.yaml").write_text("name: Test\nsteps: []\n")
+    os.makedirs(bundle_dir)
+    with open(os.path.join(bundle_dir, "template.yaml"), "w") as f:
+        f.write("name: Test\nsteps: []\n")
 
-    mock_hook_manager = MagicMock()
-    mock_hook_manager.load_hooks.return_value = hooks_with_pre_gui
-    mock_hook_manager.execute_pre_gui_hooks.return_value = {}
+    # A real preGUI hook that writes a sentinel when it runs.
+    sentinel = str(tmp_path / "pre_gui_ran.txt")
+    with open(os.path.join(bundle_dir, "prefill.py"), "w") as f:
+        f.write(f"open({sentinel!r}, 'w').write('ran')\n")
+    with open(os.path.join(bundle_dir, "hooks.yaml"), "w") as f:
+        f.write("version: '1.0'\npreGUI:\n  - command: python3\n    args: [prefill.py]\n")
 
     patches = {
         "validate_directory_symlink_containment": patch(
@@ -49,7 +43,6 @@ def _patch_submitter_deps(tmp_path, hooks_with_pre_gui):
         "read_job_bundle_parameters": patch(
             f"{MODULE}.read_job_bundle_parameters", return_value=[]
         ),
-        "HookManager": patch(f"{MODULE}._HookManager", return_value=mock_hook_manager),
         "SubmitJobToDeadlineDialog": patch(f"{MODULE}.SubmitJobToDeadlineDialog"),
         "QApplication": patch(f"{MODULE}.QApplication"),
         "QMessageBox": patch(f"{MODULE}.QMessageBox"),
@@ -61,7 +54,7 @@ def _patch_submitter_deps(tmp_path, hooks_with_pre_gui):
 
     yield {
         "bundle_dir": bundle_dir,
-        "hook_manager": mock_hook_manager,
+        "sentinel": sentinel,
         **started,
     }
 
@@ -98,14 +91,14 @@ class TestPreGuiHooksPermissionGating:
                 },
             )
 
-        ctx["hook_manager"].execute_pre_gui_hooks.assert_not_called()
+        assert not os.path.exists(ctx["sentinel"]), "preGUI hook ran despite being disabled"
         assert "bundle hooks are disabled" in caplog.text
 
     def test_hooks_blocked_even_when_env_hooks_enabled(self, _patch_submitter_deps, caplog):
-        """preGUI hooks must NOT run when only allow_environment_hooks is true.
+        """preGUI bundle hooks must NOT run when only allow_environment_hooks is true.
 
         This is the core security fix: allow_environment_hooks must not bypass
-        the allow_bundle_hooks gate for preGUI hooks.
+        the allow_bundle_hooks gate for preGUI bundle hooks.
         """
         ctx = _patch_submitter_deps
         with caplog.at_level(logging.WARNING):
@@ -117,7 +110,7 @@ class TestPreGuiHooksPermissionGating:
                 },
             )
 
-        ctx["hook_manager"].execute_pre_gui_hooks.assert_not_called()
+        assert not os.path.exists(ctx["sentinel"]), "preGUI bundle hook ran despite being disabled"
         assert "bundle hooks are disabled" in caplog.text
 
     def test_hooks_execute_when_bundle_hooks_enabled(self, _patch_submitter_deps, caplog):
@@ -132,7 +125,7 @@ class TestPreGuiHooksPermissionGating:
                 },
             )
 
-        ctx["hook_manager"].execute_pre_gui_hooks.assert_called_once()
+        assert os.path.exists(ctx["sentinel"]), "preGUI hook did not run when enabled"
         assert "bundle hooks are disabled" not in caplog.text
 
     def test_hooks_execute_without_env_hooks(self, _patch_submitter_deps, caplog):
@@ -149,5 +142,5 @@ class TestPreGuiHooksPermissionGating:
                 },
             )
 
-        ctx["hook_manager"].execute_pre_gui_hooks.assert_called_once()
+        assert os.path.exists(ctx["sentinel"]), "preGUI hook did not run when enabled"
         assert "bundle hooks are disabled" not in caplog.text


### PR DESCRIPTION
## What was the problem?

Two submission-hook gaps, surfaced by customers using DCC submitters:

1. **Pre-submission hooks could not change job parameters.** Parameters were read and
   frozen before hooks ran, so neither a hook rewriting `parameter_values.yaml` on disk
   nor one emitting a `parameters` map on stdout reached CreateJob — only template,
   priority, and asset-reference changes were honored.
2. **Pre-GUI hooks never loaded from `DEADLINE_HOOKS_DIR`.** The pre-GUI loader read only
   the job bundle directory, so environment (studio-wide) pre-GUI hooks never ran on the
   `deadline bundle gui-submit` path.

## What is the solution?

- Re-resolve job parameters after pre-submission hooks run, picking up both on-disk
  `parameter_values.yaml` rewrites and a new stdout `parameters` map. Hook-supplied values
  are layered beneath CLI `--parameter` values, so the CLI keeps precedence. The
  pre-submission output schema now validates a `parameters` object, and multiple hooks'
  parameter maps merge per key.
- Load pre-GUI hooks from `DEADLINE_HOOKS_DIR` in addition to the job bundle. Source
  selection is extracted into a Qt-free `collect_pre_gui_hook_sources()` helper so it can
  be unit-tested without a GUI binding.

## What is the impact?

Studios can use pre-submission hooks to adjust job parameters, and pre-GUI hooks now work
from the environment hooks directory on the standalone GUI submitter. The new
pre-submission `parameters` output is documented in `docs/submission-hooks.md`.

## How was it tested?

- Unit tests in `test/unit/deadline_client/job_bundle/test_hooks.py` covering: on-disk and
  stdout parameter changes reaching CreateJob (with a template-change control), CLI
  precedence over hook values, per-key parameter merge across hooks, `parameters` payload
  validation, and env/bundle pre-GUI source selection and gating.
- Ran `ruff format`, `ruff check`, and `mypy` (repo flags) plus the hook and job-bundle
  submission unit suites locally.

## Notes for reviewers

- **Deferred (out of scope):** making the in-application DCC submitter dialog
  (`SubmitJobToDeadlineDialog`) run pre-GUI hooks. That needs a reusable API for
  `deadline-cloud-for-<dcc>` packages to call and is postponed pending the unified-API
  work. This PR restores the environment pre-GUI path only for `gui-submit`.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.*
