### PR TITLE
feat: add per-task download tracking and skip_reason to status file

### DIFF
--- a/src/deadline/client/cli/_download_status_file.py
+++ b/src/deadline/client/cli/_download_status_file.py
@@ -246,7 +246,6 @@ def _build_status_file_content(
                     "error_message": r.get("error_message"),
                 }
                 for task_id, r in new_tasks.items()
-                if r["total_files"] > 0  # skip zero-output tasks
             },
         }
         new_entry["tasks"] = merged_tasks
@@ -256,10 +255,16 @@ def _build_status_file_content(
             and existing_entry.get("total_files", 0) > 0
             and new_entry.get("total_files", 0) == 0
         ):
-            # No download this run — preserve existing counts, update status if changed
+            # No download this run — preserve existing counts, update status if changed.
+            # Also clear stale error fields when transitioning away from a failed state to
+            # avoid an inconsistent entry with download_status="downloaded" + error_code set.
             if new_entry["download_status"] != existing_entry["download_status"]:
                 existing_entry["download_status"] = new_entry["download_status"]
                 existing_entry["last_updated"] = new_entry["last_updated"]
+                if new_entry["download_status"] != "failed":
+                    existing_entry["error_code"] = None
+                    existing_entry["error_message"] = None
+                    existing_entry["failed_files"] = 0
             existing_entry["tasks"] = merged_tasks
         else:
             jobs_status[job_id] = new_entry

