### PR TITLE
fix: prevent stale queue/storage profile IDs after farm change

### DIFF
--- a/src/deadline/client/ui/translations/locales/de_DE.json
+++ b/src/deadline/client/ui/translations/locales/de_DE.json
@@ -34,7 +34,7 @@
   "Current logging level": "Aktuelle Protokollierungsebene",
   "Custom host requirements": "Benutzerdefinierte Host-Anforderungen",
   "Data directory": "Datenverzeichnis",
-  "Deadline Cloud settings": "Deadline Cloud-Einstellungen",
+  "Job submission settings": "Einstellungen für die Jobübermittlung",
   "Default farm": "Standard-Farm",
   "Default queue": "Standard-Warteschlange",
   "Default storage profile": "Standard-Speicherprofil",

--- a/src/deadline/client/ui/translations/locales/en_US.json
+++ b/src/deadline/client/ui/translations/locales/en_US.json
@@ -34,7 +34,7 @@
   "Current logging level": "Current logging level",
   "Custom host requirements": "Custom host requirements",
   "Data directory": "Data directory",
-  "Deadline Cloud settings": "Deadline Cloud settings",
+  "Job submission settings": "Job submission settings",
   "Default farm": "Default farm",
   "Default queue": "Default queue",
   "Default storage profile": "Default storage profile",

--- a/src/deadline/client/ui/translations/locales/es_ES.json
+++ b/src/deadline/client/ui/translations/locales/es_ES.json
@@ -34,7 +34,7 @@
   "Current logging level": "Nivel de registro actual",
   "Custom host requirements": "Requisitos de host personalizados",
   "Data directory": "Directorio de datos",
-  "Deadline Cloud settings": "Configuración de Deadline Cloud",
+  "Job submission settings": "Configuración de envío de trabajos",
   "Default farm": "Granja predeterminada",
   "Default queue": "Cola predeterminada",
   "Default storage profile": "Perfil de almacenamiento predeterminado",

--- a/src/deadline/client/ui/translations/locales/fr_FR.json
+++ b/src/deadline/client/ui/translations/locales/fr_FR.json
@@ -34,7 +34,7 @@
   "Current logging level": "Niveau de journalisation actuel",
   "Custom host requirements": "Exigences d'hôte personnalisées",
   "Data directory": "Répertoire de données",
-  "Deadline Cloud settings": "Paramètres Deadline Cloud",
+  "Job submission settings": "Paramètres de soumission de tâche",
   "Default farm": "Ferme par défaut",
   "Default queue": "File d'attente par défaut",
   "Default storage profile": "Profil de stockage par défaut",

--- a/src/deadline/client/ui/translations/locales/id_ID.json
+++ b/src/deadline/client/ui/translations/locales/id_ID.json
@@ -34,7 +34,7 @@
   "Current logging level": "Tingkat logging saat ini",
   "Custom host requirements": "Persyaratan host kustom",
   "Data directory": "Direktori data",
-  "Deadline Cloud settings": "Pengaturan Deadline Cloud",
+  "Job submission settings": "Pengaturan pengiriman pekerjaan",
   "Default farm": "Peternakan default",
   "Default queue": "Antrian default",
   "Default storage profile": "Profil penyimpanan default",

--- a/src/deadline/client/ui/translations/locales/it_IT.json
+++ b/src/deadline/client/ui/translations/locales/it_IT.json
@@ -34,7 +34,7 @@
   "Current logging level": "Livello di registrazione corrente",
   "Custom host requirements": "Requisiti host personalizzati",
   "Data directory": "Directory dati",
-  "Deadline Cloud settings": "Impostazioni Deadline Cloud",
+  "Job submission settings": "Impostazioni di invio del lavoro",
   "Default farm": "Farm predefinita",
   "Default queue": "Coda predefinita",
   "Default storage profile": "Profilo di archiviazione predefinito",

--- a/src/deadline/client/ui/translations/locales/ja_JP.json
+++ b/src/deadline/client/ui/translations/locales/ja_JP.json
@@ -34,7 +34,7 @@
   "Current logging level": "現在のログレベル",
   "Custom host requirements": "カスタムホスト要件",
   "Data directory": "データディレクトリ",
-  "Deadline Cloud settings": "Deadline Cloud 設定",
+  "Job submission settings": "ジョブ送信設定",
   "Default farm": "デフォルトファーム",
   "Default queue": "デフォルトキュー",
   "Default storage profile": "デフォルトストレージプロファイル",

--- a/src/deadline/client/ui/translations/locales/ko_KR.json
+++ b/src/deadline/client/ui/translations/locales/ko_KR.json
@@ -34,7 +34,7 @@
   "Current logging level": "현재 로깅 수준",
   "Custom host requirements": "사용자 지정 호스트 요구 사항",
   "Data directory": "데이터 디렉터리",
-  "Deadline Cloud settings": "Deadline Cloud 설정",
+  "Job submission settings": "작업 제출 설정",
   "Default farm": "기본 팜",
   "Default queue": "기본 대기열",
   "Default storage profile": "기본 스토리지 프로필",

--- a/src/deadline/client/ui/translations/locales/pt_BR.json
+++ b/src/deadline/client/ui/translations/locales/pt_BR.json
@@ -34,7 +34,7 @@
   "Current logging level": "Nível de registro atual",
   "Custom host requirements": "Requisitos de host personalizados",
   "Data directory": "Diretório de dados",
