### PR TITLE
fix: run environment and bundle submission hooks together

### DIFF
--- a/src/deadline/client/api/_submit_job_bundle.py
+++ b/src/deadline/client/api/_submit_job_bundle.py
@@ -36,7 +36,11 @@ from ..job_bundle.loader import (
     parse_yaml_or_json_content,
     validate_directory_symlink_containment,
 )
-from ..job_bundle._hooks import HookManager, HookMetadata, _generate_hooks_confirmation_message
+from ..job_bundle._hooks import (
+    HookMetadata,
+    _generate_hooks_confirmation_message,
+    collect_submission_hook_sources,
+)
 from ..job_bundle.parameters import (
     apply_job_parameters,
     merge_queue_job_parameters,
@@ -501,81 +505,47 @@ def create_job_from_job_bundle(
     # Ensure the job bundle doesn't contain files that resolve outside of the bundle directory
     validate_directory_symlink_containment(job_bundle_dir)
 
-    # Load hooks from environment variable and/or bundle
-    env_hooks_dir = os.environ.get("DEADLINE_HOOKS_DIR")
-    allow_env_hooks = config_file.str2bool(
-        get_setting("settings.allow_environment_hooks", config=config)
+    # Collect the pre/post-submission hook sources — environment (DEADLINE_HOOKS_DIR) and/or
+    # the job bundle — in execution order (environment first, then bundle). Both sources are
+    # returned as their own HookManager so they run together; an earlier single-manager merge
+    # could only ever execute one source, so environment and bundle hooks never ran together.
+    hook_sources = collect_submission_hook_sources(
+        bundle_dir=job_bundle_dir,
+        env_hooks_dir=os.environ.get("DEADLINE_HOOKS_DIR"),
+        allow_bundle_hooks=config_file.str2bool(
+            get_setting("settings.allow_bundle_hooks", config=config)
+        ),
+        allow_environment_hooks=config_file.str2bool(
+            get_setting("settings.allow_environment_hooks", config=config)
+        ),
+        print_callback=print_function_callback,
     )
-    allow_bundle_hooks = config_file.str2bool(
-        get_setting("settings.allow_bundle_hooks", config=config)
-    )
 
-    hook_manager = HookManager(job_bundle_dir, print_function_callback)
-    all_hooks_sources: list[tuple[str, str]] = []  # (source_description, hooks_dir)
-
-    # Check environment hooks
-    if env_hooks_dir:
-        if allow_env_hooks:
-            if os.path.isdir(env_hooks_dir):
-                all_hooks_sources.append(("environment (DEADLINE_HOOKS_DIR)", env_hooks_dir))
-            else:
-                print_function_callback(
-                    f"Warning: DEADLINE_HOOKS_DIR '{env_hooks_dir}' is not a valid directory"
-                )
-        else:
+    # Show confirmation (once) if any hooks will run, listing every source's hooks.
+    if hook_sources and not config_file.str2bool(
+        get_setting("settings.auto_accept", config=config)
+    ):
+        hooks_message = "".join(
+            _generate_hooks_confirmation_message(manager.hooks, manager._original_bundle_dir)
+            for manager in hook_sources
+            if manager.hooks
+        )
+        if interactive_confirmation_callback is None:
+            print_function_callback(hooks_message)
             print_function_callback(
-                "Warning: DEADLINE_HOOKS_DIR is set but environment hooks are disabled.\n"
-                "Enable with: deadline config set settings.allow_environment_hooks true"
+                "Job submission canceled (hooks present but user confirmation not available)."
             )
+            raise DeadlineOperationCanceled()
+        elif not interactive_confirmation_callback(
+            hooks_message + "Do you want to run these hooks?", True
+        ):
+            print_function_callback("Job submission canceled (user declined hooks).")
+            raise UserInitiatedCancel()
 
-    # Check bundle hooks
-    bundle_has_hooks = hook_manager.load_hooks()
-    if bundle_has_hooks and (bundle_has_hooks.pre_submission or bundle_has_hooks.post_submission):
-        if allow_bundle_hooks:
-            all_hooks_sources.append(("bundle", job_bundle_dir))
-        else:
-            print_function_callback(
-                "Note: Job bundle contains hooks.yaml but bundle hooks are disabled.\n"
-                "Enable with: deadline config set settings.allow_bundle_hooks true"
-            )
-            hook_manager.hooks = None  # Clear bundle hooks
-
-    # Load hooks from all allowed sources
-    hooks = None
-    for source_desc, hooks_dir in all_hooks_sources:
-        if hooks_dir == job_bundle_dir:
-            # Already loaded
-            hooks = bundle_has_hooks
-        else:
-            # Load from environment hooks dir
-            env_hook_manager = HookManager(hooks_dir, print_function_callback)
-            env_hooks = env_hook_manager.load_hooks()
-            if env_hooks:
-                if hooks is None:
-                    hooks = env_hooks
-                    hook_manager = env_hook_manager
-                else:
-                    # Merge hooks - env hooks run first, then bundle hooks
-                    hooks.pre_submission = env_hooks.pre_submission + hooks.pre_submission
-                    hooks.post_submission = env_hooks.post_submission + hooks.post_submission
-
-    # Show confirmation if any hooks will run
-    if hooks and (hooks.pre_submission or hooks.post_submission):
-        if not config_file.str2bool(get_setting("settings.auto_accept", config=config)):
-            hooks_message = _generate_hooks_confirmation_message(
-                hooks, hook_manager._original_bundle_dir
-            )
-            if interactive_confirmation_callback is None:
-                print_function_callback(hooks_message)
-                print_function_callback(
-                    "Job submission canceled (hooks present but user confirmation not available)."
-                )
-                raise DeadlineOperationCanceled()
-            elif not interactive_confirmation_callback(
-                hooks_message + "Do you want to run these hooks?", True
-            ):
-                print_function_callback("Job submission canceled (user declined hooks).")
-                raise UserInitiatedCancel()
+    # Whether any source has pre-/post-submission hooks, so the guards below only build hook
+    # metadata (parsing the template, etc.) when at least one hook will actually run.
+    has_pre_submission_hooks = any(m.hooks and m.hooks.pre_submission for m in hook_sources)
+    has_post_submission_hooks = any(m.hooks and m.hooks.post_submission for m in hook_sources)
 
     # Read in the job template
     file_contents, file_type = read_yaml_or_json(job_bundle_dir, "template", required=True)
@@ -729,7 +699,7 @@ def create_job_from_job_bundle(
     known_asset_paths = _filter_redundant_known_paths(known_asset_paths)
 
     # Execute pre-submission hooks before hashing/uploading
-    if hooks and hooks.pre_submission:
+    if has_pre_submission_hooks:
         template_obj = parse_yaml_or_json_content(
             file_contents, file_type, job_bundle_dir, "template"
         )
@@ -745,7 +715,11 @@ def create_job_from_job_bundle(
             submission_payload={},  # Not yet built
             storage_profile_id=storage_profile_id if storage_profile_id else None,
         )
-        hook_result = hook_manager.execute_pre_submission_hooks(hook_metadata, {})
+        # Thread the payload through every source in order (environment first, then bundle),
+        # so a later source's hooks see — and can override — an earlier source's changes.
+        hook_result: dict = {}
+        for manager in hook_sources:
+            hook_result = manager.execute_pre_submission_hooks(hook_metadata, hook_result)
 
         # Apply template modifications from hooks via stdout output
         if "template" in hook_result:
@@ -1100,7 +1074,7 @@ def create_job_from_job_bundle(
         print_function_callback(status_message + f"\n{job_id}")
 
         # Execute post-submission hooks
-        if hooks and hooks.post_submission:
+        if has_post_submission_hooks:
             template_obj = parse_yaml_or_json_content(
                 file_contents, file_type, job_bundle_dir, "template"
             )
@@ -1117,7 +1091,9 @@ def create_job_from_job_bundle(
                 storage_profile_id=storage_profile_id if storage_profile_id else None,
                 job_id=job_id,
             )
-            hook_manager.execute_post_submission_hooks(hook_metadata)
+            # Run every source's post-submission hooks in order (environment first, then bundle).
+            for manager in hook_sources:
+                manager.execute_post_submission_hooks(hook_metadata)
 
         return job_id
     else:

--- a/src/deadline/client/api/_submit_job_bundle.py
+++ b/src/deadline/client/api/_submit_job_bundle.py
@@ -526,7 +526,9 @@ def create_job_from_job_bundle(
         get_setting("settings.auto_accept", config=config)
     ):
         hooks_message = "".join(
-            _generate_hooks_confirmation_message(manager.hooks, manager._original_bundle_dir)
+            _generate_hooks_confirmation_message(
+                manager.hooks, manager._original_bundle_dir, manager.source_label
+            )
             for manager in hook_sources
             if manager.hooks
         )

--- a/src/deadline/client/job_bundle/_hooks/__init__.py
+++ b/src/deadline/client/job_bundle/_hooks/__init__.py
@@ -6,6 +6,7 @@ from ._manager import (
     HookManager,
     _generate_hooks_confirmation_message,
     collect_pre_gui_hook_sources,
+    collect_submission_hook_sources,
 )
 from ._models import HookConfiguration, HookDefinition, HookMetadata, HookResult
 from ._validator import validate_pre_gui_output
@@ -18,5 +19,6 @@ __all__ = [
     "HookResult",
     "_generate_hooks_confirmation_message",
     "collect_pre_gui_hook_sources",
+    "collect_submission_hook_sources",
     "validate_pre_gui_output",
 ]

--- a/src/deadline/client/job_bundle/_hooks/_manager.py
+++ b/src/deadline/client/job_bundle/_hooks/_manager.py
@@ -29,9 +29,19 @@ from ._validator import validate_modified_payload as _validate_modified_payload
 _logger = _logging.getLogger(__name__)
 
 
-def _generate_hooks_confirmation_message(hooks: _HookConfiguration, bundle_dir: str) -> str:
-    """Generate a confirmation message listing hooks that will execute."""
-    lines = ["This job bundle contains submission hooks that will execute on your machine:\n"]
+def _generate_hooks_confirmation_message(
+    hooks: _HookConfiguration, source_dir: str, source_label: str = "job bundle"
+) -> str:
+    """Generate a confirmation message listing hooks that will execute.
+
+    ``source_label`` names where the hooks came from — the job bundle or the
+    ``DEADLINE_HOOKS_DIR`` environment source — and defaults to the job bundle so existing
+    callers keep their wording. Because hooks execute arbitrary code on the user's machine,
+    this prompt is the user's informed-consent point: an environment-configured source must
+    not be shown as if it came from the job bundle, so both the header and the directory line
+    identify the true origin.
+    """
+    lines = [f"This {source_label} contains submission hooks that will execute on your machine:\n"]
 
     if hooks.pre_gui:
         lines.append("  Pre-GUI hooks:")
@@ -54,7 +64,7 @@ def _generate_hooks_confirmation_message(hooks: _HookConfiguration, bundle_dir: 
             lines.append(f"    [{i + 1}] {cmd}")
         lines.append("")
 
-    lines.append(f"  Bundle: {bundle_dir}\n")
+    lines.append(f"  Location: {source_dir}\n")
     return "\n".join(lines)
 
 
@@ -96,6 +106,10 @@ def _collect_hook_sources(
             warn(f"Warning: DEADLINE_HOOKS_DIR '{env_hooks_dir}' is not a valid directory")
         else:
             env_manager = manager_cls(env_hooks_dir, print_callback)
+            # Label this source as environment-configured so the confirmation prompt does not
+            # present a DEADLINE_HOOKS_DIR source as if it came from the job bundle. Set on the
+            # instance (not via constructor) so a patched hook_manager_cls seam still works.
+            env_manager.source_label = "environment (DEADLINE_HOOKS_DIR)"
             env_hooks = env_manager.load_hooks()
             if env_hooks and has_runnable_hooks(env_hooks):
                 if allow_environment_hooks:
@@ -210,9 +224,13 @@ class HookManager:
         self,
         job_bundle_dir: str,
         print_callback: _Callable[[str], None],
+        source_label: str = "job bundle",
     ):
         self.job_bundle_dir = job_bundle_dir
         self.print_callback = print_callback
+        # Names this source's origin for the confirmation prompt ("job bundle" vs.
+        # "environment (DEADLINE_HOOKS_DIR)"); the collector sets it per source.
+        self.source_label = source_label
         self.hooks: _Optional[_HookConfiguration] = None
         self._executor = _HookExecutor(job_bundle_dir, print_callback)
         # Use original bundle path for metadata if available (GUI submit case)

--- a/src/deadline/client/job_bundle/_hooks/_manager.py
+++ b/src/deadline/client/job_bundle/_hooks/_manager.py
@@ -58,6 +58,79 @@ def _generate_hooks_confirmation_message(hooks: _HookConfiguration, bundle_dir: 
     return "\n".join(lines)
 
 
+def _collect_hook_sources(
+    bundle_dir: str,
+    env_hooks_dir: _Optional[str],
+    allow_bundle_hooks: bool,
+    allow_environment_hooks: bool,
+    print_callback: _Callable[[str], None],
+    warning_callback: _Optional[_Callable[[str], None]],
+    hook_manager_cls: _Optional[type],
+    has_runnable_hooks: _Callable[[_HookConfiguration], bool],
+    hook_kind: str,
+) -> _List["HookManager"]:
+    """Return the HookManagers with runnable hooks, in execution order (env then bundle).
+
+    Shared by :func:`collect_pre_gui_hook_sources` and
+    :func:`collect_submission_hook_sources`. ``has_runnable_hooks`` selects which phase's
+    hooks make a source runnable (preGUI vs. pre/post-submission); ``hook_kind`` names that
+    phase in the "present but disabled" guidance so both callers stay in sync while phrasing
+    their messages for their own phase.
+    """
+    warn = warning_callback or print_callback
+    manager_cls = hook_manager_cls or HookManager
+    sources: _List["HookManager"] = []
+
+    # If DEADLINE_HOOKS_DIR resolves to the job bundle directory, the two sources are the
+    # same hooks.yaml. Treat it as the bundle source only (skip the env source) so hooks are
+    # not loaded and run twice.
+    env_is_bundle = (
+        bool(env_hooks_dir)
+        and bool(bundle_dir)
+        and (_os.path.realpath(env_hooks_dir or "") == _os.path.realpath(bundle_dir or ""))
+    )
+
+    # Environment hooks first.
+    if env_hooks_dir and not env_is_bundle:
+        if not _os.path.isdir(env_hooks_dir):
+            warn(f"Warning: DEADLINE_HOOKS_DIR '{env_hooks_dir}' is not a valid directory")
+        else:
+            env_manager = manager_cls(env_hooks_dir, print_callback)
+            env_hooks = env_manager.load_hooks()
+            if env_hooks and has_runnable_hooks(env_hooks):
+                if allow_environment_hooks:
+                    sources.append(env_manager)
+                else:
+                    warn(
+                        f"Note: DEADLINE_HOOKS_DIR contains {hook_kind} hooks but environment "
+                        "hooks are disabled.\n"
+                        "Enable with: deadline config set settings.allow_environment_hooks true"
+                    )
+
+    # Bundle hooks second. When env_is_bundle, this single source covers both; it is gated
+    # by allow_bundle_hooks OR allow_environment_hooks (either grant permits the shared dir).
+    #
+    # Only consult the bundle source when there IS a bundle. DCC submitters have no on-disk
+    # bundle at pre-GUI time and pass bundle_dir="" — an empty dir would make HookManager
+    # resolve hooks.yaml/.json relative to the process CWD (os.path.join("", "hooks") →
+    # "hooks"), so a stray hooks file in the launch directory could be loaded and, with
+    # bundle hooks enabled studio-wide, executed for a submission that has no bundle. Skip
+    # the bundle source entirely when bundle_dir is falsy to avoid that CWD footgun.
+    if bundle_dir:
+        bundle_manager = manager_cls(bundle_dir, print_callback)
+        bundle_hooks = bundle_manager.load_hooks()
+        if bundle_hooks and has_runnable_hooks(bundle_hooks):
+            if allow_bundle_hooks or (env_is_bundle and allow_environment_hooks):
+                sources.append(bundle_manager)
+            else:
+                warn(
+                    f"Note: Job bundle contains {hook_kind} hooks but bundle hooks are disabled.\n"
+                    "Enable with: deadline config set settings.allow_bundle_hooks true"
+                )
+
+    return sources
+
+
 def collect_pre_gui_hook_sources(
     bundle_dir: str,
     env_hooks_dir: _Optional[str],
@@ -83,58 +156,51 @@ def collect_pre_gui_hook_sources(
     This is deliberately Qt-free so it can be unit-tested without a GUI binding; the caller
     (the submitter) handles the confirmation prompt and execution.
     """
-    warn = warning_callback or print_callback
-    manager_cls = hook_manager_cls or HookManager
-    sources: _List["HookManager"] = []
-
-    # If DEADLINE_HOOKS_DIR resolves to the job bundle directory, the two sources are the
-    # same hooks.yaml. Treat it as the bundle source only (skip the env source) so hooks are
-    # not loaded and run twice — matching the pre/post-submission path's dedup.
-    env_is_bundle = (
-        bool(env_hooks_dir)
-        and bool(bundle_dir)
-        and (_os.path.realpath(env_hooks_dir or "") == _os.path.realpath(bundle_dir or ""))
+    return _collect_hook_sources(
+        bundle_dir=bundle_dir,
+        env_hooks_dir=env_hooks_dir,
+        allow_bundle_hooks=allow_bundle_hooks,
+        allow_environment_hooks=allow_environment_hooks,
+        print_callback=print_callback,
+        warning_callback=warning_callback,
+        hook_manager_cls=hook_manager_cls,
+        has_runnable_hooks=lambda hooks: bool(hooks.pre_gui),
+        hook_kind="preGUI",
     )
 
-    # Environment hooks first.
-    if env_hooks_dir and not env_is_bundle:
-        if not _os.path.isdir(env_hooks_dir):
-            warn(f"Warning: DEADLINE_HOOKS_DIR '{env_hooks_dir}' is not a valid directory")
-        else:
-            env_manager = manager_cls(env_hooks_dir, print_callback)
-            env_hooks = env_manager.load_hooks()
-            if env_hooks and env_hooks.pre_gui:
-                if allow_environment_hooks:
-                    sources.append(env_manager)
-                else:
-                    warn(
-                        "Note: DEADLINE_HOOKS_DIR contains preGUI hooks but environment "
-                        "hooks are disabled.\n"
-                        "Enable with: deadline config set settings.allow_environment_hooks true"
-                    )
 
-    # Bundle hooks second. When env_is_bundle, this single source covers both; it is gated
-    # by allow_bundle_hooks OR allow_environment_hooks (either grant permits the shared dir).
-    #
-    # Only consult the bundle source when there IS a bundle. DCC submitters have no on-disk
-    # bundle at pre-GUI time and pass bundle_dir="" — an empty dir would make HookManager
-    # resolve hooks.yaml/.json relative to the process CWD (os.path.join("", "hooks") →
-    # "hooks"), so a stray hooks file in the launch directory could be loaded and, with
-    # bundle hooks enabled studio-wide, executed for a submission that has no bundle. Skip
-    # the bundle source entirely when bundle_dir is falsy to avoid that CWD footgun.
-    if bundle_dir:
-        bundle_manager = manager_cls(bundle_dir, print_callback)
-        bundle_hooks = bundle_manager.load_hooks()
-        if bundle_hooks and bundle_hooks.pre_gui:
-            if allow_bundle_hooks or (env_is_bundle and allow_environment_hooks):
-                sources.append(bundle_manager)
-            else:
-                warn(
-                    "Note: Job bundle contains preGUI hooks but bundle hooks are disabled.\n"
-                    "Enable with: deadline config set settings.allow_bundle_hooks true"
-                )
+def collect_submission_hook_sources(
+    bundle_dir: str,
+    env_hooks_dir: _Optional[str],
+    allow_bundle_hooks: bool,
+    allow_environment_hooks: bool,
+    print_callback: _Callable[[str], None],
+    warning_callback: _Optional[_Callable[[str], None]] = None,
+    hook_manager_cls: _Optional[type] = None,
+) -> _List["HookManager"]:
+    """Return the HookManagers whose pre/post-submission hooks should run, in execution order.
 
-    return sources
+    Submission (pre- and post-submission) hooks may come from the directory named by
+    ``DEADLINE_HOOKS_DIR`` (gated by ``allow_environment_hooks``) and/or the job bundle
+    (gated by ``allow_bundle_hooks``). Environment hooks run before bundle hooks. Sources
+    with neither pre- nor post-submission hooks are omitted.
+
+    This is the pre/post-submission analog of :func:`collect_pre_gui_hook_sources`. Both must
+    return a *list* of sources — the earlier single-``hook_manager`` merge could only ever run
+    one source, so environment and bundle submission hooks could not run together. See the
+    arguments' documentation on :func:`collect_pre_gui_hook_sources`.
+    """
+    return _collect_hook_sources(
+        bundle_dir=bundle_dir,
+        env_hooks_dir=env_hooks_dir,
+        allow_bundle_hooks=allow_bundle_hooks,
+        allow_environment_hooks=allow_environment_hooks,
+        print_callback=print_callback,
+        warning_callback=warning_callback,
+        hook_manager_cls=hook_manager_cls,
+        has_runnable_hooks=lambda hooks: bool(hooks.pre_submission or hooks.post_submission),
+        hook_kind="submission",
+    )
 
 
 class HookManager:

--- a/src/deadline/client/ui/pre_gui_hooks.py
+++ b/src/deadline/client/ui/pre_gui_hooks.py
@@ -185,7 +185,9 @@ def qt_hook_confirmation(parent: Any) -> Callable[[List[HookManager]], bool]:
     def _confirm(sources: List[HookManager]) -> bool:
         confirmation_msg = (
             "".join(
-                _generate_hooks_confirmation_message(m.hooks, m._original_bundle_dir)
+                _generate_hooks_confirmation_message(
+                    m.hooks, m._original_bundle_dir, m.source_label
+                )
                 for m in sources
                 if m.hooks
             )

--- a/test/unit/deadline_client/job_bundle/test_hooks.py
+++ b/test/unit/deadline_client/job_bundle/test_hooks.py
@@ -884,6 +884,27 @@ class TestHookManager:
         assert "Post-submission hooks:" in message
         assert "bash notify.sh" in message
         assert "/path/to/bundle" in message
+        # Defaults to the job-bundle wording so existing callers are unchanged.
+        assert "This job bundle contains submission hooks" in message
+
+    def test_confirmation_message_labels_environment_source(self):
+        """An environment (DEADLINE_HOOKS_DIR) source is identified as such — not shown as if
+        it came from the job bundle — so the consent prompt reflects the true hook origin."""
+        from deadline.client.job_bundle._hooks import _generate_hooks_confirmation_message
+
+        hooks = HookConfiguration(
+            version="1.0",
+            pre_gui=[],
+            pre_submission=[HookDefinition(command="python", args=["validate.py"])],
+            post_submission=[],
+        )
+        message = _generate_hooks_confirmation_message(
+            hooks, "/studio/hooks", "environment (DEADLINE_HOOKS_DIR)"
+        )
+        assert "This environment (DEADLINE_HOOKS_DIR) contains submission hooks" in message
+        assert "Location: /studio/hooks" in message
+        # Must not masquerade as a job-bundle source.
+        assert "This job bundle contains" not in message
 
     def test_post_hooks_not_called_on_create_job_failure(self):
         """Test that post-submission hooks are not executed when CreateJob fails.
@@ -1793,6 +1814,11 @@ class TestCollectSubmissionHookSources:
         )
 
         assert [m.job_bundle_dir for m in sources] == [studio, bundle]
+        # Each source is labeled with its true origin for the consent prompt.
+        assert [m.source_label for m in sources] == [
+            "environment (DEADLINE_HOOKS_DIR)",
+            "job bundle",
+        ]
 
     def test_post_submission_hooks_make_a_source_runnable(self, tmp_path):
         """A source with only postSubmission hooks (no preSubmission) is still collected."""

--- a/test/unit/deadline_client/job_bundle/test_hooks.py
+++ b/test/unit/deadline_client/job_bundle/test_hooks.py
@@ -21,6 +21,7 @@ from deadline.client.job_bundle._hooks import (
     HookMetadata,
     HookResult,
     collect_pre_gui_hook_sources,
+    collect_submission_hook_sources,
 )
 from deadline.client.job_bundle._hooks._merger import merge_asset_references, merge_payload
 from deadline.client.job_bundle._hooks._validator import (
@@ -1535,6 +1536,121 @@ class TestPreSubmissionHooks:
         assert scene_value == abs_scene
 
 
+class TestEnvAndBundleSubmissionHooks:
+    """Environment (DEADLINE_HOOKS_DIR) and bundle submission hooks must run together.
+
+    Regression test for the bug where the pre/post-submission submit path collapsed both hook
+    sources into a single HookManager and could only ever execute one of them — so environment
+    and bundle hooks never ran together (and the merge branch was unreachable dead code). This
+    mirrors the preGUI coverage in ``TestPreGuiHooks`` for the pre/post-submission phases.
+    """
+
+    def _configure(self):
+        config.set_setting("defaults.farm_id", _PARAM_MOCK_FARM_ID)
+        config.set_setting("defaults.queue_id", _PARAM_MOCK_QUEUE_ID)
+        config.set_setting("settings.allow_bundle_hooks", "true")
+        config.set_setting("settings.allow_environment_hooks", "true")
+        config.set_setting("settings.auto_accept", "true")
+
+    @staticmethod
+    def _write_appending_hook(directory, marker, results_file, phase):
+        """Write a hooks.yaml into ``directory`` whose single ``phase`` hook appends
+        ``marker`` (and a newline) to ``results_file``, so the caller can assert which
+        sources ran and in what order."""
+        script_name = f"{marker}_hook.py"
+        escaped = results_file.replace("\\", "\\\\")
+        with open(os.path.join(directory, script_name), "w", encoding="utf8") as f:
+            f.write(f"open(r'{escaped}', 'a').write('{marker}\\n')\n")
+        with open(os.path.join(directory, "hooks.yaml"), "w", encoding="utf8") as f:
+            f.write(f"version: '1.0'\n{phase}:\n  - command: python3\n    args: [{script_name}]\n")
+
+    @staticmethod
+    def _markers(results_file):
+        if not os.path.exists(results_file):
+            return []
+        with open(results_file, encoding="utf8") as f:
+            return [line.strip() for line in f if line.strip()]
+
+    def test_env_and_bundle_pre_submission_hooks_both_run(
+        self, fresh_deadline_config, tmp_path, monkeypatch
+    ):
+        """Both an environment and a bundle preSubmission hook run, environment first."""
+        bundle = str(tmp_path / "bundle")
+        studio = str(tmp_path / "studio")
+        os.makedirs(bundle)
+        os.makedirs(studio)
+        self._configure()
+        _write_param_bundle(bundle)
+        results = str(tmp_path / "results.txt")
+        self._write_appending_hook(studio, "env", results, "preSubmission")
+        self._write_appending_hook(bundle, "bundle", results, "preSubmission")
+        monkeypatch.setenv("DEADLINE_HOOKS_DIR", studio)
+
+        with patch_calls_for_create_job_from_job_bundle():
+            api.create_job_from_job_bundle(job_bundle_dir=bundle, queue_parameter_definitions=[])
+
+        assert self._markers(results) == ["env", "bundle"]
+
+    def test_env_and_bundle_post_submission_hooks_both_run(
+        self, fresh_deadline_config, tmp_path, monkeypatch
+    ):
+        """Both an environment and a bundle postSubmission hook run, environment first."""
+        bundle = str(tmp_path / "bundle")
+        studio = str(tmp_path / "studio")
+        os.makedirs(bundle)
+        os.makedirs(studio)
+        self._configure()
+        _write_param_bundle(bundle)
+        results = str(tmp_path / "results.txt")
+        self._write_appending_hook(studio, "env", results, "postSubmission")
+        self._write_appending_hook(bundle, "bundle", results, "postSubmission")
+        monkeypatch.setenv("DEADLINE_HOOKS_DIR", studio)
+
+        with patch_calls_for_create_job_from_job_bundle():
+            api.create_job_from_job_bundle(job_bundle_dir=bundle, queue_parameter_definitions=[])
+
+        assert self._markers(results) == ["env", "bundle"]
+
+    def test_bundle_hooks_still_run_without_env_dir(
+        self, fresh_deadline_config, tmp_path, monkeypatch
+    ):
+        """With no DEADLINE_HOOKS_DIR set, a bundle preSubmission hook still runs on its own."""
+        bundle = str(tmp_path / "bundle")
+        os.makedirs(bundle)
+        self._configure()
+        _write_param_bundle(bundle)
+        results = str(tmp_path / "results.txt")
+        self._write_appending_hook(bundle, "bundle", results, "preSubmission")
+        monkeypatch.delenv("DEADLINE_HOOKS_DIR", raising=False)
+
+        with patch_calls_for_create_job_from_job_bundle():
+            api.create_job_from_job_bundle(job_bundle_dir=bundle, queue_parameter_definitions=[])
+
+        assert self._markers(results) == ["bundle"]
+
+    def test_env_pre_submission_hook_skipped_when_env_hooks_disabled(
+        self, fresh_deadline_config, tmp_path, monkeypatch
+    ):
+        """An environment preSubmission hook does not run when environment hooks are disabled,
+        while the bundle hook still runs."""
+        bundle = str(tmp_path / "bundle")
+        studio = str(tmp_path / "studio")
+        os.makedirs(bundle)
+        os.makedirs(studio)
+        self._configure()
+        config.set_setting("settings.allow_environment_hooks", "false")
+        _write_param_bundle(bundle)
+        results = str(tmp_path / "results.txt")
+        self._write_appending_hook(studio, "env", results, "preSubmission")
+        self._write_appending_hook(bundle, "bundle", results, "preSubmission")
+        monkeypatch.setenv("DEADLINE_HOOKS_DIR", studio)
+
+        with patch_calls_for_create_job_from_job_bundle():
+            api.create_job_from_job_bundle(job_bundle_dir=bundle, queue_parameter_definitions=[])
+
+        assert self._markers(results) == ["bundle"]
+
+
 class TestPreGuiHooks:
     """Tests for pre-GUI hooks."""
 
@@ -1686,3 +1802,147 @@ class TestPreGuiHooks:
         )
 
         assert [m.job_bundle_dir for m in sources] == [bundle]
+
+
+class TestCollectSubmissionHookSources:
+    """Source-selection tests for pre/post-submission hooks.
+
+    The pre/post-submission analog of ``TestPreGuiHooks``. Both sources (environment and
+    bundle) must be returnable together so submission hooks from both can run — the earlier
+    single-manager merge could only ever run one.
+    """
+
+    @staticmethod
+    def _write_submission_hooks(directory, phase="preSubmission"):
+        """Write a hooks.yaml with a single ``phase`` hook into ``directory``."""
+        with open(os.path.join(directory, "hooks.yaml"), "w", encoding="utf8") as f:
+            f.write(f"version: '1.0'\n{phase}:\n  - command: python3\n    args: [x.py]\n")
+
+    def test_env_and_bundle_ordering(self, tmp_path):
+        """When both sources have submission hooks and are enabled, environment comes first,
+        then bundle."""
+        bundle = str(tmp_path / "bundle")
+        studio = str(tmp_path / "studio")
+        os.makedirs(bundle)
+        os.makedirs(studio)
+        self._write_submission_hooks(bundle)
+        self._write_submission_hooks(studio)
+
+        sources = collect_submission_hook_sources(
+            bundle_dir=bundle,
+            env_hooks_dir=studio,
+            allow_bundle_hooks=True,
+            allow_environment_hooks=True,
+            print_callback=lambda _msg: None,
+        )
+
+        assert [m.job_bundle_dir for m in sources] == [studio, bundle]
+
+    def test_post_submission_hooks_make_a_source_runnable(self, tmp_path):
+        """A source with only postSubmission hooks (no preSubmission) is still collected."""
+        bundle = str(tmp_path / "bundle")
+        os.makedirs(bundle)
+        self._write_submission_hooks(bundle, phase="postSubmission")
+
+        sources = collect_submission_hook_sources(
+            bundle_dir=bundle,
+            env_hooks_dir=None,
+            allow_bundle_hooks=True,
+            allow_environment_hooks=True,
+            print_callback=lambda _msg: None,
+        )
+
+        assert [m.job_bundle_dir for m in sources] == [bundle]
+
+    def test_pre_gui_only_hooks_are_not_collected(self, tmp_path):
+        """A source with only preGUI hooks is not a submission source."""
+        bundle = str(tmp_path / "bundle")
+        os.makedirs(bundle)
+        self._write_submission_hooks(bundle, phase="preGUI")
+
+        sources = collect_submission_hook_sources(
+            bundle_dir=bundle,
+            env_hooks_dir=None,
+            allow_bundle_hooks=True,
+            allow_environment_hooks=True,
+            print_callback=lambda _msg: None,
+        )
+
+        assert sources == []
+
+    def test_env_dir_ignored_when_env_hooks_disabled_warns(self, tmp_path):
+        """A disabled environment submission hook is skipped and warns about environment
+        hooks (not preGUI)."""
+        bundle = str(tmp_path / "bundle")
+        studio = str(tmp_path / "studio")
+        os.makedirs(bundle)
+        os.makedirs(studio)
+        self._write_submission_hooks(studio)
+        warnings: List[str] = []
+
+        sources = collect_submission_hook_sources(
+            bundle_dir=bundle,
+            env_hooks_dir=studio,
+            allow_bundle_hooks=True,
+            allow_environment_hooks=False,
+            print_callback=lambda _msg: None,
+            warning_callback=warnings.append,
+        )
+
+        assert sources == []
+        assert any("DEADLINE_HOOKS_DIR contains submission hooks" in w for w in warnings)
+
+    def test_bundle_hooks_ignored_when_bundle_hooks_disabled_warns(self, tmp_path):
+        """A disabled bundle submission hook is skipped and warns about bundle hooks."""
+        bundle = str(tmp_path / "bundle")
+        os.makedirs(bundle)
+        self._write_submission_hooks(bundle)
+        warnings: List[str] = []
+
+        sources = collect_submission_hook_sources(
+            bundle_dir=bundle,
+            env_hooks_dir=None,
+            allow_bundle_hooks=False,
+            allow_environment_hooks=True,
+            print_callback=lambda _msg: None,
+            warning_callback=warnings.append,
+        )
+
+        assert sources == []
+        assert any("Job bundle contains submission hooks" in w for w in warnings)
+
+    def test_env_dir_equal_to_bundle_dir_is_not_duplicated(self, tmp_path):
+        """If DEADLINE_HOOKS_DIR points at the job bundle, the shared hooks.yaml yields a
+        single source so submission hooks do not run twice."""
+        bundle = str(tmp_path / "bundle")
+        os.makedirs(bundle)
+        self._write_submission_hooks(bundle)
+
+        sources = collect_submission_hook_sources(
+            bundle_dir=bundle,
+            env_hooks_dir=bundle,  # same directory
+            allow_bundle_hooks=True,
+            allow_environment_hooks=True,
+            print_callback=lambda _msg: None,
+        )
+
+        assert [m.job_bundle_dir for m in sources] == [bundle]
+
+    def test_invalid_env_dir_warns(self, tmp_path):
+        """A DEADLINE_HOOKS_DIR that is not a directory warns and yields no env source."""
+        bundle = str(tmp_path / "bundle")
+        os.makedirs(bundle)
+        missing = str(tmp_path / "does_not_exist")
+        warnings: List[str] = []
+
+        sources = collect_submission_hook_sources(
+            bundle_dir=bundle,
+            env_hooks_dir=missing,
+            allow_bundle_hooks=True,
+            allow_environment_hooks=True,
+            print_callback=lambda _msg: None,
+            warning_callback=warnings.append,
+        )
+
+        assert sources == []
+        assert any("is not a valid directory" in w for w in warnings)

--- a/test/unit/deadline_client/job_bundle/test_hooks.py
+++ b/test/unit/deadline_client/job_bundle/test_hooks.py
@@ -1541,28 +1541,39 @@ class TestEnvAndBundleSubmissionHooks:
 
     Regression test for the bug where the pre/post-submission submit path collapsed both hook
     sources into a single HookManager and could only ever execute one of them — so environment
-    and bundle hooks never ran together (and the merge branch was unreachable dead code). This
-    mirrors the preGUI coverage in ``TestPreGuiHooks`` for the pre/post-submission phases.
+    and bundle hooks never ran together (and the merge branch was unreachable dead code).
+
+    Source *selection* (single source, disabled sources, ordering, dedup) is covered without
+    spawning subprocesses by ``TestCollectSubmissionHookSources``. This one end-to-end test
+    covers what selection cannot: that both a DEADLINE_HOOKS_DIR source and a bundle source
+    actually *execute* — for pre- and post-submission — in a single real submission, in order.
     """
 
-    def _configure(self):
-        config.set_setting("defaults.farm_id", _PARAM_MOCK_FARM_ID)
-        config.set_setting("defaults.queue_id", _PARAM_MOCK_QUEUE_ID)
-        config.set_setting("settings.allow_bundle_hooks", "true")
-        config.set_setting("settings.allow_environment_hooks", "true")
-        config.set_setting("settings.auto_accept", "true")
-
     @staticmethod
-    def _write_appending_hook(directory, marker, results_file, phase):
-        """Write a hooks.yaml into ``directory`` whose single ``phase`` hook appends
-        ``marker`` (and a newline) to ``results_file``, so the caller can assert which
-        sources ran and in what order."""
+    def _write_appending_hook(directory, marker, results_file):
+        """Write a hooks.yaml into ``directory`` whose pre- and post-submission hooks each
+        append a ``<marker>-pre`` / ``<marker>-post`` line to ``results_file``, so the caller
+        can assert which sources ran, for which phase, and in what order.
+
+        Uses ``sys.executable`` (not the ``python3`` literal): on Windows the ``python3`` name
+        can resolve to the Microsoft Store app-execution-alias stub, which hangs when run
+        non-interactively — leaving the hook subprocess (and the test worker) unable to exit.
+        """
         script_name = f"{marker}_hook.py"
         escaped = results_file.replace("\\", "\\\\")
         with open(os.path.join(directory, script_name), "w", encoding="utf8") as f:
-            f.write(f"open(r'{escaped}', 'a').write('{marker}\\n')\n")
+            f.write(
+                f"import sys\nopen(r'{escaped}', 'a').write('{marker}-' + sys.argv[1] + '\\n')\n"
+            )
         with open(os.path.join(directory, "hooks.yaml"), "w", encoding="utf8") as f:
-            f.write(f"version: '1.0'\n{phase}:\n  - command: python3\n    args: [{script_name}]\n")
+            yaml.dump(
+                {
+                    "version": "1.0",
+                    "preSubmission": [{"command": sys.executable, "args": [script_name, "pre"]}],
+                    "postSubmission": [{"command": sys.executable, "args": [script_name, "post"]}],
+                },
+                f,
+            )
 
     @staticmethod
     def _markers(results_file):
@@ -1571,84 +1582,29 @@ class TestEnvAndBundleSubmissionHooks:
         with open(results_file, encoding="utf8") as f:
             return [line.strip() for line in f if line.strip()]
 
-    def test_env_and_bundle_pre_submission_hooks_both_run(
-        self, fresh_deadline_config, tmp_path, monkeypatch
-    ):
-        """Both an environment and a bundle preSubmission hook run, environment first."""
+    def test_env_and_bundle_hooks_both_run(self, fresh_deadline_config, tmp_path, monkeypatch):
+        """Both a DEADLINE_HOOKS_DIR source and a bundle source execute their pre- and
+        post-submission hooks, environment before bundle for each phase."""
         bundle = str(tmp_path / "bundle")
         studio = str(tmp_path / "studio")
         os.makedirs(bundle)
         os.makedirs(studio)
-        self._configure()
+        config.set_setting("defaults.farm_id", _PARAM_MOCK_FARM_ID)
+        config.set_setting("defaults.queue_id", _PARAM_MOCK_QUEUE_ID)
+        config.set_setting("settings.allow_bundle_hooks", "true")
+        config.set_setting("settings.allow_environment_hooks", "true")
+        config.set_setting("settings.auto_accept", "true")
         _write_param_bundle(bundle)
         results = str(tmp_path / "results.txt")
-        self._write_appending_hook(studio, "env", results, "preSubmission")
-        self._write_appending_hook(bundle, "bundle", results, "preSubmission")
+        self._write_appending_hook(studio, "env", results)
+        self._write_appending_hook(bundle, "bundle", results)
         monkeypatch.setenv("DEADLINE_HOOKS_DIR", studio)
 
         with patch_calls_for_create_job_from_job_bundle():
             api.create_job_from_job_bundle(job_bundle_dir=bundle, queue_parameter_definitions=[])
 
-        assert self._markers(results) == ["env", "bundle"]
-
-    def test_env_and_bundle_post_submission_hooks_both_run(
-        self, fresh_deadline_config, tmp_path, monkeypatch
-    ):
-        """Both an environment and a bundle postSubmission hook run, environment first."""
-        bundle = str(tmp_path / "bundle")
-        studio = str(tmp_path / "studio")
-        os.makedirs(bundle)
-        os.makedirs(studio)
-        self._configure()
-        _write_param_bundle(bundle)
-        results = str(tmp_path / "results.txt")
-        self._write_appending_hook(studio, "env", results, "postSubmission")
-        self._write_appending_hook(bundle, "bundle", results, "postSubmission")
-        monkeypatch.setenv("DEADLINE_HOOKS_DIR", studio)
-
-        with patch_calls_for_create_job_from_job_bundle():
-            api.create_job_from_job_bundle(job_bundle_dir=bundle, queue_parameter_definitions=[])
-
-        assert self._markers(results) == ["env", "bundle"]
-
-    def test_bundle_hooks_still_run_without_env_dir(
-        self, fresh_deadline_config, tmp_path, monkeypatch
-    ):
-        """With no DEADLINE_HOOKS_DIR set, a bundle preSubmission hook still runs on its own."""
-        bundle = str(tmp_path / "bundle")
-        os.makedirs(bundle)
-        self._configure()
-        _write_param_bundle(bundle)
-        results = str(tmp_path / "results.txt")
-        self._write_appending_hook(bundle, "bundle", results, "preSubmission")
-        monkeypatch.delenv("DEADLINE_HOOKS_DIR", raising=False)
-
-        with patch_calls_for_create_job_from_job_bundle():
-            api.create_job_from_job_bundle(job_bundle_dir=bundle, queue_parameter_definitions=[])
-
-        assert self._markers(results) == ["bundle"]
-
-    def test_env_pre_submission_hook_skipped_when_env_hooks_disabled(
-        self, fresh_deadline_config, tmp_path, monkeypatch
-    ):
-        """An environment preSubmission hook does not run when environment hooks are disabled,
-        while the bundle hook still runs."""
-        bundle = str(tmp_path / "bundle")
-        studio = str(tmp_path / "studio")
-        os.makedirs(bundle)
-        os.makedirs(studio)
-        self._configure()
-        config.set_setting("settings.allow_environment_hooks", "false")
-        _write_param_bundle(bundle)
-        results = str(tmp_path / "results.txt")
-        self._write_appending_hook(studio, "env", results, "preSubmission")
-        self._write_appending_hook(bundle, "bundle", results, "preSubmission")
-        monkeypatch.setenv("DEADLINE_HOOKS_DIR", studio)
-
-        with patch_calls_for_create_job_from_job_bundle():
-            api.create_job_from_job_bundle(job_bundle_dir=bundle, queue_parameter_definitions=[])
-
-        assert self._markers(results) == ["bundle"]
+        # Pre-submission: env then bundle; post-submission: env then bundle.
+        assert self._markers(results) == ["env-pre", "bundle-pre", "env-post", "bundle-post"]
 
 
 class TestPreGuiHooks:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

On the CLI / non-GUI submit path (`create_job_from_job_bundle`), pre/post-submission hooks defined in the **environment** (`DEADLINE_HOOKS_DIR`) and in the **job bundle** (`hooks.yaml`) could not run together.

The code collected both sources into `all_hooks_sources` (environment first, bundle second) and then ran a merge loop that folded them into a single `HookManager`. When both sources had hooks:

- The environment iteration set `hooks = env_hooks` and `hook_manager = env_hook_manager`.
- The bundle iteration took the `if hooks_dir == job_bundle_dir` branch and **overwrote** `hooks = bundle_has_hooks`, but left `hook_manager` still pointing at the environment manager. The `else:` merge branch was therefore unreachable dead code.

Net effect: only the **environment** manager's hooks actually executed, while the confirmation prompt listed the **bundle** hooks — an inconsistent prompt, and one source silently dropped. Environment and bundle submission hooks never ran together.

The preGUI path already had the correct design (`collect_pre_gui_hook_sources`, which returns a *list* of managers); the pre/post-submission path never got the equivalent.

### What was the solution? (How)

Mirror the preGUI design so all hook phases share one mechanism:

- Add `collect_submission_hook_sources()`, which returns a **list** of `HookManager`s in execution order (environment first, then bundle), deduped when `DEADLINE_HOOKS_DIR` resolves to the bundle directory, with correct "present-but-disabled" / invalid-directory warnings phrased for the submission phase.
- Factor the shared source-selection logic into a private `_collect_hook_sources()` used by both the preGUI and submission collectors.
- The submit flow now shows a single confirmation across all sources and executes pre-/post-submission hooks by iterating every source in order. The pre-submission payload is threaded through the sources so a later source can override an earlier one.

### What is the impact of this change?

Environment and bundle submission hooks now both run (environment first, then bundle), consistent with the preGUI behavior. The confirmation prompt now lists exactly the hooks that will run. No public API signature changes; behavior only changes for the previously-broken both-sources case.

### How was this change tested?

- Added regression tests that a `DEADLINE_HOOKS_DIR` hook and a bundle hook **both** run, in order, for pre- and post-submission (`TestEnvAndBundleSubmissionHooks`), plus single-source and disabled-source cases.
- Added source-selection unit tests for `collect_submission_hook_sources` (`TestCollectSubmissionHookSources`), mirroring the existing preGUI coverage.
- Verified the new tests fail against the pre-fix behavior and pass with the fix.
- Drove `create_job_from_job_bundle` end-to-end with both sources enabled and confirmed all four hooks executed in env→bundle order for both phases.
- `ruff check`, `ruff format`, and `mypy` clean on the changed files.

- [x] Have you run the unit tests? Yes (hook + submission suites pass).
- [ ] Have you run the integration tests? Not run (no AWS resources in this environment).

### Was this change documented?

- Docstrings for the new/refactored helpers are added and the existing preGUI docstrings reference them. No README/CLI-argument changes.

### Does this PR introduce new dependencies?

*   [x] This PR does not add any new dependencies.

### Is this a breaking change?

No. No public contract changes; this only fixes the both-sources execution path.

### Does this change impact security?

No new files/directories or permission changes; hook execution semantics are unchanged (same gating settings `allow_bundle_hooks` / `allow_environment_hooks`).

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*