### PR TITLE
fix: regionalize endpoint URL for cross-region API calls

### DIFF
--- a/src/deadline/client/api/_session.py
+++ b/src/deadline/client/api/_session.py
@@ -140,6 +140,23 @@ def get_default_client_config(**kwargs) -> botocore.config.Config:
     return client_config
 
 
+def _regionalize_endpoint_url(url: str, session_region: str, region: str) -> Optional[str]:
+    """
+    Rewrite ``session_region`` to ``region`` in ``url`` only when it appears as a
+    dot-delimited token (e.g. ``.us-west-2.``), returning the rewritten URL.
+
+    Anchoring to ``.<region>.`` avoids mangling URLs where the region string occurs
+    in a non-region position -- e.g. a host like ``us-west-2-corp.example.com`` or an
+    account/stage token that merely contains the region. Returns ``None`` when the
+    session region is not present as such a delimited token, signalling the caller
+    to leave the resolved (custom/private) endpoint untouched.
+    """
+    token = f".{session_region}."
+    if token not in url:
+        return None
+    return url.replace(token, f".{region}.")
+
+
 @lru_cache
 def get_session_client(session: boto3.Session, service_name: str, region: Optional[str] = None):
     """
@@ -149,6 +166,16 @@ def get_session_client(session: boto3.Session, service_name: str, region: Option
     with the same session, service name, and region return the cached client to
     avoid repeating initialization where possible. The ``region`` argument is part
     of the cache key so clients for different regions are never reused for each other.
+
+    When a profile carries a ``[services ...]`` endpoint override, botocore applies that
+    single endpoint to every client regardless of the requested ``region_name``. In a
+    cross-region fan-out each client then signs SigV4 for its own region but hits the
+    session-region endpoint, so the service rejects the mismatched signature
+    (``InvalidSignatureException: Credential should be scoped to a valid region``). We
+    detect that case via the public ``client.meta.endpoint_url`` and rebuild the client
+    against a region-appropriate endpoint. Using ``meta.endpoint_url`` lets botocore
+    resolve the full override precedence (incl. ``AWS_ENDPOINT_URL_DEADLINE`` / global
+    ``AWS_ENDPOINT_URL``) for us.
 
     Args:
         session: The boto3 Session to use for creating the client
@@ -161,7 +188,21 @@ def get_session_client(session: boto3.Session, service_name: str, region: Option
     """
     if region is None:
         return session.client(service_name, config=get_default_client_config())