-  "Deadline Cloud settings": "Configurações do Deadline Cloud",
+  "Job submission settings": "Configurações de envio de trabalho",
   "Default farm": "Fazenda padrão",
   "Default queue": "Fila padrão",
   "Default storage profile": "Perfil de armazenamento padrão",

--- a/src/deadline/client/ui/translations/locales/tr_TR.json
+++ b/src/deadline/client/ui/translations/locales/tr_TR.json
@@ -34,7 +34,7 @@
   "Current logging level": "Geçerli günlük kaydı düzeyi",
   "Custom host requirements": "Özel ana bilgisayar gereksinimleri",
   "Data directory": "Veri dizini",
-  "Deadline Cloud settings": "Deadline Cloud ayarları",
+  "Job submission settings": "İş gönderimi ayarları",
   "Default farm": "Varsayılan farm",
   "Default queue": "Varsayılan kuyruk",
   "Default storage profile": "Varsayılan depolama profili",

--- a/src/deadline/client/ui/translations/locales/zh_CN.json
+++ b/src/deadline/client/ui/translations/locales/zh_CN.json
@@ -34,7 +34,7 @@
   "Current logging level": "当前日志记录级别",
   "Custom host requirements": "自定义主机要求",
   "Data directory": "数据目录",
-  "Deadline Cloud settings": "Deadline Cloud 设置",
+  "Job submission settings": "作业提交设置",
   "Default farm": "默认服务器农场",
   "Default queue": "默认队列",
   "Default storage profile": "默认存储配置文件",

--- a/src/deadline/client/ui/translations/locales/zh_TW.json
+++ b/src/deadline/client/ui/translations/locales/zh_TW.json
@@ -34,7 +34,7 @@
   "Current logging level": "目前的日誌記錄層級",
   "Custom host requirements": "自訂主機需求",
   "Data directory": "資料目錄",
-  "Deadline Cloud settings": "Deadline Cloud 設定",
+  "Job submission settings": "任務提交設定",
   "Default farm": "預設伺服器陣列",
   "Default queue": "預設佇列",
   "Default storage profile": "預設儲存設定檔",

--- a/src/deadline/client/ui/widgets/_deadline_list_combo_boxes.py
+++ b/src/deadline/client/ui/widgets/_deadline_list_combo_boxes.py
@@ -132,6 +132,7 @@ class _DeadlineResourceListComboBoxController(QWidget):
 
     def _handle_list_update(self, items_list: List) -> None:
         """Handle a wholesale list (re)set from the controller."""
+        self._sync_config()
         with block_signals(self.box):
             self.box.clear()
             self._region_by_id = {}
@@ -276,6 +277,7 @@ class _DeadlineResourceListComboBoxController(QWidget):
 
     def _handle_loading_state(self, is_loading: bool) -> None:
         """Handle loading state changes."""
+        self._sync_config()
         if is_loading:
             # Show refreshing indicator
             selected_id = config_file.get_setting(self._get_setting_name(), config=self.config)
@@ -321,15 +323,36 @@ class _DeadlineResourceListComboBoxController(QWidget):
         ``self.config`` is the object ``_maybe_auto_select_single`` and
         ``refresh_selected_id`` read the configured id from. The host hands us the
         same ``ConfigParser`` instance that ``config_file.read_config`` returns, and
