### PR TITLE
feat: add Qt-free run_pre_gui_hooks for DCC submitters

### DIFF
--- a/src/deadline/client/job_bundle/_hooks/_manager.py
+++ b/src/deadline/client/job_bundle/_hooks/_manager.py
@@ -115,16 +115,24 @@ def collect_pre_gui_hook_sources(
 
     # Bundle hooks second. When env_is_bundle, this single source covers both; it is gated
     # by allow_bundle_hooks OR allow_environment_hooks (either grant permits the shared dir).
-    bundle_manager = manager_cls(bundle_dir, print_callback)
-    bundle_hooks = bundle_manager.load_hooks()
-    if bundle_hooks and bundle_hooks.pre_gui:
-        if allow_bundle_hooks or (env_is_bundle and allow_environment_hooks):
-            sources.append(bundle_manager)
-        else:
-            warn(
-                "Note: Job bundle contains preGUI hooks but bundle hooks are disabled.\n"
-                "Enable with: deadline config set settings.allow_bundle_hooks true"
-            )
+    #
+    # Only consult the bundle source when there IS a bundle. DCC submitters have no on-disk
+    # bundle at pre-GUI time and pass bundle_dir="" — an empty dir would make HookManager
+    # resolve hooks.yaml/.json relative to the process CWD (os.path.join("", "hooks") →
+    # "hooks"), so a stray hooks file in the launch directory could be loaded and, with
+    # bundle hooks enabled studio-wide, executed for a submission that has no bundle. Skip
+    # the bundle source entirely when bundle_dir is falsy to avoid that CWD footgun.
+    if bundle_dir:
+        bundle_manager = manager_cls(bundle_dir, print_callback)
+        bundle_hooks = bundle_manager.load_hooks()
+        if bundle_hooks and bundle_hooks.pre_gui:
+            if allow_bundle_hooks or (env_is_bundle and allow_environment_hooks):
+                sources.append(bundle_manager)
+            else:
+                warn(
+                    "Note: Job bundle contains preGUI hooks but bundle hooks are disabled.\n"
+                    "Enable with: deadline config set settings.allow_bundle_hooks true"
+                )
 
     return sources
 

--- a/src/deadline/client/job_bundle/hooks.py
+++ b/src/deadline/client/job_bundle/hooks.py
@@ -1,0 +1,12 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""Public access to the submission-hook types.
+
+The hook implementation lives in the private ``_hooks`` package. This module is the public
+face of it, so callers (e.g. a DCC submitter writing a ``confirm_callback`` for
+``deadline.client.ui.pre_gui_hooks.run_pre_gui_hooks``) have a supported type to import and
+annotate against, rather than reaching into ``_hooks``.
+"""
+
+from ._hooks import HookManager
+
+__all__ = ["HookManager"]

--- a/src/deadline/client/ui/job_bundle_submitter.py
+++ b/src/deadline/client/ui/job_bundle_submitter.py
@@ -18,13 +18,11 @@ from qtpy.QtWidgets import (  # pylint: disable=import-error; type: ignore
 
 from ..config import config_file as _config_file
 from ..config.config_file import get_setting as _get_setting
-from ..exceptions import DeadlineOperationCanceled as _DeadlineOperationCanceled
 from ..exceptions import DeadlineOperationError
-from ..job_bundle._hooks import (
-    HookManager as _HookManager,
-    HookMetadata as _HookMetadata,
-    _generate_hooks_confirmation_message,
-    collect_pre_gui_hook_sources as _collect_pre_gui_hook_sources,
+from .pre_gui_hooks import (
+    PreGuiHookContext,
+    qt_hook_confirmation,
+    run_pre_gui_hooks,
 )
 from ..job_bundle.loader import (
     parse_yaml_or_json_content,
@@ -53,94 +51,49 @@ from ..api._session import session_context
 logger = getLogger(__name__)
 
 
-def _make_pre_gui_metadata(initial_settings: Any, job_bundle_dir: str) -> _HookMetadata:
-    """Build minimal HookMetadata for the pre-GUI phase."""
-    farm_id = _get_setting("defaults.farm_id") or ""
-    queue_id = _get_setting("defaults.queue_id") or ""
-    storage_profile_id = _get_setting("settings.storage_profile_id") or None
-    parameters = {
-        p["name"]: p.get("value", p.get("default"))
-        for p in getattr(initial_settings, "parameters", [])
-        if "value" in p or "default" in p
-    }
-    return _HookMetadata(
-        job_name=getattr(initial_settings, "name", ""),
-        priority=50,
-        farm_id=farm_id,
-        queue_id=queue_id,
-        job_bundle_dir=job_bundle_dir,
-        parameters=parameters,
-        submitter_name=getattr(initial_settings, "submitter_name", "JobBundle"),
-        asset_references={},
-        submission_payload={},
-        storage_profile_id=storage_profile_id,
-    )
+def apply_pre_gui_output(
+    pre_gui_output: dict[str, Any],
+    initial_settings: JobBundleSettings,
+    initial_shared_parameter_values: dict[str, Any],
+    cli_provided_param_names: Optional[set[str]] = None,
+) -> None:
+    """Apply merged pre-GUI hook output onto a ``JobBundleSettings`` and the shared values.
 
+    ``name`` / ``description`` overwrite the corresponding settings fields; ``parameters``
+    that match a job-template parameter update ``initial_settings.parameters`` in place,
+    and any others land in ``initial_shared_parameter_values`` (queue params, ``deadline:``
+    keys, etc.). CLI-supplied parameter names (``cli_provided_param_names``) always win over
+    hook values.
 
-def _run_pre_gui_hooks(
-    input_job_bundle_dir: str, initial_settings: Any, parent: Any
-) -> dict[str, Any]:
-    """Load and execute pre-GUI hooks from all allowed sources.
-
-    Pre-GUI hooks may be defined in the job bundle (gated by ``allow_bundle_hooks``) and/or
-    in the directory named by ``DEADLINE_HOOKS_DIR`` (gated by ``allow_environment_hooks``).
-    Environment hooks run before bundle hooks. Returns the merged pre-GUI output, or an
-    empty dict if no pre-GUI hooks run.
+    This helper is specific to the standalone job-bundle submitter, which holds a
+    ``JobBundleSettings`` with a ``.parameters`` template-parameter list. It lives here rather
+    than in ``pre_gui_hooks`` because it is *not* generic across submitters: DCC submitters use
+    their own settings dataclass (e.g. Maya's ``RenderSubmitterUISettings``, which has no
+    ``.parameters`` list) and map :func:`run_pre_gui_hooks`' output onto it themselves.
     """
-    # Source selection (which bundle/env HookManagers have runnable preGUI hooks) is
-    # Qt-free logic extracted into the hooks package so it can be unit-tested without a GUI.
-    sources = _collect_pre_gui_hook_sources(
-        bundle_dir=input_job_bundle_dir,
-        env_hooks_dir=os.environ.get("DEADLINE_HOOKS_DIR"),
-        allow_bundle_hooks=_config_file.str2bool(_get_setting("settings.allow_bundle_hooks")),
-        allow_environment_hooks=_config_file.str2bool(
-            _get_setting("settings.allow_environment_hooks")
-        ),
-        # Hook execution messages ("Running pre-GUI hook…") log at info; the
-        # "hooks present but disabled" guidance logs at warning (its pre-refactor severity).
-        print_callback=logger.info,
-        warning_callback=logger.warning,
-        # Pass our reference so tests can patch `{MODULE}._HookManager` as a behavior seam.
-        hook_manager_cls=_HookManager,
-    )
+    if not pre_gui_output:
+        return
 
-    if not sources:
-        return {}
-
-    # Confirmation prompt (once), unless auto_accept. Show every source's hooks.
-    if not _config_file.str2bool(_get_setting("settings.auto_accept")):
-        confirmation_msg = (
-            "".join(
-                _generate_hooks_confirmation_message(m.hooks, m._original_bundle_dir)
-                for m in sources
-                if m.hooks
-            )
-            + "Do you want to run these hooks?"
-        )
-        reply = QMessageBox.question(
-            parent,
-            tr("Job Submission Confirmation"),
-            confirmation_msg,
-            QMessageBox.Yes | QMessageBox.No,
-            QMessageBox.No,
-        )
-        if reply != QMessageBox.Yes:
-            raise _DeadlineOperationCanceled("Job submission canceled (user declined hooks).")
-
-    merged: dict[str, Any] = {}
-    for manager in sources:
-        # Every hook — bundle or environment — receives the job bundle being submitted as
-        # its job_bundle_dir, matching the pre/post-submission contract. (The manager still
-        # resolves relative hook script paths against its own directory.)
-        metadata = _make_pre_gui_metadata(initial_settings, input_job_bundle_dir)
-        output = manager.execute_pre_gui_hooks(metadata)
-        # Later sources (bundle) override earlier (env) for scalars; parameters merge.
-        params = merged.pop("parameters", {})
-        params.update(output.pop("parameters", {}))
-        merged.update(output)
-        if params:
-            merged["parameters"] = params
-    return merged
+    cli_provided_param_names = cli_provided_param_names or set()
+    hook_params = pre_gui_output.get("parameters", {})
+    template_param_names = {p["name"] for p in initial_settings.parameters}
+    for param_name, param_value in hook_params.items():
+        # CLI --parameter values take precedence over hook values.
+        if param_name in cli_provided_param_names:
+            continue
+        if param_name in template_param_names:
+            # Job template parameter — update initial_settings.parameters in-place
+            for p in initial_settings.parameters:
+                if p["name"] == param_name:
+                    p["value"] = param_value
+                    break
+        else:
+            # Shared job property (deadline: keys, queue parameters, etc.)
+            initial_shared_parameter_values[param_name] = param_value
+    if "name" in pre_gui_output:
+        initial_settings.name = pre_gui_output["name"]
+    if "description" in pre_gui_output:
+        initial_settings.description = pre_gui_output["description"]
 
 
 def _resolve_template_host_requirements(template: dict[str, Any]) -> Optional[Dict[str, Any]]:
@@ -407,8 +360,26 @@ def show_job_bundle_submitter(
     # Run pre-GUI hooks to allow studios to pre-populate dialog fields. Pre-GUI hooks may
     # come from the job bundle (gated by allow_bundle_hooks) and/or the directory named by
     # DEADLINE_HOOKS_DIR (gated by allow_environment_hooks). Environment hooks run first,
-    # then bundle hooks — matching the pre/post-submission ordering.
-    pre_gui_output = _run_pre_gui_hooks(input_job_bundle_dir, initial_settings, parent)
+    # then bundle hooks. The confirmation prompt is skipped when auto_accept is set;
+    # otherwise the standard Qt dialog is shown.
+    confirm_callback = (
+        None
+        if _config_file.str2bool(_get_setting("settings.auto_accept"))
+        else qt_hook_confirmation(parent)
+    )
+    pre_gui_output = run_pre_gui_hooks(
+        PreGuiHookContext(
+            bundle_dir=input_job_bundle_dir,
+            job_name=getattr(initial_settings, "name", ""),
+            parameters={
+                p["name"]: p.get("value", p.get("default"))
+                for p in initial_settings.parameters
+                if "value" in p or "default" in p
+            },
+            submitter_name=getattr(initial_settings, "submitter_name", "JobBundle"),
+        ),
+        confirm_callback=confirm_callback,
+    )
 
     initial_shared_parameter_values = {}
 
@@ -444,29 +415,15 @@ def show_job_bundle_submitter(
     for parameter in job_parameters_dict.values():
         initial_shared_parameter_values[parameter["name"]] = parameter["value"]
 
-    # Merge pre-GUI hook output. CLI-supplied parameters take precedence over hook values.
-    if pre_gui_output:
-        hook_params = pre_gui_output.get("parameters", {})
-        template_param_names = {p["name"] for p in initial_settings.parameters}
-        for param_name, param_value in hook_params.items():
-            # CLI --parameter values take precedence over hook values. Check the up-front
-            # set rather than job_parameters_dict, whose template entries were already popped
-            # above — otherwise a hook could silently override a CLI-supplied template param.
-            if param_name in cli_provided_param_names:
-                continue
-            if param_name in template_param_names:
-                # Job template parameter — update initial_settings.parameters in-place
-                for p in initial_settings.parameters:
-                    if p["name"] == param_name:
-                        p["value"] = param_value
-                        break
-            else:
-                # Shared job property (deadline: keys, queue parameters, etc.)
-                initial_shared_parameter_values[param_name] = param_value
-        if "name" in pre_gui_output:
-            initial_settings.name = pre_gui_output["name"]
-        if "description" in pre_gui_output:
-            initial_settings.description = pre_gui_output["description"]
+    # Merge pre-GUI hook output onto the initial settings. CLI-supplied parameters take
+    # precedence over hook values — pass the up-front CLI name set (job_parameters_dict has
+    # had its template entries popped above, so it can no longer report the CLI names).
+    apply_pre_gui_output(
+        pre_gui_output,
+        initial_settings,
+        initial_shared_parameter_values,
+        cli_provided_param_names=cli_provided_param_names,
+    )
 
     # Pre-fill the host requirements tab from the job template's steps so the GUI
     # reflects the requirements already declared in the bundle.

--- a/src/deadline/client/ui/job_bundle_submitter.py
+++ b/src/deadline/client/ui/job_bundle_submitter.py
@@ -51,6 +51,11 @@ from ..api._session import session_context
 
 logger = getLogger(__name__)
 
+# The pre-GUI helpers are imported here for use by show_job_bundle_submitter; their public
+# home is deadline.client.ui.pre_gui_hooks. Declaring __all__ keeps them (and internal
+# imports like logger) from being re-exported as this module's public API.
+__all__ = ["show_job_bundle_submitter"]
+
 
 def _resolve_template_host_requirements(template: dict[str, Any]) -> Optional[Dict[str, Any]]:
     """

--- a/src/deadline/client/ui/job_bundle_submitter.py
+++ b/src/deadline/client/ui/job_bundle_submitter.py
@@ -21,6 +21,7 @@ from ..config.config_file import get_setting as _get_setting
 from ..exceptions import DeadlineOperationError
 from .pre_gui_hooks import (
     PreGuiHookContext,
+    apply_pre_gui_output,
     qt_hook_confirmation,
     run_pre_gui_hooks,
 )
@@ -49,51 +50,6 @@ from ..job_bundle.submission import AssetReferences
 from ..api._session import session_context
 
 logger = getLogger(__name__)
-
-
-def apply_pre_gui_output(
-    pre_gui_output: dict[str, Any],
-    initial_settings: JobBundleSettings,
-    initial_shared_parameter_values: dict[str, Any],
-    cli_provided_param_names: Optional[set[str]] = None,
-) -> None:
-    """Apply merged pre-GUI hook output onto a ``JobBundleSettings`` and the shared values.
-
-    ``name`` / ``description`` overwrite the corresponding settings fields; ``parameters``
-    that match a job-template parameter update ``initial_settings.parameters`` in place,
-    and any others land in ``initial_shared_parameter_values`` (queue params, ``deadline:``
-    keys, etc.). CLI-supplied parameter names (``cli_provided_param_names``) always win over
-    hook values.
-
-    This helper is specific to the standalone job-bundle submitter, which holds a
-    ``JobBundleSettings`` with a ``.parameters`` template-parameter list. It lives here rather
-    than in ``pre_gui_hooks`` because it is *not* generic across submitters: DCC submitters use
-    their own settings dataclass (e.g. Maya's ``RenderSubmitterUISettings``, which has no
-    ``.parameters`` list) and map :func:`run_pre_gui_hooks`' output onto it themselves.
-    """
-    if not pre_gui_output:
-        return
-
-    cli_provided_param_names = cli_provided_param_names or set()
-    hook_params = pre_gui_output.get("parameters", {})
-    template_param_names = {p["name"] for p in initial_settings.parameters}
-    for param_name, param_value in hook_params.items():
-        # CLI --parameter values take precedence over hook values.
-        if param_name in cli_provided_param_names:
-            continue
-        if param_name in template_param_names:
-            # Job template parameter — update initial_settings.parameters in-place
-            for p in initial_settings.parameters:
-                if p["name"] == param_name:
-                    p["value"] = param_value
-                    break
-        else:
-            # Shared job property (deadline: keys, queue parameters, etc.)
-            initial_shared_parameter_values[param_name] = param_value
-    if "name" in pre_gui_output:
-        initial_settings.name = pre_gui_output["name"]
-    if "description" in pre_gui_output:
-        initial_settings.description = pre_gui_output["description"]
 
 
 def _resolve_template_host_requirements(template: dict[str, Any]) -> Optional[Dict[str, Any]]:

--- a/src/deadline/client/ui/pre_gui_hooks.py
+++ b/src/deadline/client/ui/pre_gui_hooks.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass, field
 from logging import getLogger
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, Optional
 
 from ..config import config_file as _config_file
 from ..config.config_file import get_setting as _get_setting
@@ -30,6 +30,13 @@ from ..job_bundle._hooks import (
 from ._utils import tr
 
 logger = getLogger(__name__)
+
+__all__ = [
+    "PreGuiHookContext",
+    "apply_pre_gui_output",
+    "qt_hook_confirmation",
+    "run_pre_gui_hooks",
+]
 
 
 @dataclass
@@ -66,7 +73,7 @@ class PreGuiHookContext:
 def run_pre_gui_hooks(
     context: PreGuiHookContext,
     *,
-    confirm_callback: Optional[Callable[[List["_HookManager"]], bool]] = None,
+    confirm_callback: Optional[Callable[[list], bool]] = None,
 ) -> dict[str, Any]:
     """Run all allowed pre-GUI hooks and return their merged output.
 
@@ -164,7 +171,7 @@ def run_pre_gui_hooks(
     return merged
 
 
-def qt_hook_confirmation(parent: Any) -> Callable[[List["_HookManager"]], bool]:
+def qt_hook_confirmation(parent: Any) -> Callable[[list], bool]:
     """Return a ``confirm_callback`` for :func:`run_pre_gui_hooks` that shows the standard
     Qt confirmation dialog listing every hook that will run.
 
@@ -175,7 +182,7 @@ def qt_hook_confirmation(parent: Any) -> Callable[[List["_HookManager"]], bool]:
     """
     from qtpy.QtWidgets import QMessageBox  # pylint: disable=import-error
 
-    def _confirm(sources: List["_HookManager"]) -> bool:
+    def _confirm(sources: list) -> bool:
         confirmation_msg = (
             "".join(
                 _generate_hooks_confirmation_message(m.hooks, m._original_bundle_dir)

--- a/src/deadline/client/ui/pre_gui_hooks.py
+++ b/src/deadline/client/ui/pre_gui_hooks.py
@@ -194,3 +194,56 @@ def qt_hook_confirmation(parent: Any) -> Callable[[List["_HookManager"]], bool]:
         return reply == QMessageBox.Yes
 
     return _confirm
+
+
+def apply_pre_gui_output(
+    pre_gui_output: dict[str, Any],
+    initial_settings: Any,
+    initial_shared_parameter_values: dict[str, Any],
+    cli_provided_param_names: Optional[set[str]] = None,
+) -> None:
+    """Apply merged pre-GUI hook output onto a submitter's settings and its shared values.
+
+    ``name`` / ``description`` overwrite the corresponding fields on ``initial_settings``.
+    For ``parameters``: any name that matches a job-template parameter (an entry in
+    ``initial_settings.parameters``) updates that entry in place; every other name lands in
+    ``initial_shared_parameter_values`` (queue parameters, ``deadline:`` job properties, etc.).
+    CLI-supplied parameter names (``cli_provided_param_names``) always win over hook values.
+
+    This is generic across submitters:
+
+    * The standalone job-bundle submitter passes a ``JobBundleSettings`` whose ``parameters``
+      is a list of template-parameter dicts, so template params are routed onto it in place.
+    * DCC submitters (Maya, Nuke, etc.) pass their own settings dataclass, which has no
+      ``parameters`` list. With no template-parameter list, every hook parameter is treated
+      as a shared value — matching how a DCC seeds ``initial_shared_parameter_values``.
+
+    ``initial_settings`` only needs assignable ``name`` / ``description`` attributes and,
+    optionally, a ``parameters`` list of ``{"name": ..., "value": ...}`` dicts.
+    """
+    if not pre_gui_output:
+        return
+
+    cli_provided_param_names = cli_provided_param_names or set()
+    hook_params = pre_gui_output.get("parameters", {})
+    # DCC settings have no template-parameter list; treat their absence as "no template
+    # params", so every hook parameter flows to the shared values dict below.
+    template_parameters = getattr(initial_settings, "parameters", None) or []
+    template_param_names = {p["name"] for p in template_parameters}
+    for param_name, param_value in hook_params.items():
+        # CLI --parameter values take precedence over hook values.
+        if param_name in cli_provided_param_names:
+            continue
+        if param_name in template_param_names:
+            # Job template parameter — update initial_settings.parameters in-place
+            for p in template_parameters:
+                if p["name"] == param_name:
+                    p["value"] = param_value
+                    break
+        else:
+            # Shared job property (deadline: keys, queue parameters, etc.)
+            initial_shared_parameter_values[param_name] = param_value
+    if "name" in pre_gui_output:
+        initial_settings.name = pre_gui_output["name"]
+    if "description" in pre_gui_output:
+        initial_settings.description = pre_gui_output["description"]

--- a/src/deadline/client/ui/pre_gui_hooks.py
+++ b/src/deadline/client/ui/pre_gui_hooks.py
@@ -16,17 +16,17 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass, field
 from logging import getLogger
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from ..config import config_file as _config_file
 from ..config.config_file import get_setting as _get_setting
 from ..exceptions import DeadlineOperationCanceled as _DeadlineOperationCanceled
 from ..job_bundle._hooks import (
-    HookManager as _HookManager,
     HookMetadata as _HookMetadata,
     _generate_hooks_confirmation_message,
     collect_pre_gui_hook_sources as _collect_pre_gui_hook_sources,
 )
+from ..job_bundle.hooks import HookManager
 from ._utils import tr
 
 logger = getLogger(__name__)
@@ -73,7 +73,7 @@ class PreGuiHookContext:
 def run_pre_gui_hooks(
     context: PreGuiHookContext,
     *,
-    confirm_callback: Optional[Callable[[list], bool]] = None,
+    confirm_callback: Optional[Callable[[List[HookManager]], bool]] = None,
 ) -> dict[str, Any]:
     """Run all allowed pre-GUI hooks and return their merged output.
 
@@ -113,8 +113,8 @@ def run_pre_gui_hooks(
         # disabled" guidance logs at warning (its pre-refactor severity).
         print_callback=logger.info,
         warning_callback=logger.warning,
-        # Pass our reference so tests can patch `{MODULE}._HookManager` as a behavior seam.
-        hook_manager_cls=_HookManager,
+        # Pass our reference so tests can patch `{MODULE}.HookManager` as a behavior seam.
+        hook_manager_cls=HookManager,
     )
 
     if not sources:
@@ -171,7 +171,7 @@ def run_pre_gui_hooks(
     return merged
 
 
-def qt_hook_confirmation(parent: Any) -> Callable[[list], bool]:
+def qt_hook_confirmation(parent: Any) -> Callable[[List[HookManager]], bool]:
     """Return a ``confirm_callback`` for :func:`run_pre_gui_hooks` that shows the standard
     Qt confirmation dialog listing every hook that will run.
 
@@ -182,7 +182,7 @@ def qt_hook_confirmation(parent: Any) -> Callable[[list], bool]:
     """
     from qtpy.QtWidgets import QMessageBox  # pylint: disable=import-error
 
-    def _confirm(sources: list) -> bool:
+    def _confirm(sources: List[HookManager]) -> bool:
         confirmation_msg = (
             "".join(
                 _generate_hooks_confirmation_message(m.hooks, m._original_bundle_dir)

--- a/src/deadline/client/ui/pre_gui_hooks.py
+++ b/src/deadline/client/ui/pre_gui_hooks.py
@@ -1,0 +1,196 @@
+# coding: utf-8
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""Pre-GUI submission hooks.
+
+This module is the entry point DCC submitters (Maya, Nuke, etc.) and the standalone
+``gui-submit`` command call to run pre-GUI hooks before building
+``SubmitJobToDeadlineDialog``, so studios can pre-populate dialog fields.
+
+It is deliberately kept out of ``job_bundle_submitter.py`` — which imports ``qtpy`` at module
+top — so that ``run_pre_gui_hooks`` can be imported and unit-tested **headless** (no Qt
+bindings). The one Qt-coupled helper, :func:`qt_hook_confirmation`, imports Qt lazily inside
+its body, so importing this module never requires Qt.
+"""
+
+from __future__ import annotations
+import os
+from dataclasses import dataclass, field
+from logging import getLogger
+from typing import Any, Callable, Dict, List, Optional
+
+from ..config import config_file as _config_file
+from ..config.config_file import get_setting as _get_setting
+from ..exceptions import DeadlineOperationCanceled as _DeadlineOperationCanceled
+from ..job_bundle._hooks import (
+    HookManager as _HookManager,
+    HookMetadata as _HookMetadata,
+    _generate_hooks_confirmation_message,
+    collect_pre_gui_hook_sources as _collect_pre_gui_hook_sources,
+)
+from ._utils import tr
+
+logger = getLogger(__name__)
+
+
+@dataclass
+class PreGuiHookContext:
+    """The inputs passed to pre-GUI hooks, bundled into one object.
+
+    Collecting these into a dataclass (rather than passing each as a keyword argument to
+    :func:`run_pre_gui_hooks`) keeps that function's signature stable as the pre-GUI hook
+    metadata grows: a new field is added here — with a default, so it stays backward
+    compatible — instead of adding another parameter to every call site.
+
+    Attributes:
+        bundle_dir: The job bundle directory, or ``None`` for env-only (DCC) sourcing. DCC
+            submitters have no on-disk bundle at pre-GUI time and leave this ``None``, so
+            their only hook source is ``DEADLINE_HOOKS_DIR``.
+        job_name: Initial job name passed to hooks as ``jobName``.
+        parameters: Current parameter values passed to hooks (name -> value).
+        submitter_name: The submitter identity passed to hooks (e.g. "maya", "nuke").
+        priority: Initial priority passed to hooks.
+        farm_id / queue_id / storage_profile_id: Passed to hooks; when ``None`` the
+            farm/queue default from config (and the storage-profile setting) is used.
+    """
+
+    bundle_dir: Optional[str] = None
+    job_name: str = ""
+    parameters: Dict[str, Any] = field(default_factory=dict)
+    submitter_name: str = "JobBundle"
+    priority: int = 50
+    farm_id: Optional[str] = None
+    queue_id: Optional[str] = None
+    storage_profile_id: Optional[str] = None
+
+
+def run_pre_gui_hooks(
+    context: PreGuiHookContext,
+    *,
+    confirm_callback: Optional[Callable[[List["_HookManager"]], bool]] = None,
+) -> dict[str, Any]:
+    """Run all allowed pre-GUI hooks and return their merged output.
+
+    This is the entry point DCC submitters (Maya, Nuke, etc.) call before building
+    ``SubmitJobToDeadlineDialog`` so studios can pre-populate dialog fields. It is
+    deliberately free of any Qt import so it can be called (and unit-tested) headless;
+    the confirmation prompt is injected via ``confirm_callback``.
+
+    Pre-GUI hooks may come from the directory named by ``DEADLINE_HOOKS_DIR`` (gated by
+    ``settings.allow_environment_hooks``) and, when ``context.bundle_dir`` is given, the job
+    bundle (gated by ``settings.allow_bundle_hooks``). Environment hooks run first, then bundle
+    hooks. DCC submitters pass ``bundle_dir=None``, so their only source is ``DEADLINE_HOOKS_DIR``.
+
+    Args:
+        context: The :class:`PreGuiHookContext` carrying the data passed to hooks. Callers
+            build one object rather than passing many keyword arguments, so this signature
+            stays stable as the hook metadata grows.
+        confirm_callback: Called once with the list of ``HookManager`` sources whose
+            preGUI hooks will run; returns ``True`` to proceed or ``False`` to cancel
+            (raising ``DeadlineOperationCanceled``). When ``None``, hooks run without
+            prompting — callers that want the standard prompt pass ``qt_hook_confirmation``.
+
+    Returns:
+        The merged pre-GUI output (any of ``name``, ``description``, ``parameters``), or an
+        empty dict if no pre-GUI hooks ran.
+    """
+    # Source selection (which bundle/env HookManagers have runnable preGUI hooks) is
+    # Qt-free logic in the hooks package so it can be unit-tested without a GUI.
+    sources = _collect_pre_gui_hook_sources(
+        bundle_dir=context.bundle_dir or "",
+        env_hooks_dir=os.environ.get("DEADLINE_HOOKS_DIR"),
+        allow_bundle_hooks=_config_file.str2bool(_get_setting("settings.allow_bundle_hooks")),
+        allow_environment_hooks=_config_file.str2bool(
+            _get_setting("settings.allow_environment_hooks")
+        ),
+        # Hook execution messages ("Running pre-GUI hook…") log at info; "hooks present but
+        # disabled" guidance logs at warning (its pre-refactor severity).
+        print_callback=logger.info,
+        warning_callback=logger.warning,
+        # Pass our reference so tests can patch `{MODULE}._HookManager` as a behavior seam.
+        hook_manager_cls=_HookManager,
+    )
+
+    if not sources:
+        return {}
+
+    # Confirmation is injected rather than built-in because:
+    # 1. Building it in would require importing Qt (QMessageBox) here, making this function
+    #    impossible to call or unit-test without Qt bindings — but DCC callers need it headless.
+    # 2. The auto_accept policy differs by call site (gui-submit checks settings; a DCC may
+    #    always prompt; a CI job may never prompt). Injecting keeps this function policy-free.
+    # Callers pass qt_hook_confirmation(parent) for the standard dialog, or None to skip.
+    if confirm_callback is not None and not confirm_callback(sources):
+        raise _DeadlineOperationCanceled("Job submission canceled (user declined hooks).")
+
+    resolved_farm_id = (
+        context.farm_id if context.farm_id is not None else (_get_setting("defaults.farm_id") or "")
+    )
+    resolved_queue_id = (
+        context.queue_id
+        if context.queue_id is not None
+        else (_get_setting("defaults.queue_id") or "")
+    )
+    resolved_storage_profile_id = (
+        context.storage_profile_id
+        if context.storage_profile_id is not None
+        else (_get_setting("settings.storage_profile_id") or None)
+    )
+
+    merged: dict[str, Any] = {}
+    for manager in sources:
+        # Every hook — bundle or environment — receives the job bundle being submitted as
+        # its job_bundle_dir, matching the pre/post-submission contract. (The manager still
+        # resolves relative hook script paths against its own directory.) DCC callers pass
+        # bundle_dir=None, so hooks see an empty jobBundleDir at pre-GUI time.
+        metadata = _HookMetadata(
+            job_name=context.job_name,
+            priority=context.priority,
+            farm_id=resolved_farm_id,
+            queue_id=resolved_queue_id,
+            job_bundle_dir=context.bundle_dir or "",
+            parameters=dict(context.parameters or {}),
+            submitter_name=context.submitter_name,
+            asset_references={},
+            submission_payload={},
+            storage_profile_id=resolved_storage_profile_id,
+        )
+        output = manager.execute_pre_gui_hooks(metadata)
+        # Later sources (bundle) override earlier (env) for scalars; parameters merge.
+        params = merged.pop("parameters", {})
+        params.update(output.pop("parameters", {}))
+        merged.update(output)
+        if params:
+            merged["parameters"] = params
+    return merged
+
+
+def qt_hook_confirmation(parent: Any) -> Callable[[List["_HookManager"]], bool]:
+    """Return a ``confirm_callback`` for :func:`run_pre_gui_hooks` that shows the standard
+    Qt confirmation dialog listing every hook that will run.
+
+    This is the only Qt-coupled part of the pre-GUI flow. Qt is imported lazily inside the
+    returned callable — not at module top — so importing this module (and calling
+    ``run_pre_gui_hooks``) never requires Qt bindings. Returns a callable that returns
+    ``True`` when the user accepts and ``False`` otherwise.
+    """
+    from qtpy.QtWidgets import QMessageBox  # pylint: disable=import-error
+
+    def _confirm(sources: List["_HookManager"]) -> bool:
+        confirmation_msg = (
+            "".join(
+                _generate_hooks_confirmation_message(m.hooks, m._original_bundle_dir)
+                for m in sources
+                if m.hooks
+            )
+            + "Do you want to run these hooks?"
+        )
+        reply = QMessageBox.question(
+            parent,
+            tr("Job Submission Confirmation"),
+            confirmation_msg,
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.No,
+        )
+        return reply == QMessageBox.Yes
+
+    return _confirm

--- a/test/unit/deadline_client/job_bundle/test_hooks.py
+++ b/test/unit/deadline_client/job_bundle/test_hooks.py
@@ -1618,6 +1618,41 @@ class TestPreGuiHooks:
 
         assert sources == []
 
+    def test_empty_bundle_dir_uses_env_source_only(self, tmp_path):
+        """A DCC caller passes bundle_dir="" (no on-disk bundle). Only the env source is
+        collected; the empty bundle dir must not become a hook source."""
+        studio = str(tmp_path / "studio")
+        os.makedirs(studio)
+        self._write_pre_gui_hooks(studio)
+
+        sources = collect_pre_gui_hook_sources(
+            bundle_dir="",
+            env_hooks_dir=studio,
+            allow_bundle_hooks=True,
+            allow_environment_hooks=True,
+            print_callback=lambda _msg: None,
+        )
+
+        assert [m.job_bundle_dir for m in sources] == [studio]
+
+    def test_empty_bundle_dir_does_not_load_hooks_from_cwd(self, tmp_path, monkeypatch):
+        """Regression: bundle_dir="" must NOT resolve hooks.yaml relative to the process
+        CWD. Otherwise a stray hooks file in a DCC's launch directory would be loaded (and,
+        with bundle hooks enabled, executed) for a submission that has no bundle."""
+        # Put a bundle hooks.yaml in the current working directory.
+        self._write_pre_gui_hooks(str(tmp_path))
+        monkeypatch.chdir(tmp_path)
+
+        sources = collect_pre_gui_hook_sources(
+            bundle_dir="",  # DCC: no bundle
+            env_hooks_dir=None,
+            allow_bundle_hooks=True,  # even with bundle hooks enabled...
+            allow_environment_hooks=True,
+            print_callback=lambda _msg: None,
+        )
+
+        assert sources == []  # ...the CWD hooks.yaml is not picked up
+
     def test_env_dir_equal_to_bundle_dir_is_not_duplicated(self, tmp_path):
         """If DEADLINE_HOOKS_DIR points at the job bundle, the shared hooks.yaml yields a
         single source (not two) so preGUI hooks do not run twice."""

--- a/test/unit/deadline_client/ui/test_pregui_hooks.py
+++ b/test/unit/deadline_client/ui/test_pregui_hooks.py
@@ -1,21 +1,39 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
-"""Tests that preGUI submission hooks work as expected on the gui-submit path.
+"""Tests that preGUI submission hooks work as expected.
 
-These exercise ``show_job_bundle_submitter`` with the Qt-heavy dependencies patched (no
-GUI binding required), focusing on hook *behavior*: environment (DEADLINE_HOOKS_DIR) hooks
-are loaded in addition to bundle hooks, and a preGUI hook's output (name, description,
-parameters) is applied to the dialog's initial settings. The gating rules (allow_bundle_hooks)
-are covered separately in ``test_pregui_hooks_permission.py``.
+Two layers are covered:
+
+* ``show_job_bundle_submitter`` integration (the gui-submit path) with the Qt-heavy
+  dependencies patched (no GUI binding required), focusing on hook *behavior*: environment
+  (DEADLINE_HOOKS_DIR) hooks are loaded in addition to bundle hooks, and a preGUI hook's
+  output (name, description, parameters) is applied to the dialog's initial settings.
+* ``run_pre_gui_hooks`` / ``apply_pre_gui_output`` called directly (the way DCC submitters
+  call them), headless — no dialog, no Qt.
+
+The pre-GUI logic lives in ``deadline.client.ui.pre_gui_hooks`` (Qt-free); the confirmation
+prompt and the ``show_job_bundle_submitter`` call site live in ``job_bundle_submitter``. The
+gating rules (allow_bundle_hooks) are covered separately in ``test_pregui_hooks_permission.py``.
 """
 
 import os
+from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
-from deadline.client.job_bundle._hooks import HookConfiguration, HookDefinition
-from deadline.client.ui.job_bundle_submitter import show_job_bundle_submitter
+import pytest
 
+from deadline.client.exceptions import DeadlineOperationCanceled
+from deadline.client.job_bundle._hooks import HookConfiguration, HookDefinition
+from deadline.client.ui.dataclasses import JobBundleSettings
+from deadline.client.ui.job_bundle_submitter import apply_pre_gui_output, show_job_bundle_submitter
+from deadline.client.ui.pre_gui_hooks import PreGuiHookContext, run_pre_gui_hooks
+
+# Seams in the submitter module (dialog construction, bundle loading, auto_accept check).
 MODULE = "deadline.client.ui.job_bundle_submitter"
+# Seams in the pre-GUI hooks module (source selection + config gates that run_pre_gui_hooks
+# resolves). _HookManager lives here now; _get_setting / _config_file are imported by BOTH
+# modules, so integration tests patch them in both places.
+HOOKS_MODULE = "deadline.client.ui.pre_gui_hooks"
 
 
 def _pre_gui_config(pre_gui=True):
@@ -27,9 +45,24 @@ def _pre_gui_config(pre_gui=True):
     )
 
 
-def _run_submitter(bundle_dir, settings_map, hook_manager, *, env=None):
+def _run_submitter(bundle_dir, settings_map, hook_manager, *, env=None, job_parameters=None):
     """Drive show_job_bundle_submitter with Qt/deps patched, returning the constructed
     SubmitJobToDeadlineDialog mock so callers can inspect the initial settings passed to it."""
+
+    return _run_submitter_with_factory(
+        bundle_dir,
+        settings_map,
+        hook_factory=lambda *a, **k: hook_manager,
+        env=env,
+        job_parameters=job_parameters,
+    )
+
+
+def _run_submitter_with_factory(
+    bundle_dir, settings_map, hook_factory, *, bundle_parameters=None, env=None, job_parameters=None
+):
+    """Like _run_submitter but constructs a fresh _HookManager per source via hook_factory,
+    so tests can distinguish the env-dir manager from the bundle-dir manager."""
 
     def fake_get_setting(name, config=None):
         return settings_map.get(name, "false")
@@ -41,17 +74,22 @@ def _run_submitter(bundle_dir, settings_map, hook_manager, *, env=None):
             f"{MODULE}.read_yaml_or_json_object",
             side_effect=lambda _dir, name, *a, **k: template if name == "template" else None,
         ),
-        patch(f"{MODULE}.read_job_bundle_parameters", return_value=[]),
-        patch(f"{MODULE}._HookManager", return_value=hook_manager),
+        patch(f"{MODULE}.read_job_bundle_parameters", return_value=bundle_parameters or []),
+        patch(f"{HOOKS_MODULE}._HookManager", side_effect=hook_factory),
         patch(f"{MODULE}.SubmitJobToDeadlineDialog") as dialog_cls,
         patch(f"{MODULE}.QApplication"),
         patch(f"{MODULE}.QMessageBox"),
+        # _get_setting / _config_file are read by both the submitter (auto_accept) and the
+        # hooks module (allow_* gates + farm/queue defaults) — patch both.
         patch(f"{MODULE}._get_setting", side_effect=fake_get_setting),
+        patch(f"{HOOKS_MODULE}._get_setting", side_effect=fake_get_setting),
         patch(f"{MODULE}._config_file") as mock_config_file,
+        patch(f"{HOOKS_MODULE}._config_file") as hooks_config_file,
         patch.dict(os.environ, env or {}, clear=False),
     ):
         mock_config_file.str2bool.side_effect = lambda v: str(v).lower() == "true"
-        show_job_bundle_submitter(input_job_bundle_dir=bundle_dir)
+        hooks_config_file.str2bool.side_effect = lambda v: str(v).lower() == "true"
+        show_job_bundle_submitter(input_job_bundle_dir=bundle_dir, job_parameters=job_parameters)
     return dialog_cls
 
 
@@ -158,31 +196,16 @@ class TestPreGuiEnvironmentHooksLoaded:
             m.execute_pre_gui_hooks.return_value = {}
             return m
 
-        def fake_get_setting(name, config=None):
-            return {
+        _run_submitter_with_factory(
+            bundle_dir,
+            {
                 "settings.allow_bundle_hooks": "true",
                 "settings.allow_environment_hooks": "true",
                 "settings.auto_accept": "true",
-            }.get(name, "false")
-
-        template = {"name": "Bundle Job", "steps": []}
-        with (
-            patch(f"{MODULE}.validate_directory_symlink_containment"),
-            patch(
-                f"{MODULE}.read_yaml_or_json_object",
-                side_effect=lambda _dir, name, *a, **k: template if name == "template" else None,
-            ),
-            patch(f"{MODULE}.read_job_bundle_parameters", return_value=[]),
-            patch(f"{MODULE}._HookManager", side_effect=factory),
-            patch(f"{MODULE}.SubmitJobToDeadlineDialog"),
-            patch(f"{MODULE}.QApplication"),
-            patch(f"{MODULE}.QMessageBox"),
-            patch(f"{MODULE}._get_setting", side_effect=fake_get_setting),
-            patch(f"{MODULE}._config_file") as mock_config_file,
-            patch.dict(os.environ, {"DEADLINE_HOOKS_DIR": studio}, clear=False),
-        ):
-            mock_config_file.str2bool.side_effect = lambda v: str(v).lower() == "true"
-            show_job_bundle_submitter(input_job_bundle_dir=bundle_dir)
+            },
+            hook_factory=factory,
+            env={"DEADLINE_HOOKS_DIR": studio},
+        )
 
         assert studio in constructed_with  # env dir was consulted
         assert bundle_dir in constructed_with
@@ -210,31 +233,16 @@ class TestPreGuiEnvironmentHooksLoaded:
             m.execute_pre_gui_hooks.side_effect = _exec
             return m
 
-        def fake_get_setting(name, config=None):
-            return {
+        _run_submitter_with_factory(
+            bundle_dir,
+            {
                 "settings.allow_bundle_hooks": "true",
                 "settings.allow_environment_hooks": "false",
                 "settings.auto_accept": "true",
-            }.get(name, "false")
-
-        template = {"name": "Bundle Job", "steps": []}
-        with (
-            patch(f"{MODULE}.validate_directory_symlink_containment"),
-            patch(
-                f"{MODULE}.read_yaml_or_json_object",
-                side_effect=lambda _dir, name, *a, **k: template if name == "template" else None,
-            ),
-            patch(f"{MODULE}.read_job_bundle_parameters", return_value=[]),
-            patch(f"{MODULE}._HookManager", side_effect=factory),
-            patch(f"{MODULE}.SubmitJobToDeadlineDialog"),
-            patch(f"{MODULE}.QApplication"),
-            patch(f"{MODULE}.QMessageBox"),
-            patch(f"{MODULE}._get_setting", side_effect=fake_get_setting),
-            patch(f"{MODULE}._config_file") as mock_config_file,
-            patch.dict(os.environ, {"DEADLINE_HOOKS_DIR": studio}, clear=False),
-        ):
-            mock_config_file.str2bool.side_effect = lambda v: str(v).lower() == "true"
-            show_job_bundle_submitter(input_job_bundle_dir=bundle_dir)
+            },
+            hook_factory=factory,
+            env={"DEADLINE_HOOKS_DIR": studio},
+        )
 
         assert executed == []  # env preGUI hook did not run (env hooks disabled)
 
@@ -243,34 +251,6 @@ class TestPreGuiHookCliPrecedence:
     """CLI --parameter values take precedence over preGUI hook parameters, for both template
     and shared parameters. Regression for a bug where template CLI params were popped out of
     the working dict before the hook merge ran, letting a hook silently override them."""
-
-    def _run(self, bundle_dir, hook_manager, bundle_parameters, job_parameters):
-        def fake_get_setting(name, config=None):
-            return {
-                "settings.allow_bundle_hooks": "true",
-                "settings.auto_accept": "true",
-            }.get(name, "false")
-
-        template = {"name": "Bundle Job", "steps": []}
-        with (
-            patch(f"{MODULE}.validate_directory_symlink_containment"),
-            patch(
-                f"{MODULE}.read_yaml_or_json_object",
-                side_effect=lambda _dir, name, *a, **k: template if name == "template" else None,
-            ),
-            patch(f"{MODULE}.read_job_bundle_parameters", return_value=bundle_parameters),
-            patch(f"{MODULE}._HookManager", return_value=hook_manager),
-            patch(f"{MODULE}.SubmitJobToDeadlineDialog") as dialog_cls,
-            patch(f"{MODULE}.QApplication"),
-            patch(f"{MODULE}.QMessageBox"),
-            patch(f"{MODULE}._get_setting", side_effect=fake_get_setting),
-            patch(f"{MODULE}._config_file") as mock_config_file,
-        ):
-            mock_config_file.str2bool.side_effect = lambda v: str(v).lower() == "true"
-            show_job_bundle_submitter(
-                input_job_bundle_dir=bundle_dir, job_parameters=job_parameters
-            )
-        return dialog_cls
 
     def test_cli_template_parameter_wins_over_hook(self, tmp_path):
         """A CLI --parameter value for a *template* parameter is not overridden by a preGUI
@@ -282,9 +262,10 @@ class TestPreGuiHookCliPrecedence:
         hook_manager._original_bundle_dir = bundle_dir
         hook_manager.execute_pre_gui_hooks.return_value = {"parameters": {"Foo": "hook_value"}}
 
-        dialog_cls = self._run(
+        dialog_cls = _run_submitter_with_factory(
             bundle_dir,
-            hook_manager,
+            {"settings.allow_bundle_hooks": "true", "settings.auto_accept": "true"},
+            hook_factory=lambda *a, **k: hook_manager,
             bundle_parameters=[{"name": "Foo", "type": "STRING", "default": "bundle_value"}],
             job_parameters=[{"name": "Foo", "value": "cli_value"}],
         )
@@ -303,9 +284,10 @@ class TestPreGuiHookCliPrecedence:
         hook_manager._original_bundle_dir = bundle_dir
         hook_manager.execute_pre_gui_hooks.return_value = {"parameters": {"Foo": "hook_value"}}
 
-        dialog_cls = self._run(
+        dialog_cls = _run_submitter_with_factory(
             bundle_dir,
-            hook_manager,
+            {"settings.allow_bundle_hooks": "true", "settings.auto_accept": "true"},
+            hook_factory=lambda *a, **k: hook_manager,
             bundle_parameters=[{"name": "Foo", "type": "STRING", "default": "bundle_value"}],
             job_parameters=[],
         )
@@ -313,3 +295,216 @@ class TestPreGuiHookCliPrecedence:
         initial_settings = dialog_cls.call_args.kwargs["initial_job_settings"]
         foo = next(p for p in initial_settings.parameters if p["name"] == "Foo")
         assert foo["value"] == "hook_value"
+
+
+def _make_env_hook_manager(hooks_dir):
+    """A _HookManager stand-in whose preGUI hook echoes the metadata it received back to the
+    caller, so tests can assert on what run_pre_gui_hooks passed in."""
+    m = MagicMock()
+    m.hooks = _pre_gui_config()
+    m.load_hooks.return_value = m.hooks
+    m._original_bundle_dir = hooks_dir
+    return m
+
+
+@contextmanager
+def _headless_run(settings_map, hook_manager, env=None):
+    """Patch the hooks-package seam + config so run_pre_gui_hooks runs headless (no Qt, no
+    dialog). Yields nothing — callers just invoke run_pre_gui_hooks inside the block."""
+
+    def fake_get_setting(name, config=None):
+        return settings_map.get(name, "false")
+
+    with (
+        patch(f"{HOOKS_MODULE}._HookManager", return_value=hook_manager),
+        patch(f"{HOOKS_MODULE}._get_setting", side_effect=fake_get_setting),
+        patch(f"{HOOKS_MODULE}._config_file") as cfg,
+        patch.dict(os.environ, env or {}, clear=False),
+    ):
+        cfg.str2bool.side_effect = lambda v: str(v).lower() == "true"
+        yield
+
+
+class TestRunPreGuiHooksHeadless:
+    """run_pre_gui_hooks is Qt-free and callable directly by DCC submitters. These tests do
+    NOT construct any dialog — they exercise the public function the way Maya/Nuke will."""
+
+    def test_dcc_env_only_source_runs_without_a_bundle(self, tmp_path):
+        """The DCC scenario: bundle_dir=None, hooks come only from DEADLINE_HOOKS_DIR. The
+        env hook runs and its output is returned — no dialog, no Qt, no bundle on disk."""
+        studio = str(tmp_path / "studio")
+        os.makedirs(studio)
+        hook_manager = _make_env_hook_manager(studio)
+        hook_manager.execute_pre_gui_hooks.return_value = {"name": "PREGUI_RAN"}
+
+        with _headless_run(
+            {
+                "settings.allow_environment_hooks": "true",
+                "defaults.farm_id": "farm-123",
+                "defaults.queue_id": "queue-456",
+            },
+            hook_manager,
+            env={"DEADLINE_HOOKS_DIR": studio},
+        ):
+            output = run_pre_gui_hooks(
+                PreGuiHookContext(bundle_dir=None, job_name="Initial", submitter_name="maya")
+            )
+
+        assert output == {"name": "PREGUI_RAN"}
+        hook_manager.execute_pre_gui_hooks.assert_called_once()
+        # The metadata handed to the hook carries the DCC context and an empty bundle dir.
+        metadata = hook_manager.execute_pre_gui_hooks.call_args.args[0]
+        assert metadata.submitter_name == "maya"
+        assert metadata.job_bundle_dir == ""
+        assert metadata.farm_id == "farm-123"
+        assert metadata.queue_id == "queue-456"
+
+    def test_no_sources_returns_empty_and_skips_confirmation(self, tmp_path):
+        """With no runnable preGUI hooks, the function returns {} and never calls the
+        confirm callback (nothing to confirm)."""
+        studio = str(tmp_path / "studio")
+        os.makedirs(studio)
+        hook_manager = _make_env_hook_manager(studio)
+        hook_manager.hooks = _pre_gui_config(pre_gui=False)
+        hook_manager.load_hooks.return_value = hook_manager.hooks
+
+        confirm = MagicMock(return_value=True)
+        with _headless_run(
+            {"settings.allow_environment_hooks": "true"},
+            hook_manager,
+            env={"DEADLINE_HOOKS_DIR": studio},
+        ):
+            output = run_pre_gui_hooks(PreGuiHookContext(bundle_dir=None), confirm_callback=confirm)
+
+        assert output == {}
+        confirm.assert_not_called()
+        hook_manager.execute_pre_gui_hooks.assert_not_called()
+
+    def test_confirm_callback_declined_raises_cancel(self, tmp_path):
+        """A confirm_callback returning False cancels the submission and no hook runs."""
+        studio = str(tmp_path / "studio")
+        os.makedirs(studio)
+        hook_manager = _make_env_hook_manager(studio)
+
+        with _headless_run(
+            {"settings.allow_environment_hooks": "true"},
+            hook_manager,
+            env={"DEADLINE_HOOKS_DIR": studio},
+        ):
+            with pytest.raises(DeadlineOperationCanceled):
+                run_pre_gui_hooks(
+                    PreGuiHookContext(bundle_dir=None), confirm_callback=lambda _sources: False
+                )
+
+        hook_manager.execute_pre_gui_hooks.assert_not_called()
+
+    def test_confirm_callback_accepted_runs_hook(self, tmp_path):
+        """A confirm_callback returning True lets the hook run; it receives the source list."""
+        studio = str(tmp_path / "studio")
+        os.makedirs(studio)
+        hook_manager = _make_env_hook_manager(studio)
+        hook_manager.execute_pre_gui_hooks.return_value = {"description": "ok"}
+
+        seen = {}
+
+        def confirm(sources):
+            seen["count"] = len(sources)
+            return True
+
+        with _headless_run(
+            {"settings.allow_environment_hooks": "true"},
+            hook_manager,
+            env={"DEADLINE_HOOKS_DIR": studio},
+        ):
+            output = run_pre_gui_hooks(PreGuiHookContext(bundle_dir=None), confirm_callback=confirm)
+
+        assert output == {"description": "ok"}
+        assert seen["count"] == 1
+        hook_manager.execute_pre_gui_hooks.assert_called_once()
+
+    def test_none_confirm_callback_runs_without_prompting(self, tmp_path):
+        """confirm_callback=None (e.g. auto_accept at the call site) runs hooks silently."""
+        studio = str(tmp_path / "studio")
+        os.makedirs(studio)
+        hook_manager = _make_env_hook_manager(studio)
+        hook_manager.execute_pre_gui_hooks.return_value = {"name": "N"}
+
+        with _headless_run(
+            {"settings.allow_environment_hooks": "true"},
+            hook_manager,
+            env={"DEADLINE_HOOKS_DIR": studio},
+        ):
+            output = run_pre_gui_hooks(PreGuiHookContext(bundle_dir=None), confirm_callback=None)
+
+        assert output == {"name": "N"}
+        hook_manager.execute_pre_gui_hooks.assert_called_once()
+
+
+class TestApplyPreGuiOutput:
+    """apply_pre_gui_output routes merged hook output onto a JobBundleSettings + shared dict."""
+
+    def _settings(self, parameters=None):
+        s = JobBundleSettings(input_job_bundle_dir="/bundle", name="Original")
+        s.parameters = parameters or []
+        return s
+
+    def test_name_and_description_applied(self):
+        settings = self._settings()
+        shared: dict = {}
+        apply_pre_gui_output({"name": "NEW", "description": "desc"}, settings, shared)
+        assert settings.name == "NEW"
+        assert settings.description == "desc"
+
+    def test_template_parameter_updated_in_place(self):
+        settings = self._settings(parameters=[{"name": "Foo", "type": "STRING", "default": "orig"}])
+        shared: dict = {}
+        apply_pre_gui_output({"parameters": {"Foo": "from_hook"}}, settings, shared)
+        foo = next(p for p in settings.parameters if p["name"] == "Foo")
+        assert foo["value"] == "from_hook"
+        assert "Foo" not in shared  # template param stays on settings, not shared
+
+    def test_non_template_parameter_lands_in_shared(self):
+        settings = self._settings()
+        shared: dict = {}
+        apply_pre_gui_output({"parameters": {"deadline:priority": 90}}, settings, shared)
+        assert shared["deadline:priority"] == 90
+
+    def test_cli_provided_name_blocks_hook_override(self):
+        settings = self._settings(
+            parameters=[{"name": "Foo", "type": "STRING", "value": "cli_value"}]
+        )
+        shared: dict = {}
+        apply_pre_gui_output(
+            {"parameters": {"Foo": "hook_value"}},
+            settings,
+            shared,
+            cli_provided_param_names={"Foo"},
+        )
+        foo = next(p for p in settings.parameters if p["name"] == "Foo")
+        assert foo["value"] == "cli_value"  # CLI wins
+
+    def test_empty_output_is_a_noop(self):
+        settings = self._settings()
+        shared: dict = {}
+        apply_pre_gui_output({}, settings, shared)
+        assert settings.name == "Original"
+        assert shared == {}
+
+
+class TestPreGuiHookContext:
+    """PreGuiHookContext bundles hook inputs so run_pre_gui_hooks' signature stays stable."""
+
+    def test_defaults_match_env_only_dcc_usage(self):
+        """A bare context is the DCC default: no bundle, JobBundle submitter identity."""
+        ctx = PreGuiHookContext()
+        assert ctx.bundle_dir is None
+        assert ctx.parameters == {}
+        assert ctx.submitter_name == "JobBundle"
+        assert ctx.priority == 50
+
+    def test_parameters_default_is_not_shared_between_instances(self):
+        """The mutable ``parameters`` default is per-instance (field(default_factory=dict))."""
+        a = PreGuiHookContext()
+        a.parameters["x"] = 1
+        b = PreGuiHookContext()
+        assert b.parameters == {}

--- a/test/unit/deadline_client/ui/test_pregui_hooks.py
+++ b/test/unit/deadline_client/ui/test_pregui_hooks.py
@@ -522,7 +522,7 @@ class TestApplyPreGuiOutput:
         """With no template-parameter list, every hook parameter lands in the shared values —
         the generic behavior DCC submitters (Maya, Nuke) rely on."""
         settings = _DccSettings()
-        shared = {"RezPackages": "mayaIO-2024 deadline_cloud_for_maya"}
+        shared: dict = {"RezPackages": "mayaIO-2024 deadline_cloud_for_maya"}
         apply_pre_gui_output(
             {"parameters": {"deadline:priority": 90, "RezPackages": "mayaIO-2024 custom_pkg"}},
             settings,

--- a/test/unit/deadline_client/ui/test_pregui_hooks.py
+++ b/test/unit/deadline_client/ui/test_pregui_hooks.py
@@ -35,7 +35,7 @@ from deadline.client.ui.pre_gui_hooks import (
 # Seams in the submitter module (dialog construction, bundle loading, auto_accept check).
 MODULE = "deadline.client.ui.job_bundle_submitter"
 # Seams in the pre-GUI hooks module (source selection + config gates that run_pre_gui_hooks
-# resolves). _HookManager lives here now; _get_setting / _config_file are imported by BOTH
+# resolves). HookManager lives here now; _get_setting / _config_file are imported by BOTH
 # modules, so integration tests patch them in both places.
 HOOKS_MODULE = "deadline.client.ui.pre_gui_hooks"
 
@@ -65,7 +65,7 @@ def _run_submitter(bundle_dir, settings_map, hook_manager, *, env=None, job_para
 def _run_submitter_with_factory(
     bundle_dir, settings_map, hook_factory, *, bundle_parameters=None, env=None, job_parameters=None
 ):
-    """Like _run_submitter but constructs a fresh _HookManager per source via hook_factory,
+    """Like _run_submitter but constructs a fresh HookManager per source via hook_factory,
     so tests can distinguish the env-dir manager from the bundle-dir manager."""
 
     def fake_get_setting(name, config=None):
@@ -79,7 +79,7 @@ def _run_submitter_with_factory(
             side_effect=lambda _dir, name, *a, **k: template if name == "template" else None,
         ),
         patch(f"{MODULE}.read_job_bundle_parameters", return_value=bundle_parameters or []),
-        patch(f"{HOOKS_MODULE}._HookManager", side_effect=hook_factory),
+        patch(f"{HOOKS_MODULE}.HookManager", side_effect=hook_factory),
         patch(f"{MODULE}.SubmitJobToDeadlineDialog") as dialog_cls,
         patch(f"{MODULE}.QApplication"),
         patch(f"{MODULE}.QMessageBox"),
@@ -183,7 +183,7 @@ class TestPreGuiEnvironmentHooksLoaded:
     """PreGUI hooks are loaded from DEADLINE_HOOKS_DIR, not just the job bundle."""
 
     def test_env_hooks_dir_is_used_as_a_source(self, tmp_path):
-        """With DEADLINE_HOOKS_DIR set and environment hooks enabled, a _HookManager is
+        """With DEADLINE_HOOKS_DIR set and environment hooks enabled, a HookManager is
         constructed for the env dir (the #2 fix — the loader must consult it)."""
         bundle_dir = _make_bundle(tmp_path)
         studio = str(tmp_path / "studio")
@@ -302,7 +302,7 @@ class TestPreGuiHookCliPrecedence:
 
 
 def _make_env_hook_manager(hooks_dir):
-    """A _HookManager stand-in whose preGUI hook echoes the metadata it received back to the
+    """A HookManager stand-in whose preGUI hook echoes the metadata it received back to the
     caller, so tests can assert on what run_pre_gui_hooks passed in."""
     m = MagicMock()
     m.hooks = _pre_gui_config()
@@ -320,7 +320,7 @@ def _headless_run(settings_map, hook_manager, env=None):
         return settings_map.get(name, "false")
 
     with (
-        patch(f"{HOOKS_MODULE}._HookManager", return_value=hook_manager),
+        patch(f"{HOOKS_MODULE}.HookManager", return_value=hook_manager),
         patch(f"{HOOKS_MODULE}._get_setting", side_effect=fake_get_setting),
         patch(f"{HOOKS_MODULE}._config_file") as cfg,
         patch.dict(os.environ, env or {}, clear=False),

--- a/test/unit/deadline_client/ui/test_pregui_hooks.py
+++ b/test/unit/deadline_client/ui/test_pregui_hooks.py
@@ -25,8 +25,12 @@ import pytest
 from deadline.client.exceptions import DeadlineOperationCanceled
 from deadline.client.job_bundle._hooks import HookConfiguration, HookDefinition
 from deadline.client.ui.dataclasses import JobBundleSettings
-from deadline.client.ui.job_bundle_submitter import apply_pre_gui_output, show_job_bundle_submitter
-from deadline.client.ui.pre_gui_hooks import PreGuiHookContext, run_pre_gui_hooks
+from deadline.client.ui.job_bundle_submitter import show_job_bundle_submitter
+from deadline.client.ui.pre_gui_hooks import (
+    PreGuiHookContext,
+    apply_pre_gui_output,
+    run_pre_gui_hooks,
+)
 
 # Seams in the submitter module (dialog construction, bundle loading, auto_accept check).
 MODULE = "deadline.client.ui.job_bundle_submitter"
@@ -440,8 +444,24 @@ class TestRunPreGuiHooksHeadless:
         hook_manager.execute_pre_gui_hooks.assert_called_once()
 
 
+class _DccSettings:
+    """A minimal DCC-style settings object: assignable name/description, NO parameters list.
+
+    Stands in for Maya's RenderSubmitterUISettings / Nuke's SubmitterUISettings, which have no
+    template-parameter list — so apply_pre_gui_output must route every hook parameter to the
+    shared values dict rather than onto the settings object."""
+
+    def __init__(self):
+        self.name = "Original"
+        self.description = ""
+
+
 class TestApplyPreGuiOutput:
-    """apply_pre_gui_output routes merged hook output onto a JobBundleSettings + shared dict."""
+    """apply_pre_gui_output routes merged hook output onto a settings object + shared dict.
+
+    It is generic: JobBundleSettings (with a .parameters template list) gets template params
+    routed in place, while DCC settings (no .parameters) send every param to the shared dict.
+    """
 
     def _settings(self, parameters=None):
         s = JobBundleSettings(input_job_bundle_dir="/bundle", name="Original")
@@ -489,6 +509,27 @@ class TestApplyPreGuiOutput:
         apply_pre_gui_output({}, settings, shared)
         assert settings.name == "Original"
         assert shared == {}
+
+    def test_dcc_settings_name_and_description_applied(self):
+        """A DCC settings object (no .parameters) still gets name/description applied."""
+        settings = _DccSettings()
+        shared: dict = {}
+        apply_pre_gui_output({"name": "NEW", "description": "desc"}, settings, shared)
+        assert settings.name == "NEW"
+        assert settings.description == "desc"
+
+    def test_dcc_settings_all_parameters_go_to_shared(self):
+        """With no template-parameter list, every hook parameter lands in the shared values —
+        the generic behavior DCC submitters (Maya, Nuke) rely on."""
+        settings = _DccSettings()
+        shared = {"RezPackages": "mayaIO-2024 deadline_cloud_for_maya"}
+        apply_pre_gui_output(
+            {"parameters": {"deadline:priority": 90, "RezPackages": "mayaIO-2024 custom_pkg"}},
+            settings,
+            shared,
+        )
+        assert shared["deadline:priority"] == 90
+        assert shared["RezPackages"] == "mayaIO-2024 custom_pkg"  # overrides default
 
 
 class TestPreGuiHookContext:

--- a/test/unit/deadline_client/ui/test_pregui_hooks_permission.py
+++ b/test/unit/deadline_client/ui/test_pregui_hooks_permission.py
@@ -10,7 +10,11 @@ import pytest
 from deadline.client.job_bundle._hooks import HookConfiguration, HookDefinition
 from deadline.client.ui.job_bundle_submitter import show_job_bundle_submitter
 
+# show_job_bundle_submitter lives here (dialog construction, auto_accept check)...
 MODULE = "deadline.client.ui.job_bundle_submitter"
+# ...but the pre-GUI hook sourcing + gating it delegates to lives in this module, so the
+# _HookManager seam and the allow_*_hooks config reads must be patched here.
+HOOKS_MODULE = "deadline.client.ui.pre_gui_hooks"
 
 
 @pytest.fixture
@@ -49,7 +53,7 @@ def _patch_submitter_deps(tmp_path, hooks_with_pre_gui):
         "read_job_bundle_parameters": patch(
             f"{MODULE}.read_job_bundle_parameters", return_value=[]
         ),
-        "HookManager": patch(f"{MODULE}._HookManager", return_value=mock_hook_manager),
+        "HookManager": patch(f"{HOOKS_MODULE}._HookManager", return_value=mock_hook_manager),
         "SubmitJobToDeadlineDialog": patch(f"{MODULE}.SubmitJobToDeadlineDialog"),
         "QApplication": patch(f"{MODULE}.QApplication"),
         "QMessageBox": patch(f"{MODULE}.QMessageBox"),
@@ -75,11 +79,16 @@ def _call_submitter(bundle_dir, settings_map):
     def fake_get_setting(name, config=None):
         return settings_map.get(name, "false")
 
+    # _get_setting / _config_file are read by both the submitter (auto_accept) and the
+    # pre_gui_hooks module (allow_bundle_hooks / allow_environment_hooks gates) — patch both.
     with (
         patch(f"{MODULE}._get_setting", side_effect=fake_get_setting),
         patch(f"{MODULE}._config_file") as mock_config_file,
+        patch(f"{HOOKS_MODULE}._get_setting", side_effect=fake_get_setting),
+        patch(f"{HOOKS_MODULE}._config_file") as hooks_config_file,
     ):
         mock_config_file.str2bool.side_effect = lambda v: v.lower() == "true"
+        hooks_config_file.str2bool.side_effect = lambda v: v.lower() == "true"
         show_job_bundle_submitter(input_job_bundle_dir=bundle_dir)
 
 

--- a/test/unit/deadline_client/ui/test_pregui_hooks_permission.py
+++ b/test/unit/deadline_client/ui/test_pregui_hooks_permission.py
@@ -13,7 +13,7 @@ from deadline.client.ui.job_bundle_submitter import show_job_bundle_submitter
 # show_job_bundle_submitter lives here (dialog construction, auto_accept check)...
 MODULE = "deadline.client.ui.job_bundle_submitter"
 # ...but the pre-GUI hook sourcing + gating it delegates to lives in this module, so the
-# _HookManager seam and the allow_*_hooks config reads must be patched here.
+# HookManager seam and the allow_*_hooks config reads must be patched here.
 HOOKS_MODULE = "deadline.client.ui.pre_gui_hooks"
 
 
@@ -53,7 +53,7 @@ def _patch_submitter_deps(tmp_path, hooks_with_pre_gui):
         "read_job_bundle_parameters": patch(
             f"{MODULE}.read_job_bundle_parameters", return_value=[]
         ),
-        "HookManager": patch(f"{HOOKS_MODULE}._HookManager", return_value=mock_hook_manager),
+        "HookManager": patch(f"{HOOKS_MODULE}.HookManager", return_value=mock_hook_manager),
         "SubmitJobToDeadlineDialog": patch(f"{MODULE}.SubmitJobToDeadlineDialog"),
         "QApplication": patch(f"{MODULE}.QApplication"),
         "QMessageBox": patch(f"{MODULE}.QMessageBox"),


### PR DESCRIPTION
## What

Adds a public, Qt-free `run_pre_gui_hooks` (in a new `deadline.client.ui.pre_gui_hooks` module) that in-application (DCC) submitters — Maya, Nuke, Blender, etc. — can call to run **pre-GUI** submission hooks and pre-populate their dialog fields. Today DCC submitters cannot run pre-GUI hooks at all; this closes that gap without baking hook execution into the shared `SubmitJobToDeadlineDialog`.

## Why

Pre-GUI hooks are the intended `DEADLINE_HOOKS_DIR` mechanism for DCCs (which have no on-disk bundle at submission time), but the logic lived inline in `job_bundle_submitter.py` — coupled to `qtpy` (imported at module top) and to `JobBundleSettings`. A DCC couldn't reuse it: it holds a different settings dataclass and can't supply the inline `QMessageBox` prompt or settings-shaped metadata.

## How

- **New module `deadline/client/ui/pre_gui_hooks.py`** (no top-level `qtpy` import, so it is headless-importable):
  - `PreGuiHookContext` — dataclass bundling the hook inputs, so `run_pre_gui_hooks`' signature stays stable as pre-GUI metadata grows.
  - `run_pre_gui_hooks(context, *, confirm_callback=None)` — public, Qt-free; sources hooks from `DEADLINE_HOOKS_DIR` and (when `bundle_dir` is given) the bundle; returns merged `{name, description, parameters}`. DCC callers pass `bundle_dir=None`.
  - `qt_hook_confirmation(parent)` — the sole Qt adapter; imports Qt lazily and is passed as `confirm_callback` when the standard prompt is wanted.
- `apply_pre_gui_output` stays in `job_bundle_submitter.py` — it is `JobBundleSettings`-specific (the standalone submitter's type) and not generic across submitters.
- `show_job_bundle_submitter` refactored onto the above; **gui-submit behavior is unchanged**.

## Testing

Adds headless unit tests exercising `run_pre_gui_hooks` (env-only DCC scenario, confirm-callback accept/decline/none, scalar-override + parameter-merge across sources), `apply_pre_gui_output` (routing + CLI precedence), and `PreGuiHookContext` defaults. Existing gui-submit behavior tests are preserved as regression coverage.

## Follow-ups

DCC adoption lands in each DCC repo separately (Maya first — separate PR). Each bumps its `deadline` dependency floor to the release that ships `run_pre_gui_hooks`.