### PR TITLE
feat: filter out cross-region CMK farms from all-farms list

### DIFF
--- a/src/deadline/client/api/_list_apis.py
+++ b/src/deadline/client/api/_list_apis.py
@@ -9,8 +9,10 @@ from configparser import ConfigParser
 from typing import Iterator, List, Optional, Tuple
 
 from ._session import (
+    AwsCredentialsSource,
     get_boto3_client,
     get_boto3_session,
+    get_credentials_source,
     get_user_and_identity_store_id,
 )
 from .. import api
@@ -73,6 +75,18 @@ def _has_explicit_region_list(config: Optional[ConfigParser] = None) -> bool:
         return True
     config_value = config_file.get_setting("settings.deadline_regions", config=config)
     return bool(config_value and config_value.strip())
+
+
+def _is_farm_visible_across_regions(farm: dict, monitor_region: Optional[str]) -> bool:
+    """
+    Whether a farm should be shown by the all-farms fan-out.
+
+    Farms with a customer-managed KMS key (``kmsKeyArn``) aren't yet supported across
+    regions, so a CMK farm is hidden when it lives outside the monitor's own region. A
+    farm in the monitor's region is always kept -- CMK farms are only ever hidden
+    cross-region.
+    """
+    return farm.get("region") == monitor_region or not farm.get("kmsKeyArn")
 
 
 def _list_farms_with_client(
@@ -185,6 +199,20 @@ def _iter_farms_by_region(
         region: get_boto3_client("deadline", config=config, region=region) for region in regions
     }
 
+    # The CMK filter applies only to Deadline Cloud Monitor credentials; BYO credentials
+    # are single-region, so there's nothing cross-region to hide. Resolved up front here
+    # (the calling thread), not in the workers.
+    monitor_region = (
+        get_boto3_session(config=config).region_name
+        if get_credentials_source(config=config)
+        == AwsCredentialsSource.DEADLINE_CLOUD_MONITOR_LOGIN
+        else None
+    )
+    # Fail open: only filter when we know BOTH that these are monitor credentials AND the
+    # monitor's own region. Without a resolved region we can't tell which farms are
+    # cross-region, so we hide nothing rather than risk hiding home-region CMK farms.
+    filter_cmk_farms = monitor_region is not None
+
     max_workers = min(len(regions), _MAX_FANOUT_WORKERS)
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
         future_to_region = {
@@ -204,6 +232,9 @@ def _iter_farms_by_region(
                 # operation can be interrupted rather than silently swallowed.
                 yield (region, None, exc)
             else:
+                # Filter at this shared chokepoint so the CLI and GUI paths stay in sync.
+                if filter_cmk_farms:
+                    farms = [f for f in farms if _is_farm_visible_across_regions(f, monitor_region)]
                 yield (region, farms, None)
 
 

--- a/test/unit/deadline_client/api/test_api_list_multi_region.py
+++ b/test/unit/deadline_client/api/test_api_list_multi_region.py
@@ -38,6 +38,13 @@ def _make_farm(farm_id, display_name="Farm"):
     return {"farmId": farm_id, "displayName": display_name, "description": ""}
 
 
+def _make_cmk_farm(farm_id, display_name="Farm", kms_key_arn="arn:aws:kms:::key/abc"):
+    """A farm encrypted with a customer-managed KMS key (has a ``kmsKeyArn``)."""
+    farm = _make_farm(farm_id, display_name)
+    farm["kmsKeyArn"] = kms_key_arn
+    return farm
+
+
 def _client_returning(farms):
     """Builds a mock deadline client whose list_farms returns a single (unpaginated) page."""
     client = MagicMock()
@@ -946,3 +953,249 @@ def test_iter_farms_by_region_high_concurrency_stress(fresh_deadline_config):
     assert max_concurrent_builds == 1
     # ...while the network calls genuinely ran in parallel across the worker pool.
     assert len(call_threads) > 1
+
+
+# ---------------------------------------------------------------------------
+# Cross-region customer-managed-key (CMK) filtering
+#
+# Farms encrypted with a customer-managed KMS key (kmsKeyArn) are not yet supported
+# across regions -- the backend can't serve their detail/follow-up calls from a region
+# other than the one the farm lives in. So the fan-out hides a CMK farm when it lives
+# outside the monitor's own region (the boto3 session/profile region). A farm in the
+# monitor's own region is ALWAYS kept, CMK or not; the only farms ever removed are
+# cross-region CMK farms. Filtering happens in _iter_farms_by_region -- the shared
+# chokepoint -- so the CLI (list_farms) and the GUI streaming path stay in lockstep.
+# ---------------------------------------------------------------------------
+
+
+def _patch_monitor_creds(is_monitor=True):
+    """
+    Patches get_credentials_source so the fan-out believes it is (or isn't) running with
+    Deadline Cloud Monitor credentials. The CMK filter only applies to monitor creds.
+    """
+    from deadline.client.api._session import AwsCredentialsSource
+
+    source = (
+        AwsCredentialsSource.DEADLINE_CLOUD_MONITOR_LOGIN
+        if is_monitor
+        else AwsCredentialsSource.HOST_PROVIDED
+    )
+    return patch.object(_list_apis, "get_credentials_source", return_value=source)
+
+
+class TestIsFarmVisibleAcrossRegions:
+    """Unit tests for the predicate itself, with emphasis on current-region safety."""
+
+    MONITOR_REGION = "us-west-2"
+    OTHER_REGION = "eu-west-1"
+
+    def test_keeps_current_region_farm_without_cmk(self):
+        farm = {"region": self.MONITOR_REGION}
+        assert _list_apis._is_farm_visible_across_regions(farm, self.MONITOR_REGION) is True
+
+    def test_keeps_current_region_farm_with_cmk(self):
+        # A CMK farm in the monitor's own region is fully supported; the CMK must not
+        # cause it to be filtered out.
+        farm = {"region": self.MONITOR_REGION, "kmsKeyArn": "arn:aws:kms:us-west-2:1234:key/x"}
+        assert _list_apis._is_farm_visible_across_regions(farm, self.MONITOR_REGION) is True
+
+    def test_keeps_cross_region_farm_without_cmk(self):
+        farm = {"region": self.OTHER_REGION}
+        assert _list_apis._is_farm_visible_across_regions(farm, self.MONITOR_REGION) is True
+
+    def test_hides_cross_region_farm_with_cmk(self):
+        # The only case the filter removes.
+        farm = {"region": self.OTHER_REGION, "kmsKeyArn": "arn:aws:kms:eu-west-1:1234:key/x"}
+        assert _list_apis._is_farm_visible_across_regions(farm, self.MONITOR_REGION) is False
+
+    def test_keeps_cross_region_farm_with_empty_kms_arn(self):
+        # An empty arn is not a real customer-managed key, so the farm stays.
+        farm = {"region": self.OTHER_REGION, "kmsKeyArn": ""}
+        assert _list_apis._is_farm_visible_across_regions(farm, self.MONITOR_REGION) is True
+
+    def test_keeps_farm_with_missing_kms_arn_key(self):
+        # kmsKeyArn absent entirely (service-managed key) -> kept anywhere.
+        farm = {"region": self.OTHER_REGION}
+        assert _list_apis._is_farm_visible_across_regions(farm, self.MONITOR_REGION) is True
+
+    def test_none_monitor_region_treated_as_its_own_region(self):
+        # The endpoint-override path tags farms with region=None; a None monitor region
+        # must match so those farms are never spuriously hidden.
+        farm = {"region": None, "kmsKeyArn": "arn:aws:kms:::key/x"}
+        assert _list_apis._is_farm_visible_across_regions(farm, None) is True
+
+
+def test_list_farms_hides_cross_region_cmk_farm_keeps_current_region(fresh_deadline_config):
+    """
+    The same CMK farm surfaced by every region survives only in the monitor's own region;
+    its cross-region copies are hidden. Proves the current region is never affected.
+    """
+    regions = ["us-west-2", "us-east-1", "eu-west-1"]
+    monitor_region = "us-west-2"
+    # Every region reports the identical CMK farm (tagged with that region downstream).
+    clients = {r: _client_returning([_make_cmk_farm("farm-cmk")]) for r in regions}
+
+    def fake_get_client(service_name, config=None, region=None):
+        return clients[region]
+
+    mock_session = MagicMock()
+    mock_session.region_name = monitor_region
+
+    with (
+        patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client),
+        patch.object(_list_apis, "get_boto3_session", return_value=mock_session),
+        _patch_monitor_creds(),
+        patch.object(_list_apis.config_file, "get_deadline_regions", return_value=regions),
+        patch.object(_list_apis, "_apply_principal_id_filter"),
+    ):
+        result = api.list_farms()
+
+    farms = result["farms"]
+    # Kept exactly once -- for the monitor's own region only.
+    assert [f["region"] for f in farms] == [monitor_region]
+    assert farms[0]["farmId"] == "farm-cmk"
+
+
+def test_list_farms_keeps_non_cmk_farm_in_every_region(fresh_deadline_config):
+    """A farm without a customer-managed key is surfaced from every region (nothing hidden)."""
+    regions = ["us-west-2", "us-east-1", "eu-west-1"]
+    clients = {r: _client_returning([_make_farm(f"farm-{r}")]) for r in regions}
+
+    def fake_get_client(service_name, config=None, region=None):
+        return clients[region]
+
+    mock_session = MagicMock()
+    mock_session.region_name = "us-west-2"
+
+    with (
+        patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client),
+        patch.object(_list_apis, "get_boto3_session", return_value=mock_session),
+        _patch_monitor_creds(),
+        patch.object(_list_apis.config_file, "get_deadline_regions", return_value=regions),
+        patch.object(_list_apis, "_apply_principal_id_filter"),
+    ):
+        result = api.list_farms()
+
+    assert {f["region"] for f in result["farms"]} == set(regions)
+
+
+def test_list_farms_mixed_cmk_and_non_cmk_in_cross_region(fresh_deadline_config):
+    """
+    In a non-monitor region, a CMK farm is hidden while a sibling non-CMK farm from the
+    same region is kept -- filtering is per-farm, not per-region.
+    """
+    regions = ["us-west-2", "eu-west-1"]
+    monitor_region = "us-west-2"
+    clients = {
+        "us-west-2": _client_returning([_make_farm("farm-home")]),
+        "eu-west-1": _client_returning([_make_cmk_farm("farm-eu-cmk"), _make_farm("farm-eu-open")]),
+    }
+
+    def fake_get_client(service_name, config=None, region=None):
+        return clients[region]
+
+    mock_session = MagicMock()
+    mock_session.region_name = monitor_region
+
+    with (
+        patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client),
+        patch.object(_list_apis, "get_boto3_session", return_value=mock_session),
+        _patch_monitor_creds(),
+        patch.object(_list_apis.config_file, "get_deadline_regions", return_value=regions),
+        patch.object(_list_apis, "_apply_principal_id_filter"),
+    ):
+        result = api.list_farms()
+
+    by_id = {f["farmId"] for f in result["farms"]}
+    assert by_id == {"farm-home", "farm-eu-open"}
+    assert "farm-eu-cmk" not in by_id
+
+
+def test_iter_farms_by_region_hides_cross_region_cmk_farm(fresh_deadline_config):
+    """
+    The shared generator (used directly by the GUI) applies the same CMK filter: the
+    cross-region CMK copy is dropped, the monitor-region copy is yielded.
+    """
+    regions = ["us-west-2", "eu-west-1"]
+    monitor_region = "us-west-2"
+    clients = {r: _client_returning([_make_cmk_farm("farm-cmk")]) for r in regions}
+
+    def fake_get_client(service_name, config=None, region=None):
+        return clients[region]
+
+    mock_session = MagicMock()
+    mock_session.region_name = monitor_region
+
+    with (
+        patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client),
+        patch.object(_list_apis, "get_boto3_session", return_value=mock_session),
+        _patch_monitor_creds(),
+        patch.object(_list_apis, "_apply_principal_id_filter"),
+    ):
+        results = list(_list_apis._iter_farms_by_region(regions=regions))
+
+    by_region = {region: farms for region, farms, exc in results}
+    # Monitor region keeps its CMK farm; the other region's copy is filtered to empty.
+    west_farms = by_region["us-west-2"]
+    assert west_farms is not None
+    assert [f["farmId"] for f in west_farms] == ["farm-cmk"]
+    assert by_region["eu-west-1"] == []
+
+
+def test_list_farms_does_not_filter_cmk_farms_for_non_monitor_creds(fresh_deadline_config):
+    """
+    The CMK filter is gated on Deadline Cloud Monitor credentials. With host-provided
+    (BYO) credentials, a cross-region CMK farm must NOT be hidden -- those callers are
+    responsible for their own region scoping and we must never silently drop their farms.
+    """
+    regions = ["us-west-2", "eu-west-1"]
+    # A CMK farm lives in a region other than the session region; under monitor creds this
+    # would be hidden, but here the creds are host-provided so it must survive.
+    clients = {r: _client_returning([_make_cmk_farm(f"farm-{r}")]) for r in regions}
+
+    def fake_get_client(service_name, config=None, region=None):
+        return clients[region]
+
+    mock_session = MagicMock()
+    mock_session.region_name = "us-west-2"
+
+    with (
+        patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client),
+        patch.object(_list_apis, "get_boto3_session", return_value=mock_session),
+        _patch_monitor_creds(is_monitor=False),
+        patch.object(_list_apis.config_file, "get_deadline_regions", return_value=regions),
+        patch.object(_list_apis, "_apply_principal_id_filter"),
+    ):
+        result = api.list_farms()
+
+    # Nothing filtered: every region's CMK farm is present.
+    assert {f["region"] for f in result["farms"]} == set(regions)
+
+
+def test_list_farms_monitor_creds_no_session_region_fails_open(fresh_deadline_config):
+    """
+    Fail-open guard: under monitor credentials but with no resolved session region, we
+    can't tell which farms are cross-region, so NOTHING is filtered. Without this, a
+    None monitor region would match no concrete region tag and hide EVERY CMK farm --
+    including the user's home region.
+    """
+    regions = ["us-west-2", "eu-west-1"]
+    clients = {r: _client_returning([_make_cmk_farm(f"farm-{r}")]) for r in regions}
+
+    def fake_get_client(service_name, config=None, region=None):
+        return clients[region]
+
+    mock_session = MagicMock()
+    mock_session.region_name = None  # no resolved default region
+
+    with (
+        patch.object(_list_apis, "get_boto3_client", side_effect=fake_get_client),
+        patch.object(_list_apis, "get_boto3_session", return_value=mock_session),
+        _patch_monitor_creds(),  # monitor creds, but region is unknown
+        patch.object(_list_apis.config_file, "get_deadline_regions", return_value=regions),
+        patch.object(_list_apis, "_apply_principal_id_filter"),
+    ):
+        result = api.list_farms()
+
+    # Every CMK farm survives despite being "cross-region" -- we failed open.
+    assert {f["region"] for f in result["farms"]} == set(regions)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Farms encrypted with a customer-managed KMS key (CMK) are not yet supported across regions — the backend cannot serve their detail and follow-up calls from a region other than the one the farm lives in. In the multi-region all-farms fan-out, such a farm surfaces in every region it can be listed from, but interacting with the cross-region copies then fails.