-        the controller persists selections via the module-level ``set_setting``,
-        which mutates that shared instance in place. So a cascade's clears (e.g.
-        ``select_farm`` zeroing ``queue_id``) are visible here without a re-snapshot.
-        This relies on the combo and the controller observing the *same* config
-        object - if config caching ever starts handing out copies, these reads would
-        go stale and a lone-resource auto-select could be wrongly suppressed.
+        the controller persists selections via the module-level ``set_setting``.
+
+        ``set_setting`` writes to disk, and the next ``read_config`` then detects the
+        mtime change and swaps in a *fresh* ``ConfigParser`` — so the object handed in
+        here can go stale after a cascade (e.g. ``select_farm`` zeroing ``queue_id``).
+        ``_sync_config`` re-points ``self.config`` at the live config before each
+        display sync so those reads never observe the pre-cascade values.
         """
         self.config = config
         self._controller.set_config(config)
+
+    def _sync_config(self) -> None:
+        """Re-point ``self.config`` at the live global config before a display sync.
+
+        ``set_setting`` (used by the controller's ``select_*`` cascade) writes to
+        disk, which makes the next ``read_config()`` detect the mtime change and
+        build a *new* ``ConfigParser``, replacing the cached ``__config``. A combo
+        that keeps its original reference in ``self.config`` would then read stale
+        values - e.g. after selecting a farm the user has used before, the old
+        queue/storage-profile ids stored under that farm's section would still be
+        visible, so the combo shows a raw id instead of "<none selected>".
+
+        Re-reading here (only when the combo was configured through ``set_config``,
+        i.e. running inside a real dialog rather than a bare unit test) keeps the
+        display in sync with what the controller just persisted. When nothing was
+        configured yet, ``self.config`` stays ``None`` and reads fall through to the
+        global config as before.
+        """
+        if self.config is not None:
+            self.config = config_file.read_config()
 
     def clear_list(self) -> None:
         """

--- a/src/deadline/client/ui/widgets/_deadline_list_combo_boxes.py
+++ b/src/deadline/client/ui/widgets/_deadline_list_combo_boxes.py
@@ -74,6 +74,12 @@ class _DeadlineResourceListComboBoxController(QWidget):
 
         self.resource_name = resource_name
         self.config: Optional[ConfigParser] = None
+        # True only while ``self.config`` is the live module-level config object
+        # (i.e. ``set_config`` was handed ``config_file.read_config()``). When a
+        # caller injects a *different* parser - e.g. the config dialog's deep copy
+        # with unsaved edits layered on - this stays False so ``_sync_config`` won't
+        # clobber those pending edits by re-reading from disk. See ``_sync_config``.
+        self._config_tracks_global: bool = False
         self._controller = DeadlineUIController.getInstance()
         # Maps resource_id -> region for resources that carry a region (farms).
         self._region_by_id: dict = {}
@@ -321,17 +327,25 @@ class _DeadlineResourceListComboBoxController(QWidget):
         """Updates the AWS Deadline Cloud config object the control uses.
 
         ``self.config`` is the object ``_maybe_auto_select_single`` and
-        ``refresh_selected_id`` read the configured id from. The host hands us the
-        same ``ConfigParser`` instance that ``config_file.read_config`` returns, and
-        the controller persists selections via the module-level ``set_setting``.
+        ``refresh_selected_id`` read the configured id from. Two kinds of caller hand
+        it in:
 
-        ``set_setting`` writes to disk, and the next ``read_config`` then detects the
-        mtime change and swaps in a *fresh* ``ConfigParser`` — so the object handed in
-        here can go stale after a cascade (e.g. ``select_farm`` zeroing ``queue_id``).
-        ``_sync_config`` re-points ``self.config`` at the live config before each
-        display sync so those reads never observe the pre-cascade values.
+        - The submit dialog passes the live ``config_file.read_config()`` object and
+          persists selections through the module-level ``set_setting``. ``set_setting``
+          writes to disk, and the next ``read_config`` detects the mtime change and
+          swaps in a *fresh* ``ConfigParser`` — so the object handed in here can go
+          stale after a cascade (e.g. ``select_farm`` zeroing ``queue_id``).
+          ``_sync_config`` re-points ``self.config`` at the live config before each
+          display sync so those reads never observe the pre-cascade values.
+
+        - The config dialog builds a *copy* of the config and layers the user's
+          unsaved ``changes`` on top before handing it in. That copy intentionally
+          differs from disk, so ``_sync_config`` must NOT re-read over it or the
+          pending edits would vanish from the display. We detect this by identity: the
+          re-sync only happens when the config we were given *is* the live global.
         """
         self.config = config
+        self._config_tracks_global = config is config_file.read_config()
         self._controller.set_config(config)
 
     def _sync_config(self) -> None:
@@ -345,13 +359,14 @@ class _DeadlineResourceListComboBoxController(QWidget):
         queue/storage-profile ids stored under that farm's section would still be
         visible, so the combo shows a raw id instead of "<none selected>".
 
-        Re-reading here (only when the combo was configured through ``set_config``,
-        i.e. running inside a real dialog rather than a bare unit test) keeps the
-        display in sync with what the controller just persisted. When nothing was
+        Only re-read when ``self.config`` is tracking the live global object (see
+        ``set_config``). If a caller injected its own parser - e.g. the config
+        dialog's copy carrying unsaved edits - re-reading would silently discard
+        those edits, so we leave ``self.config`` untouched. When nothing was
         configured yet, ``self.config`` stays ``None`` and reads fall through to the
         global config as before.
         """
-        if self.config is not None:
+        if self.config is not None and self._config_tracks_global:
             self.config = config_file.read_config()
 
     def clear_list(self) -> None:

--- a/src/deadline/client/ui/widgets/shared_job_settings_tab.py
+++ b/src/deadline/client/ui/widgets/shared_job_settings_tab.py
@@ -82,7 +82,7 @@ class SharedJobSettingsWidget(QWidget):  # pylint: disable=too-few-public-method
         )
         layout.addWidget(self.shared_job_properties_box)
 
-        # Breathing room between the Job Properties container and the Deadline Cloud
+        # Breathing room between the Job Properties container and the Job submission
         # settings group below it.
         layout.addSpacing(12)
 
@@ -483,7 +483,7 @@ class DeadlineCloudSettingsWidget(QGroupBox):
     _PLACEHOLDER_TEXTS = ("<refreshing>", "<none selected>")
 
     def __init__(self, *, parent: Optional[QWidget] = None):
-        super().__init__(tr("Deadline Cloud settings"), parent=parent)
+        super().__init__(tr("Job submission settings"), parent=parent)
         self.deadline_settings: Dict[str, Any] = {"counter": -1}
         self.layout = QFormLayout(self)
         self.layout.setFieldGrowthPolicy(QFormLayout.AllNonFixedFieldsGrow)

--- a/test/unit/deadline_client/ui/gui/test_gui_shared_job_settings.py
+++ b/test/unit/deadline_client/ui/gui/test_gui_shared_job_settings.py
@@ -159,6 +159,21 @@ def _select_by_data(combo, data):
     combo.activated.emit(index)
 
 
+def _current_os_family() -> str:
+    """The storage-profile osFamily matching this host.
+
+    The controller filters storage profiles to the current OS, so a profile seeded for
+    a test must use this OS family to actually appear in (and later linger in) the combo.
+    """
+    if sys.platform.startswith("linux"):
+        return "LINUX"
+    elif sys.platform.startswith("darwin"):
+        return "MACOS"
+    elif sys.platform.startswith("win"):
+        return "WINDOWS"
+    return "LINUX"
+
+
 def _configure_profile(profile_name, *, farm_id="", queue_id=""):
     """Write farm/queue defaults under *profile_name* (settings are profile-scoped)."""
     config_file.set_setting("defaults.aws_profile_name", profile_name)
@@ -418,6 +433,66 @@ class TestCascade:
         queue_items = _items(widget.queue_box.box)
         assert "Queue B only" in queue_items, f"cascade fetched wrong farm's queues: {queue_items}"
         assert "Test Queue" not in queue_items, f"stale farm A queue still present: {queue_items}"
+
+    def test_farm_change_does_not_show_stale_queue_or_storage_id(
+        self, qtbot, widget, seeded_backend
+    ):
+        """Regression for the reported bug: changing farms must not leave the queue and
+        storage-profile combos *displaying a raw id* from the previously selected farm.
+
+        The user picks a new farm that has neither queues nor storage profiles. The old
+        farm's queue/storage ids must not linger as raw-id rows (``queue-...`` /
+        ``sp-...``); the combos must fall back to ``<none selected>``.
+
+        The defect only surfaces when the combo reads a *stale* config object: when
+        ``select_farm`` persists the cleared ids, ``set_setting`` writes to disk and the
+        next ``read_config()`` swaps in a fresh ``ConfigParser``, orphaning the combo's
+        reference. Whether that swap happens hinges on the config file's mtime changing,
+        which is filesystem-granularity dependent -- so we force it deterministically by
+        making ``_should_read_config`` always report a change. That way every
+        ``read_config()`` hands back a new object, reliably reproducing the staleness
+        through the real farm-pick -> cascade -> list-update signal chain regardless of
+        host filesystem. (This test fails if the ``_sync_config`` fix is reverted.)
+        """
+        backend, farm_a, queue_a = seeded_backend
+        # Start on farm A with its queue + a stored storage profile (as after prior use).
+        config_file.set_setting("defaults.farm_id", farm_a)
+        config_file.set_setting("defaults.queue_id", queue_a)
+        sp_a = backend.create_storage_profile(
+            farmId=farm_a,
+            queueId=queue_a,
+            displayName="Farm A SP",
+            osFamily=_current_os_family(),
+        )["storageProfileId"]
+        config_file.set_setting("settings.storage_profile_id", sp_a)
+
+        # Farm B has no queues and no storage profiles, so nothing can auto-select back
+        # in -- any queue/storage shown afterward would be a stale leftover from farm A.
+        farm_b = backend.create_farm(displayName="Farm B")["farmId"]
+
+        controller = DeadlineUIController.getInstance()
+        widget.refresh_setting_controls(deadline_authorized=True)
+        _wait_for_farm(qtbot, widget, farm_b)
+
+        # Force every read_config() to rebuild the ConfigParser, deterministically
+        # orphaning the combo's cached self.config the way a real mtime change would.
+        with patch.object(config_file, "_should_read_config", return_value=True):
+            with qtbot.waitSignal(controller.queues_updated, timeout=5000):
+                _select_by_data(widget.farm_box.box, farm_b)
+            QApplication.processEvents()
+
+        # Config is genuinely cleared...
+        assert config_file.get_setting("defaults.queue_id") == ""
+        assert config_file.get_setting("settings.storage_profile_id") == ""
+
+        # ...and, crucially, the *display* reflects that -- no raw ids from farm A.
+        queue_text = widget.queue_box.box.currentText()
+        assert queue_text != queue_a, f"queue combo shows stale raw id: {queue_text!r}"
+        assert widget.queue_box.box.currentData() == ""
+
+        sp_text = widget.storage_profile_box.box.currentText()
+        assert sp_text != sp_a, f"storage profile combo shows stale raw id: {sp_text!r}"
+        assert widget.storage_profile_box.box.currentData() == ""
 
 
 class TestProfileSwitch:

--- a/test/unit/deadline_client/ui/widgets/test_deadline_list_combo_boxes.py
+++ b/test/unit/deadline_client/ui/widgets/test_deadline_list_combo_boxes.py
@@ -575,15 +575,18 @@ class TestDeadlineStorageProfileListComboBoxController:
 class TestStaleConfigOnFarmChange:
     """Regression tests: changing farms must not show stale queue/storage profile IDs.
 
