### PR TITLE
ci: add Security Scan stub (zizmor via reusable org workflow)

### DIFF
--- a/.github/workflows/api-change-detection.yml
+++ b/.github/workflows/api-change-detection.yml
@@ -9,12 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.13'
 
@@ -23,28 +23,37 @@ jobs:
           pip install --upgrade hatch
 
       - name: Check for API breaking changes (griffe)
+        env:
+          # Pass context via env, not inline ${{ }}, to avoid template injection.
+          BASE_REF: ${{ github.base_ref }}
         run: |
           # Use griffe to check for breaking changes against the target branch (mainline)
-          echo "🔍 Running griffe check command: hatch run docs:check-api-breaks --against origin/${{ github.base_ref }}"
-          hatch run docs:check-api-breaks --against origin/${{ github.base_ref }}
+          echo "🔍 Running griffe check command: hatch run docs:check-api-breaks --against origin/$BASE_REF"
+          hatch run docs:check-api-breaks --against "origin/$BASE_REF"
         continue-on-error: true
         id: breaking-changes-check
 
       - name: Show breaking changes details
         if: steps.breaking-changes-check.outcome == 'failure'
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
           echo "🚨 Breaking changes to existing interfaces were detected! If these changes are intentional, please mark your commit as a breaking change and provide details in the commit message. Here are the details:"
-          echo "🔍 Running verbose griffe check command: hatch run docs:check-api-breaks --against origin/${{ github.base_ref }} --verbose"
-          hatch run docs:check-api-breaks --against origin/${{ github.base_ref }} --verbose
+          echo "🔍 Running verbose griffe check command: hatch run docs:check-api-breaks --against origin/$BASE_REF --verbose"
+          hatch run docs:check-api-breaks --against "origin/$BASE_REF" --verbose
 
       - name: Generate baseline API snapshot from base branch
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          echo "📊 Generating baseline API snapshot from base branch: ${{ github.base_ref }}"
-          hatch run docs:generate-api-snapshot /tmp/baseline_api_snapshot.json ${{ github.base_ref }}
+          echo "📊 Generating baseline API snapshot from base branch: $BASE_REF"
+          hatch run docs:generate-api-snapshot /tmp/baseline_api_snapshot.json "$BASE_REF"
 
       - name: Validate API snapshot against baseline
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          echo "📊 Validating current API against baseline snapshot from ${{ github.base_ref }}..."
+          echo "📊 Validating current API against baseline snapshot from $BASE_REF..."
           hatch run docs:validate-api-snapshot /tmp/baseline_api_snapshot.json
         continue-on-error: true
         id: snapshot-comparison
@@ -58,8 +67,10 @@ jobs:
 
       - name: Fail if API changes found
         if: steps.snapshot-comparison.outcome == 'failure'
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          echo "❌ API changes detected compared to baseline from ${{ github.base_ref }}."
+          echo "❌ API changes detected compared to baseline from $BASE_REF."
           echo "If these changes are intentional:"
           echo "  1. Review the changes above"
           echo "  2. Ensure your commit message follows conventional commit format"

--- a/.github/workflows/auto_approve.yml
+++ b/.github/workflows/auto_approve.yml
@@ -7,11 +7,12 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    # canonical dependabot auto-approve pattern; the job only has pull-requests: write and runs Dependabot's own metadata action
+    if: ${{ github.actor == 'dependabot[bot]' }} # zizmor: ignore[bot-conditions]
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Approve a PR

--- a/.github/workflows/blender_submitter_ui_test.yml
+++ b/.github/workflows/blender_submitter_ui_test.yml
@@ -1,3 +1,7 @@
+# The cache steps below carry `# zizmor: ignore[cache-poisoning]`: this is a
+# test-only workflow whose caches (pip, apt, a pinned Blender version) use
+# deterministic keys and are not published as release artifacts, so the
+# cache-poisoning risk does not apply here.
 name: Blender Submitter UI Integration Test
 
 on:
@@ -19,23 +23,26 @@ jobs:
     env:
       DISPLAY: ':99'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0 # zizmor: ignore[cache-poisoning]
         with:
           python-version: '3.11'
           cache: pip
 
       - name: Cache apt packages
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0 # zizmor: ignore[cache-poisoning]
         id: cache-apt
         with:
           path: ~/apt-cache
           key: apt-blender-ui-${{ runner.os }}-v1
 
       - name: Install system dependencies
+        env:
+          # Pass via env, not inline ${{ }}, to avoid template injection.
+          CACHE_HIT: ${{ steps.cache-apt.outputs.cache-hit }}
         run: |
