### PR TITLE
fix: show only profile name when logged out in submitter status bar

### DIFF
--- a/src/deadline/client/ui/widgets/deadline_authentication_status_widget.py
+++ b/src/deadline/client/ui/widgets/deadline_authentication_status_widget.py
@@ -247,10 +247,10 @@ class DeadlineAuthenticationStatusWidget(QGroupBox):
                 logout_visible=self._should_show_logout,
             ),
             AuthenticationState.NEEDS_LOGIN: AuthenticationStateConfig(
+                # The warning icon and the "Log in" button convey the logged-out
+                # state, so the profile button only shows the profile name.
                 icon=QStyle.StandardPixmap.SP_MessageBoxWarning,
-                text=tr("{profile}  -  You are logged out.").format(
-                    profile=self._get_profile_name()
-                ),
+                text=self._get_profile_name,
                 switch_profile_button_visible=True,
                 login_visible=True,
             ),

--- a/test/unit/deadline_client/ui/widgets/test_deadline_authentication_status_widget.py
+++ b/test/unit/deadline_client/ui/widgets/test_deadline_authentication_status_widget.py
@@ -1,0 +1,86 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+try:
+    from deadline.client.ui.widgets.deadline_authentication_status_widget import (
+        AuthenticationState,
+        DeadlineAuthenticationStatusWidget,
+    )
+except ImportError:
+    # The tests in this file should be skipped if Qt UI related modules cannot be loaded
+    pytest.importorskip("deadline.client.ui.widgets.deadline_authentication_status_widget")
+
+from deadline.client import api
+
+MODULE = "deadline.client.ui.widgets.deadline_authentication_status_widget"
+
+
+@pytest.fixture
+def mock_status():
+    """A stand-in for the DeadlineAuthenticationStatus singleton the widget connects to."""
+    status = MagicMock()
+    status.creds_source = api.AwsCredentialsSource.DEADLINE_CLOUD_MONITOR_LOGIN
+    status.auth_status = api.AwsAuthenticationStatus.NEEDS_LOGIN
+    status.config = MagicMock()
+    return status
+
+
+def _make_widget(qtbot, mock_status, profile_name="my-profile"):
+    with (
+        patch(f"{MODULE}.DeadlineAuthenticationStatus.getInstance", return_value=mock_status),
+        patch(f"{MODULE}.config_file.get_setting", return_value=profile_name),
+    ):
+        widget = DeadlineAuthenticationStatusWidget()
+        qtbot.addWidget(widget)
+        return widget
+
+
+def test_needs_login_shows_only_profile_name(qtbot, mock_status):
+    """Regression test for issue #769.
+
+    When logged out, the profile button must show only the profile name and not the
+    longer "You are logged out." message, which was clipped behind the switch profile
+    and log in buttons at default scaling / narrow window widths. The warning icon and
+    the visible "Log in" button already communicate the logged-out state.
+    """
+    mock_status.auth_status = api.AwsAuthenticationStatus.NEEDS_LOGIN
+
+    widget = _make_widget(qtbot, mock_status, profile_name="my-profile")
+
+    assert widget._get_current_auth_state_key() == AuthenticationState.NEEDS_LOGIN
+    # Only the profile name is shown -- no "logged out" text to be clipped.
+    assert widget._profile_button.text() == "my-profile"
+    assert "logged out" not in widget._profile_button.text().lower()
+    # The next step is obvious: the warning icon plus the visible Log in button.
+    # isVisibleTo avoids depending on the top-level widget being shown on screen.
+    assert widget._login_button.isVisibleTo(widget)
+    assert widget._switch_profile_button.isVisibleTo(widget)
+
+
+def test_authenticated_shows_profile_name(qtbot, mock_status):
+    mock_status.auth_status = api.AwsAuthenticationStatus.AUTHENTICATED
+
+    widget = _make_widget(qtbot, mock_status, profile_name="my-profile")
+
+    assert widget._get_current_auth_state_key() == AuthenticationState.AUTHENTICATED_READY
+    assert widget._profile_button.text() == "my-profile"
+    assert not widget._login_button.isVisibleTo(widget)
+
+
+def test_needs_login_hides_switch_profile_button_when_disabled(qtbot, mock_status):
+    """With profile switching disabled, the switch profile button stays hidden even
+    when logged out, but the Log in button remains the obvious next step."""
+    mock_status.auth_status = api.AwsAuthenticationStatus.NEEDS_LOGIN
+
+    with (
+        patch(f"{MODULE}.DeadlineAuthenticationStatus.getInstance", return_value=mock_status),
+        patch(f"{MODULE}.config_file.get_setting", return_value="my-profile"),
+    ):
+        widget = DeadlineAuthenticationStatusWidget(show_profile_switch=False)
+        qtbot.addWidget(widget)
+
+    assert not widget._switch_profile_button.isVisibleTo(widget)
+    assert widget._login_button.isVisibleTo(widget)


### PR DESCRIPTION
## What was changed

Fixes #769.

When the submitter is opened while logged out, the authentication status bar showed `{profile}  -  You are logged out.` in the profile button. In the horizontal layout this long string was clipped behind the fixed-width **Switch profile** and **Log in** buttons at default scaling / narrow window widths, partially hiding the login status.

The profile button now shows only the profile name in the `NEEDS_LOGIN` state — consistent with every other authentication state. The warning icon and the conditionally-shown **Log in** button already communicate the logged-out state and the obvious next step, so no information is lost and nothing overlaps.

### Before / After

![before and after](https://raw.githubusercontent.com/crowecawcaw/deadline-cloud/pr-assets/issue769_compare.png)

## How it was tested

- Added unit tests in `test/unit/deadline_client/ui/widgets/test_deadline_authentication_status_widget.py` covering the `NEEDS_LOGIN`, `AUTHENTICATED_READY`, and profile-switch-disabled states.
- `hatch run test`, `hatch run fmt`, `hatch run lint` all pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