-    When `select_farm` writes to the config file via `set_setting`, `read_config()`
-    detects the on-disk change and creates a new ConfigParser object. If the combo
-    boxes still hold a reference to the OLD object, `refresh_selected_id` reads stale
-    values and shows raw IDs instead of <none selected>.
+    When `select_farm` writes to the config file via `set_setting`, the next
+    `read_config()` detects the change and creates a fresh ConfigParser, leaving any
+    combo that still holds the OLD object in `self.config` reading stale values --
+    showing a raw id instead of "<none selected>".
 
-    The bug triggers when switching to a farm the user has previously used (so the
-    config file has stored queue/storage IDs for that farm in its section) AND the
-    file mtime changes between successive set_setting calls (which happens any time
-    there's >0 seconds between them -- common in practice on real filesystems).
+    These tests reproduce that staleness *deterministically*, independent of the host
+    filesystem's mtime granularity: the combo is handed an isolated ConfigParser
+    snapshot (a copy that later `set_setting` writes to the global config cannot
+    update), then the cleared values are persisted. The fix (`_sync_config`) makes the
+    combo re-read the live config on display, so it must reflect the cleared values.
+    Without the fix, `refresh_selected_id` reads the frozen snapshot and shows the
+    stale id.
     """
 
     def setup_method(self):
@@ -595,45 +598,48 @@ class TestStaleConfigOnFarmChange:
         DeadlineThreadPool.shutdown(wait_for_done=True, timeout_ms=2000)
         DeadlineThreadPool.reset()
 
+    @staticmethod
+    def _snapshot_config() -> ConfigParser:
+        """An independent copy of the current global config.
+
+        `set_setting` (without an explicit config) mutates the module-level global,
+        never this copy -- so it stays frozen at the pre-clear state, exactly like a
+        combo's orphaned `self.config` reference after a cascade swapped the global.
+        """
+        snapshot = ConfigParser()
+        snapshot.read_dict(config_file.read_config())
+        return snapshot
+
     @patch("deadline.client.ui.controllers._deadline_controller.api")
     def test_storage_profile_cleared_after_farm_change(
         self, mock_api, qtbot, fresh_deadline_config
     ):
         """After select_farm, storage profile combo must show <none selected>, not stale ID."""
-        import time
         from deadline.client.config import set_setting
 
         mock_api.list_queues.return_value = {"queues": []}
 
-        # Set up TWO farms the user has previously used.
-        set_setting("defaults.farm_id", "farm-A")
-        set_setting("defaults.queue_id", "queue-A")
-        set_setting("settings.storage_profile_id", "sp-A")
-
+        # Persisted state at dialog open: farm-B is selected and still carries the
+        # queue/storage profile the user previously used with it.
         set_setting("defaults.farm_id", "farm-B")
         set_setting("defaults.queue_id", "queue-B")
         set_setting("settings.storage_profile_id", "sp-stale-id")
 
-        # User is currently on farm-A.
-        set_setting("defaults.farm_id", "farm-A")
-
-        # Create the storage profile combo and give it the current config (dialog open).
+        # The combo captures that state in an isolated snapshot (its self.config).
         widget = DeadlineStorageProfileListComboBoxController()
         qtbot.addWidget(widget)
-        widget.set_config(config_file.read_config())
+        widget.set_config(self._snapshot_config())
 
-        # Force mtime to differ on next write (simulates real-world time between
-        # dialog open and user action).
-        time.sleep(1.1)
-
-        # User picks farm-B. The controller clears queue/storage for farm-B.
+        # The user re-selects farm-B; the controller clears the now-invalid queue/
+        # storage selection. These writes hit the global config, NOT the combo's frozen
+        # snapshot -- so the snapshot still holds "sp-stale-id" under farm-B's section.
         controller = DeadlineUIController.getInstance()
         controller.select_farm("farm-B")
 
-        # Simulate storage_profiles_updated([]) signal arriving (QueuedConnection).
+        # storage_profiles_updated([]) arrives -> _handle_list_update([]).
         widget._handle_list_update([])
 
-        # The combo must NOT show the stale "sp-stale-id" from farm-B's old section.
+        # Must reflect the cleared value, not the stale snapshot's "sp-stale-id".
         assert widget.box.currentText() != "sp-stale-id", (
             "Storage profile combo shows stale ID after farm change"
         )
@@ -642,37 +648,27 @@ class TestStaleConfigOnFarmChange:
     @patch("deadline.client.ui.controllers._deadline_controller.api")
     def test_queue_cleared_after_farm_change(self, mock_api, qtbot, fresh_deadline_config):
         """After select_farm, queue combo must show <none selected>, not stale ID."""
-        import time
         from deadline.client.config import set_setting
 
         mock_api.list_queues.return_value = {"queues": []}
 
-        # Set up TWO farms the user has previously used.
-        set_setting("defaults.farm_id", "farm-A")
-        set_setting("defaults.queue_id", "queue-A")
-
+        # Persisted state at dialog open: farm-B selected with its stored queue.
         set_setting("defaults.farm_id", "farm-B")
         set_setting("defaults.queue_id", "queue-stale-id")
 
-        # User is currently on farm-A.
-        set_setting("defaults.farm_id", "farm-A")
-
-        # Create the queue combo and give it the current config.
+        # The combo captures that state in an isolated snapshot.
         widget = DeadlineQueueListComboBoxController()
         qtbot.addWidget(widget)
-        widget.set_config(config_file.read_config())
+        widget.set_config(self._snapshot_config())
 
-        # Force mtime change.
-        time.sleep(1.1)
-
-        # User picks farm-B.
+        # select_farm clears the queue in the global config; the snapshot is untouched.
         controller = DeadlineUIController.getInstance()
         controller.select_farm("farm-B")
 
-        # The queues_updated signal arrives with the new farm's queue list (empty).
+        # queues_updated arrives with the new (empty) list -> _handle_list_update([]).
         widget._handle_list_update([])
 
-        # The combo must NOT show the stale queue ID.
+        # Must reflect the cleared value, not the stale snapshot's "queue-stale-id".
         assert widget.box.currentText() != "queue-stale-id", (
             "Queue combo shows stale ID after farm change"
         )

--- a/test/unit/deadline_client/ui/widgets/test_deadline_list_combo_boxes.py
+++ b/test/unit/deadline_client/ui/widgets/test_deadline_list_combo_boxes.py
@@ -580,13 +580,18 @@ class TestStaleConfigOnFarmChange:
     combo that still holds the OLD object in `self.config` reading stale values --
     showing a raw id instead of "<none selected>".
 
-    These tests reproduce that staleness *deterministically*, independent of the host
-    filesystem's mtime granularity: the combo is handed an isolated ConfigParser
-    snapshot (a copy that later `set_setting` writes to the global config cannot
-    update), then the cleared values are persisted. The fix (`_sync_config`) makes the
-    combo re-read the live config on display, so it must reflect the cleared values.
-    Without the fix, `refresh_selected_id` reads the frozen snapshot and shows the
-    stale id.
+    These tests reproduce that staleness the way it happens in the submit dialog: the
+    combo is handed the *live* global config object (exactly what the dialog passes),
+    then the cascade's writes force `read_config()` to swap in a fresh parser,
+    orphaning the combo's reference. The swap normally hinges on the config file's
+    mtime changing, which is filesystem-granularity dependent -- so we force it
+    deterministically by making `_should_read_config` always report a change *during
+    the cascade only*. (It must NOT be forced while `set_config` runs: `set_config`
+    records whether it was handed the live global via an identity check, and forcing a
+    swap there would hand it a different object and defeat the check.) The fix
+    (`_sync_config`) re-reads the live config on display, so the combo must reflect the
+    cleared values. Without the fix, `refresh_selected_id` reads the orphaned parser
+    and shows the stale id.
     """
 
     def setup_method(self):
@@ -597,18 +602,6 @@ class TestStaleConfigOnFarmChange:
         DeadlineUIController.resetInstance()
         DeadlineThreadPool.shutdown(wait_for_done=True, timeout_ms=2000)
         DeadlineThreadPool.reset()
-
-    @staticmethod
-    def _snapshot_config() -> ConfigParser:
-        """An independent copy of the current global config.
-
-        `set_setting` (without an explicit config) mutates the module-level global,
-        never this copy -- so it stays frozen at the pre-clear state, exactly like a
-        combo's orphaned `self.config` reference after a cascade swapped the global.
-        """
-        snapshot = ConfigParser()
-        snapshot.read_dict(config_file.read_config())
-        return snapshot
 
     @patch("deadline.client.ui.controllers._deadline_controller.api")
     def test_storage_profile_cleared_after_farm_change(
@@ -625,21 +618,23 @@ class TestStaleConfigOnFarmChange:
         set_setting("defaults.queue_id", "queue-B")
         set_setting("settings.storage_profile_id", "sp-stale-id")
 
-        # The combo captures that state in an isolated snapshot (its self.config).
+        # The combo is configured with the live global config, like the submit dialog.
+        # No swap is forced here so the identity check in set_config sees the global.
         widget = DeadlineStorageProfileListComboBoxController()
         qtbot.addWidget(widget)
-        widget.set_config(self._snapshot_config())
+        widget.set_config(config_file.read_config())
 
         # The user re-selects farm-B; the controller clears the now-invalid queue/
-        # storage selection. These writes hit the global config, NOT the combo's frozen
-        # snapshot -- so the snapshot still holds "sp-stale-id" under farm-B's section.
+        # storage selection. Forcing _should_read_config to True makes every
+        # read_config() rebuild the parser, orphaning the combo's reference exactly the
+        # way a real mtime change would -- so self.config keeps "sp-stale-id".
         controller = DeadlineUIController.getInstance()
-        controller.select_farm("farm-B")
+        with patch.object(config_file, "_should_read_config", return_value=True):
+            controller.select_farm("farm-B")
+            # storage_profiles_updated([]) arrives -> _handle_list_update([]).
+            widget._handle_list_update([])
 
-        # storage_profiles_updated([]) arrives -> _handle_list_update([]).
-        widget._handle_list_update([])
-
-        # Must reflect the cleared value, not the stale snapshot's "sp-stale-id".
+        # Must reflect the cleared value, not the stale "sp-stale-id".
         assert widget.box.currentText() != "sp-stale-id", (
             "Storage profile combo shows stale ID after farm change"
         )
@@ -656,20 +651,112 @@ class TestStaleConfigOnFarmChange:
         set_setting("defaults.farm_id", "farm-B")
         set_setting("defaults.queue_id", "queue-stale-id")
 
-        # The combo captures that state in an isolated snapshot.
+        # Configured with the live global config, like the submit dialog.
         widget = DeadlineQueueListComboBoxController()
         qtbot.addWidget(widget)
-        widget.set_config(self._snapshot_config())
+        widget.set_config(config_file.read_config())
 
-        # select_farm clears the queue in the global config; the snapshot is untouched.
+        # select_farm clears the queue; forcing the swap orphans the combo's reference.
         controller = DeadlineUIController.getInstance()
-        controller.select_farm("farm-B")
+        with patch.object(config_file, "_should_read_config", return_value=True):
+            controller.select_farm("farm-B")
+            # queues_updated arrives with the new (empty) list -> _handle_list_update([]).
+            widget._handle_list_update([])
 
-        # queues_updated arrives with the new (empty) list -> _handle_list_update([]).
-        widget._handle_list_update([])
-
-        # Must reflect the cleared value, not the stale snapshot's "queue-stale-id".
+        # Must reflect the cleared value, not the stale "queue-stale-id".
         assert widget.box.currentText() != "queue-stale-id", (
             "Queue combo shows stale ID after farm change"
         )
         assert widget.box.currentData() == ""
+
+
+class TestInjectedConfigPreservedOnSync:
+    """`_sync_config` must not clobber a caller-injected config that differs from disk.
+
+    The config dialog (`deadline_config_dialog.refresh`) builds a *copy* of the config
+    and layers the user's unsaved `changes` on top before handing it to these combos
+    via `set_config`. That copy intentionally differs from the on-disk config. A naive
+    `_sync_config` that unconditionally re-reads the live config on every display sync
+    would discard those pending edits -- the combo would snap back to the persisted id
+    instead of showing what the user just picked.
+
+    The fix gates the re-read on an identity check (`self.config is the live global`),
+    so an injected copy is left untouched. These tests assert that: after a list
+    update triggers `_sync_config`, the combo still reflects the injected copy's value,
+    not the value on disk. Without the identity gate they fail (the pending edit is
+    lost); with the previous unconditional-read behavior they would also fail.
+    """
+
+    def setup_method(self):
+        DeadlineUIController.resetInstance()
+        DeadlineThreadPool.reset()
+
+    def teardown_method(self):
+        DeadlineUIController.resetInstance()
+        DeadlineThreadPool.shutdown(wait_for_done=True, timeout_ms=2000)
+        DeadlineThreadPool.reset()
+
+    @staticmethod
+    def _config_copy_with_pending_edit(setting_name: str, value: str) -> ConfigParser:
+        """Mimic deadline_config_dialog.refresh: copy the live config, layer an edit.
+
+        `set_setting` with an explicit config mutates only that copy (never disk), so
+        the returned parser holds an unsaved value that differs from the persisted one.
+        """
+        copy = ConfigParser()
+        copy.read_dict(config_file.read_config())
+        config_file.set_setting(setting_name, value, copy)
+        return copy
+
+    @patch("deadline.client.ui.controllers._deadline_controller.api")
+    def test_pending_storage_profile_edit_survives_list_update(
+        self, mock_api, qtbot, fresh_deadline_config
+    ):
+        """A list update must not revert an unsaved storage-profile pick to the saved id."""
+        from deadline.client.config import set_setting
+
+        mock_api.list_queues.return_value = {"queues": []}
+
+        # Persisted (saved) selection on disk.
+        set_setting("defaults.farm_id", "farm-A")
+        set_setting("settings.storage_profile_id", "sp-saved")
+
+        # The config dialog hands the combo a copy carrying the user's unsaved pick.
+        injected = self._config_copy_with_pending_edit("settings.storage_profile_id", "sp-pending")
+        widget = DeadlineStorageProfileListComboBoxController()
+        qtbot.addWidget(widget)
+        widget.set_config(injected)
+        assert widget._config_tracks_global is False  # a copy, not the live global
+
+        # A list update arrives (both profiles are selectable) -> _sync_config runs.
+        widget._handle_list_update([("Saved SP", "sp-saved"), ("Pending SP", "sp-pending")])
+
+        # The pending edit must win; _sync_config must not have re-read disk's "sp-saved".
+        assert widget.box.currentData() == "sp-pending", (
+            "Injected pending storage-profile edit was clobbered by _sync_config"
+        )
+        # And the injected copy itself must be untouched (not swapped for the global).
+        assert widget.config is injected
+
+    @patch("deadline.client.ui.controllers._deadline_controller.api")
+    def test_pending_queue_edit_survives_loading_state(
+        self, mock_api, qtbot, fresh_deadline_config
+    ):
+        """The loading-state sync must also preserve an injected, unsaved queue pick."""
+        from deadline.client.config import set_setting
+
+        mock_api.list_queues.return_value = {"queues": []}
+
+        set_setting("defaults.farm_id", "farm-A")
+        set_setting("defaults.queue_id", "queue-saved")
+
+        injected = self._config_copy_with_pending_edit("defaults.queue_id", "queue-pending")
+        widget = DeadlineQueueListComboBoxController()
+        qtbot.addWidget(widget)
+        widget.set_config(injected)
+
+        # _handle_loading_state(True) also calls _sync_config; it must keep the copy.
+        widget._handle_loading_state(True)
+
+        assert widget.config is injected, "Injected config was replaced during loading sync"
+        assert config_file.get_setting("defaults.queue_id", config=widget.config) == "queue-pending"

--- a/test/unit/deadline_client/ui/widgets/test_deadline_list_combo_boxes.py
+++ b/test/unit/deadline_client/ui/widgets/test_deadline_list_combo_boxes.py
@@ -11,6 +11,7 @@ from configparser import ConfigParser
 
 pytest.importorskip("deadline.client.ui.widgets._deadline_list_combo_boxes")
 
+from deadline.client.config import config_file  # noqa: E402
 from deadline.client.ui.widgets._deadline_list_combo_boxes import (  # noqa: E402
     DeadlineFarmListComboBoxController,
     DeadlineQueueListComboBoxController,
@@ -568,4 +569,111 @@ class TestDeadlineStorageProfileListComboBoxController:
             widget._handle_list_update([["Only Profile", "profile-only"]])
 
         # No configured id and no auto-select -> stays on the "<none selected>" entry.
+        assert widget.box.currentData() == ""
+
+
+class TestStaleConfigOnFarmChange:
+    """Regression tests: changing farms must not show stale queue/storage profile IDs.
+
+    When `select_farm` writes to the config file via `set_setting`, `read_config()`
+    detects the on-disk change and creates a new ConfigParser object. If the combo
+    boxes still hold a reference to the OLD object, `refresh_selected_id` reads stale
+    values and shows raw IDs instead of <none selected>.
+
+    The bug triggers when switching to a farm the user has previously used (so the
+    config file has stored queue/storage IDs for that farm in its section) AND the
+    file mtime changes between successive set_setting calls (which happens any time
+    there's >0 seconds between them -- common in practice on real filesystems).
+    """
+
+    def setup_method(self):
+        DeadlineUIController.resetInstance()
+        DeadlineThreadPool.reset()
+
+    def teardown_method(self):
+        DeadlineUIController.resetInstance()
+        DeadlineThreadPool.shutdown(wait_for_done=True, timeout_ms=2000)
+        DeadlineThreadPool.reset()
+
+    @patch("deadline.client.ui.controllers._deadline_controller.api")
+    def test_storage_profile_cleared_after_farm_change(
+        self, mock_api, qtbot, fresh_deadline_config
+    ):
+        """After select_farm, storage profile combo must show <none selected>, not stale ID."""
+        import time
+        from deadline.client.config import set_setting
+
+        mock_api.list_queues.return_value = {"queues": []}
+
+        # Set up TWO farms the user has previously used.
+        set_setting("defaults.farm_id", "farm-A")
+        set_setting("defaults.queue_id", "queue-A")
+        set_setting("settings.storage_profile_id", "sp-A")
+
+        set_setting("defaults.farm_id", "farm-B")
+        set_setting("defaults.queue_id", "queue-B")
+        set_setting("settings.storage_profile_id", "sp-stale-id")
+
+        # User is currently on farm-A.
+        set_setting("defaults.farm_id", "farm-A")
+
+        # Create the storage profile combo and give it the current config (dialog open).
+        widget = DeadlineStorageProfileListComboBoxController()
+        qtbot.addWidget(widget)
+        widget.set_config(config_file.read_config())
+
+        # Force mtime to differ on next write (simulates real-world time between
+        # dialog open and user action).
+        time.sleep(1.1)
+
+        # User picks farm-B. The controller clears queue/storage for farm-B.
+        controller = DeadlineUIController.getInstance()
+        controller.select_farm("farm-B")
+
+        # Simulate storage_profiles_updated([]) signal arriving (QueuedConnection).
+        widget._handle_list_update([])
+
+        # The combo must NOT show the stale "sp-stale-id" from farm-B's old section.
+        assert widget.box.currentText() != "sp-stale-id", (
+            "Storage profile combo shows stale ID after farm change"
+        )
+        assert widget.box.currentData() == ""
+
+    @patch("deadline.client.ui.controllers._deadline_controller.api")
+    def test_queue_cleared_after_farm_change(self, mock_api, qtbot, fresh_deadline_config):
+        """After select_farm, queue combo must show <none selected>, not stale ID."""
+        import time
+        from deadline.client.config import set_setting
+
+        mock_api.list_queues.return_value = {"queues": []}
+
+        # Set up TWO farms the user has previously used.
+        set_setting("defaults.farm_id", "farm-A")
+        set_setting("defaults.queue_id", "queue-A")
+
+        set_setting("defaults.farm_id", "farm-B")
+        set_setting("defaults.queue_id", "queue-stale-id")
+
+        # User is currently on farm-A.
+        set_setting("defaults.farm_id", "farm-A")
+
+        # Create the queue combo and give it the current config.
+        widget = DeadlineQueueListComboBoxController()
+        qtbot.addWidget(widget)
+        widget.set_config(config_file.read_config())
+
+        # Force mtime change.
+        time.sleep(1.1)
+
+        # User picks farm-B.
+        controller = DeadlineUIController.getInstance()
+        controller.select_farm("farm-B")
+
+        # The queues_updated signal arrives with the new farm's queue list (empty).
+        widget._handle_list_update([])
+
+        # The combo must NOT show the stale queue ID.
+        assert widget.box.currentText() != "queue-stale-id", (
+            "Queue combo shows stale ID after farm change"
+        )
         assert widget.box.currentData() == ""


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Changing the farm in the job submitter left the queue and storage profile
combos *displaying a raw id* (e.g. `queue-2ba3...`, `sp-7568...`) from the
previously selected farm instead of clearing. Also, the section header
`Deadline Cloud settings` was generic.

### What was the solution? (How)

The combos cache a `ConfigParser` in `self.config`. The `select_farm` cascade
calls `set_setting()`, which writes to disk; the next `read_config()` swaps in
a fresh parser, orphaning the cached reference so `refresh_selected_id` reads
the prior farm's stale ids and renders them as raw-id rows. Added
`_sync_config()` to re-point `self.config` at the live config before each
display sync (only when already set, so mock configs in tests are unaffected).
Renamed the header to `Job submission settings` across all 12 locales.

### What is the impact of this change?

Queue/storage profile now correctly clear to `<none selected>` on farm
change. UI-only; no API or public-contract changes.

### How was this change tested?

- Have you run the unit tests? Yes.
  - Deterministic combo-level regression tests (`TestStaleConfigOnFarmChange`).
  - A GUI (pytest-qt) regression test driving the real farm-pick → cascade →
    list-update signal chain and asserting the *displayed* combo text, not just
    persisted config. Both forms force the config-cache swap deterministically
    (`_should_read_config`/isolated snapshot), so they don't depend on
    filesystem mtime granularity, and both fail if `_sync_config` is reverted.
  - Full UI suite green; `fmt` + `lint` clean.
- Have you run the integration tests? No (UI-only change).

### Was this change documented?

Docstrings for `set_config`/`_sync_config` updated. No README/CLI changes.

### Does this PR introduce new dependencies?

*   [x] This PR does not add any new dependencies.

### Is this a breaking change?

No.

### Does this change impact security?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