-          if [ "${{ steps.cache-apt.outputs.cache-hit }}" = "true" ]; then
+          if [ "$CACHE_HIT" = "true" ]; then
             sudo cp -r ~/apt-cache/*.deb /var/cache/apt/archives/ 2>/dev/null || true
           fi
           sudo apt-get update
@@ -52,7 +59,7 @@ jobs:
           cp /var/cache/apt/archives/*.deb ~/apt-cache/ 2>/dev/null || true
 
       - name: Cache Blender
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0 # zizmor: ignore[cache-poisoning]
         id: cache-blender
         with:
           path: /opt/blender-${{ env.BLENDER_VERSION }}-linux-x64
@@ -95,7 +102,7 @@ jobs:
 
       - name: Upload screenshots
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: screenshots-linux
           path: /tmp/*.png
@@ -106,15 +113,15 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0 # zizmor: ignore[cache-poisoning]
         with:
           python-version: '3.11'
           cache: pip
 
       - name: Cache Blender
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0 # zizmor: ignore[cache-poisoning]
         id: cache-blender
         with:
           path: /Applications/Blender.app
@@ -158,7 +165,7 @@ jobs:
 
       - name: Upload screenshots
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: screenshots-macos
           path: /tmp/*.png
@@ -170,15 +177,15 @@ jobs:
     timeout-minutes: 15
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0 # zizmor: ignore[cache-poisoning]
         with:
           python-version: '3.11'
           cache: pip
 
       - name: Cache Blender
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0 # zizmor: ignore[cache-poisoning]
         id: cache-blender
         with:
           path: C:\Tools\blender-${{ env.BLENDER_VERSION }}-windows-x64
@@ -226,7 +233,7 @@ jobs:
 
       - name: Upload screenshots
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: screenshots-windows
           path: C:\Users\runneradmin\AppData\Local\Temp\*.png

--- a/.github/workflows/claude_pr_review.yml
+++ b/.github/workflows/claude_pr_review.yml
@@ -11,7 +11,7 @@
 # workflow_run identifiers and the role-ARN secret.
 name: Claude PR Review
 
-on:
+on: # zizmor: ignore[dangerous-triggers] -- workflow_run is intentional and safe here; see the header comment above (runs from default branch, fork PRs cannot alter behavior/secrets)
   workflow_run:
     workflows: ["Claude PR Review (collect)"]
     types:

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -32,10 +32,10 @@ jobs:
     name: Attributions
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{inputs.tag}}
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.13'
       - run: pip install hatch

--- a/.github/workflows/dcm_integration_test_linux.yml
+++ b/.github/workflows/dcm_integration_test_linux.yml
@@ -35,11 +35,11 @@ jobs:
       MOZ_ENABLE_WAYLAND: '0'
       MOZ_ACCESSIBILITY_ATK2: '1'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ inputs.tag || github.ref }}
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.12'
 
@@ -115,7 +115,7 @@ jobs:
 
       - name: Upload screenshots
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: screenshots-linux
           path: /tmp/*.png

--- a/.github/workflows/dcm_integration_test_macos.yml
+++ b/.github/workflows/dcm_integration_test_macos.yml
@@ -27,11 +27,11 @@ jobs:
       # deadline-cloud-monitor:// URL scheme without an "Open Link" prompt.
       BROWSER_NAME: Safari
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ inputs.tag || github.ref }}
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.12'
 
@@ -74,7 +74,7 @@ jobs:
 
       - name: Upload screenshots
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: screenshots-macos
           path: /tmp/*.png

--- a/.github/workflows/dcm_integration_test_windows.yml
+++ b/.github/workflows/dcm_integration_test_windows.yml
@@ -28,11 +28,11 @@ jobs:
       OPEN_LINK_LABELS: "Open,Open Link,Open link,Yes"
       SCREENSHOT_DIR: ${{ github.workspace }}\screenshots
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ inputs.tag || github.ref }}
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.12'
 
@@ -84,7 +84,7 @@ jobs:
 
       - name: Upload screenshots
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: screenshots-windows
           path: ${{ env.SCREENSHOT_DIR }}\*.png

--- a/.github/workflows/manual_pypi_release.yml
+++ b/.github/workflows/manual_pypi_release.yml
@@ -36,7 +36,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ inputs.tag }}
           fetch-depth: 0
@@ -49,7 +49,7 @@ jobs:
             exit 1
           fi
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.13'
       - name: Install dependencies
@@ -59,5 +59,5 @@ jobs:
         run: hatch -v build
       # # See https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
 

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.13'
 

--- a/.github/workflows/mkdocs_quality.yml
+++ b/.github/workflows/mkdocs_quality.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.13'
 

--- a/.github/workflows/on_opened_pr.yml
+++ b/.github/workflows/on_opened_pr.yml
@@ -1,6 +1,9 @@
 name: On Opened PR
 
-on:
+on: # zizmor: ignore[dangerous-triggers]
+  # workflow_run is intentional: it runs from the default branch with this
+  # repo's context (never a fork's copy), and only consumes the PR artifact via
+  # the reusable extract-PR-details workflow. A fork PR cannot alter behavior.
   workflow_run:
     workflows: ["Record PR"]
     types:

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -159,12 +159,12 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ needs.TagRelease.outputs.tag }}
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ needs.TagRelease.outputs.build-python-version }}
       - name: Install dependencies
@@ -174,4 +174,4 @@ jobs:
         run: hatch -v build
       # # See https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0

--- a/.github/workflows/security_scan.yml
+++ b/.github/workflows/security_scan.yml
@@ -1,0 +1,21 @@
+name: "Security Scan"
+
+on:
+  push:
+    branches: [ "mainline", "feature_*", "patch_*" ]
+  pull_request:
+    branches: [ "mainline", "feature_*", "patch_*" ]
+  schedule:
+    - cron: '0 8 * * MON'
+
+jobs:
+  Scan:
+    name: Scan
+    # Central, extensible security-scan workflow (currently zizmor). New checks
+    # added there apply here automatically — no change needed to this stub.
+    uses: aws-deadline/.github/.github/workflows/reusable_security_scan.yml@mainline
+    permissions:
+      # The reusable workflow checks out this repo and fetches the central
+      # zizmor config, and reports findings to the run log / PR annotations
+      # (not the Security tab), so it only needs read access.
+      contents: read

--- a/.github/workflows/ui_tests.yml
+++ b/.github/workflows/ui_tests.yml
@@ -11,8 +11,8 @@ jobs:
     name: UI Tests (Linux)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.13'
 
@@ -56,8 +56,8 @@ jobs:
     name: UI Tests (macOS)
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.13'
 
@@ -91,8 +91,8 @@ jobs:
     name: UI Tests (Windows)
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.13'
 

--- a/.github/workflows/weekly_release_digest.yml
+++ b/.github/workflows/weekly_release_digest.yml
@@ -37,10 +37,10 @@ jobs:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.12"
 
@@ -53,7 +53,7 @@ jobs:
         # created to read the PGP signing key from Secrets Manager), it also
         # grants the bedrock:InvokeModel permission this digest needs, so we
         # reuse it rather than provisioning a separate Bedrock role.
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
         with:
           role-to-assume: ${{ secrets.AWS_PGP_KEY_SECRET_ROLE }}
           aws-region: us-west-2


### PR DESCRIPTION
## What

1. **`security_scan.yml` stub** — thin caller for the org's reusable `reusable_security_scan.yml` (zizmor GitHub Actions static analysis). Mirrors the `codeql.yml` caller.

2. **Fix all high-severity findings** so this repo passes the new fail-on-high gate:

**unpinned-uses (46)** — pinned all third-party actions (`actions/*`, `aws-actions/*`, `dependabot/*`, `pypa/*`) to full commit SHAs with version comments. Dependabot keeps them current. Internal `aws-deadline/*@mainline` refs left as-is (intentional central-bump model).

**template-injection (8)** — moved `${{ github.base_ref }}` out of `run:` blocks in `api-change-detection.yml` into `env:` vars referenced as shell `$VARS`. Behavior-preserving; closes the shell-injection surface.

**Suppressed-with-justification (10)** — intentional design, not bugs; "fixing" would break working features:
- `dangerous-triggers` (2): `workflow_run` in `claude_pr_review` / `on_opened_pr` runs from the default branch, so fork PRs cannot alter behavior or secrets.
- `bot-conditions` (1): canonical Dependabot auto-approve actor check.
- `cache-poisoning` (7): test-only workflow, deterministic cache keys, no published release artifacts.

After: `zizmor --min-severity high` reports **0 findings** on `.github/`.

## Gate behavior

Inherits the org reusable workflow's fail-on-high gate (findings reported in the run log + PR annotations). Medium/low findings (`excessive-permissions`, `secrets-inherit`, `artipacked`) remain visible but non-blocking — accepted as hygiene follow-up per the org standard.

## Depends on

`aws-deadline/.github#89` (gate + high fixes in the reusable workflow). Merge that first so `reusable_security_scan.yml@mainline` resolves with the new behavior.

🤖 Draft — not published for review yet.