-    return session.client(service_name, config=get_default_client_config(), region_name=region)
+
+    client = session.client(service_name, config=get_default_client_config(), region_name=region)
+    resolved = client.meta.endpoint_url
+    session_region = session.region_name
+    # An endpoint override leaked the session's region into a cross-region endpoint.
+    if region not in resolved and session_region and session_region in resolved:
+        regionalized = _regionalize_endpoint_url(resolved, session_region, region)
+        if regionalized is not None:
+            return session.client(
+                service_name,
+                config=get_default_client_config(),
+                region_name=region,
+                endpoint_url=regionalized,
+            )
+    return client
 
 
 def _resolve_region(

--- a/test/unit/deadline_client/api/test_api_session.py
+++ b/test/unit/deadline_client/api/test_api_session.py
@@ -233,6 +233,11 @@ def test_resolve_region_backcompat_empty(fresh_deadline_config):
 def test_get_boto3_client_with_region(fresh_deadline_config):
     """get_boto3_client passes region_name to the client when a region is given."""
     mock_session = MagicMock()
+    # Standard regional endpoint already scoped to the requested region -> no recreation.
+    mock_session.region_name = "eu-west-1"
+    mock_session.client.return_value.meta.endpoint_url = (
+        "https://deadline.eu-west-1.amazonaws.com"
+    )
     with patch.object(api._session, "get_boto3_session", return_value=mock_session):
         # Make sure no stale cache entry interferes.
         get_session_client.cache_clear()
@@ -245,6 +250,10 @@ def test_get_boto3_client_with_farm_region_config(fresh_deadline_config):
     """get_boto3_client resolves region from defaults.farm_region when not passed."""
     config.set_setting("defaults.farm_region", "ap-south-1")
     mock_session = MagicMock()
+    mock_session.region_name = "ap-south-1"
+    mock_session.client.return_value.meta.endpoint_url = (
+        "https://deadline.ap-south-1.amazonaws.com"
+    )
     with patch.object(api._session, "get_boto3_session", return_value=mock_session):
         get_session_client.cache_clear()
         get_boto3_client("deadline")
@@ -343,6 +352,117 @@ def test_get_session_client_same_region_cached():
     client2 = get_session_client(session, "s3", region="eu-west-1")
 
     assert client1 is client2
+
+
+class TestGetSessionClientCrossRegion:
+    """
+    Cross-region endpoint handling in get_session_client.
+
+    When a profile carries a ``[services ...]`` endpoint override, botocore pins that
+    single endpoint to every deadline client regardless of the requested region. In a
+    cross-region fan-out each client signs SigV4 for its own region but hits the
+    session-region endpoint, yielding InvalidSignatureException. get_session_client
+    detects that leak via the public ``client.meta.endpoint_url`` and rebuilds the
+    client against a region-appropriate endpoint -- but only when the session region
+    appears as a dot-delimited token, to avoid mangling custom/private endpoints.
+    """
+
+    def test_gamma_override_endpoint_regionalized(self):
+        """A gamma-style override endpoint gets its ``.us-west-2.`` token rewritten
+        to the requested region, and the client is rebuilt with that endpoint."""
+        get_session_client.cache_clear()
+        session = MagicMock()
+        session.region_name = "us-west-2"
+
+        first_client = MagicMock()
+        first_client.meta.endpoint_url = "https://gamma.example.us-west-2.amazonaws.com"
+        second_client = MagicMock()
+        session.client.side_effect = [first_client, second_client]
+
+        result = get_session_client(session, "deadline", region="us-east-1")
+
+        assert result is second_client
+        assert session.client.call_count == 2
+        # The rebuilt client uses the regionalized endpoint URL.
+        session.client.assert_called_with(
+            "deadline",
+            config=ANY,
+            region_name="us-east-1",
+            endpoint_url="https://gamma.example.us-east-1.amazonaws.com",
+        )
+
+    def test_standard_endpoint_already_scoped_not_recreated(self):
+        """A standard AWS endpoint that already contains the requested region is left
+        alone -- the original client is returned and .client() is called once."""
+        get_session_client.cache_clear()
+        session = MagicMock()
+        session.region_name = "us-west-2"
+
+        client = MagicMock()
+        client.meta.endpoint_url = "https://deadline.us-east-1.amazonaws.com"
+        session.client.return_value = client
+
+        result = get_session_client(session, "deadline", region="us-east-1")
+
+        assert result is client
+        session.client.assert_called_once_with(
+            "deadline", config=ANY, region_name="us-east-1"
+        )
+
+    def test_session_without_region_not_recreated(self):
+        """When the session has no region_name, there is nothing to rewrite; the
+        original client is returned and .client() is called once."""
+        get_session_client.cache_clear()
+        session = MagicMock()
+        session.region_name = None
+
+        client = MagicMock()
+        client.meta.endpoint_url = "https://custom.example.us-west-2.amazonaws.com"
+        session.client.return_value = client
+
+        result = get_session_client(session, "deadline", region="us-east-1")
+
+        assert result is client
+        session.client.assert_called_once_with(
+            "deadline", config=ANY, region_name="us-east-1"
+        )
+
+    def test_resolved_endpoint_without_session_region_not_recreated(self):
+        """If the resolved endpoint does not contain the session region at all, no
+        regionalization occurs and the original client is returned."""
+        get_session_client.cache_clear()
+        session = MagicMock()
+        session.region_name = "us-west-2"
+
+        client = MagicMock()
+        client.meta.endpoint_url = "https://custom.example.eu-central-1.amazonaws.com"
+        session.client.return_value = client
+
+        result = get_session_client(session, "deadline", region="us-east-1")
+
+        assert result is client
+        session.client.assert_called_once_with(
+            "deadline", config=ANY, region_name="us-east-1"
+        )
+
+    def test_non_delimited_region_substring_not_rewritten(self):
+        """Hardening: the session region appears only as a NON-delimited substring
+        (e.g. host ``us-west-2-corp.example.com``). It must NOT be rewritten -- the
+        original client is returned and .client() is called once."""
+        get_session_client.cache_clear()
+        session = MagicMock()
+        session.region_name = "us-west-2"
+
+        client = MagicMock()
+        client.meta.endpoint_url = "https://us-west-2-corp.example.com"
+        session.client.return_value = client
+
+        result = get_session_client(session, "deadline", region="us-east-1")
+
+        assert result is client
+        session.client.assert_called_once_with(
+            "deadline", config=ANY, region_name="us-east-1"
+        )
 
 
 def test_get_queue_user_boto3_session_uses_resolved_farm_region(fresh_deadline_config):


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

When a profile has a non-standard endpoint override (e.g. via the `[services ...]` section in `~/.aws/config` for gamma/beta environments, as used by Deadline Cloud Monitor profiles), boto3 applies that single endpoint to **every** `deadline` client regardless of the `region_name` passed to `.client()`.

In the multi-region `list_farms` fan-out this means each per-region client signs SigV4 for its own region but hits the session-region endpoint, so the service rejects the mismatched signature:

```
InvalidSignatureException: Credential should be scoped to a valid region.
```

The result is that cross-region calls (farm list fan-out, job submission to a farm in another region, etc.) fail for anyone using a DCM gamma/beta profile — the fan-out only ever succeeds in the session region and spams a warning per other region.

### What was the solution? (How)

Detect the override in `get_session_client` via the public `client.meta.endpoint_url` and rebuild the client against a region-appropriate endpoint when the resolved endpoint carries the session region instead of the requested one.

Using `client.meta.endpoint_url` (rather than reaching into botocore internals) lets botocore resolve the full override precedence for us — client `endpoint_url` > `AWS_ENDPOINT_URL_DEADLINE` > global `AWS_ENDPOINT_URL` > profile `[services]` section — so we regionalize whatever endpoint botocore actually chose.

The region rewrite is anchored to a **dot-delimited token** (`.<region>.`) so a host that merely contains the region string in a non-region position (e.g. `us-west-2-corp.example.com`, or an account/stage token) is left untouched rather than mangled. When the session region isn't present as such a token, the resolved (custom/private) endpoint is returned unchanged.

### What is the impact of this change?

Cross-region resource interactions work when an endpoint override is present (such as a DCM gamma profile). Verified against a live gamma profile: the fan-out now succeeds in every region and surfaces farms that were previously unreachable, with no `InvalidSignatureException` warnings.

### Note

This supersedes #1233 — same root cause, adopting the maintainer-suggested `client.meta.endpoint_url` approach and additionally hardening the region rewrite against non-region substring matches (per the review feedback) and dropping the real internal endpoint from the tests.

### How was this change tested?

- Added unit tests in `test/unit/deadline_client/api/test_api_session.py` covering: gamma-style override regionalization, standard endpoints already scoped (no recreation), no session region, resolved endpoint without the session region, and the hardening case (non-delimited region substring left untouched). Uses example endpoints, not real internal hosts.
- All unit tests pass (29), `ruff` clean, `mypy` clean.
- Manually verified against a live DCM gamma us-west-2 profile: `_iter_farms_by_region` across us-west-2/us-east-1/ap-northeast-1 all succeed (previously only us-west-2 worked; the rest failed with `InvalidSignatureException`).

### Was this change documented?

- Added docstrings to the new helper and extended the `get_session_client` docstring explaining the SigV4 scope mismatch.

### Does this PR introduce new dependencies?

*   This PR does not add any new dependencies.

### Is this a breaking change?

Not a breaking change.

### Does this change impact security?

No change to security posture.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*