### PR TITLE
fix: handle missing storage profile in sync-output unmapped-paths warning to prevent UnboundLocalError with --ignore-storage-profiles

### DIFF
--- a/src/deadline/client/cli/_incremental_download.py
+++ b/src/deadline/client/cli/_incremental_download.py
@@ -1110,6 +1110,7 @@ def _incremental_output_download(
     durations._get_job_sessions = time.perf_counter_ns() - start_t
 
     # If storage profiles are being used, get them and construct all the path mapping rules
+    storage_profiles: dict[str, dict[str, Any]] = {}
     path_mapping_rule_appliers: dict[str, Optional[_PathMappingRuleApplier]] = {}
     if checkpoint.local_storage_profile_id:
         start_t = time.perf_counter_ns()
@@ -1154,14 +1155,18 @@ def _incremental_output_download(
             print_function_callback(
                 f"    Job {download_candidate_jobs[job_id]['name']} ({job_id}) has outputs with unmapped paths that will not be downloaded"
             )
-            storage_profile = storage_profiles[download_candidate_jobs[job_id]["storageProfileId"]]
-            print_function_callback(
-                f"      Job storage profile is {storage_profile['displayName']} ({storage_profile['storageProfileId']})"
+            storage_profile = storage_profiles.get(
+                download_candidate_jobs[job_id].get("storageProfileId", "")
             )
+            if storage_profile is not None:
+                print_function_callback(
+                    f"      Job storage profile is {storage_profile['displayName']} ({storage_profile['storageProfileId']})"
+                )
             print_function_callback("      Summary of unmapped paths:")
             path_format = (
                 PathFormat.WINDOWS
-                if storage_profile["osFamily"] == StorageProfileOperatingSystemFamily.WINDOWS.value
+                if storage_profile is not None
+                and storage_profile["osFamily"] == StorageProfileOperatingSystemFamily.WINDOWS.value
                 else PathFormat.POSIX
             )
             paths_summary = summarize_path_list(

--- a/test/unit/deadline_client/cli/test_cli_queue_incremental_download.py
+++ b/test/unit/deadline_client/cli/test_cli_queue_incremental_download.py
@@ -1189,3 +1189,106 @@ def test_incremental_output_download_stats_telemetry(
             "unmapped_paths": 0,
         },
     )
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
+)
+def test_incremental_output_download_unmapped_paths_without_storage_profile(
+    fresh_deadline_config, deadline_mock, checkpoint_dir
+):
+    """
+    Regression test: when running with --ignore-storage-profiles (no storage profile),
+    outputs whose manifest paths are dropped (e.g. by the job attachments path-traversal
+    containment check) are surfaced via `unmapped_paths`. The warning that reports them
+    must not reference a storage profile that does not exist. Previously this raised
+    UnboundLocalError: cannot access local variable 'storage_profiles'.
+    """
+    mock_jobs = create_fake_job_list(1)
+    mock_jobs[0]["name"] = "Mock Job"
+    mock_jobs[0]["jobId"] = MOCK_JOB_ID
+    mock_jobs[0]["taskRunStatus"] = "SUCCEEDED"
+    mock_jobs[0]["taskRunStatusCounts"] = {"SUCCEEDED": 1, "READY": 0}
+    mock_jobs[0]["attachments"] = {
+        "manifests": [
+            {"rootPath": "/", "rootPathFormat": "posix", "outputRelativeDirectories": ["."]}
+        ],
+        "fileSystem": "COPIED",
+    }
+    mock_jobs[0]["endedAt"] = datetime.fromisoformat(ISO_FREEZE_TIME)
+    deadline_mock.search_jobs = mock_search_jobs_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+    deadline_mock.get_job = mock_get_job_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+
+    deadline_mock.list_sessions.return_value = {
+        "sessions": [
+            {
+                "sessionId": MOCK_SESSION_ID,
+                "fleetId": MOCK_FLEET_ID,
+                "workerId": MOCK_WORKER_ID,
+                "startedAt": datetime.fromisoformat("2025-08-06T00:15:45.712000+00:00"),
+                "endedAt": datetime.fromisoformat("2025-08-06T00:20:59.992000+00:00"),
+                "lifecycleStatus": "ENDED",
+            }
+        ]
+    }
+    deadline_mock.list_session_actions.return_value = {
+        "sessionActions": [
+            {
+                "sessionActionId": MOCK_SESSION_ACTION_ID_1,
+                "status": "SUCCEEDED",
+                "startedAt": "2025-08-06T00:20:58.454000+00:00",
+                "endedAt": "2025-08-06T00:20:59.992000+00:00",
+                "progressPercent": 100.0,
+                "definition": {
+                    "taskRun": {
+                        "taskId": "task-b1764261dff54214aace3932bde8ae7e-0",
+                        "stepId": "step-b1764261dff54214aace3932bde8ae7e",
+                    }
+                },
+                "manifests": [],
+            },
+        ]
+    }
+
+    # Simulate the job attachments layer dropping an out-of-root output path into
+    # unmapped_paths (as the path-traversal containment check does), returning no
+    # downloadable manifests.
+    def fake_download_all_manifests(
+        queue,
+        download_candidate_jobs,
+        job_sessions,
+        path_mapping_rule_appliers,
+        output_unmapped_paths,
+        boto3_session_for_s3,
+        print_function_callback=lambda msg: None,
+    ):
+        output_unmapped_paths[MOCK_JOB_ID] = ["/etc/cron.d/evil"]
+        return []
+
+    runner = CliRunner()
+    with patch(
+        "deadline.client.cli._incremental_download._download_all_manifests_with_absolute_paths",
+        side_effect=fake_download_all_manifests,
+    ), freeze_time(ISO_FREEZE_TIME):
+        result = runner.invoke(
+            main,
+            [
+                "queue",
+                "sync-output",
+                "--ignore-storage-profiles",
+                "--force-bootstrap",
+                "--bootstrap-lookback-minutes",
+                "120",
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--checkpoint-dir",
+                checkpoint_dir,
+            ],
+        )
+
+    # Must not crash (previously raised UnboundLocalError on 'storage_profiles').
+    assert result.exit_code == 0, result.output
+    assert "WARNING: THE FOLLOWING FILES WILL NOT BE DOWNLOADED" in result.output, result.output
+    assert "/etc/cron.d/evil" in result.output, result.output

--- a/test/unit/deadline_client/cli/test_cli_queue_incremental_download.py
+++ b/test/unit/deadline_client/cli/test_cli_queue_incremental_download.py
@@ -1191,9 +1191,6 @@ def test_incremental_output_download_stats_telemetry(
     )
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
-)
 def test_incremental_output_download_unmapped_paths_without_storage_profile(
     fresh_deadline_config, deadline_mock, checkpoint_dir
 ):


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

`deadline queue sync-output` crashes with `UnboundLocalError: cannot access local variable 'storage_profiles'` whenever it needs to warn about unmapped output paths in `--ignore-storage-profiles` mode (or when the queue has no storage profile). The warning loop in `_incremental_download.py` unconditionally indexes `storage_profiles`, but that variable is only assigned when `checkpoint.local_storage_profile_id` is set.

This path became reachable after the job-attachments path-traversal fix, which now routes out-of-root manifest paths into `unmapped_paths`. Previously nothing populated `unmapped_paths` in ignore-storage-profiles mode, so the buggy line never executed.

### What was the solution? (How)

- Initialize `storage_profiles` to an empty dict before the conditional block so it always exists.
- Make the unmapped-paths warning tolerate a missing storage profile: skip the "Job storage profile is ..." line when there is none, and default the path format to POSIX. Behavior is unchanged when a storage profile is present.

### What is the impact of this change?

`sync-output` now warns about skipped paths and continues downloading the remaining (valid) files instead of crashing. No change for the storage-profile path.

### How was this change tested?

Reproduced end-to-end against a real farm/queue with a malicious output manifest (absolute + `..` paths) using `sync-output --ignore-storage-profiles`:
- Before: crashes with `UnboundLocalError` after printing the warning header.

```
Downloading 1 asset manifests from S3...
Using 10 threads
...downloaded manifests in 0:00:01.010632

WARNING: THE FOLLOWING FILES WILL NOT BE DOWNLOADED
    Job JA Output Test (job-e50fdd8e29bf492b9a685c7d70cb9d0a) has outputs with unmapped paths that will not be downloaded
The AWS Deadline Cloud CLI encountered the following exception:
Traceback (most recent call last):
  File "/tmp/ja-e2e-venv/lib/python3.12/site-packages/deadline/client/cli/_common.py", line 71, in wraps
    func(*args, **kwargs)
  File "/tmp/ja-e2e-venv/lib/python3.12/site-packages/deadline/client/api/_telemetry.py", line 536, in wrapper
    result = function(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/ja-e2e-venv/lib/python3.12/site-packages/deadline/client/cli/_groups/queue_group.py", line 488, in sync_output
    updated_download_state: IncrementalDownloadState = _incremental_output_download(
                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/ja-e2e-venv/lib/python3.12/site-packages/deadline/client/api/_telemetry.py", line 569, in wrapper
    ret_val = function(*args, **kwargs)
              ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/ja-e2e-venv/lib/python3.12/site-packages/deadline/client/cli/_incremental_download.py", line 1157, in _incremental_output_download
    storage_profile = storage_profiles[download_candidate_jobs[job_id]["storageProfileId"]]
                      ^^^^^^^^^^^^^^^^
UnboundLocalError: cannot access local variable 'storage_profiles' where it is not associated with a value
``` 
- After: prints the warning listing the skipped paths, downloads the legitimate file, exits 0. No files written outside the download root.

```
Ignoring all storage profiles.
Started incremental download for queue: Test Queue
Checkpoint: /Volumes/workplace/fork/deadline-cloud-job-attachments/e2e_tmp/checkpoint/queue-90535d8cf99d4b108886a8882aa2abbe_ignore-storage-profiles_download_checkpoint.json

Bootstrap forced, lookback is 120.0 minutes
Initializing from: 2026-07-06T09:37:23.698228-07:00

Updating download state across time interval:
    From: 2026-07-06T09:37:23.698228-07:00
      To: 2026-07-06T11:37:23.699628-07:00
  Length: 1:58:00.001400 + 0:02:00 (eventual consistency allowance)

Retrieving updated data from Deadline Cloud...
DEBUG: Got 0 active jobs
DEBUG: Filtered down to 0 active jobs based on SUCCEEDED task filter
DEBUG: Got 1 jobs with job[endedAt] >= 2026-07-06T09:37:23.698228-07:00
DEBUG: Filtered down to 1 jobs based on SUCCEEDED task filter
...retrieval completed in 0:00:00.576473

Categorizing 0 checkpoint jobs against 1 download candidate jobs...
NEW Job: JA Output Test (job-e50fdd8e29bf492b9a685c7d70cb9d0a)
  Succeeded tasks: 1 / 1
  Manifest file system paths:
    - /Volumes/workplace/fork/deadline-cloud-job-attachments/e2e_tmp/job_output (posix)
...categorization completed in 0:00:00.150046

Retrieving sessions for 1 jobs...
Using 3 threads
...retrieval completed in 0:00:00.294068

Retrieving session actions for 1 sessions...
Using 3 threads
...retrieval completed in 0:00:00.143690

Populating missing manifest S3 keys...
...populated in 0:00:00.000030

Downloading 1 asset manifests from S3...
Using 10 threads
...downloaded manifests in 0:00:00.849687

WARNING: THE FOLLOWING FILES WILL NOT BE DOWNLOADED
    Job JA Output Test (job-e50fdd8e29bf492b9a685c7d70cb9d0a) has outputs with unmapped paths that will not be downloaded
      Summary of unmapped paths:
      /tmp/evil_absolute.txt (1 file)
      /tmp/evil_traversal.txt (1 file)


Summary of paths to download:
/Volumes/workplace/fork/deadline-cloud-job-attachments/e2e_tmp/job_output/renders/frame001.txt (1 file, 25 B)


Downloading 1 files from S3...
Using 5 threads
Downloaded 25 B / 25 B of 1 file (Transfer rate: 0 B/s)
...downloaded in 0:00:00.037974

Summary of incremental output download:
  Downloaded session actions: 1
  Downloaded files: 1
  Downloaded bytes: 25 B
  Jobs with downloads:
    completed: 1
    added: 0
    updated: 0
  Jobs without downloads:
    not using job attachments: 0
    missing storage profile: 0
    unchanged: 0
    inactive: 0
Checkpoint saved
```

### Is this a breaking change?

No.