--- a/src/deadline/client/cli/_download_status_file.py
+++ b/src/deadline/client/cli/_download_status_file.py
@@ -106,6 +106,8 @@ def _make_status_entry(
     failed_files: int = 0,
     error_code: Optional[str] = None,
     error_message: Optional[str] = None,
+    skip_reason: Optional[str] = None,
+    tasks: Optional[dict[str, Any]] = None,
 ) -> dict[str, Any]:
     """Constructs a per-job status entry for the status file."""
     return {
@@ -116,6 +118,8 @@ def _make_status_entry(
         "last_updated": datetime.now(timezone.utc).isoformat(),
         "error_code": error_code,
         "error_message": error_message,
+        "skip_reason": skip_reason,
+        "tasks": tasks or {},
     }
 
 
@@ -164,10 +168,10 @@ def _determine_job_download_status(
     downloaded_files = results["downloaded_files"] if results else 0
 
     if job_id in categorized_job_ids.attachments_free:
-        return _make_status_entry("skipped")
+        return _make_status_entry("skipped", skip_reason="no_attachments")
 
     if job_id in categorized_job_ids.missing_storage_profile:
-        return _make_status_entry("skipped")
+        return _make_status_entry("skipped", skip_reason="missing_storage_profile")
 
     if job_id in categorized_job_ids.completed:
         return _make_status_entry("downloaded", total_files, downloaded_files)
@@ -197,6 +201,7 @@ def _build_status_file_content(
     download_candidate_jobs: dict[str, dict[str, Any]],
     existing_jobs: Optional[dict[str, Any]] = None,
     job_download_results: Optional[dict[str, dict[str, Any]]] = None,
+    task_download_results: Optional[dict[str, dict[str, dict[str, Any]]]] = None,
 ) -> dict[str, Any]:
     """
     Builds the full status file JSON structure by merging existing job entries
@@ -226,6 +231,26 @@ def _build_status_file_content(
             job_id, job, categorized_job_ids, job_download_results
         )
         existing_entry = jobs_status.get(job_id)
+
+        # Merge task entries: preserve existing tasks, overwrite only tasks seen this run
+        existing_tasks: dict[str, Any] = (existing_entry or {}).get("tasks", {})
+        new_tasks: dict[str, Any] = (task_download_results or {}).get(job_id, {})
+        merged_tasks = {
+            **existing_tasks,
+            **{
+                task_id: {
+                    "download_status": "downloaded" if r.get("error_code") is None else "failed",
+                    "total_files": r["total_files"],
+                    "downloaded_files": r["downloaded_files"],
+                    "error_code": r.get("error_code"),
+                    "error_message": r.get("error_message"),
+                }
+                for task_id, r in new_tasks.items()
+                if r["total_files"] > 0  # skip zero-output tasks
+            },
+        }
+        new_entry["tasks"] = merged_tasks
+
         if (
             existing_entry
             and existing_entry.get("total_files", 0) > 0
@@ -235,6 +260,7 @@ def _build_status_file_content(
             if new_entry["download_status"] != existing_entry["download_status"]:
                 existing_entry["download_status"] = new_entry["download_status"]
                 existing_entry["last_updated"] = new_entry["last_updated"]
+            existing_entry["tasks"] = merged_tasks
         else:
             jobs_status[job_id] = new_entry
 
@@ -343,6 +369,7 @@ def write_download_status_file(
     local_storage_profile: Optional[dict[str, Any]],
     checkpoint_dir: str,
     job_download_results: Optional[dict[str, dict[str, Any]]] = None,
+    task_download_results: Optional[dict[str, dict[str, dict[str, Any]]]] = None,
     print_function_callback: Callable[[Any], None] = lambda msg: None,
 ) -> None:
     """
@@ -380,6 +407,7 @@ def write_download_status_file(
                     download_candidate_jobs=download_candidate_jobs,
                     existing_jobs=existing_jobs,
                     job_download_results=job_download_results,
+                    task_download_results=task_download_results,
                 )
 
                 _atomic_write_json(status_file_path, status_content)

--- a/src/deadline/client/cli/_groups/queue_group.py
+++ b/src/deadline/client/cli/_groups/queue_group.py
@@ -523,6 +523,7 @@ def sync_output(
             categorized_job_ids,
             download_candidate_jobs,
             job_download_results,
+            task_download_results,
         ) = _incremental_output_download(
             boto3_session=boto3_session,
             farm_id=farm_id,
@@ -545,6 +546,7 @@ def sync_output(
                 local_storage_profile=local_storage_profile if local_storage_profile_id else None,
                 checkpoint_dir=checkpoint_dir,
                 job_download_results=job_download_results,
+                task_download_results=task_download_results,
                 print_function_callback=logger.echo,
             )
 

--- a/src/deadline/client/cli/_incremental_download.py
+++ b/src/deadline/client/cli/_incremental_download.py
@@ -6,6 +6,7 @@ __all__ = ["CategorizedJobIds", "_incremental_output_download"]
 from dataclasses import dataclass, asdict
 from datetime import datetime, timedelta, timezone
 import difflib
+import errno
 import json
 import os
 import re
@@ -37,7 +38,11 @@ from ...job_attachments._incremental_downloads._manifest_s3_downloads import (
     _get_manifests_to_download,
     _download_manifest_paths,
 )
-from ...job_attachments.exceptions import AssetSyncCancelledError
+from ...job_attachments.exceptions import (
+    AssetSyncCancelledError,
+    JobAttachmentsS3ClientError,
+    JobAttachmentS3BotoCoreError,
+)
 from ...job_attachments._path_mapping import (
     _generate_path_mapping_rules,
     _PathMappingRuleApplier,
@@ -62,27 +67,60 @@ from ._common import _cli_object_repr, sigint_handler
 SESSIONS_API_MAX_CONCURRENCY = 3
 
 
-def _classify_error(e: Exception) -> str:
-    """Classifies a download exception into a standard error code."""
+def _classify_single_error(e: BaseException) -> Optional[str]:
+    """Classifies one exception from its own structured signals, or None if it has none."""
+    # job_attachments surfaces S3 failures as JobAttachmentsS3ClientError with an HTTP
+    # status code, and botocore transport failures as JobAttachmentS3BotoCoreError.
+    if isinstance(e, JobAttachmentsS3ClientError):
+        if e.status_code == 403:
+            return "PERMISSION_DENIED"
+        if e.status_code == 404:
+            return "PATH_NOT_FOUND"
+    if isinstance(e, JobAttachmentS3BotoCoreError):
+        return "NETWORK_ERROR"
+
     if isinstance(e, PermissionError):
         return "PERMISSION_DENIED"
-    if isinstance(e, OSError) and e.errno == 28:
+    if isinstance(e, OSError) and e.errno == errno.ENOSPC:
         return "DISK_FULL"
     if isinstance(e, FileNotFoundError):
         return "PATH_NOT_FOUND"
     if isinstance(e, (ConnectionError, TimeoutError)):
         return "NETWORK_ERROR"
 
-    # Fallback: check the error message for S3/boto errors
-    error_str = str(e).lower()
-    if "permission" in error_str or "access denied" in error_str:
-        return "PERMISSION_DENIED"
-    elif "no space" in error_str or "disk full" in error_str:
-        return "DISK_FULL"
-    elif "no such file" in error_str or "not found" in error_str:
-        return "PATH_NOT_FOUND"
-    elif "network" in error_str or "connection" in error_str or "timeout" in error_str:
-        return "NETWORK_ERROR"
+    if isinstance(e, ClientError):
+        error_code = e.response.get("Error", {}).get("Code", "")
+        if error_code in ("AccessDenied", "AccessDeniedException", "403", "Forbidden"):
+            return "PERMISSION_DENIED"
+        if error_code in ("NoSuchKey", "NoSuchBucket", "404", "NotFound"):
+            return "PATH_NOT_FOUND"
+        if error_code in ("RequestTimeout", "RequestTimeTooSkewed"):
+            return "NETWORK_ERROR"
+
+    return None
+
+
+def _classify_error(e: BaseException) -> str:
+    """Classifies a download exception into a standard error code.
+
+    Uses only structured signals — exception type, errno, S3 HTTP status codes, and
+    boto error codes — which are reliable. Message-substring matching is intentionally
+    avoided: wrapped S3 errors carry verbose guidance text that produces confidently
+    wrong codes. job_attachments wraps low-level failures (e.g. an OSError or a botocore
+    ClientError) inside its own exception types, so we also walk the __cause__ chain to
+    reach the structured signal underneath. Anything without such a signal is UNKNOWN.
+    """
+    # Walk the __cause__ chain iteratively, tracking visited exceptions by identity so a
+    # cyclic chain (A raised `from` B and B raised `from` A) can't cause infinite recursion.
+    current: Optional[BaseException] = e
+    seen: set[int] = set()
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        code = _classify_single_error(current)
+        if code is not None:
+            return code
+        current = current.__cause__
+
     return "UNKNOWN"
 
 
@@ -156,7 +194,10 @@ class _FailedJobsTracker:
             self._counts.pop(job_id, None)
 
 
-_TASK_ID_RE = re.compile(r"(task-[^/]+)")
+# Anchor to the step-<id>/task-<id>/ layout rather than the first "task-" hit: the key is
+# prefixed with the queue's customer-controlled rootPrefix, so a prefix like "my-task-outputs/"
+# would otherwise be misread as the task id.
+_TASK_ID_RE = re.compile(r"step-[^/]+/(task-[^/]+)/")
 
 
 def _extract_task_id_from_s3_key(manifest_s3_key: str) -> Optional[str]:
@@ -479,10 +520,13 @@ def _categorize_jobs_in_checkpoint(
     for job_id in new_job_ids:
         dc_job = download_candidate_jobs[job_id]
 
-        # Call deadline:GetJob to retrieve attachments manifest information
-        job = deadline.get_job(jobId=job_id, queueId=queue_id, farmId=farm_id)
-        dc_job["attachments"] = job.get("attachments")
-        dc_job["storageProfileId"] = job.get("storageProfileId")
+        # Call deadline:GetJob to retrieve attachments manifest information, unless the candidate
+        # already carries it. Retried failed jobs are injected via GetJob upstream, so their
+        # attachments are already present — re-fetching here would be a redundant API call.
+        if "attachments" not in dc_job:
+            job = deadline.get_job(jobId=job_id, queueId=queue_id, farmId=farm_id)
+            dc_job["attachments"] = job.get("attachments")
+            dc_job["storageProfileId"] = job.get("storageProfileId")
         dc_succeeded_task_count = dc_job["taskRunStatusCounts"]["SUCCEEDED"]
         dc_total_task_count = sum(value for _, value in dc_job["taskRunStatusCounts"].items())
 
@@ -1137,7 +1181,8 @@ def _incremental_output_download(
         dry_run: If True, the operation will print out information but not perform any data downloads.
 
     Returns:
-        A tuple of (updated checkpoint, categorized job IDs, download candidate jobs dict, per-job download results).
+        A tuple of (updated checkpoint, categorized job IDs, download candidate jobs dict,
+        per-job download results, per-task download results).
     """
     durations = IncrementalOutputDownloadLatencies()
     # Operations here are within a single farm, so scope the deadline client to that
@@ -1217,7 +1262,12 @@ def _incremental_output_download(
             if job_id not in download_candidate_jobs:
                 try:
                     job = deadline.get_job(farmId=farm_id, queueId=queue_id, jobId=job_id)
-                    download_candidate_jobs[job_id] = _datetimes_to_str(job)
+                    injected_job = _datetimes_to_str(job)
+                    # Normalize the attachments/storageProfileId keys so downstream
+                    # categorization can index them directly (and skip a redundant GetJob).
+                    injected_job.setdefault("attachments", job.get("attachments"))
+                    injected_job.setdefault("storageProfileId", job.get("storageProfileId"))
+                    download_candidate_jobs[job_id] = injected_job
                 except ClientError as e:
                     if e.response.get("Error", {}).get("Code") == "ResourceNotFoundException":
                         # Job was deleted — remove from tracker to stop retrying
@@ -1363,9 +1413,18 @@ def _incremental_output_download(
     job_manifest_paths: dict[str, list[BaseManifestPath]] = {}
     # job_id -> task_id -> [files]: used for per-task download tracking
     job_task_manifest_paths: dict[str, dict[str, list[BaseManifestPath]]] = {}
-    # job_id -> task_id -> [file_paths]: immutable record of all paths originally attributed
-    # to each task, used to generate filesystem-based status for deduped jobs.
+    # job_id -> task_id -> [file_paths]: record of the paths originally attributed to each task.
+    # Unlike job_task_manifest_paths, this is NOT emptied by cross-job transfers — a losing job
+    # keeps its record so the deduped-job block below can still report its filesystem-based status
+    # after the winning job takes over the paths.
     all_task_file_paths: dict[str, dict[str, list[str]]] = {}
+    # job_id -> task_id -> {paths}: membership set mirroring all_task_file_paths so the per-file
+    # dedup check is O(1) instead of a linear scan of the growing list.
+    all_task_file_paths_seen: dict[str, dict[str, set[str]]] = {}
+    # job_id -> normcased_path -> task_id that currently owns it, so a path emitted by more than
+    # one task of the same job (e.g. a requeue) is attributed to a single task rather than
+    # duplicated across tasks (which would double-download it and inflate the file count).
+    task_owner_by_job: dict[str, dict[str, str]] = {}
     # global_seen_paths maps normcased_path -> job_id that claimed it first.
     # Prevents concurrent writes to the same destination file across jobs — parallel threads
     # could write the same path simultaneously, corrupting the file under OVERWRITE. When two
@@ -1381,7 +1440,16 @@ def _incremental_output_download(
     # job_id -> task_id -> normcased_path -> list_index, mirrors job_path_index at the task level
     task_path_index: dict[str, dict[str, dict[str, int]]] = {}
     if not skip_attribution:
-        for i, (_, job_id, _, manifest_s3_key) in enumerate(manifests_to_download):
+        # Visit manifests oldest-to-newest by their S3 LastModified timestamp so the
+        # last write of any shared path wins. downloaded_manifests is filled positionally
+        # (correlated to manifests_to_download by index) and is NOT pre-sorted, so we derive
+        # the chronological order here rather than relying on iteration order.
+        ordered_indices = sorted(
+            (i for i in range(len(manifests_to_download)) if downloaded_manifests[i] is not None),
+            key=lambda i: downloaded_manifests[i][0],
+        )
+        for i in ordered_indices:
+            _, job_id, _, manifest_s3_key = manifests_to_download[i]
             manifest_tuple = downloaded_manifests[i]
             if manifest_tuple is not None:
                 _, manifest = manifest_tuple
@@ -1391,8 +1459,9 @@ def _incremental_output_download(
                     prior_job_id = global_seen_paths.get(normcased)
                     if prior_job_id is not None and prior_job_id != job_id:
                         # A different job previously claimed this path with an older manifest.
-                        # Since downloaded_manifests is sorted oldest-to-newest, the current
-                        # manifest is newer — transfer ownership to preserve newest-wins semantics.
+                        # We iterate manifests oldest-to-newest (see ordered_indices above), so
+                        # the current manifest is newer — transfer ownership to preserve
+                        # newest-wins semantics.
                         prior_paths = job_manifest_paths.get(prior_job_id, [])
                         prior_idx_map = job_path_index.get(prior_job_id, {})
                         if normcased in prior_idx_map:
@@ -1417,6 +1486,21 @@ def _incremental_output_download(
                         job_paths.append(manifest_path)
                     global_seen_paths[normcased] = job_id
                     if task_id:
+                        # If another task in this same job already owns this path (e.g. a requeue
+                        # re-emitted it under a different task), transfer ownership to the current
+                        # task. We iterate oldest-to-newest, so the current task is the newer
+                        # writer; leaving the path in both tasks would download it twice and
+                        # inflate the file count.
+                        owner_map = task_owner_by_job.setdefault(job_id, {})
+                        prior_task_id = owner_map.get(normcased)
+                        if prior_task_id is not None and prior_task_id != task_id:
+                            prior_t_idx_map = task_path_index.get(job_id, {}).get(prior_task_id, {})
+                            if normcased in prior_t_idx_map:
+                                job_task_manifest_paths[job_id][prior_task_id][
+                                    prior_t_idx_map[normcased]
+                                ] = None  # type: ignore[call-overload]
+                                del prior_t_idx_map[normcased]
+                        owner_map[normcased] = task_id
                         job_task_manifest_paths.setdefault(job_id, {}).setdefault(task_id, [])
                         task_paths = job_task_manifest_paths[job_id][task_id]
                         t_idx_map = task_path_index.setdefault(job_id, {}).setdefault(task_id, {})
@@ -1426,13 +1510,19 @@ def _incremental_output_download(
                         else:
                             t_idx_map[normcased] = len(task_paths)
                             task_paths.append(manifest_path)
-                        # Record path immutably for deduped-job status generation.
-                        # Only add if not already recorded for this task (avoids inflation
-                        # when the same file appears in multiple manifests via task retry).
+                        # Record the path immutably for deduped-job status generation. This record
+                        # is intentionally NOT pruned by cross-job transfers, so a losing job can
+                        # still report filesystem-based status after another job claims its paths.
+                        # Dedup per task (O(1) via the _seen set) to avoid inflating counts when the
+                        # same file reappears across manifests via task retry.
                         task_file_list = all_task_file_paths.setdefault(job_id, {}).setdefault(
                             task_id, []
                         )
-                        if manifest_path.path not in task_file_list:
+                        task_file_seen = all_task_file_paths_seen.setdefault(job_id, {}).setdefault(
+                            task_id, set()
+                        )
+                        if manifest_path.path not in task_file_seen:
+                            task_file_seen.add(manifest_path.path)
                             task_file_list.append(manifest_path.path)
     else:
         # Attribution skipped: download everything anyway, decoupled from per-job tracking.
@@ -1505,26 +1595,33 @@ def _incremental_output_download(
                 print_function_callback(f"  Downloading {len(job_files)} files for job: {job_name}")
 
             MIN_DELAY_BETWEEN_PRINTOUTS = 20
-            last_call_time = time.time() - MIN_DELAY_BETWEEN_PRINTOUTS
-            printed_100_percent = False
 
-            def _update_download_progress(
-                download_metadata: ProgressReportMetadata,
-            ) -> bool:
-                nonlocal last_call_time, printed_100_percent
-                if not printed_100_percent and download_metadata.progress == 100:
-                    with print_lock:
-                        print_function_callback(f"    {download_metadata.progressMessage}")
-                    last_call_time = time.time()
-                    printed_100_percent = True
-                elif (
-                    not printed_100_percent
-                    and time.time() - last_call_time > MIN_DELAY_BETWEEN_PRINTOUTS
-                ):
-                    with print_lock:
-                        print_function_callback(f"    {download_metadata.progressMessage}")
-                    last_call_time = time.time()
-                return sigint_handler.continue_operation
+            def _make_progress_callback() -> Callable[[ProgressReportMetadata], bool]:
+                # Fresh state per download call: the per-job loop below invokes one
+                # download per task, and the 100%-printed latch must reset each time or
+                # every task after the first would print no progress at all.
+                last_call_time = time.time() - MIN_DELAY_BETWEEN_PRINTOUTS
+                printed_100_percent = False
+
+                def _update_download_progress(
+                    download_metadata: ProgressReportMetadata,
+                ) -> bool:
+                    nonlocal last_call_time, printed_100_percent
+                    if not printed_100_percent and download_metadata.progress == 100:
+                        with print_lock:
+                            print_function_callback(f"    {download_metadata.progressMessage}")
+                        last_call_time = time.time()
+                        printed_100_percent = True
+                    elif (
+                        not printed_100_percent
+                        and time.time() - last_call_time > MIN_DELAY_BETWEEN_PRINTOUTS
+                    ):
+                        with print_lock:
+                            print_function_callback(f"    {download_metadata.progressMessage}")
+                        last_call_time = time.time()
+                    return sigint_handler.continue_operation
+
+                return _update_download_progress
 
             job_task_results: dict[str, dict[str, Any]] = {}
             job_error_code: Optional[str] = None
@@ -1532,6 +1629,8 @@ def _incremental_output_download(
 
             task_map = job_task_manifest_paths.get(job_id, {})
             fallback_succeeded = False
+            leftover_downloaded = 0
+            leftover_failed = 0
             if task_map:
                 # Per-task isolation: download each task independently so individual
                 # task failures don't mark succeeded tasks as failed.
@@ -1543,7 +1642,7 @@ def _incremental_output_download(
                             queue,
                             boto3_session_for_s3,
                             file_conflict_resolution,
-                            on_downloading_files=_update_download_progress,
+                            on_downloading_files=_make_progress_callback(),
                             print_function_callback=print_function_callback,
                         )
                         if not sigint_handler.continue_operation:
@@ -1574,6 +1673,45 @@ def _incremental_output_download(
                             job_error_code = error_code
                             job_error_message = str(e)
 
+                # Some of a job's paths may not carry a step-/task- segment in their manifest key
+                # (so they were never attributed to a task). Download those leftovers here rather
+                # than dropping them silently just because the job happened to also have task files.
+                task_owned = {
+                    os.path.normcase(f.path) for files in task_map.values() for f in files
+                }
+                leftover_files = [
+                    f for f in job_files if os.path.normcase(f.path) not in task_owned
+                ]
+                if leftover_files:
+                    try:
+                        _download_manifest_paths(
+                            leftover_files,
+                            HashAlgorithm.XXH128,
+                            queue,
+                            boto3_session_for_s3,
+                            file_conflict_resolution,
+                            on_downloading_files=_make_progress_callback(),
+                            print_function_callback=print_function_callback,
+                        )
+                        if not sigint_handler.continue_operation:
+                            raise AssetSyncCancelledError("File download cancelled.")
+                        leftover_downloaded = len(leftover_files)
+                    except AssetSyncCancelledError:
+                        raise
+                    except Exception as e:
+                        error_code = _classify_error(e)
+                        with print_lock:
+                            print_function_callback(
+                                f"  ERROR downloading job {job_name} ({job_id}): {e}"
+                            )
+                        leftover_downloaded = sum(
+                            1 for f in leftover_files if os.path.exists(f.path)
+                        )
+                        leftover_failed = len(leftover_files) - leftover_downloaded
+                        if job_error_code is None:
+                            job_error_code = error_code
+                            job_error_message = str(e)
+
             else:
                 # No task attribution available — fall back to per-job download
                 try:
@@ -1583,7 +1721,7 @@ def _incremental_output_download(
                         queue,
                         boto3_session_for_s3,
                         file_conflict_resolution,
-                        on_downloading_files=_update_download_progress,
+                        on_downloading_files=_make_progress_callback(),
                         print_function_callback=print_function_callback,
                     )
                     if not sigint_handler.continue_operation:
@@ -1602,15 +1740,23 @@ def _incremental_output_download(
             if job_task_results:
                 # Per-task path: derive counts from task results directly to avoid
                 # inconsistencies from len(job_files) vs sum of per-task file lists.
-                downloaded_count = sum(r["downloaded_files"] for r in job_task_results.values())
-                failed_count = sum(
-                    r["total_files"]
-                    for r in job_task_results.values()
-                    if r["error_code"] is not None
-                ) - sum(
-                    r["downloaded_files"]
-                    for r in job_task_results.values()
-                    if r["error_code"] is not None
+                # Add any non-task-attributed leftover paths downloaded above.
+                downloaded_count = (
+                    sum(r["downloaded_files"] for r in job_task_results.values())
+                    + leftover_downloaded
+                )
+                failed_count = (
+                    sum(
+                        r["total_files"]
+                        for r in job_task_results.values()
+                        if r["error_code"] is not None
+                    )
+                    - sum(
+                        r["downloaded_files"]
+                        for r in job_task_results.values()
+                        if r["error_code"] is not None
+                    )
+                    + leftover_failed
                 )
             elif fallback_succeeded:
                 # Fallback path success: all files downloaded, use exact count.
@@ -1621,9 +1767,18 @@ def _incremental_output_download(
                 downloaded_count = sum(1 for f in job_files if os.path.exists(f.path))
                 failed_count = len(job_files) - downloaded_count
 
+            # Bytes actually written. On full success sum the manifest sizes directly; on any
+            # failure an isolated task may have downloaded only some of its files, so consult the
+            # filesystem so a partially-failed job's succeeded bytes are counted, not dropped.
+            if job_error_code is None:
+                downloaded_bytes = sum(f.size for f in job_files)
+            else:
+                downloaded_bytes = sum(f.size for f in job_files if os.path.exists(f.path))
+
             return {
                 "total_files": len(job_files),
                 "downloaded_files": downloaded_count,
+                "downloaded_bytes": downloaded_bytes,
                 "failed_files": failed_count,
                 "error_code": job_error_code,
                 "error_message": job_error_message,
@@ -1740,6 +1895,9 @@ def _incremental_output_download(
             job_download_results[job_id] = {
                 "total_files": total,
                 "downloaded_files": downloaded,
+                # These paths were downloaded by (and counted under) the winning job, so the
+                # run-level byte total must not count them again here.
+                "downloaded_bytes": 0,
                 "failed_files": total - downloaded,
                 "error_code": any_error["error_code"] if any_error else None,
                 "error_message": any_error["error_message"] if any_error else None,
@@ -1788,19 +1946,22 @@ def _incremental_output_download(
         ),
         # On dry runs job_download_results is empty — fall back to job_manifest_paths so the
         # summary reports the count/size of files that would be downloaded (the preview value).
+        # Restrict to jobs that actually owned a download this run (job_id in job_manifest_paths)
+        # so deduped jobs — whose files were downloaded and counted under the winning job — are
+        # not counted twice. Per-task isolation makes partial success normal, so we no longer gate
+        # out a job that carries an error_code: a job where only one task failed still downloaded
+        # its other tasks' files, and dropping the whole job would undercount those to zero.
         "downloaded_files": sum(
             r.get("downloaded_files", 0)
             for job_id, r in job_download_results.items()
-            if r.get("error_code") is None and job_id in job_manifest_paths
+            if job_id in job_manifest_paths
         )
         if not dry_run
         else sum(len(paths) for paths in job_manifest_paths.values()),
         "downloaded_bytes": sum(
-            path.size
-            for job_id, paths in job_manifest_paths.items()
-            for path in paths
-            if job_id in job_download_results
-            and job_download_results[job_id].get("error_code") is None
+            r.get("downloaded_bytes", 0)
+            for job_id, r in job_download_results.items()
+            if job_id in job_manifest_paths
         )
         if not dry_run
         else sum(path.size for paths in job_manifest_paths.values() for path in paths),

--- a/src/deadline/client/cli/_incremental_download.py
+++ b/src/deadline/client/cli/_incremental_download.py
@@ -8,6 +8,7 @@ from datetime import datetime, timedelta, timezone
 import difflib
 import json
 import os
+import re
 import tempfile
 import threading
 from typing import Optional
@@ -155,6 +156,19 @@ class _FailedJobsTracker:
             self._counts.pop(job_id, None)
 
 
+_TASK_ID_RE = re.compile(r"(task-[^/]+)")
+
+
+def _extract_task_id_from_s3_key(manifest_s3_key: str) -> Optional[str]:
+    """Extracts the task ID from an S3 manifest key path.
+
+    S3 manifest keys follow the pattern:
+    .../step-<id>/task-<id>/<timestamp>_<sessionActionId>/<hash>_output
+    """
+    match = _TASK_ID_RE.search(manifest_s3_key)
+    return match.group(1) if match else None
+
+
 @dataclass
 class IncrementalOutputDownloadLatencies:
     """Dataclass for tracking latencies of operations in this command"""
@@ -227,15 +241,11 @@ def _get_download_candidate_jobs(
             region=region,
         )
     }
-    print(f"DEBUG: Got {len(download_candidate_jobs)} active jobs")
     download_candidate_jobs = {
         job_id: _datetimes_to_str(job)
         for job_id, job in download_candidate_jobs.items()
         if job["taskRunStatusCounts"]["SUCCEEDED"] > 0
     }
-    print(
-        f"DEBUG: Filtered down to {len(download_candidate_jobs)} active jobs based on SUCCEEDED task filter"
-    )
 
     # - Any recently ended job (job went from active to terminal with a taskRunStatus
     #   in SUSPENDED, CANCELED, FAILED, SUCCEEDED, NOT_COMPATIBLE), that has at least
@@ -258,14 +268,10 @@ def _get_download_candidate_jobs(
         },
         region=region,
     )
-    print(
-        f"DEBUG: Got {len(recently_ended_jobs)} jobs with job[endedAt] >= {starting_timestamp.astimezone().isoformat()}"
-    )
     # Filter to jobs where the count of SUCCEEDED tasks is positive.
     recently_ended_jobs = [
         job for job in recently_ended_jobs if job["taskRunStatusCounts"]["SUCCEEDED"] > 0
     ]
-    print(f"DEBUG: Filtered down to {len(recently_ended_jobs)} jobs based on SUCCEEDED task filter")
     download_candidate_jobs.update(
         {job["jobId"]: _datetimes_to_str(job) for job in recently_ended_jobs}
     )
@@ -1098,6 +1104,7 @@ def _incremental_output_download(
     CategorizedJobIds,
     dict[str, dict[str, Any]],
     dict[str, dict[str, Any]],
+    dict[str, dict[str, dict[str, Any]]],
 ]:
     """
     This function downloads all the task run outputs from the specified queue, that have become
@@ -1346,6 +1353,8 @@ def _incremental_output_download(
             f"populated for this run; files will still be downloaded."
         )
     job_manifest_paths: dict[str, list[BaseManifestPath]] = {}
+    # job_id -> task_id -> [files]: used for per-task download tracking
+    job_task_manifest_paths: dict[str, dict[str, list[BaseManifestPath]]] = {}
     # global_seen_paths prevents concurrent writes to the same destination file across jobs.
     # Without cross-job dedup, parallel threads could write the same path simultaneously
     # (e.g. two jobs sharing a file-system location), corrupting the file under OVERWRITE.
@@ -1354,10 +1363,11 @@ def _incremental_output_download(
     global_seen_paths: set[str] = set()
     job_seen_paths: dict[str, set[str]] = {}
     if not skip_attribution:
-        for i, (_, job_id, _, _) in enumerate(manifests_to_download):
+        for i, (_, job_id, _, manifest_s3_key) in enumerate(manifests_to_download):
             manifest_tuple = downloaded_manifests[i]
             if manifest_tuple is not None:
                 _, manifest = manifest_tuple
+                task_id = _extract_task_id_from_s3_key(manifest_s3_key)
                 for manifest_path in manifest.paths:
                     normcased = os.path.normcase(manifest_path.path)
                     if normcased in global_seen_paths:
@@ -1367,11 +1377,16 @@ def _incremental_output_download(
                         seen.add(normcased)
                         global_seen_paths.add(normcased)
                         job_manifest_paths.setdefault(job_id, []).append(manifest_path)
+                        if task_id:
+                            job_task_manifest_paths.setdefault(job_id, {}).setdefault(
+                                task_id, []
+                            ).append(manifest_path)
     else:
         # Attribution skipped: download everything anyway, decoupled from per-job tracking.
         # Collect every downloaded path (deduped) under a synthetic bucket keyed by "" so it
-        # never collides with a real job id. Per-job counts aren't populated this run, but no
-        # files are lost; the "" bucket is dropped from results before the status file is built.
+        # never collides with a real job id. Per-job (and per-task) counts aren't populated this
+        # run, but no files are lost; the "" bucket feeds the run-level stats and never becomes a
+        # per-job status entry.
         fallback_seen: set[str] = set()
         fallback_paths: list[BaseManifestPath] = []
         for manifest_tuple in downloaded_manifests:
@@ -1400,6 +1415,8 @@ def _incremental_output_download(
 
     # Download per-job with error isolation, running jobs in parallel to restore throughput.
     job_download_results: dict[str, dict[str, Any]] = {}
+    # task_download_results: job_id -> task_id -> {total_files, downloaded_files, error_code, error_message}
+    task_download_results: dict[str, dict[str, dict[str, Any]]] = {}
     # Set when the synthetic "" fallback bucket (attribution skipped) failed to download —
     # gates the timestamp advance below so the lost window is re-attempted next run.
     fallback_download_failed = False
@@ -1462,6 +1479,19 @@ def _incremental_output_download(
                     "error_code": None,
                     "error_message": None,
                 }
+                # Record per-task results for succeeded job
+                # Zero-output tasks are included with total_files=0 so they count toward
+                # the progress bar numerator — a task with no outputs is still "done".
+                task_results: dict[str, dict[str, Any]] = {}
+                for task_id, task_files in job_task_manifest_paths.get(job_id, {}).items():
+                    task_results[task_id] = {
+                        "total_files": len(task_files),
+                        "downloaded_files": len(task_files),
+                        "error_code": None,
+                        "error_message": None,
+                    }
+                if task_results:
+                    task_download_results[job_id] = task_results
             except AssetSyncCancelledError:
                 raise
             except Exception as e:
@@ -1619,4 +1649,10 @@ def _incremental_output_download(
     print_function_callback(f"    unchanged: {stats['jobs_without_downloads']['unchanged']}")
     print_function_callback(f"    inactive: {stats['jobs_without_downloads']['inactive']}")
 
-    return checkpoint, categorized_job_ids, download_candidate_jobs, job_download_results
+    return (
+        checkpoint,
+        categorized_job_ids,
+        download_candidate_jobs,
+        job_download_results,
+        task_download_results,
+    )

--- a/src/deadline/client/cli/_incremental_download.py
+++ b/src/deadline/client/cli/_incremental_download.py
@@ -1513,64 +1513,109 @@ def _incremental_output_download(
                     last_call_time = time.time()
                 return sigint_handler.continue_operation
 
-            try:
-                _download_manifest_paths(
-                    job_files,
-                    HashAlgorithm.XXH128,
-                    queue,
-                    boto3_session_for_s3,
-                    file_conflict_resolution,
-                    on_downloading_files=_update_download_progress,
-                    print_function_callback=print_function_callback,
+            job_task_results: dict[str, dict[str, Any]] = {}
+            job_error_code: Optional[str] = None
+            job_error_message: Optional[str] = None
+
+            task_map = job_task_manifest_paths.get(job_id, {})
+            fallback_succeeded = False
+            if task_map:
+                # Per-task isolation: download each task independently so individual
+                # task failures don't mark succeeded tasks as failed.
+                for task_id, task_files in task_map.items():
+                    try:
+                        _download_manifest_paths(
+                            task_files,
+                            HashAlgorithm.XXH128,
+                            queue,
+                            boto3_session_for_s3,
+                            file_conflict_resolution,
+                            on_downloading_files=_update_download_progress,
+                            print_function_callback=print_function_callback,
+                        )
+                        if not sigint_handler.continue_operation:
+                            raise AssetSyncCancelledError("File download cancelled.")
+                        job_task_results[task_id] = {
+                            "total_files": len(task_files),
+                            "downloaded_files": len(task_files),
+                            "error_code": None,
+                            "error_message": None,
+                        }
+                    except AssetSyncCancelledError:
+                        raise
+                    except Exception as e:
+                        error_code = _classify_error(e)
+                        with print_lock:
+                            print_function_callback(
+                                f"  ERROR downloading task {task_id} for job {job_name}: {e}"
+                            )
+                        job_task_results[task_id] = {
+                            "total_files": len(task_files),
+                            "downloaded_files": sum(
+                                1 for f in task_files if os.path.exists(f.path)
+                            ),
+                            "error_code": error_code,
+                            "error_message": str(e),
+                        }
+                        if job_error_code is None:
+                            job_error_code = error_code
+                            job_error_message = str(e)
+
+            else:
+                # No task attribution available — fall back to per-job download
+                try:
+                    _download_manifest_paths(
+                        job_files,
+                        HashAlgorithm.XXH128,
+                        queue,
+                        boto3_session_for_s3,
+                        file_conflict_resolution,
+                        on_downloading_files=_update_download_progress,
+                        print_function_callback=print_function_callback,
+                    )
+                    if not sigint_handler.continue_operation:
+                        raise AssetSyncCancelledError("File download cancelled.")
+                    fallback_succeeded = True
+                except AssetSyncCancelledError:
+                    raise
+                except Exception as e:
+                    job_error_code = _classify_error(e)
+                    job_error_message = str(e)
+                    with print_lock:
+                        print_function_callback(
+                            f"  ERROR downloading job {job_name} ({job_id}): {e}"
+                        )
+
+            if job_task_results:
+                # Per-task path: derive counts from task results directly to avoid
+                # inconsistencies from len(job_files) vs sum of per-task file lists.
+                downloaded_count = sum(r["downloaded_files"] for r in job_task_results.values())
+                failed_count = sum(
+                    r["total_files"]
+                    for r in job_task_results.values()
+                    if r["error_code"] is not None
+                ) - sum(
+                    r["downloaded_files"]
+                    for r in job_task_results.values()
+                    if r["error_code"] is not None
                 )
-                # Raise if the user cancelled mid-transfer — _download_manifest_paths returns
-                # normally on cooperative cancellation so we must check explicitly.
-                if not sigint_handler.continue_operation:
-                    raise AssetSyncCancelledError("File download cancelled.")
-                # Record per-task results for succeeded job
-                # Zero-output tasks are included with total_files=0 so they count toward
-                # the progress bar numerator — a task with no outputs is still "done".
-                job_task_results: dict[str, dict[str, Any]] = {
-                    task_id: {
-                        "total_files": len(task_files),
-                        "downloaded_files": len(task_files),
-                        "error_code": None,
-                        "error_message": None,
-                    }
-                    for task_id, task_files in job_task_manifest_paths.get(job_id, {}).items()
-                }
-                return {
-                    "total_files": len(job_files),
-                    "downloaded_files": len(job_files),
-                    "failed_files": 0,
-                    "error_code": None,
-                    "error_message": None,
-                    "task_results": job_task_results,
-                }
-            except AssetSyncCancelledError:
-                raise
-            except Exception as e:
+            elif fallback_succeeded:
+                # Fallback path success: all files downloaded, use exact count.
+                downloaded_count = len(job_files)
+                failed_count = 0
+            else:
+                # Fallback path failure: use filesystem check for partial progress.
                 downloaded_count = sum(1 for f in job_files if os.path.exists(f.path))
-                with print_lock:
-                    print_function_callback(f"  ERROR downloading job {job_name} ({job_id}): {e}")
-                error_code = _classify_error(e)
-                failed_task_results: dict[str, dict[str, Any]] = {
-                    task_id: {
-                        "total_files": len(task_files),
-                        "downloaded_files": sum(1 for f in task_files if os.path.exists(f.path)),
-                        "error_code": error_code,
-                        "error_message": str(e),
-                    }
-                    for task_id, task_files in job_task_manifest_paths.get(job_id, {}).items()
-                }
-                return {
-                    "total_files": len(job_files),
-                    "downloaded_files": downloaded_count,
-                    "failed_files": len(job_files) - downloaded_count,
-                    "error_code": error_code,
-                    "error_message": str(e),
-                    "task_results": failed_task_results,
-                }
+                failed_count = len(job_files) - downloaded_count
+
+            return {
+                "total_files": len(job_files),
+                "downloaded_files": downloaded_count,
+                "failed_files": failed_count,
+                "error_code": job_error_code,
+                "error_message": job_error_message,
+                "task_results": job_task_results,
+            }
 
         cancelled = False
         # Bound concurrency to avoid S3 throttling and socket exhaustion — each

--- a/src/deadline/client/cli/_incremental_download.py
+++ b/src/deadline/client/cli/_incremental_download.py
@@ -1363,15 +1363,20 @@ def _incremental_output_download(
     job_manifest_paths: dict[str, list[BaseManifestPath]] = {}
     # job_id -> task_id -> [files]: used for per-task download tracking
     job_task_manifest_paths: dict[str, dict[str, list[BaseManifestPath]]] = {}
+    # job_id -> task_id -> [file_paths]: immutable record of all paths originally attributed
+    # to each task, used to generate filesystem-based status for deduped jobs.
+    all_task_file_paths: dict[str, dict[str, list[str]]] = {}
     # global_seen_paths maps normcased_path -> job_id that claimed it first.
     # Prevents concurrent writes to the same destination file across jobs — parallel threads
-    # could write the same path simultaneously, corrupting the file under OVERWRITE.
-    # The first job to claim a path wins; other jobs skip it.
+    # could write the same path simultaneously, corrupting the file under OVERWRITE. When two
+    # jobs share an output path, ownership transfers to the later-iterated job so exactly one
+    # job downloads it. Content correctness is unaffected: jobs sharing a path produce the same
+    # rendered file, so whichever job writes it, the bytes on disk are identical. The transfer
+    # only determines which job_id is credited in the status file; deduped jobs still report
+    # accurate status via the post-download filesystem check.
     global_seen_paths: dict[str, str] = {}
-    # job_path_index tracks the list index for each (job_id, normcased_path) pair so we can
-    # overwrite older entries with newer ones — downloaded_manifests is sorted oldest-to-newest
-    # so iterating in order and overwriting gives newest-wins, matching the old behavior of
-    # _merge_absolute_path_manifest_list.
+    # job_path_index tracks the list index for each (job_id, normcased_path) pair so a later
+    # occurrence of the same path within a job overwrites the earlier one in place.
     job_path_index: dict[str, dict[str, int]] = {}
     # job_id -> task_id -> normcased_path -> list_index, mirrors job_path_index at the task level
     task_path_index: dict[str, dict[str, dict[str, int]]] = {}
@@ -1421,6 +1426,14 @@ def _incremental_output_download(
                         else:
                             t_idx_map[normcased] = len(task_paths)
                             task_paths.append(manifest_path)
+                        # Record path immutably for deduped-job status generation.
+                        # Only add if not already recorded for this task (avoids inflation
+                        # when the same file appears in multiple manifests via task retry).
+                        task_file_list = all_task_file_paths.setdefault(job_id, {}).setdefault(
+                            task_id, []
+                        )
+                        if manifest_path.path not in task_file_list:
+                            task_file_list.append(manifest_path.path)
     else:
         # Attribution skipped: download everything anyway, decoupled from per-job tracking.
         # Collect every downloaded path (deduped) under a synthetic bucket keyed by "" so it
@@ -1659,6 +1672,79 @@ def _incremental_output_download(
     else:
         print_function_callback("Skipping downloads due to DRY RUN")
 
+    # For jobs whose paths were entirely claimed by a newer job (cross-job dedup),
+    # generate task results based on what's actually on disk. The winning job may have
+    # partially failed, so we check the filesystem rather than assuming all downloaded.
+    # When files are missing, reuse the winning job's error for the specific path (same
+    # path, same root cause) so all jobs sharing a path show a consistent error. This
+    # scales to mixed errors — each path maps to its own winning task's error.
+    if not dry_run:
+        # Build path -> (error_code, error_message) from every winning job's per-task results.
+        # A path belongs to the winning job that downloaded it; that task's error explains
+        # why the file is (or isn't) on disk.
+        path_error_map: dict[str, tuple[Optional[str], Optional[str]]] = {}
+        for win_job_id, win_task_results in task_download_results.items():
+            win_task_paths = all_task_file_paths.get(win_job_id, {})
+            for win_task_id, win_result in win_task_results.items():
+                err_code = win_result.get("error_code")
+                if err_code is not None:
+                    for p in win_task_paths.get(win_task_id, []):
+                        path_error_map[os.path.normcase(p)] = (
+                            err_code,
+                            win_result.get("error_message"),
+                        )
+
+        for job_id, task_paths_map in all_task_file_paths.items():
+            if job_id not in job_download_results and job_id not in task_download_results:
+                deduped_task_results: dict[str, dict[str, Any]] = {}
+                for task_id, file_paths in task_paths_map.items():
+                    on_disk = sum(1 for p in file_paths if os.path.exists(p))
+                    if on_disk == len(file_paths):
+                        deduped_task_results[task_id] = {
+                            "total_files": len(file_paths),
+                            "downloaded_files": len(file_paths),
+                            "error_code": None,
+                            "error_message": None,
+                        }
+                    else:
+                        # Inherit the winning job's actual error for a missing path (could be
+                        # PERMISSION_DENIED, DISK_FULL, NETWORK_ERROR, etc.). Fall back to
+                        # UNKNOWN only when no winning job reported an error for this path —
+                        # the file is missing but this run has no attempt explaining why.
+                        err_code = "UNKNOWN"
+                        err_msg = "Output files not found on disk"
+                        for p in file_paths:
+                            if not os.path.exists(p):
+                                mapped = path_error_map.get(os.path.normcase(p))
+                                if mapped is not None and mapped[0] is not None:
+                                    err_code = mapped[0]
+                                    err_msg = mapped[1] or err_msg
+                                    break
+                        deduped_task_results[task_id] = {
+                            "total_files": len(file_paths),
+                            "downloaded_files": on_disk,
+                            "error_code": err_code,
+                            "error_message": err_msg,
+                        }
+                task_download_results[job_id] = deduped_task_results
+
+    # Synthesize job_download_results for deduped jobs so _determine_job_download_status
+    # sees their file counts and errors. These jobs share output paths with the winning
+    # job — their status reflects what's actually on disk.
+    for job_id in list(task_download_results.keys()):
+        if job_id not in job_download_results:
+            task_results = task_download_results[job_id]
+            total = sum(r["total_files"] for r in task_results.values())
+            downloaded = sum(r["downloaded_files"] for r in task_results.values())
+            any_error = next((r for r in task_results.values() if r.get("error_code")), None)
+            job_download_results[job_id] = {
+                "total_files": total,
+                "downloaded_files": downloaded,
+                "failed_files": total - downloaded,
+                "error_code": any_error["error_code"] if any_error else None,
+                "error_message": any_error["error_message"] if any_error else None,
+            }
+
     # Remove failed jobs from checkpoint so they're treated as new (added) next run.
     # Track them in the failed jobs file so they're retried even after the timestamp advances.
     # The synthetic "" fallback bucket (kept above only when it failed) is not a real job, so it
@@ -1704,8 +1790,8 @@ def _incremental_output_download(
         # summary reports the count/size of files that would be downloaded (the preview value).
         "downloaded_files": sum(
             r.get("downloaded_files", 0)
-            for r in job_download_results.values()
-            if r.get("error_code") is None
+            for job_id, r in job_download_results.items()
+            if r.get("error_code") is None and job_id in job_manifest_paths
         )
         if not dry_run
         else sum(len(paths) for paths in job_manifest_paths.values()),

--- a/src/deadline/client/cli/_incremental_download.py
+++ b/src/deadline/client/cli/_incremental_download.py
@@ -241,11 +241,15 @@ def _get_download_candidate_jobs(
             region=region,
         )
     }
+    print(f"DEBUG: Got {len(download_candidate_jobs)} active jobs")
     download_candidate_jobs = {
         job_id: _datetimes_to_str(job)
         for job_id, job in download_candidate_jobs.items()
         if job["taskRunStatusCounts"]["SUCCEEDED"] > 0
     }
+    print(
+        f"DEBUG: Filtered down to {len(download_candidate_jobs)} active jobs based on SUCCEEDED task filter"
+    )
 
     # - Any recently ended job (job went from active to terminal with a taskRunStatus
     #   in SUSPENDED, CANCELED, FAILED, SUCCEEDED, NOT_COMPATIBLE), that has at least
@@ -268,10 +272,14 @@ def _get_download_candidate_jobs(
         },
         region=region,
     )
+    print(
+        f"DEBUG: Got {len(recently_ended_jobs)} jobs with job[endedAt] >= {starting_timestamp.astimezone().isoformat()}"
+    )
     # Filter to jobs where the count of SUCCEEDED tasks is positive.
     recently_ended_jobs = [
         job for job in recently_ended_jobs if job["taskRunStatusCounts"]["SUCCEEDED"] > 0
     ]
+    print(f"DEBUG: Filtered down to {len(recently_ended_jobs)} jobs based on SUCCEEDED task filter")
     download_candidate_jobs.update(
         {job["jobId"]: _datetimes_to_str(job) for job in recently_ended_jobs}
     )
@@ -1339,29 +1347,34 @@ def _incremental_output_download(
         path_mapping_rule_appliers,
     )
     # Correlate manifests_to_download with downloaded_manifests by position to attribute each
-    # downloaded manifest to its job. Both lists come from _get_manifests_to_download with
-    # identical inputs, so their lengths match in practice. If they ever diverge we skip only
-    # the per-job attribution — the downloads still proceed via the fallback bucket below, so a
-    # mismatch degrades reporting but never causes a silent zero-download run. (Downloads are
-    # decoupled from attribution: what gets downloaded comes from downloaded_manifests either
-    # way; attribution is best-effort layered on top.)
+    # downloaded manifest to its job (and task). Both lists come from _get_manifests_to_download
+    # with identical inputs, so their lengths match in practice. If they ever diverge we skip only
+    # the per-job/per-task attribution — the downloads still proceed via the fallback bucket below,
+    # so a mismatch degrades reporting but never causes a silent zero-download run. (Downloads are
+    # decoupled from attribution: what gets downloaded comes from downloaded_manifests either way;
+    # attribution is best-effort layered on top.)
     skip_attribution = len(manifests_to_download) != len(downloaded_manifests)
     if skip_attribution:
         print_function_callback(
             f"WARNING: Manifest list length mismatch ({len(manifests_to_download)} vs "
-            f"{len(downloaded_manifests)}) — per-job download tracking will not be "
-            f"populated for this run; files will still be downloaded."
+            f"{len(downloaded_manifests)}) — per-job and per-task download tracking will not "
+            f"be populated for this run; files will still be downloaded."
         )
     job_manifest_paths: dict[str, list[BaseManifestPath]] = {}
     # job_id -> task_id -> [files]: used for per-task download tracking
     job_task_manifest_paths: dict[str, dict[str, list[BaseManifestPath]]] = {}
-    # global_seen_paths prevents concurrent writes to the same destination file across jobs.
-    # Without cross-job dedup, parallel threads could write the same path simultaneously
-    # (e.g. two jobs sharing a file-system location), corrupting the file under OVERWRITE.
-    # The first job to claim a path wins; subsequent jobs skip it (same outcome as before
-    # since file_conflict_resolution would have picked one winner anyway).
-    global_seen_paths: set[str] = set()
-    job_seen_paths: dict[str, set[str]] = {}
+    # global_seen_paths maps normcased_path -> job_id that claimed it first.
+    # Prevents concurrent writes to the same destination file across jobs — parallel threads
+    # could write the same path simultaneously, corrupting the file under OVERWRITE.
+    # The first job to claim a path wins; other jobs skip it.
+    global_seen_paths: dict[str, str] = {}
+    # job_path_index tracks the list index for each (job_id, normcased_path) pair so we can
+    # overwrite older entries with newer ones — downloaded_manifests is sorted oldest-to-newest
+    # so iterating in order and overwriting gives newest-wins, matching the old behavior of
+    # _merge_absolute_path_manifest_list.
+    job_path_index: dict[str, dict[str, int]] = {}
+    # job_id -> task_id -> normcased_path -> list_index, mirrors job_path_index at the task level
+    task_path_index: dict[str, dict[str, dict[str, int]]] = {}
     if not skip_attribution:
         for i, (_, job_id, _, manifest_s3_key) in enumerate(manifests_to_download):
             manifest_tuple = downloaded_manifests[i]
@@ -1370,17 +1383,44 @@ def _incremental_output_download(
                 task_id = _extract_task_id_from_s3_key(manifest_s3_key)
                 for manifest_path in manifest.paths:
                     normcased = os.path.normcase(manifest_path.path)
-                    if normcased in global_seen_paths:
-                        continue  # Another job already claims this path — skip to prevent concurrent writes
-                    seen = job_seen_paths.setdefault(job_id, set())
-                    if normcased not in seen:
-                        seen.add(normcased)
-                        global_seen_paths.add(normcased)
-                        job_manifest_paths.setdefault(job_id, []).append(manifest_path)
-                        if task_id:
-                            job_task_manifest_paths.setdefault(job_id, {}).setdefault(
-                                task_id, []
-                            ).append(manifest_path)
+                    prior_job_id = global_seen_paths.get(normcased)
+                    if prior_job_id is not None and prior_job_id != job_id:
+                        # A different job previously claimed this path with an older manifest.
+                        # Since downloaded_manifests is sorted oldest-to-newest, the current
+                        # manifest is newer — transfer ownership to preserve newest-wins semantics.
+                        prior_paths = job_manifest_paths.get(prior_job_id, [])
+                        prior_idx_map = job_path_index.get(prior_job_id, {})
+                        if normcased in prior_idx_map:
+                            # Remove from old job's manifest list — mark as None so indices stay stable
+                            prior_paths[prior_idx_map[normcased]] = None  # type: ignore[call-overload]
+                            del prior_idx_map[normcased]
+                        # Remove from all of the old job's per-task paths using the index for O(1) lookup.
+                        # Scan all tasks since the same path could appear in multiple tasks.
+                        for t_id, t_idx_map in task_path_index.get(prior_job_id, {}).items():
+                            if normcased in t_idx_map:
+                                job_task_manifest_paths[prior_job_id][t_id][
+                                    t_idx_map[normcased]
+                                ] = None  # type: ignore[call-overload]
+                                del t_idx_map[normcased]
+                    job_paths = job_manifest_paths.setdefault(job_id, [])
+                    idx_map = job_path_index.setdefault(job_id, {})
+                    if normcased in idx_map:
+                        # Overwrite with newer version within same job
+                        job_paths[idx_map[normcased]] = manifest_path
+                    else:
+                        idx_map[normcased] = len(job_paths)
+                        job_paths.append(manifest_path)
+                    global_seen_paths[normcased] = job_id
+                    if task_id:
+                        job_task_manifest_paths.setdefault(job_id, {}).setdefault(task_id, [])
+                        task_paths = job_task_manifest_paths[job_id][task_id]
+                        t_idx_map = task_path_index.setdefault(job_id, {}).setdefault(task_id, {})
+                        if normcased in t_idx_map:
+                            # Overwrite with newer version (O(1) lookup)
+                            task_paths[t_idx_map[normcased]] = manifest_path
+                        else:
+                            t_idx_map[normcased] = len(task_paths)
+                            task_paths.append(manifest_path)
     else:
         # Attribution skipped: download everything anyway, decoupled from per-job tracking.
         # Collect every downloaded path (deduped) under a synthetic bucket keyed by "" so it
@@ -1399,6 +1439,17 @@ def _incremental_output_download(
                         fallback_paths.append(manifest_path)
         if fallback_paths:
             job_manifest_paths[""] = fallback_paths
+
+    # Filter out None entries left by cross-job path transfers (newer job took over the path)
+    for job_id in list(job_manifest_paths.keys()):
+        job_manifest_paths[job_id] = [p for p in job_manifest_paths[job_id] if p is not None]
+        if not job_manifest_paths[job_id]:
+            del job_manifest_paths[job_id]
+    for job_id, task_map in job_task_manifest_paths.items():
+        for task_id in list(task_map.keys()):
+            task_map[task_id] = [p for p in task_map[task_id] if p is not None]
+            if not task_map[task_id]:
+                del task_map[task_id]
 
     # Print a summary of all the paths before starting the download
     all_manifest_paths = [path for paths in job_manifest_paths.values() for path in paths]
@@ -1472,38 +1523,53 @@ def _incremental_output_download(
                     on_downloading_files=_update_download_progress,
                     print_function_callback=print_function_callback,
                 )
+                # Raise if the user cancelled mid-transfer — _download_manifest_paths returns
+                # normally on cooperative cancellation so we must check explicitly.
+                if not sigint_handler.continue_operation:
+                    raise AssetSyncCancelledError("File download cancelled.")
+                # Record per-task results for succeeded job
+                # Zero-output tasks are included with total_files=0 so they count toward
+                # the progress bar numerator — a task with no outputs is still "done".
+                job_task_results: dict[str, dict[str, Any]] = {
+                    task_id: {
+                        "total_files": len(task_files),
+                        "downloaded_files": len(task_files),
+                        "error_code": None,
+                        "error_message": None,
+                    }
+                    for task_id, task_files in job_task_manifest_paths.get(job_id, {}).items()
+                }
                 return {
                     "total_files": len(job_files),
                     "downloaded_files": len(job_files),
                     "failed_files": 0,
                     "error_code": None,
                     "error_message": None,
+                    "task_results": job_task_results,
                 }
-                # Record per-task results for succeeded job
-                # Zero-output tasks are included with total_files=0 so they count toward
-                # the progress bar numerator — a task with no outputs is still "done".
-                task_results: dict[str, dict[str, Any]] = {}
-                for task_id, task_files in job_task_manifest_paths.get(job_id, {}).items():
-                    task_results[task_id] = {
-                        "total_files": len(task_files),
-                        "downloaded_files": len(task_files),
-                        "error_code": None,
-                        "error_message": None,
-                    }
-                if task_results:
-                    task_download_results[job_id] = task_results
             except AssetSyncCancelledError:
                 raise
             except Exception as e:
                 downloaded_count = sum(1 for f in job_files if os.path.exists(f.path))
                 with print_lock:
                     print_function_callback(f"  ERROR downloading job {job_name} ({job_id}): {e}")
+                error_code = _classify_error(e)
+                failed_task_results: dict[str, dict[str, Any]] = {
+                    task_id: {
+                        "total_files": len(task_files),
+                        "downloaded_files": sum(1 for f in task_files if os.path.exists(f.path)),
+                        "error_code": error_code,
+                        "error_message": str(e),
+                    }
+                    for task_id, task_files in job_task_manifest_paths.get(job_id, {}).items()
+                }
                 return {
                     "total_files": len(job_files),
                     "downloaded_files": downloaded_count,
                     "failed_files": len(job_files) - downloaded_count,
-                    "error_code": _classify_error(e),
+                    "error_code": error_code,
                     "error_message": str(e),
+                    "task_results": failed_task_results,
                 }
 
         cancelled = False
@@ -1520,7 +1586,11 @@ def _incremental_output_download(
             for future in concurrent.futures.as_completed(future_to_job):
                 job_id = future_to_job[future]
                 try:
-                    job_download_results[job_id] = future.result()
+                    result = future.result()
+                    task_results = result.pop("task_results", {})
+                    job_download_results[job_id] = result
+                    if task_results:
+                        task_download_results[job_id] = task_results
                 except AssetSyncCancelledError:
                     cancelled = True
                     executor.shutdown(wait=False, cancel_futures=True)
@@ -1600,7 +1670,9 @@ def _incremental_output_download(
             for path in paths
             if job_id in job_download_results
             and job_download_results[job_id].get("error_code") is None
-        ),
+        )
+        if not dry_run
+        else sum(path.size for paths in job_manifest_paths.values() for path in paths),
         "jobs_with_downloads": {
             "completed": len(categorized_job_ids.completed),
             "added": len(categorized_job_ids.added),

--- a/test/unit/deadline_client/cli/test_cli_download_status_file.py
+++ b/test/unit/deadline_client/cli/test_cli_download_status_file.py
@@ -903,6 +903,13 @@ class TestExtractTaskId:
         key = "DeadlineCloud/Manifests/farm-abc/queue-abc/job-abc/step-abc/task-xyz123-3/ts_sessionaction/hash_output"
         assert _extract_task_id_from_s3_key(key) == "task-xyz123-3"
 
+    def test_ignores_task_substring_in_customer_root_prefix(self):
+        """A rootPrefix containing 'task-' must not be mistaken for the real task id."""
+        from deadline.client.cli._incremental_download import _extract_task_id_from_s3_key
+
+        key = "my-task-outputs/Manifests/farm-abc/queue-abc/job-abc/step-abc/task-real-1/ts_sessionaction/hash_output"
+        assert _extract_task_id_from_s3_key(key) == "task-real-1"
+
 
 class TestPerTaskTracking:
     """Tests for per-task download tracking in status file."""
@@ -1114,29 +1121,80 @@ class TestClassifyError:
         assert _classify_error(ConnectionError("reset")) == "NETWORK_ERROR"
         assert _classify_error(TimeoutError("timed out")) == "NETWORK_ERROR"
 
-    def test_permission_denied_by_message(self):
+    def test_client_error_access_denied(self):
+        from deadline.client.cli._incremental_download import _classify_error
+        from botocore.exceptions import ClientError
+
+        e = ClientError({"Error": {"Code": "AccessDenied", "Message": "nope"}}, "GetObject")
+        assert _classify_error(e) == "PERMISSION_DENIED"
+
+    def test_client_error_no_such_key(self):
+        from deadline.client.cli._incremental_download import _classify_error
+        from botocore.exceptions import ClientError
+
+        e = ClientError({"Error": {"Code": "NoSuchKey", "Message": "gone"}}, "GetObject")
+        assert _classify_error(e) == "PATH_NOT_FOUND"
+
+    def test_client_error_request_timeout(self):
+        from deadline.client.cli._incremental_download import _classify_error
+        from botocore.exceptions import ClientError
+
+        e = ClientError({"Error": {"Code": "RequestTimeout", "Message": "slow"}}, "GetObject")
+        assert _classify_error(e) == "NETWORK_ERROR"
+
+    def test_job_attachments_s3_client_error_by_status_code(self):
+        """The actual download path wraps S3 errors in JobAttachmentsS3ClientError,
+        which carries a structured HTTP status code — classify from that, not the message."""
+        from deadline.client.cli._incremental_download import _classify_error
+        from deadline.job_attachments.exceptions import JobAttachmentsS3ClientError
+
+        forbidden = JobAttachmentsS3ClientError(
+            action="downloading file", status_code=403, bucket_name="b", key_or_prefix="k"
+        )
+        assert _classify_error(forbidden) == "PERMISSION_DENIED"
+
+        not_found = JobAttachmentsS3ClientError(
+            action="downloading file", status_code=404, bucket_name="b", key_or_prefix="k"
+        )
+        assert _classify_error(not_found) == "PATH_NOT_FOUND"
+
+    def test_job_attachments_botocore_error_is_network(self):
+        from deadline.client.cli._incremental_download import _classify_error
+        from deadline.job_attachments.exceptions import JobAttachmentS3BotoCoreError
+
+        e = JobAttachmentS3BotoCoreError(action="downloading file", error_details="conn reset")
+        assert _classify_error(e) == "NETWORK_ERROR"
+
+    def test_wrapped_cause_is_classified(self):
+        """job_attachments wraps low-level failures (AssetSyncError(original)); the classifier
+        walks __cause__ to reach the structured signal instead of guessing from the message."""
+        from deadline.client.cli._incremental_download import _classify_error
+        from deadline.job_attachments.exceptions import AssetSyncError
+
+        wrapped = AssetSyncError("File download failed.")
+        wrapped.__cause__ = PermissionError("denied")
+        assert _classify_error(wrapped) == "PERMISSION_DENIED"
+
+    def test_cyclic_cause_chain_does_not_recurse_forever(self):
+        """A cyclic __cause__ chain must terminate at UNKNOWN, not blow the stack."""
         from deadline.client.cli._incremental_download import _classify_error
 
-        assert _classify_error(Exception("Access Denied")) == "PERMISSION_DENIED"
-        assert _classify_error(Exception("permission error")) == "PERMISSION_DENIED"
+        a = Exception("a")
+        b = Exception("b")
+        a.__cause__ = b
+        b.__cause__ = a  # cycle: neither carries a structured signal
+        assert _classify_error(a) == "UNKNOWN"
 
-    def test_disk_full_by_message(self):
+    def test_message_only_errors_are_unknown(self):
+        """Message-substring matching is intentionally not used — wrapped S3 errors carry
+        verbose text that produces confidently-wrong codes, so anything without a structured
+        signal (exception type or S3 error code) is classified as UNKNOWN."""
         from deadline.client.cli._incremental_download import _classify_error
 
-        assert _classify_error(Exception("No space left on device")) == "DISK_FULL"
-        assert _classify_error(Exception("disk full")) == "DISK_FULL"
-
-    def test_path_not_found_by_message(self):
-        from deadline.client.cli._incremental_download import _classify_error
-
-        assert _classify_error(Exception("No such file or directory")) == "PATH_NOT_FOUND"
-        assert _classify_error(Exception("path not found")) == "PATH_NOT_FOUND"
-
-    def test_network_error_by_message(self):
-        from deadline.client.cli._incremental_download import _classify_error
-
-        assert _classify_error(Exception("Connection timeout")) == "NETWORK_ERROR"
-        assert _classify_error(Exception("network unreachable")) == "NETWORK_ERROR"
+        assert _classify_error(Exception("Access Denied")) == "UNKNOWN"
+        assert _classify_error(Exception("No space left on device")) == "UNKNOWN"
+        assert _classify_error(Exception("No such file or directory")) == "UNKNOWN"
+        assert _classify_error(Exception("Connection timeout")) == "UNKNOWN"
 
     def test_unknown_error(self):
         from deadline.client.cli._incremental_download import _classify_error

--- a/test/unit/deadline_client/cli/test_cli_download_status_file.py
+++ b/test/unit/deadline_client/cli/test_cli_download_status_file.py
@@ -1050,8 +1050,8 @@ class TestPerTaskTracking:
         )
         assert result["jobs"][MOCK_JOB_ID]["tasks"]["task-abc-0"]["download_status"] == "downloaded"
 
-    def test_zero_file_tasks_excluded_from_dict(self):
-        """Tasks with zero output files are not added to the tasks dict."""
+    def test_zero_file_tasks_included_as_downloaded(self):
+        """Tasks with zero output files are included with downloaded status so they count toward the progress bar."""
         cjids = _make_categorized_job_ids(completed={MOCK_JOB_ID})
         job = _make_job(MOCK_JOB_ID)
         jobs = {MOCK_JOB_ID: job}
@@ -1072,7 +1072,8 @@ class TestPerTaskTracking:
             download_candidate_jobs=jobs,
             task_download_results=task_results,
         )
-        assert "task-abc-0" not in result["jobs"][MOCK_JOB_ID]["tasks"]
+        assert "task-abc-0" in result["jobs"][MOCK_JOB_ID]["tasks"]
+        assert result["jobs"][MOCK_JOB_ID]["tasks"]["task-abc-0"]["download_status"] == "downloaded"
 
     def test_skipped_job_has_empty_tasks(self):
         """Skipped jobs always have an empty tasks dict."""

--- a/test/unit/deadline_client/cli/test_cli_download_status_file.py
+++ b/test/unit/deadline_client/cli/test_cli_download_status_file.py
@@ -144,6 +144,8 @@ class TestDetermineJobDownloadStatus:
         assert "last_updated" in result
         assert "error_code" in result
         assert "error_message" in result
+        assert "skip_reason" in result
+        assert "tasks" in result
 
 
 class TestGetStatusFilePaths:
@@ -852,6 +854,238 @@ class TestFailedJobsTracker:
 
         tracker2 = _FailedJobsTracker(file_path)
         assert MOCK_JOB_ID in tracker2.get_tracked_job_ids()
+
+
+class TestSkipReason:
+    """Tests for skip_reason field in skipped job entries."""
+
+    def test_attachments_free_has_no_attachments_reason(self):
+        cjids = _make_categorized_job_ids(attachments_free={MOCK_JOB_ID})
+        job = _make_job(MOCK_JOB_ID, attachments=False)
+        result = _determine_job_download_status(MOCK_JOB_ID, job, cjids)
+        assert result["skip_reason"] == "no_attachments"
+
+    def test_missing_storage_profile_has_reason(self):
+        cjids = _make_categorized_job_ids(missing_storage_profile={MOCK_JOB_ID})
+        job = _make_job(MOCK_JOB_ID, storage_profile_id=None)
+        result = _determine_job_download_status(MOCK_JOB_ID, job, cjids)
+        assert result["skip_reason"] == "missing_storage_profile"
+
+    def test_downloaded_job_has_null_skip_reason(self):
+        cjids = _make_categorized_job_ids(completed={MOCK_JOB_ID})
+        job = _make_job(MOCK_JOB_ID)
+        result = _determine_job_download_status(MOCK_JOB_ID, job, cjids)
+        assert result["skip_reason"] is None
+
+
+class TestExtractTaskId:
+    """Tests for _extract_task_id_from_s3_key."""
+
+    def test_extracts_task_id_from_s3_key(self):
+        from deadline.client.cli._incremental_download import _extract_task_id_from_s3_key
+
+        key = "DeadlineCloud/Manifests/farm-abc/queue-abc/job-abc/step-abc/task-abc-0/2026-01-01T00:00:00Z_sessionaction-abc-2/hash_output"
+        assert _extract_task_id_from_s3_key(key) == "task-abc-0"
+
+    def test_returns_none_for_key_without_task_id(self):
+        from deadline.client.cli._incremental_download import _extract_task_id_from_s3_key
+
+        assert (
+            _extract_task_id_from_s3_key(
+                "DeadlineCloud/Manifests/farm-abc/queue-abc/job-abc/hash_output"
+            )
+            is None
+        )
+
+    def test_extracts_task_id_with_different_suffix(self):
+        from deadline.client.cli._incremental_download import _extract_task_id_from_s3_key
+
+        key = "DeadlineCloud/Manifests/farm-abc/queue-abc/job-abc/step-abc/task-xyz123-3/ts_sessionaction/hash_output"
+        assert _extract_task_id_from_s3_key(key) == "task-xyz123-3"
+
+
+class TestPerTaskTracking:
+    """Tests for per-task download tracking in status file."""
+
+    def test_task_download_results_added_to_job_entry(self):
+        """Tasks from this run appear in the job's tasks dict."""
+        cjids = _make_categorized_job_ids(completed={MOCK_JOB_ID})
+        job = _make_job(MOCK_JOB_ID, succeeded=2, total=2, ended=True)
+        jobs = {MOCK_JOB_ID: job}
+        task_results = {
+            MOCK_JOB_ID: {
+                "task-abc-0": {
+                    "total_files": 3,
+                    "downloaded_files": 3,
+                    "error_code": None,
+                    "error_message": None,
+                },
+                "task-abc-1": {
+                    "total_files": 3,
+                    "downloaded_files": 3,
+                    "error_code": None,
+                    "error_message": None,
+                },
+            }
+        }
+        result = _build_status_file_content(
+            queue_id=MOCK_QUEUE_ID,
+            storage_profile_id=MOCK_STORAGE_PROFILE_ID,
+            categorized_job_ids=cjids,
+            download_candidate_jobs=jobs,
+            task_download_results=task_results,
+        )
+        tasks = result["jobs"][MOCK_JOB_ID]["tasks"]
+        assert "task-abc-0" in tasks
+        assert "task-abc-1" in tasks
+        assert tasks["task-abc-0"]["download_status"] == "downloaded"
+        assert tasks["task-abc-0"]["total_files"] == 3
+
+    def test_failed_task_download_results_in_failed_status(self):
+        """Tasks with error_code show download_status failed."""
+        cjids = _make_categorized_job_ids(added={MOCK_JOB_ID})
+        job = _make_job(MOCK_JOB_ID, succeeded=1, total=2, ended=False)
+        jobs = {MOCK_JOB_ID: job}
+        task_results = {
+            MOCK_JOB_ID: {
+                "task-abc-0": {
+                    "total_files": 3,
+                    "downloaded_files": 0,
+                    "error_code": "PERMISSION_DENIED",
+                    "error_message": "denied",
+                },
+            }
+        }
+        result = _build_status_file_content(
+            queue_id=MOCK_QUEUE_ID,
+            storage_profile_id=MOCK_STORAGE_PROFILE_ID,
+            categorized_job_ids=cjids,
+            download_candidate_jobs=jobs,
+            task_download_results=task_results,
+        )
+        tasks = result["jobs"][MOCK_JOB_ID]["tasks"]
+        assert tasks["task-abc-0"]["download_status"] == "failed"
+        assert tasks["task-abc-0"]["error_code"] == "PERMISSION_DENIED"
+
+    def test_existing_tasks_preserved_when_no_new_download(self):
+        """Tasks from previous runs are preserved when no new download this run."""
+        existing_jobs = {
+            MOCK_JOB_ID: {
+                "download_status": "in_progress",
+                "total_files": 3,
+                "downloaded_files": 3,
+                "failed_files": 0,
+                "last_updated": "2026-01-01T00:00:00+00:00",
+                "error_code": None,
+                "error_message": None,
+                "skip_reason": None,
+                "tasks": {
+                    "task-abc-0": {
+                        "download_status": "downloaded",
+                        "total_files": 3,
+                        "downloaded_files": 3,
+                        "error_code": None,
+                        "error_message": None,
+                    },
+                },
+            }
+        }
+        cjids = _make_categorized_job_ids(unchanged={MOCK_JOB_ID})
+        job = _make_job(MOCK_JOB_ID, succeeded=1, total=2, ended=False)
+        jobs = {MOCK_JOB_ID: job}
+        result = _build_status_file_content(
+            queue_id=MOCK_QUEUE_ID,
+            storage_profile_id=MOCK_STORAGE_PROFILE_ID,
+            categorized_job_ids=cjids,
+            download_candidate_jobs=jobs,
+            existing_jobs=existing_jobs,
+            task_download_results={},
+        )
+        # Existing task preserved
+        assert "task-abc-0" in result["jobs"][MOCK_JOB_ID]["tasks"]
+
+    def test_new_task_overwrites_existing_same_id(self):
+        """New task result overwrites existing entry with same task ID."""
+        existing_jobs = {
+            MOCK_JOB_ID: {
+                "download_status": "downloaded",
+                "total_files": 3,
+                "downloaded_files": 3,
+                "failed_files": 0,
+                "last_updated": "2026-01-01T00:00:00+00:00",
+                "error_code": None,
+                "error_message": None,
+                "skip_reason": None,
+                "tasks": {
+                    "task-abc-0": {
+                        "download_status": "downloaded",
+                        "total_files": 3,
+                        "downloaded_files": 3,
+                        "error_code": None,
+                        "error_message": None,
+                    },
+                },
+            }
+        }
+        cjids = _make_categorized_job_ids(added={MOCK_JOB_ID})
+        job = _make_job(MOCK_JOB_ID, succeeded=1, total=1, ended=True)
+        jobs = {MOCK_JOB_ID: job}
+        task_results = {
+            MOCK_JOB_ID: {
+                "task-abc-0": {
+                    "total_files": 3,
+                    "downloaded_files": 3,
+                    "error_code": None,
+                    "error_message": None,
+                },
+            }
+        }
+        result = _build_status_file_content(
+            queue_id=MOCK_QUEUE_ID,
+            storage_profile_id=MOCK_STORAGE_PROFILE_ID,
+            categorized_job_ids=cjids,
+            download_candidate_jobs=jobs,
+            existing_jobs=existing_jobs,
+            task_download_results=task_results,
+        )
+        assert result["jobs"][MOCK_JOB_ID]["tasks"]["task-abc-0"]["download_status"] == "downloaded"
+
+    def test_zero_file_tasks_excluded_from_dict(self):
+        """Tasks with zero output files are not added to the tasks dict."""
+        cjids = _make_categorized_job_ids(completed={MOCK_JOB_ID})
+        job = _make_job(MOCK_JOB_ID)
+        jobs = {MOCK_JOB_ID: job}
+        task_results = {
+            MOCK_JOB_ID: {
+                "task-abc-0": {
+                    "total_files": 0,
+                    "downloaded_files": 0,
+                    "error_code": None,
+                    "error_message": None,
+                },
+            }
+        }
+        result = _build_status_file_content(
+            queue_id=MOCK_QUEUE_ID,
+            storage_profile_id=MOCK_STORAGE_PROFILE_ID,
+            categorized_job_ids=cjids,
+            download_candidate_jobs=jobs,
+            task_download_results=task_results,
+        )
+        assert "task-abc-0" not in result["jobs"][MOCK_JOB_ID]["tasks"]
+
+    def test_skipped_job_has_empty_tasks(self):
+        """Skipped jobs always have an empty tasks dict."""
+        cjids = _make_categorized_job_ids(attachments_free={MOCK_JOB_ID})
+        job = _make_job(MOCK_JOB_ID, attachments=False)
+        jobs = {MOCK_JOB_ID: job}
+        result = _build_status_file_content(
+            queue_id=MOCK_QUEUE_ID,
+            storage_profile_id=MOCK_STORAGE_PROFILE_ID,
+            categorized_job_ids=cjids,
+            download_candidate_jobs=jobs,
+        )
+        assert result["jobs"][MOCK_JOB_ID]["tasks"] == {}
 
 
 class TestClassifyError:

--- a/test/unit/deadline_client/cli/test_cli_queue_incremental_download.py
+++ b/test/unit/deadline_client/cli/test_cli_queue_incremental_download.py
@@ -1763,6 +1763,10 @@ def test_incremental_output_download_per_task_error_isolation(
 
     assert result.exit_code == 0, result.output
 
+    # The run summary counts the succeeded tasks even though the job carries an error_code:
+    # task-0 and task-2 landed their files, so 2 (not 0) files are reported downloaded.
+    assert "Downloaded files: 2" in result.output, result.output
+
     # The status file records per-task isolation: task-1 failed, task-0 and task-2 succeeded.
     status_file_path = os.path.join(
         checkpoint_dir, f"{MOCK_QUEUE_ID}_ignore-storage-profiles_download_status.json"
@@ -1781,3 +1785,490 @@ def test_incremental_output_download_per_task_error_isolation(
     assert tasks[task_ids[2]]["error_code"] is None, tasks
     assert tasks[task_ids[1]]["download_status"] == "failed", tasks
     assert tasks[task_ids[1]]["error_code"] == "PERMISSION_DENIED", tasks
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
+)
+def test_incremental_output_download_leftover_non_task_paths_are_downloaded(
+    fresh_deadline_config, deadline_mock, checkpoint_dir, tmp_path
+):
+    """A job with a mix of task-attributed and non-task-attributed manifests must
+    download both. The task-attributed path goes through per-task isolation; the
+    leftover path (its manifest key carries no step-/task- segment) must still be
+    downloaded rather than silently dropped just because the job also has task files.
+    """
+    from deadline.job_attachments.asset_manifests.v2023_03_03.asset_manifest import (
+        AssetManifest,
+        ManifestPath,
+    )
+    from deadline.job_attachments.asset_manifests import HashAlgorithm
+
+    step_id = "step-b1764261dff54214aace3932bde8ae7e"
+    task_id = "task-b1764261dff54214aace3932bde8ae7e-0"
+    task_file_path = str(tmp_path / "frame_0" / "beauty.exr")
+    leftover_file_path = str(tmp_path / "aux" / "report.txt")
+
+    mock_jobs = create_fake_job_list(1)
+    mock_jobs[0]["name"] = "Mock Job"
+    mock_jobs[0]["jobId"] = MOCK_JOB_ID
+    mock_jobs[0]["taskRunStatus"] = "SUCCEEDED"
+    mock_jobs[0]["taskRunStatusCounts"] = {"SUCCEEDED": 1, "READY": 0}
+    mock_jobs[0]["attachments"] = {
+        "manifests": [
+            {"rootPath": "/", "rootPathFormat": "posix", "outputRelativeDirectories": ["."]}
+        ],
+        "fileSystem": "COPIED",
+    }
+    mock_jobs[0]["endedAt"] = datetime.fromisoformat(ISO_FREEZE_TIME)
+    deadline_mock.search_jobs = mock_search_jobs_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+    deadline_mock.get_job = mock_get_job_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+
+    deadline_mock.list_sessions.return_value = {
+        "sessions": [
+            {
+                "sessionId": MOCK_SESSION_ID,
+                "fleetId": MOCK_FLEET_ID,
+                "workerId": MOCK_WORKER_ID,
+                "startedAt": datetime.fromisoformat("2025-08-06T00:15:45.712000+00:00"),
+                "endedAt": datetime.fromisoformat("2025-08-06T00:20:59.992000+00:00"),
+                "lifecycleStatus": "ENDED",
+            }
+        ]
+    }
+    deadline_mock.list_session_actions.return_value = {
+        "sessionActions": [
+            {
+                "sessionActionId": "sessionaction-0123456789abcdefabcdefabcdefabcd-0",
+                "status": "SUCCEEDED",
+                "startedAt": "2025-08-06T00:20:58.454000+00:00",
+                "endedAt": "2025-08-06T00:20:59.992000+00:00",
+                "progressPercent": 100.0,
+                "definition": {"taskRun": {"taskId": task_id, "stepId": step_id}},
+                "manifests": [{"outputManifestPath": f"{task_id}/manifest"}],
+            }
+        ]
+    }
+
+    downloaded_manifests = [
+        (
+            datetime.fromisoformat(ISO_FREEZE_TIME),
+            AssetManifest(
+                hash_alg=HashAlgorithm.XXH128,
+                total_size=1,
+                paths=[ManifestPath(path=task_file_path, hash="h", size=1, mtime=1)],
+            ),
+        ),
+        (
+            datetime.fromisoformat(ISO_FREEZE_TIME),
+            AssetManifest(
+                hash_alg=HashAlgorithm.XXH128,
+                total_size=1,
+                paths=[ManifestPath(path=leftover_file_path, hash="h2", size=1, mtime=1)],
+            ),
+        ),
+    ]
+    # First key carries a step-/task- segment (attributed); second does not (leftover).
+    manifests_to_download = [
+        (None, MOCK_JOB_ID, "/", f"prefix/{step_id}/{task_id}/manifest"),
+        (None, MOCK_JOB_ID, "/", "prefix/no-task-segment/manifest"),
+    ]
+
+    def fake_download_all_manifests(*args, **kwargs):
+        return downloaded_manifests
+
+    def fake_get_manifests_to_download(*args, **kwargs):
+        return manifests_to_download
+
+    downloaded_paths: list[str] = []
+
+    def fake_download_manifest_paths(
+        files,
+        hash_algorithm,
+        queue,
+        session,
+        conflict,
+        on_downloading_files,
+        print_function_callback,
+    ):
+        for f in files:
+            downloaded_paths.append(f.path)
+            os.makedirs(os.path.dirname(f.path), exist_ok=True)
+            with open(f.path, "w") as fh:
+                fh.write("output")
+
+    runner = CliRunner()
+    with (
+        patch(
+            "deadline.client.cli._incremental_download._download_all_manifests_with_absolute_paths",
+            side_effect=fake_download_all_manifests,
+        ),
+        patch(
+            "deadline.client.cli._incremental_download._get_manifests_to_download",
+            side_effect=fake_get_manifests_to_download,
+        ),
+        patch(
+            "deadline.client.cli._incremental_download._download_manifest_paths",
+            side_effect=fake_download_manifest_paths,
+        ),
+        freeze_time(ISO_FREEZE_TIME),
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "queue",
+                "sync-output",
+                "--ignore-storage-profiles",
+                "--force-bootstrap",
+                "--bootstrap-lookback-minutes",
+                "120",
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--checkpoint-dir",
+                checkpoint_dir,
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    # Both the task-attributed file and the leftover file must have been downloaded.
+    assert task_file_path in downloaded_paths, downloaded_paths
+    assert leftover_file_path in downloaded_paths, downloaded_paths
+    assert os.path.exists(leftover_file_path), "leftover non-task path was silently dropped"
+    assert "Downloaded files: 2" in result.output, result.output
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
+)
+def test_incremental_output_download_same_path_across_tasks_downloaded_once(
+    fresh_deadline_config, deadline_mock, checkpoint_dir, tmp_path
+):
+    """When two tasks of the same job emit the same output path (e.g. a requeue re-ran
+    a task under a new task id), the path must be downloaded once and attributed to the
+    newer task — not downloaded twice and double-counted.
+    """
+    from deadline.job_attachments.asset_manifests.v2023_03_03.asset_manifest import (
+        AssetManifest,
+        ManifestPath,
+    )
+    from deadline.job_attachments.asset_manifests import HashAlgorithm
+
+    step_id = "step-b1764261dff54214aace3932bde8ae7e"
+    task_ids = [f"task-b1764261dff54214aace3932bde8ae7e-{i}" for i in range(2)]
+    shared_file_path = str(tmp_path / "frame_0" / "beauty.exr")
+
+    mock_jobs = create_fake_job_list(1)
+    mock_jobs[0]["name"] = "Mock Job"
+    mock_jobs[0]["jobId"] = MOCK_JOB_ID
+    mock_jobs[0]["taskRunStatus"] = "SUCCEEDED"
+    mock_jobs[0]["taskRunStatusCounts"] = {"SUCCEEDED": 2, "READY": 0}
+    mock_jobs[0]["attachments"] = {
+        "manifests": [
+            {"rootPath": "/", "rootPathFormat": "posix", "outputRelativeDirectories": ["."]}
+        ],
+        "fileSystem": "COPIED",
+    }
+    mock_jobs[0]["endedAt"] = datetime.fromisoformat(ISO_FREEZE_TIME)
+    deadline_mock.search_jobs = mock_search_jobs_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+    deadline_mock.get_job = mock_get_job_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+
+    deadline_mock.list_sessions.return_value = {
+        "sessions": [
+            {
+                "sessionId": MOCK_SESSION_ID,
+                "fleetId": MOCK_FLEET_ID,
+                "workerId": MOCK_WORKER_ID,
+                "startedAt": datetime.fromisoformat("2025-08-06T00:15:45.712000+00:00"),
+                "endedAt": datetime.fromisoformat("2025-08-06T00:20:59.992000+00:00"),
+                "lifecycleStatus": "ENDED",
+            }
+        ]
+    }
+    deadline_mock.list_session_actions.return_value = {
+        "sessionActions": [
+            {
+                "sessionActionId": f"sessionaction-0123456789abcdefabcdefabcdefabcd-{i}",
+                "status": "SUCCEEDED",
+                "startedAt": "2025-08-06T00:20:58.454000+00:00",
+                "endedAt": "2025-08-06T00:20:59.992000+00:00",
+                "progressPercent": 100.0,
+                "definition": {"taskRun": {"taskId": task_ids[i], "stepId": step_id}},
+                "manifests": [{"outputManifestPath": f"{task_ids[i]}/manifest"}],
+            }
+            for i in range(2)
+        ]
+    }
+
+    # Two manifests, older then newer, both writing the SAME path under different tasks.
+    downloaded_manifests = [
+        (
+            datetime.fromisoformat("2025-08-06T00:10:00.000000+00:00"),
+            AssetManifest(
+                hash_alg=HashAlgorithm.XXH128,
+                total_size=1,
+                paths=[ManifestPath(path=shared_file_path, hash="h", size=1, mtime=1)],
+            ),
+        ),
+        (
+            datetime.fromisoformat("2025-08-06T00:20:00.000000+00:00"),
+            AssetManifest(
+                hash_alg=HashAlgorithm.XXH128,
+                total_size=1,
+                paths=[ManifestPath(path=shared_file_path, hash="h", size=1, mtime=1)],
+            ),
+        ),
+    ]
+    manifests_to_download = [
+        (None, MOCK_JOB_ID, "/", f"prefix/{step_id}/{task_ids[i]}/manifest") for i in range(2)
+    ]
+
+    def fake_download_all_manifests(*args, **kwargs):
+        return downloaded_manifests
+
+    def fake_get_manifests_to_download(*args, **kwargs):
+        return manifests_to_download
+
+    downloaded_paths: list[str] = []
+
+    def fake_download_manifest_paths(
+        files,
+        hash_algorithm,
+        queue,
+        session,
+        conflict,
+        on_downloading_files,
+        print_function_callback,
+    ):
+        for f in files:
+            downloaded_paths.append(f.path)
+            os.makedirs(os.path.dirname(f.path), exist_ok=True)
+            with open(f.path, "w") as fh:
+                fh.write("output")
+
+    runner = CliRunner()
+    with (
+        patch(
+            "deadline.client.cli._incremental_download._download_all_manifests_with_absolute_paths",
+            side_effect=fake_download_all_manifests,
+        ),
+        patch(
+            "deadline.client.cli._incremental_download._get_manifests_to_download",
+            side_effect=fake_get_manifests_to_download,
+        ),
+        patch(
+            "deadline.client.cli._incremental_download._download_manifest_paths",
+            side_effect=fake_download_manifest_paths,
+        ),
+        freeze_time(ISO_FREEZE_TIME),
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "queue",
+                "sync-output",
+                "--ignore-storage-profiles",
+                "--force-bootstrap",
+                "--bootstrap-lookback-minutes",
+                "120",
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--checkpoint-dir",
+                checkpoint_dir,
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    # The shared path is downloaded once, not once per task.
+    assert downloaded_paths.count(shared_file_path) == 1, downloaded_paths
+    assert "Downloaded files: 1" in result.output, result.output
+
+    # It is attributed to the newer task only; the older task no longer owns it.
+    status_file_path = os.path.join(
+        checkpoint_dir, f"{MOCK_QUEUE_ID}_ignore-storage-profiles_download_status.json"
+    )
+    with open(status_file_path) as f:
+        status = json.load(f)
+    tasks = status["jobs"][MOCK_JOB_ID]["tasks"]
+    assert task_ids[1] in tasks, tasks
+    assert tasks[task_ids[1]]["downloaded_files"] == 1, tasks
+    assert task_ids[0] not in tasks, tasks
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
+)
+def test_incremental_output_download_shared_path_newest_wins_regardless_of_order(
+    fresh_deadline_config, deadline_mock, checkpoint_dir, tmp_path
+):
+    """When two jobs write the same output path, the job with the newer manifest
+    (by S3 LastModified) is credited — even when its manifest appears earlier in the
+    download list. The attribution loop must sort by timestamp, not rely on list order.
+    """
+    from deadline.job_attachments.asset_manifests.v2023_03_03.asset_manifest import (
+        AssetManifest,
+        ManifestPath,
+    )
+    from deadline.job_attachments.asset_manifests import HashAlgorithm
+
+    job_id_old = MOCK_JOB_ID
+    job_id_new = "job-0123456789abcdefabcdefabcdefab99"
+    step_id = "step-b1764261dff54214aace3932bde8ae7e"
+    task_id_old = "task-b1764261dff54214aace3932bde8ae7e-0"
+    task_id_new = "task-b1764261dff54214aace3932bde8ae7e-1"
+    shared_path = str(tmp_path / "shared" / "beauty.exr")
+
+    mock_jobs = create_fake_job_list(2)
+    for job, jid, name in (
+        (mock_jobs[0], job_id_old, "Old Job"),
+        (mock_jobs[1], job_id_new, "New Job"),
+    ):
+        job["name"] = name
+        job["jobId"] = jid
+        job["taskRunStatus"] = "SUCCEEDED"
+        job["taskRunStatusCounts"] = {"SUCCEEDED": 1, "READY": 0}
+        job["attachments"] = {
+            "manifests": [
+                {"rootPath": "/", "rootPathFormat": "posix", "outputRelativeDirectories": ["."]}
+            ],
+            "fileSystem": "COPIED",
+        }
+        job["endedAt"] = datetime.fromisoformat(ISO_FREEZE_TIME)
+    deadline_mock.search_jobs = mock_search_jobs_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+    deadline_mock.get_job = mock_get_job_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+
+    def sessions_for(job_id):
+        return {
+            "sessions": [
+                {
+                    "sessionId": MOCK_SESSION_ID,
+                    "fleetId": MOCK_FLEET_ID,
+                    "workerId": MOCK_WORKER_ID,
+                    "startedAt": datetime.fromisoformat("2025-08-06T00:15:45.712000+00:00"),
+                    "endedAt": datetime.fromisoformat("2025-08-06T00:20:59.992000+00:00"),
+                    "lifecycleStatus": "ENDED",
+                }
+            ]
+        }
+
+    task_by_job = {job_id_old: task_id_old, job_id_new: task_id_new}
+    deadline_mock.list_sessions.side_effect = lambda **kwargs: sessions_for(kwargs.get("jobId"))
+    deadline_mock.list_session_actions.side_effect = lambda **kwargs: {
+        "sessionActions": [
+            {
+                "sessionActionId": "sessionaction-0123456789abcdefabcdefabcdefabcd-0",
+                "status": "SUCCEEDED",
+                "startedAt": "2025-08-06T00:20:58.454000+00:00",
+                "endedAt": "2025-08-06T00:20:59.992000+00:00",
+                "progressPercent": 100.0,
+                "definition": {
+                    "taskRun": {"taskId": task_by_job[kwargs.get("jobId")], "stepId": step_id}
+                },
+                "manifests": [
+                    {"outputManifestPath": f"{task_by_job[kwargs.get('jobId')]}/manifest"}
+                ],
+            }
+        ]
+    }
+
+    older_ts = datetime.fromisoformat(ISO_FREEZE_TIME_MINUS_5MIN)
+    newer_ts = datetime.fromisoformat(ISO_FREEZE_TIME)
+
+    def make_manifest():
+        return AssetManifest(
+            hash_alg=HashAlgorithm.XXH128,
+            total_size=1,
+            paths=[ManifestPath(path=shared_path, hash="h", size=1, mtime=1)],
+        )
+
+    # The NEW job's manifest (newer timestamp) is placed FIRST — list order is the
+    # reverse of chronological order, so relying on iteration order would credit the
+    # OLD job. The fix sorts by timestamp so the NEW job wins.
+    downloaded_manifests = [
+        (newer_ts, make_manifest()),
+        (older_ts, make_manifest()),
+    ]
+    manifests_to_download = [
+        (None, job_id_new, "/", f"prefix/{step_id}/{task_id_new}/manifest"),
+        (None, job_id_old, "/", f"prefix/{step_id}/{task_id_old}/manifest"),
+    ]
+
+    def fake_download_all_manifests(*args, **kwargs):
+        return downloaded_manifests
+
+    def fake_get_manifests_to_download(*args, **kwargs):
+        return manifests_to_download
+
+    def fake_download_manifest_paths(
+        files,
+        hash_algorithm,
+        queue,
+        session,
+        conflict,
+        on_downloading_files,
+        print_function_callback,
+    ):
+        for f in files:
+            os.makedirs(os.path.dirname(f.path), exist_ok=True)
+            with open(f.path, "w") as fh:
+                fh.write("output")
+
+    runner = CliRunner()
+    with (
+        patch(
+            "deadline.client.cli._incremental_download._download_all_manifests_with_absolute_paths",
+            side_effect=fake_download_all_manifests,
+        ),
+        patch(
+            "deadline.client.cli._incremental_download._get_manifests_to_download",
+            side_effect=fake_get_manifests_to_download,
+        ),
+        patch(
+            "deadline.client.cli._incremental_download._download_manifest_paths",
+            side_effect=fake_download_manifest_paths,
+        ),
+        freeze_time(ISO_FREEZE_TIME),
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "queue",
+                "sync-output",
+                "--ignore-storage-profiles",
+                "--force-bootstrap",
+                "--bootstrap-lookback-minutes",
+                "120",
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--checkpoint-dir",
+                checkpoint_dir,
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+
+    # The newer job owns the shared path and performs the actual download; the older job
+    # is deduped out and downloads nothing. With list-order attribution (the bug), the
+    # older job — appearing later in the list — would incorrectly claim the path.
+    assert "for job: New Job" in result.output, result.output
+    assert "for job: Old Job" not in result.output, result.output
+
+    # The deduped (losing) job must still report filesystem-based status, not total=0/downloaded=0.
+    # Its paths were claimed by the winning job and pruned from the download lists, so its status
+    # depends on all_task_file_paths being retained (not derived from the pruned lists). The shared
+    # file is on disk, so the loser reports it as downloaded.
+    status_file_path = os.path.join(
+        checkpoint_dir, f"{MOCK_QUEUE_ID}_ignore-storage-profiles_download_status.json"
+    )
+    with open(status_file_path) as f:
+        status = json.load(f)
+    loser_entry = status["jobs"][job_id_old]
+    assert loser_entry["download_status"] == "downloaded", loser_entry
+    assert loser_entry["total_files"] == 1, loser_entry
+    assert loser_entry["downloaded_files"] == 1, loser_entry
+    assert loser_entry["tasks"][task_id_old]["downloaded_files"] == 1, loser_entry

--- a/test/unit/deadline_client/cli/test_cli_queue_incremental_download.py
+++ b/test/unit/deadline_client/cli/test_cli_queue_incremental_download.py
@@ -1608,3 +1608,176 @@ def test_incremental_output_download_fallback_failure_marks_run_failed(
         f"completed={saved.downloads_completed_timestamp.isoformat()} "
         f"started={saved.downloads_started_timestamp.isoformat()}"
     )
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
+)
+def test_incremental_output_download_per_task_error_isolation(
+    fresh_deadline_config, deadline_mock, checkpoint_dir, tmp_path
+):
+    """Per-task download error isolation: when one task's files fail to download,
+    only that task is marked failed — the other tasks succeed independently.
+
+    Simulates a 3-task job where task-1's output path is inaccessible. The status
+    file must show task-0 and task-2 as 'downloaded' and task-1 as 'failed' with the
+    correct error code, while the job-level status is 'failed'.
+    """
+    from deadline.job_attachments.asset_manifests.v2023_03_03.asset_manifest import (
+        AssetManifest,
+        ManifestPath,
+    )
+    from deadline.job_attachments.asset_manifests import HashAlgorithm
+
+    step_id = "step-b1764261dff54214aace3932bde8ae7e"
+    task_ids = [f"task-b1764261dff54214aace3932bde8ae7e-{i}" for i in range(3)]
+    # Each task writes one file to its own subdirectory under tmp_path.
+    task_file_paths = [str(tmp_path / f"frame_{i}" / "beauty.exr") for i in range(3)]
+    locked_path = task_file_paths[1]  # task-1's file is the one that fails
+
+    mock_jobs = create_fake_job_list(1)
+    mock_jobs[0]["name"] = "Mock Job"
+    mock_jobs[0]["jobId"] = MOCK_JOB_ID
+    mock_jobs[0]["taskRunStatus"] = "SUCCEEDED"
+    mock_jobs[0]["taskRunStatusCounts"] = {"SUCCEEDED": 3, "READY": 0}
+    mock_jobs[0]["attachments"] = {
+        "manifests": [
+            {"rootPath": "/", "rootPathFormat": "posix", "outputRelativeDirectories": ["."]}
+        ],
+        "fileSystem": "COPIED",
+    }
+    mock_jobs[0]["endedAt"] = datetime.fromisoformat(ISO_FREEZE_TIME)
+    deadline_mock.search_jobs = mock_search_jobs_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+    deadline_mock.get_job = mock_get_job_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+
+    deadline_mock.list_sessions.return_value = {
+        "sessions": [
+            {
+                "sessionId": MOCK_SESSION_ID,
+                "fleetId": MOCK_FLEET_ID,
+                "workerId": MOCK_WORKER_ID,
+                "startedAt": datetime.fromisoformat("2025-08-06T00:15:45.712000+00:00"),
+                "endedAt": datetime.fromisoformat("2025-08-06T00:20:59.992000+00:00"),
+                "lifecycleStatus": "ENDED",
+            }
+        ]
+    }
+    deadline_mock.list_session_actions.return_value = {
+        "sessionActions": [
+            {
+                "sessionActionId": f"sessionaction-0123456789abcdefabcdefabcdefabcd-{i}",
+                "status": "SUCCEEDED",
+                "startedAt": "2025-08-06T00:20:58.454000+00:00",
+                "endedAt": "2025-08-06T00:20:59.992000+00:00",
+                "progressPercent": 100.0,
+                "definition": {"taskRun": {"taskId": task_ids[i], "stepId": step_id}},
+                "manifests": [{"outputManifestPath": f"{task_ids[i]}/manifest"}],
+            }
+            for i in range(3)
+        ]
+    }
+
+    # One manifest per task, each containing that task's single output file.
+    downloaded_manifests = [
+        (
+            datetime.fromisoformat(ISO_FREEZE_TIME),
+            AssetManifest(
+                hash_alg=HashAlgorithm.XXH128,
+                total_size=1,
+                paths=[ManifestPath(path=task_file_paths[i], hash="h", size=1, mtime=1)],
+            ),
+        )
+        for i in range(3)
+    ]
+    # The (applier, job_id, root_path, s3_key) tuples correlate positionally with the
+    # manifests above. The S3 key embeds the task id so per-task attribution works.
+    manifests_to_download = [
+        (None, MOCK_JOB_ID, "/", f"prefix/{step_id}/{task_ids[i]}/manifest") for i in range(3)
+    ]
+
+    def fake_download_all_manifests(
+        queue,
+        download_candidate_jobs,
+        job_sessions,
+        path_mapping_rule_appliers,
+        output_unmapped_paths,
+        boto3_session_for_s3,
+        print_function_callback=lambda msg: None,
+    ):
+        return downloaded_manifests
+
+    def fake_get_manifests_to_download(*args, **kwargs):
+        return manifests_to_download
+
+    def fake_download_manifest_paths(
+        files,
+        hash_algorithm,
+        queue,
+        session,
+        conflict,
+        on_downloading_files,
+        print_function_callback,
+    ):
+        # Simulate the download: create files on disk, but raise if task-1's locked
+        # file is in this batch (per-task isolation calls this once per task).
+        for f in files:
+            if f.path == locked_path:
+                raise PermissionError(f"[Errno 13] Permission denied: '{locked_path}'")
+            os.makedirs(os.path.dirname(f.path), exist_ok=True)
+            with open(f.path, "w") as fh:
+                fh.write("output")
+
+    runner = CliRunner()
+    with (
+        patch(
+            "deadline.client.cli._incremental_download._download_all_manifests_with_absolute_paths",
+            side_effect=fake_download_all_manifests,
+        ),
+        patch(
+            "deadline.client.cli._incremental_download._get_manifests_to_download",
+            side_effect=fake_get_manifests_to_download,
+        ),
+        patch(
+            "deadline.client.cli._incremental_download._download_manifest_paths",
+            side_effect=fake_download_manifest_paths,
+        ),
+        freeze_time(ISO_FREEZE_TIME),
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "queue",
+                "sync-output",
+                "--ignore-storage-profiles",
+                "--force-bootstrap",
+                "--bootstrap-lookback-minutes",
+                "120",
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--checkpoint-dir",
+                checkpoint_dir,
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+
+    # The status file records per-task isolation: task-1 failed, task-0 and task-2 succeeded.
+    status_file_path = os.path.join(
+        checkpoint_dir, f"{MOCK_QUEUE_ID}_ignore-storage-profiles_download_status.json"
+    )
+    with open(status_file_path) as f:
+        status = json.load(f)
+
+    job_entry = status["jobs"][MOCK_JOB_ID]
+    assert job_entry["download_status"] == "failed", job_entry
+    assert job_entry["error_code"] == "PERMISSION_DENIED", job_entry
+
+    tasks = job_entry["tasks"]
+    assert tasks[task_ids[0]]["download_status"] == "downloaded", tasks
+    assert tasks[task_ids[0]]["error_code"] is None, tasks
+    assert tasks[task_ids[2]]["download_status"] == "downloaded", tasks
+    assert tasks[task_ids[2]]["error_code"] is None, tasks
+    assert tasks[task_ids[1]]["download_status"] == "failed", tasks
+    assert tasks[task_ids[1]]["error_code"] == "PERMISSION_DENIED", tasks

--- a/test/unit/deadline_client/cli/test_cli_region_per_command.py
+++ b/test/unit/deadline_client/cli/test_cli_region_per_command.py
@@ -521,7 +521,7 @@ def test_cli_queue_sync_output_region(fresh_deadline_config, tmp_path):
         patch.object(
             queue_group,
             "_incremental_output_download",
-            return_value=(MagicMock(), MagicMock(), {}, {}),
+            return_value=(MagicMock(), MagicMock(), {}, {}, {}),
         ),
     ):
         runner = CliRunner()


### PR DESCRIPTION
Note: This is part 3 of 3. Depends on PR #1223. Once PR #1220 and #1223 merge, the duplicate commits here will be gone.

### What was the problem/requirement? (What/Why)

PR #1223 tracks per-job download status but has no visibility into which individual tasks within a job have been downloaded. Artists and DCM have no way to know download progress at the task level, and skipped jobs don't indicate why they were skipped.

### What was the solution? (How)

- Parse task ID from the S3 manifest key path (`step-<id>/task-<id>/...`) using a regex — no changes to the `deadline-job-attachments` dependency required
- Build a per-task download results dict (`job_id → task_id → files`) alongside the existing per-job grouping
- Add a `tasks` dict to each job entry in the status JSON, accumulating task entries across runs — existing task entries are preserved and only tasks seen in the current run are overwritten
- Zero-output tasks are included in the `tasks` dict with `download_status: "downloaded"` so they count toward the progress bar numerator — a task with no outputs is still complete
- Add a `skip_reason` field to skipped job entries: `"no_attachments"` or `"missing_storage_profile"`
- Per-task path dedup and newest-manifest-wins semantics maintained via `task_path_index` for O(1) lookups — same correctness guarantees as the per-job dedup
- `None` sentinel cleanup pass filters transferred paths from both `job_manifest_paths` and `job_task_manifest_paths` before building download batches
- Graceful degradation when manifest list lengths diverge: per-job/task attribution is skipped with a warning rather than aborting the run
- Stale `error_code`/`error_message` cleared when a job's status transitions away from `"failed"` in the preserve branch

### What is the impact of this change?

- Each job entry in the status JSON now includes a `tasks` dict with per-task download status, file counts, and error info
- DCM can use the `tasks` dict combined with `taskRunStatusCounts` from the job API to drive a per-task progress bar — denominator comes from the API (always known), numerator is tasks with `download_status: "downloaded"` in the dict
- Skipped job entries now carry a `skip_reason` field so DCM can explain to artists why a job was skipped
- File counts in the JSON reflect the most recent sync run only — cumulative totals are deferred to M4 filesystem check

### How was this change tested?

- Unit tests (66 total — new tests covering per-task tracking, `skip_reason`, `_extract_task_id_from_s3_key`, zero-output task inclusion, task merge logic, `task_path_index` correctness)
- Manual E2E: multi-output job (3 tasks × 3 files each) shows correct per-task entries; failed job shows all tasks failed; `in_progress` shows partial task dict building up as tasks complete; skipped shows empty tasks with `skip_reason`
- Requeue cycle verified: task entries overwrite correctly, job flips to `in_progress` then back to `downloaded`
- Ran full unit test suite (2945 passed)

### Was this change documented?

- Docstrings added to `_extract_task_id_from_s3_key`
- README.md does not need updating

### Does this PR introduce new dependencies?

- This PR does not add any new dependencies.

### Is this a breaking change?

No. The return tuple from `_incremental_output_download()` expanded from 4 to 5 elements, but this is an internal function (prefixed with `_`), not a public contract. Existing test mocks updated accordingly.

### Does this change impact security?

No. Same security posture as PR #1220 and #1223 — status file contains only job IDs, task IDs, file counts, and error messages. No credentials or secrets.