To avoid surfacing farms that fail on interaction, hide a CMK farm when it lives outside the monitor's own region.

### What was the solution? (How)

A shared predicate, `_is_farm_visible_across_regions(farm, monitor_region)`: a farm is kept when EITHER it lives in the monitor's own region OR it has no customer-managed key (`kmsKeyArn`). The monitor-region clause is checked first and unconditionally, so **current-region farms are ALWAYS kept regardless of CMK** — the filter can only ever remove cross-region CMK farms.

The filter is applied in `_iter_farms_by_region`, the shared chokepoint that both the CLI (`list_farms`) and the GUI streaming path consume, so the two stay in lockstep.

It is gated on **Deadline Cloud Monitor credentials** (detected via `get_credentials_source`): host-provided (BYO) credentials are single-region, so there is nothing cross-region to hide and their farms are never dropped. "The monitor's own region" is the boto3 session/profile region.

This mirrors the equivalent change in the Deadline Cloud Monitor web app, which applies the same predicate in its `useFarms()` hook and `listDeadlineFarms` agent tool.

### What is the impact of this change?

Under a Monitor profile, a CMK farm in a region other than the monitor's own region is hidden from the aggregated farm list; CMK farms in the monitor's own region, and all non-CMK farms, are unaffected. Non-monitor credentials see no behavior change.

### How was this change tested?

- Added unit tests in `test/unit/deadline_client/api/test_api_list_multi_region.py`: the predicate directly (current-region kept with/without CMK, cross-region CMK hidden, empty/missing arn, `None` region), the filter through both `list_farms` and `_iter_farms_by_region` under monitor creds, mixed per-farm filtering within one region, and the non-monitor gate (BYO creds keep all farms).
- All unit tests pass (48 in the module), `ruff` clean, `mypy` clean.
- Manually verified against a live Deadline Cloud Monitor gamma profile: a real cross-region CMK farm (in us-east-1, monitor region us-west-2) is hidden, while three CMK farms in the monitor's own region are correctly kept. A/B toggling the monitor-creds gate confirms the filter is the cause.

### Was this change documented?

- Added docstrings/comments to the new predicate and the gate in `_iter_farms_by_region`.

### Does this PR introduce new dependencies?

*   This PR does not add any new dependencies.

### Is this a breaking change?

Not a breaking change.

### Does this change impact security?

No change to security posture.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*