### PR TITLE
fix: standardize deadline.client.api params on camelCase (boto3 style)

### DIFF
--- a/src/deadline/_mcp/registry.py
+++ b/src/deadline/_mcp/registry.py
@@ -86,33 +86,33 @@ TOOL_REGISTRY: Dict[str, ToolDefinition] = {
     # Diagnostics - Primitive APIs
     "get_job": {
         "func": api.get_job,
-        "param_names": ["farm_id", "queue_id", "job_id"],
+        "param_names": ["farmId", "queueId", "jobId"],
     },
     "get_session": {
         "func": api.get_session,
-        "param_names": ["farm_id", "queue_id", "job_id", "session_id"],
+        "param_names": ["farmId", "queueId", "jobId", "sessionId"],
     },
     "list_sessions": {
         "func": api.list_sessions,
-        "param_names": ["farm_id", "queue_id", "job_id"],
+        "param_names": ["farmId", "queueId", "jobId"],
     },
     "list_steps": {
         "func": api.list_steps,
-        "param_names": ["farm_id", "queue_id", "job_id"],
+        "param_names": ["farmId", "queueId", "jobId"],
     },
     "list_tasks": {
         "func": api.list_tasks,
-        "param_names": ["farm_id", "queue_id", "job_id", "step_id"],
+        "param_names": ["farmId", "queueId", "jobId", "stepId"],
     },
     "search_jobs": {
         "func": api.search_jobs,
         "param_names": [
-            "farm_id",
-            "queue_ids",
-            "task_run_status",
-            "name_contains",
-            "page_size",
-            "item_offset",
+            "farmId",
+            "queueIds",
+            "taskRunStatus",
+            "nameContains",
+            "pageSize",
+            "itemOffset",
         ],
     },
 }

--- a/src/deadline/_mcp/tools/logs.py
+++ b/src/deadline/_mcp/tools/logs.py
@@ -39,7 +39,7 @@ def get_session_and_worker_logs(
     """
     # Get session details to find the worker and fleet
     session_details = get_session(
-        farm_id=farm_id, queue_id=queue_id, job_id=job_id, session_id=session_id
+        farmId=farm_id, queueId=queue_id, jobId=job_id, sessionId=session_id
     )
     worker_id = session_details.get("workerId")
     fleet_id = session_details.get("fleetId")

--- a/src/deadline/client/api/_mcp.py
+++ b/src/deadline/client/api/_mcp.py
@@ -4,14 +4,57 @@
 APIs for job diagnostics - get, list, and search operations for jobs, sessions, steps, and tasks.
 """
 
+import warnings
 from configparser import ConfigParser
-from typing import Any, Dict, List, Optional, TYPE_CHECKING
+from functools import wraps
+from typing import Any, Callable, Dict, List, Optional, TYPE_CHECKING
 
 from ._session import get_boto3_client, _resolve_region
 from . import record_function_latency_telemetry_event
 
 if TYPE_CHECKING:
     from mypy_boto3_deadline import DeadlineClient
+
+
+def _accept_deprecated_snake_case(aliases: Dict[str, str]) -> Callable:
+    """
+    Decorator that lets a function keep accepting its old snake_case keyword arguments
+    while its canonical parameters are the camelCase (boto3-style) names.
+
+    ``aliases`` maps each deprecated ``snake_case`` name to its canonical ``camelCase``
+    equivalent. When a caller passes a snake_case keyword, its value is forwarded to the
+    matching camelCase parameter and a :class:`DeprecationWarning` is emitted.
+
+    .. deprecated::
+        The snake_case aliases exist only to avoid breaking existing callers in this
+        release. They are slated for removal in the next breaking release -- at which
+        point this decorator (and the ``aliases`` maps below) should be deleted and the
+        functions left with their camelCase parameters only.
+    """
+
+    def decorator(func: Callable) -> Callable:
+        @wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            for snake, camel in aliases.items():
+                if snake not in kwargs:
+                    continue
+                if kwargs.get(camel) is not None:
+                    raise TypeError(
+                        f"{func.__name__}() received both '{camel}' and its deprecated "
+                        f"alias '{snake}'; pass only '{camel}'."
+                    )
+                warnings.warn(
+                    f"The '{snake}' parameter of {func.__name__}() is deprecated and will be "
+                    f"removed in a future release; use '{camel}' instead.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+                kwargs[camel] = kwargs.pop(snake)
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
 
 
 def _call_paginated_deadline_list_api(
@@ -36,10 +79,11 @@ def _call_paginated_deadline_list_api(
 
 
 @record_function_latency_telemetry_event()
+@_accept_deprecated_snake_case({"farm_id": "farmId", "queue_id": "queueId", "job_id": "jobId"})
 def get_job(
-    farm_id: str,
-    queue_id: str,
-    job_id: str,
+    farmId: str,
+    queueId: str,
+    jobId: str,
     config: Optional[ConfigParser] = None,
     region: Optional[str] = None,
 ) -> Dict[str, Any]:
@@ -47,27 +91,40 @@ def get_job(
     Get detailed information about a specific job.
 
     Args:
-        farm_id: The ID of the farm containing the job.
-        queue_id: The ID of the queue containing the job.
-        job_id: The ID of the job to retrieve.
+        farmId: The ID of the farm containing the job.
+        queueId: The ID of the queue containing the job.
+        jobId: The ID of the job to retrieve.
         config: Optional configuration object.
         region: The AWS region of the farm. When omitted, it is resolved for this farm
             from the config (defaults.farm_region), otherwise the session/profile region.
 
     Returns:
         Job details including name, status, taskRunStatusCounts, timestamps, and lifecycle info.
+
+    .. deprecated::
+        The snake_case keyword arguments ``farm_id``, ``queue_id`` and ``job_id`` are
+        deprecated in favor of the camelCase ``farmId``, ``queueId`` and ``jobId``. They
+        still work in this release but will be removed in the next breaking release.
     """
-    region = _resolve_region(config=config, region=region, farm_id=farm_id)
+    region = _resolve_region(config=config, region=region, farm_id=farmId)
     deadline: "DeadlineClient" = get_boto3_client("deadline", config=config, region=region)
-    return deadline.get_job(farmId=farm_id, queueId=queue_id, jobId=job_id)
+    return deadline.get_job(farmId=farmId, queueId=queueId, jobId=jobId)
 
 
 @record_function_latency_telemetry_event()
+@_accept_deprecated_snake_case(
+    {
+        "farm_id": "farmId",
+        "queue_id": "queueId",
+        "job_id": "jobId",
+        "session_id": "sessionId",
+    }
+)
 def get_session(
-    farm_id: str,
-    queue_id: str,
-    job_id: str,
-    session_id: str,
+    farmId: str,
+    queueId: str,
+    jobId: str,
+    sessionId: str,
     config: Optional[ConfigParser] = None,
     region: Optional[str] = None,
 ) -> Dict[str, Any]:
@@ -75,30 +132,42 @@ def get_session(
     Get detailed information about a specific session.
 
     Args:
-        farm_id: The ID of the farm containing the session.
-        queue_id: The ID of the queue containing the session.
-        job_id: The ID of the job containing the session.
-        session_id: The ID of the session to retrieve.
+        farmId: The ID of the farm containing the session.
+        queueId: The ID of the queue containing the session.
+        jobId: The ID of the job containing the session.
+        sessionId: The ID of the session to retrieve.
         config: Optional configuration object.
         region: The AWS region of the farm. When omitted, it is resolved for this farm
             from the config (defaults.farm_region), otherwise the session/profile region.
 
     Returns:
         Session details including lifecycleStatus, log configuration, worker info.
+
+    .. deprecated::
+        The snake_case keyword arguments ``farm_id``, ``queue_id``, ``job_id`` and
+        ``session_id`` are deprecated in favor of the camelCase ``farmId``, ``queueId``,
+        ``jobId`` and ``sessionId``. They still work in this release but will be removed
+        in the next breaking release.
     """
-    region = _resolve_region(config=config, region=region, farm_id=farm_id)
+    region = _resolve_region(config=config, region=region, farm_id=farmId)
     deadline: "DeadlineClient" = get_boto3_client("deadline", config=config, region=region)
-    return deadline.get_session(
-        farmId=farm_id, queueId=queue_id, jobId=job_id, sessionId=session_id
-    )
+    return deadline.get_session(farmId=farmId, queueId=queueId, jobId=jobId, sessionId=sessionId)
 
 
 @record_function_latency_telemetry_event()
+@_accept_deprecated_snake_case(
+    {
+        "farm_id": "farmId",
+        "queue_id": "queueId",
+        "job_id": "jobId",
+        "max_results": "maxResults",
+    }
+)
 def list_sessions(
-    farm_id: str,
-    queue_id: str,
-    job_id: str,
-    max_results: Optional[int] = None,
+    farmId: str,
+    queueId: str,
+    jobId: str,
+    maxResults: Optional[int] = None,
     config: Optional[ConfigParser] = None,
     region: Optional[str] = None,
 ) -> Dict[str, Any]:
@@ -106,26 +175,32 @@ def list_sessions(
     List all sessions for a job.
 
     Args:
-        farm_id: The ID of the farm containing the job.
-        queue_id: The ID of the queue containing the job.
-        job_id: The ID of the job to list sessions for.
-        max_results: Optional maximum number of sessions to return per page (API default if not provided).
+        farmId: The ID of the farm containing the job.
+        queueId: The ID of the queue containing the job.
+        jobId: The ID of the job to list sessions for.
+        maxResults: Optional maximum number of sessions to return per page (API default if not provided).
         config: Optional configuration object.
         region: The AWS region of the farm. When omitted, it is resolved for this farm
             from the config (defaults.farm_region), otherwise the session/profile region.
 
     Returns:
         {"sessions": [...]} with session summaries including sessionId, lifecycleStatus, workerId.
+
+    .. deprecated::
+        The snake_case keyword arguments ``farm_id``, ``queue_id``, ``job_id`` and
+        ``max_results`` are deprecated in favor of the camelCase ``farmId``, ``queueId``,
+        ``jobId`` and ``maxResults``. They still work in this release but will be removed
+        in the next breaking release.
     """
-    region = _resolve_region(config=config, region=region, farm_id=farm_id)
+    region = _resolve_region(config=config, region=region, farm_id=farmId)
     deadline: "DeadlineClient" = get_boto3_client("deadline", config=config, region=region)
     kwargs: Dict[str, Any] = {
-        "farmId": farm_id,
-        "queueId": queue_id,
-        "jobId": job_id,
+        "farmId": farmId,
+        "queueId": queueId,
+        "jobId": jobId,
     }
-    if max_results is not None:
-        kwargs["maxResults"] = max_results
+    if maxResults is not None:
+        kwargs["maxResults"] = maxResults
     return _call_paginated_deadline_list_api(
         deadline.list_sessions,
         "sessions",
@@ -134,11 +209,19 @@ def list_sessions(
 
 
 @record_function_latency_telemetry_event()
+@_accept_deprecated_snake_case(
+    {
+        "farm_id": "farmId",
+        "queue_id": "queueId",
+        "job_id": "jobId",
+        "max_results": "maxResults",
+    }
+)
 def list_steps(
-    farm_id: str,
-    queue_id: str,
-    job_id: str,
-    max_results: Optional[int] = None,
+    farmId: str,
+    queueId: str,
+    jobId: str,
+    maxResults: Optional[int] = None,
     config: Optional[ConfigParser] = None,
     region: Optional[str] = None,
 ) -> Dict[str, Any]:
@@ -146,26 +229,32 @@ def list_steps(
     List all steps for a job.
 
     Args:
-        farm_id: The ID of the farm containing the job.
-        queue_id: The ID of the queue containing the job.
-        job_id: The ID of the job to list steps for.
-        max_results: Optional maximum number of steps to return per page (API default if not provided).
+        farmId: The ID of the farm containing the job.
+        queueId: The ID of the queue containing the job.
+        jobId: The ID of the job to list steps for.
+        maxResults: Optional maximum number of steps to return per page (API default if not provided).
         config: Optional configuration object.
         region: The AWS region of the farm. When omitted, it is resolved for this farm
             from the config (defaults.farm_region), otherwise the session/profile region.
 
     Returns:
         {"steps": [...]} with step summaries including stepId, name, taskRunStatus, taskRunStatusCounts.
+
+    .. deprecated::
+        The snake_case keyword arguments ``farm_id``, ``queue_id``, ``job_id`` and
+        ``max_results`` are deprecated in favor of the camelCase ``farmId``, ``queueId``,
+        ``jobId`` and ``maxResults``. They still work in this release but will be removed
+        in the next breaking release.
     """
-    region = _resolve_region(config=config, region=region, farm_id=farm_id)
+    region = _resolve_region(config=config, region=region, farm_id=farmId)
     deadline: "DeadlineClient" = get_boto3_client("deadline", config=config, region=region)
     kwargs: Dict[str, Any] = {
-        "farmId": farm_id,
-        "queueId": queue_id,
-        "jobId": job_id,
+        "farmId": farmId,
+        "queueId": queueId,
+        "jobId": jobId,
     }
-    if max_results is not None:
-        kwargs["maxResults"] = max_results
+    if maxResults is not None:
+        kwargs["maxResults"] = maxResults
     return _call_paginated_deadline_list_api(
         deadline.list_steps,
         "steps",
@@ -174,12 +263,21 @@ def list_steps(
 
 
 @record_function_latency_telemetry_event()
+@_accept_deprecated_snake_case(
+    {
+        "farm_id": "farmId",
+        "queue_id": "queueId",
+        "job_id": "jobId",
+        "step_id": "stepId",
+        "max_results": "maxResults",
+    }
+)
 def list_tasks(
-    farm_id: str,
-    queue_id: str,
-    job_id: str,
-    step_id: str,
-    max_results: Optional[int] = None,
+    farmId: str,
+    queueId: str,
+    jobId: str,
+    stepId: str,
+    maxResults: Optional[int] = None,
     config: Optional[ConfigParser] = None,
     region: Optional[str] = None,
 ) -> Dict[str, Any]:
@@ -187,28 +285,34 @@ def list_tasks(
     List all tasks for a step.
 
     Args:
-        farm_id: The ID of the farm containing the job.
-        queue_id: The ID of the queue containing the job.
-        job_id: The ID of the job containing the step.
-        step_id: The ID of the step to list tasks for.
-        max_results: Optional maximum number of tasks to return per page (API default if not provided).
+        farmId: The ID of the farm containing the job.
+        queueId: The ID of the queue containing the job.
+        jobId: The ID of the job containing the step.
+        stepId: The ID of the step to list tasks for.
+        maxResults: Optional maximum number of tasks to return per page (API default if not provided).
         config: Optional configuration object.
         region: The AWS region of the farm. When omitted, it is resolved for this farm
             from the config (defaults.farm_region), otherwise the session/profile region.
 
     Returns:
         {"tasks": [...]} with task summaries including taskId, runStatus, parameters.
+
+    .. deprecated::
+        The snake_case keyword arguments ``farm_id``, ``queue_id``, ``job_id``, ``step_id``
+        and ``max_results`` are deprecated in favor of the camelCase ``farmId``, ``queueId``,
+        ``jobId``, ``stepId`` and ``maxResults``. They still work in this release but will be
+        removed in the next breaking release.
     """
-    region = _resolve_region(config=config, region=region, farm_id=farm_id)
+    region = _resolve_region(config=config, region=region, farm_id=farmId)
     deadline: "DeadlineClient" = get_boto3_client("deadline", config=config, region=region)
     kwargs: Dict[str, Any] = {
-        "farmId": farm_id,
-        "queueId": queue_id,
-        "jobId": job_id,
-        "stepId": step_id,
+        "farmId": farmId,
+        "queueId": queueId,
+        "jobId": jobId,
+        "stepId": stepId,
     }
-    if max_results is not None:
-        kwargs["maxResults"] = max_results
+    if maxResults is not None:
+        kwargs["maxResults"] = maxResults
     return _call_paginated_deadline_list_api(
         deadline.list_tasks,
         "tasks",
@@ -217,13 +321,23 @@ def list_tasks(
 
 
 @record_function_latency_telemetry_event()
+@_accept_deprecated_snake_case(
+    {
+        "farm_id": "farmId",
+        "queue_ids": "queueIds",
+        "task_run_status": "taskRunStatus",
+        "name_contains": "nameContains",
+        "page_size": "pageSize",
+        "item_offset": "itemOffset",
+    }
+)
 def search_jobs(
-    farm_id: Optional[str] = None,
-    queue_ids: Optional[List[str]] = None,
-    task_run_status: Optional[str] = None,
-    name_contains: Optional[str] = None,
-    page_size: int = 25,
-    item_offset: int = 0,
+    farmId: Optional[str] = None,
+    queueIds: Optional[List[str]] = None,
+    taskRunStatus: Optional[str] = None,
+    nameContains: Optional[str] = None,
+    pageSize: int = 25,
+    itemOffset: int = 0,
     config: Optional[ConfigParser] = None,
     region: Optional[str] = None,
 ) -> Dict[str, Any]:
@@ -231,64 +345,71 @@ def search_jobs(
     Search for jobs with optional filters.
 
     Args:
-        farm_id: Farm ID to search in (uses default from config if not provided).
-        queue_ids: List of queue IDs to search, 1-10 (uses default from config if not provided).
-        task_run_status: Filter by status (PENDING, READY, RUNNING, FAILED, SUCCEEDED, etc.).
-        name_contains: Filter jobs by name substring.
-        page_size: Results per page (1-100, default 25).
-        item_offset: Offset for pagination (0-10000).
+        farmId: Farm ID to search in (uses default from config if not provided).
+        queueIds: List of queue IDs to search, 1-10 (uses default from config if not provided).
+        taskRunStatus: Filter by status (PENDING, READY, RUNNING, FAILED, SUCCEEDED, etc.).
+        nameContains: Filter jobs by name substring.
+        pageSize: Results per page (1-100, default 25).
+        itemOffset: Offset for pagination (0-10000).
         config: Optional configuration object.
         region: The AWS region of the farm. When omitted, it is resolved for the resolved
             farm from the config (defaults.farm_region), otherwise the session/profile region.
 
     Returns:
         {"jobs": [...], "totalResults": N, "nextItemOffset": N}
+
+    .. deprecated::
+        The snake_case keyword arguments ``farm_id``, ``queue_ids``, ``task_run_status``,
+        ``name_contains``, ``page_size`` and ``item_offset`` are deprecated in favor of the
+        camelCase ``farmId``, ``queueIds``, ``taskRunStatus``, ``nameContains``, ``pageSize``
+        and ``itemOffset``. They still work in this release but will be removed in the next
+        breaking release.
     """
     from ..config import config_file
 
-    farm_id = farm_id or config_file.get_setting("defaults.farm_id", config=config)
-    if not farm_id:
-        raise ValueError("farm_id is required (not found in config defaults)")
+    farmId = farmId or config_file.get_setting("defaults.farm_id", config=config)
+    if not farmId:
+        raise ValueError("farmId is required (not found in config defaults)")
 
-    queue_ids = queue_ids or (
+    queueIds = queueIds or (
         [q] if (q := config_file.get_setting("defaults.queue_id", config=config)) else None
     )
-    if not queue_ids:
-        raise ValueError("queue_ids is required (not found in config defaults)")
+    if not queueIds:
+        raise ValueError("queueIds is required (not found in config defaults)")
 
-    # Resolve the region only after farm_id is finalized (it may come from config defaults).
-    region = _resolve_region(config=config, region=region, farm_id=farm_id)
+    # Resolve the region only after farmId is finalized (it may come from config defaults).
+    region = _resolve_region(config=config, region=region, farm_id=farmId)
     deadline: "DeadlineClient" = get_boto3_client("deadline", config=config, region=region)
 
     # Build filter expressions
     filter_expressions: List[Dict[str, Any]] = []
 
-    if task_run_status:
+    if taskRunStatus:
         filter_expressions.append(
             {
                 "stringFilter": {
                     "name": "TASK_RUN_STATUS",
                     "operator": "EQUAL",
-                    "value": task_run_status,
+                    "value": taskRunStatus,
                 }
             }
         )
 
-    if name_contains:
+    if nameContains:
         filter_expressions.append(
             {
                 "searchTermFilter": {
-                    "searchTerm": name_contains,
+                    "searchTerm": nameContains,
                 }
             }
         )
 
     # Build request parameters
     params: Dict[str, Any] = {
-        "farmId": farm_id,
-        "queueIds": queue_ids,
-        "pageSize": min(max(page_size, 1), 100),
-        "itemOffset": min(max(item_offset, 0), 10000),
+        "farmId": farmId,
+        "queueIds": queueIds,
+        "pageSize": min(max(pageSize, 1), 100),
+        "itemOffset": min(max(itemOffset, 0), 10000),
     }
 
     if filter_expressions:

--- a/test/unit/deadline_client/api/test_mcp.py
+++ b/test/unit/deadline_client/api/test_mcp.py
@@ -128,9 +128,9 @@ class TestGetJob:
             mock_get_client.return_value = deadline_mock
 
             result = get_job(
-                farm_id=MOCK_FARM_ID,
-                queue_id=MOCK_QUEUE_ID,
-                job_id=MOCK_JOB_ID,
+                farmId=MOCK_FARM_ID,
+                queueId=MOCK_QUEUE_ID,
+                jobId=MOCK_JOB_ID,
             )
 
             assert result["jobId"] == MOCK_JOB_ID
@@ -156,10 +156,10 @@ class TestGetSession:
             mock_get_client.return_value = deadline_mock
 
             result = get_session(
-                farm_id=MOCK_FARM_ID,
-                queue_id=MOCK_QUEUE_ID,
-                job_id=MOCK_JOB_ID,
-                session_id=MOCK_SESSION_ID,
+                farmId=MOCK_FARM_ID,
+                queueId=MOCK_QUEUE_ID,
+                jobId=MOCK_JOB_ID,
+                sessionId=MOCK_SESSION_ID,
             )
 
             assert result["sessionId"] == MOCK_SESSION_ID
@@ -185,9 +185,9 @@ class TestListSessions:
             mock_get_client.return_value = deadline_mock
 
             result = list_sessions(
-                farm_id=MOCK_FARM_ID,
-                queue_id=MOCK_QUEUE_ID,
-                job_id=MOCK_JOB_ID,
+                farmId=MOCK_FARM_ID,
+                queueId=MOCK_QUEUE_ID,
+                jobId=MOCK_JOB_ID,
             )
 
             assert len(result["sessions"]) == 2
@@ -216,9 +216,9 @@ class TestListSessions:
             mock_get_client.return_value = deadline_mock
 
             result = list_sessions(
-                farm_id=MOCK_FARM_ID,
-                queue_id=MOCK_QUEUE_ID,
-                job_id=MOCK_JOB_ID,
+                farmId=MOCK_FARM_ID,
+                queueId=MOCK_QUEUE_ID,
+                jobId=MOCK_JOB_ID,
             )
 
             assert len(result["sessions"]) == 2
@@ -238,10 +238,10 @@ class TestListSessions:
             mock_get_client.return_value = deadline_mock
 
             result = list_sessions(
-                farm_id=MOCK_FARM_ID,
-                queue_id=MOCK_QUEUE_ID,
-                job_id=MOCK_JOB_ID,
-                max_results=2,
+                farmId=MOCK_FARM_ID,
+                queueId=MOCK_QUEUE_ID,
+                jobId=MOCK_JOB_ID,
+                maxResults=2,
             )
 
             assert len(result["sessions"]) == 2
@@ -261,9 +261,9 @@ class TestListSteps:
             mock_get_client.return_value = deadline_mock
 
             result = list_steps(
-                farm_id=MOCK_FARM_ID,
-                queue_id=MOCK_QUEUE_ID,
-                job_id=MOCK_JOB_ID,
+                farmId=MOCK_FARM_ID,
+                queueId=MOCK_QUEUE_ID,
+                jobId=MOCK_JOB_ID,
             )
 
             assert len(result["steps"]) == 2
@@ -288,10 +288,10 @@ class TestListTasks:
             mock_get_client.return_value = deadline_mock
 
             result = list_tasks(
-                farm_id=MOCK_FARM_ID,
-                queue_id=MOCK_QUEUE_ID,
-                job_id=MOCK_JOB_ID,
-                step_id=MOCK_STEP_ID,
+                farmId=MOCK_FARM_ID,
+                queueId=MOCK_QUEUE_ID,
+                jobId=MOCK_JOB_ID,
+                stepId=MOCK_STEP_ID,
             )
 
             assert len(result["tasks"]) == 2
@@ -317,8 +317,8 @@ class TestSearchJobs:
             mock_get_client.return_value = deadline_mock
 
             result = search_jobs(
-                farm_id=MOCK_FARM_ID,
-                queue_ids=[MOCK_QUEUE_ID],
+                farmId=MOCK_FARM_ID,
+                queueIds=[MOCK_QUEUE_ID],
             )
 
             assert len(result["jobs"]) == 2
@@ -339,9 +339,9 @@ class TestSearchJobs:
             mock_get_client.return_value = deadline_mock
 
             result = search_jobs(
-                farm_id=MOCK_FARM_ID,
-                queue_ids=[MOCK_QUEUE_ID],
-                task_run_status="FAILED",
+                farmId=MOCK_FARM_ID,
+                queueIds=[MOCK_QUEUE_ID],
+                taskRunStatus="FAILED",
             )
 
             assert len(result["jobs"]) == 2
@@ -362,9 +362,9 @@ class TestSearchJobs:
             mock_get_client.return_value = deadline_mock
 
             result = search_jobs(
-                farm_id=MOCK_FARM_ID,
-                queue_ids=[MOCK_QUEUE_ID],
-                name_contains="Render",
+                farmId=MOCK_FARM_ID,
+                queueIds=[MOCK_QUEUE_ID],
+                nameContains="Render",
             )
 
             assert len(result["jobs"]) == 2
@@ -384,10 +384,10 @@ class TestSearchJobs:
             mock_get_client.return_value = deadline_mock
 
             result = search_jobs(
-                farm_id=MOCK_FARM_ID,
-                queue_ids=[MOCK_QUEUE_ID],
-                task_run_status="FAILED",
-                name_contains="Render",
+                farmId=MOCK_FARM_ID,
+                queueIds=[MOCK_QUEUE_ID],
+                taskRunStatus="FAILED",
+                nameContains="Render",
             )
 
             assert len(result["jobs"]) == 2
@@ -407,10 +407,10 @@ class TestSearchJobs:
             mock_get_client.return_value = deadline_mock
 
             search_jobs(
-                farm_id=MOCK_FARM_ID,
-                queue_ids=[MOCK_QUEUE_ID],
-                page_size=50,
-                item_offset=100,
+                farmId=MOCK_FARM_ID,
+                queueIds=[MOCK_QUEUE_ID],
+                pageSize=50,
+                itemOffset=100,
             )
 
             call_args = deadline_mock.search_jobs.call_args
@@ -424,21 +424,21 @@ class TestSearchJobs:
             deadline_mock.search_jobs.return_value = MOCK_SEARCH_JOBS_RESPONSE
             mock_get_client.return_value = deadline_mock
 
-            # Test page_size > 100 gets clamped
+            # Test pageSize > 100 gets clamped
             search_jobs(
-                farm_id=MOCK_FARM_ID,
-                queue_ids=[MOCK_QUEUE_ID],
-                page_size=200,
+                farmId=MOCK_FARM_ID,
+                queueIds=[MOCK_QUEUE_ID],
+                pageSize=200,
             )
 
             call_args = deadline_mock.search_jobs.call_args
             assert call_args.kwargs["pageSize"] == 100
 
-            # Test page_size < 1 gets clamped
+            # Test pageSize < 1 gets clamped
             search_jobs(
-                farm_id=MOCK_FARM_ID,
-                queue_ids=[MOCK_QUEUE_ID],
-                page_size=0,
+                farmId=MOCK_FARM_ID,
+                queueIds=[MOCK_QUEUE_ID],
+                pageSize=0,
             )
 
             call_args = deadline_mock.search_jobs.call_args
@@ -468,17 +468,17 @@ class TestSearchJobs:
             )
 
     def test_search_jobs_missing_farm_id_raises(self, fresh_deadline_config):
-        """Test search_jobs raises error when farm_id is missing."""
-        with pytest.raises(ValueError, match="farm_id is required"):
+        """Test search_jobs raises error when farmId is missing."""
+        with pytest.raises(ValueError, match="farmId is required"):
             search_jobs()
 
     def test_search_jobs_missing_queue_ids_raises(self, fresh_deadline_config):
-        """Test search_jobs raises error when queue_ids is missing."""
+        """Test search_jobs raises error when queueIds is missing."""
         from deadline.client.config import config_file
 
         config_file.set_setting("defaults.farm_id", MOCK_FARM_ID)
 
-        with pytest.raises(ValueError, match="queue_ids is required"):
+        with pytest.raises(ValueError, match="queueIds is required"):
             search_jobs()
 
 
@@ -498,7 +498,7 @@ class TestMcpRegionScoping:
             mock_resolve.return_value = "eu-west-1"
             mock_get_client.return_value = MagicMock()
 
-            get_job(farm_id=MOCK_FARM_ID, queue_id=MOCK_QUEUE_ID, job_id=MOCK_JOB_ID)
+            get_job(farmId=MOCK_FARM_ID, queueId=MOCK_QUEUE_ID, jobId=MOCK_JOB_ID)
 
             mock_resolve.assert_called_once_with(config=None, region=None, farm_id=MOCK_FARM_ID)
             assert mock_get_client.call_args.kwargs.get("region") == "eu-west-1"
@@ -512,10 +512,10 @@ class TestMcpRegionScoping:
             mock_get_client.return_value = MagicMock()
 
             get_session(
-                farm_id=MOCK_FARM_ID,
-                queue_id=MOCK_QUEUE_ID,
-                job_id=MOCK_JOB_ID,
-                session_id=MOCK_SESSION_ID,
+                farmId=MOCK_FARM_ID,
+                queueId=MOCK_QUEUE_ID,
+                jobId=MOCK_JOB_ID,
+                sessionId=MOCK_SESSION_ID,
             )
 
             mock_resolve.assert_called_once_with(config=None, region=None, farm_id=MOCK_FARM_ID)
@@ -531,7 +531,7 @@ class TestMcpRegionScoping:
             deadline_mock.list_sessions.return_value = {"sessions": []}
             mock_get_client.return_value = deadline_mock
 
-            list_sessions(farm_id=MOCK_FARM_ID, queue_id=MOCK_QUEUE_ID, job_id=MOCK_JOB_ID)
+            list_sessions(farmId=MOCK_FARM_ID, queueId=MOCK_QUEUE_ID, jobId=MOCK_JOB_ID)
 
             mock_resolve.assert_called_once_with(config=None, region=None, farm_id=MOCK_FARM_ID)
             assert mock_get_client.call_args.kwargs.get("region") == "eu-west-1"
@@ -546,7 +546,7 @@ class TestMcpRegionScoping:
             deadline_mock.list_steps.return_value = {"steps": []}
             mock_get_client.return_value = deadline_mock
 
-            list_steps(farm_id=MOCK_FARM_ID, queue_id=MOCK_QUEUE_ID, job_id=MOCK_JOB_ID)
+            list_steps(farmId=MOCK_FARM_ID, queueId=MOCK_QUEUE_ID, jobId=MOCK_JOB_ID)
 
             mock_resolve.assert_called_once_with(config=None, region=None, farm_id=MOCK_FARM_ID)
             assert mock_get_client.call_args.kwargs.get("region") == "eu-west-1"
@@ -562,10 +562,10 @@ class TestMcpRegionScoping:
             mock_get_client.return_value = deadline_mock
 
             list_tasks(
-                farm_id=MOCK_FARM_ID,
-                queue_id=MOCK_QUEUE_ID,
-                job_id=MOCK_JOB_ID,
-                step_id=MOCK_STEP_ID,
+                farmId=MOCK_FARM_ID,
+                queueId=MOCK_QUEUE_ID,
+                jobId=MOCK_JOB_ID,
+                stepId=MOCK_STEP_ID,
             )
 
             mock_resolve.assert_called_once_with(config=None, region=None, farm_id=MOCK_FARM_ID)
@@ -581,7 +581,7 @@ class TestMcpRegionScoping:
             deadline_mock.search_jobs.return_value = MOCK_SEARCH_JOBS_RESPONSE
             mock_get_client.return_value = deadline_mock
 
-            search_jobs(farm_id=MOCK_FARM_ID, queue_ids=[MOCK_QUEUE_ID])
+            search_jobs(farmId=MOCK_FARM_ID, queueIds=[MOCK_QUEUE_ID])
 
             mock_resolve.assert_called_once_with(config=None, region=None, farm_id=MOCK_FARM_ID)
             assert mock_get_client.call_args.kwargs.get("region") == "eu-west-1"
@@ -596,9 +596,9 @@ class TestMcpRegionScoping:
             mock_get_client.return_value = MagicMock()
 
             get_job(
-                farm_id=MOCK_FARM_ID,
-                queue_id=MOCK_QUEUE_ID,
-                job_id=MOCK_JOB_ID,
+                farmId=MOCK_FARM_ID,
+                queueId=MOCK_QUEUE_ID,
+                jobId=MOCK_JOB_ID,
                 region="ap-south-1",
             )
 
@@ -606,3 +606,143 @@ class TestMcpRegionScoping:
                 config=None, region="ap-south-1", farm_id=MOCK_FARM_ID
             )
             assert mock_get_client.call_args.kwargs.get("region") == "ap-south-1"
+
+
+class TestDeprecatedSnakeCaseAliases:
+    """
+    The functions in this module standardized on camelCase (boto3-style) parameters. The
+    former snake_case keyword arguments remain accepted for one release, forwarding to their
+    camelCase equivalents while emitting a DeprecationWarning. These tests pin that behavior
+    so the aliases keep working until they are removed in the next breaking release.
+    """
+
+    def test_get_job_snake_case_still_works_and_warns(self):
+        with patch("deadline.client.api._mcp.get_boto3_client") as mock_get_client:
+            deadline_mock = MagicMock()
+            deadline_mock.get_job.return_value = MOCK_GET_JOB_RESPONSE
+            mock_get_client.return_value = deadline_mock
+
+            with pytest.warns(DeprecationWarning, match="farm_id"):
+                result = get_job(
+                    farm_id=MOCK_FARM_ID,
+                    queue_id=MOCK_QUEUE_ID,
+                    job_id=MOCK_JOB_ID,
+                )
+
+            assert result["jobId"] == MOCK_JOB_ID
+            # The deprecated names are translated to camelCase before hitting boto3.
+            deadline_mock.get_job.assert_called_once_with(
+                farmId=MOCK_FARM_ID,
+                queueId=MOCK_QUEUE_ID,
+                jobId=MOCK_JOB_ID,
+            )
+
+    def test_get_session_snake_case_still_works(self):
+        with patch("deadline.client.api._mcp.get_boto3_client") as mock_get_client:
+            deadline_mock = MagicMock()
+            deadline_mock.get_session.return_value = MOCK_GET_SESSION_RESPONSE
+            mock_get_client.return_value = deadline_mock
+
+            with pytest.warns(DeprecationWarning):
+                result = get_session(
+                    farm_id=MOCK_FARM_ID,
+                    queue_id=MOCK_QUEUE_ID,
+                    job_id=MOCK_JOB_ID,
+                    session_id=MOCK_SESSION_ID,
+                )
+
+            assert result["sessionId"] == MOCK_SESSION_ID
+            deadline_mock.get_session.assert_called_once_with(
+                farmId=MOCK_FARM_ID,
+                queueId=MOCK_QUEUE_ID,
+                jobId=MOCK_JOB_ID,
+                sessionId=MOCK_SESSION_ID,
+            )
+
+    def test_list_sessions_snake_case_max_results(self):
+        with patch("deadline.client.api._mcp.get_boto3_client") as mock_get_client:
+            deadline_mock = MagicMock()
+            deadline_mock.list_sessions.return_value = MOCK_LIST_SESSIONS_RESPONSE
+            mock_get_client.return_value = deadline_mock
+
+            with pytest.warns(DeprecationWarning, match="max_results"):
+                list_sessions(
+                    farm_id=MOCK_FARM_ID,
+                    queue_id=MOCK_QUEUE_ID,
+                    job_id=MOCK_JOB_ID,
+                    max_results=5,
+                )
+
+            call_args = deadline_mock.list_sessions.call_args
+            assert call_args.kwargs["farmId"] == MOCK_FARM_ID
+            assert call_args.kwargs["maxResults"] == 5
+
+    def test_list_tasks_snake_case_still_works(self):
+        with patch("deadline.client.api._mcp.get_boto3_client") as mock_get_client:
+            deadline_mock = MagicMock()
+            deadline_mock.list_tasks.return_value = MOCK_LIST_TASKS_RESPONSE
+            mock_get_client.return_value = deadline_mock
+
+            with pytest.warns(DeprecationWarning, match="step_id"):
+                list_tasks(
+                    farm_id=MOCK_FARM_ID,
+                    queue_id=MOCK_QUEUE_ID,
+                    job_id=MOCK_JOB_ID,
+                    step_id=MOCK_STEP_ID,
+                )
+
+            deadline_mock.list_tasks.assert_called_once_with(
+                farmId=MOCK_FARM_ID,
+                queueId=MOCK_QUEUE_ID,
+                jobId=MOCK_JOB_ID,
+                stepId=MOCK_STEP_ID,
+            )
+
+    def test_search_jobs_snake_case_filters(self, fresh_deadline_config):
+        with patch("deadline.client.api._mcp.get_boto3_client") as mock_get_client:
+            deadline_mock = MagicMock()
+            deadline_mock.search_jobs.return_value = MOCK_SEARCH_JOBS_RESPONSE
+            mock_get_client.return_value = deadline_mock
+
+            with pytest.warns(DeprecationWarning):
+                result = search_jobs(
+                    farm_id=MOCK_FARM_ID,
+                    queue_ids=[MOCK_QUEUE_ID],
+                    task_run_status="FAILED",
+                    name_contains="Render",
+                    page_size=50,
+                    item_offset=10,
+                )
+
+            assert len(result["jobs"]) == 2
+            call_args = deadline_mock.search_jobs.call_args
+            assert call_args.kwargs["farmId"] == MOCK_FARM_ID
+            assert call_args.kwargs["queueIds"] == [MOCK_QUEUE_ID]
+            assert call_args.kwargs["pageSize"] == 50
+            assert call_args.kwargs["itemOffset"] == 10
+            filters = call_args.kwargs["filterExpressions"]["filters"]
+            assert len(filters) == 2
+
+    def test_camel_case_does_not_warn(self, recwarn):
+        """Passing the canonical camelCase names must not emit a DeprecationWarning."""
+        with patch("deadline.client.api._mcp.get_boto3_client") as mock_get_client:
+            deadline_mock = MagicMock()
+            deadline_mock.get_job.return_value = MOCK_GET_JOB_RESPONSE
+            mock_get_client.return_value = deadline_mock
+
+            get_job(farmId=MOCK_FARM_ID, queueId=MOCK_QUEUE_ID, jobId=MOCK_JOB_ID)
+
+        assert not [w for w in recwarn.list if issubclass(w.category, DeprecationWarning)]
+
+    def test_mixing_snake_and_camel_for_same_param_raises(self):
+        """Passing both a camelCase param and its deprecated snake_case alias is an error."""
+        with patch("deadline.client.api._mcp.get_boto3_client") as mock_get_client:
+            mock_get_client.return_value = MagicMock()
+
+            with pytest.raises(TypeError, match="both 'farmId' and its deprecated alias"):
+                get_job(
+                    farmId=MOCK_FARM_ID,
+                    farm_id=MOCK_FARM_ID,
+                    queueId=MOCK_QUEUE_ID,
+                    jobId=MOCK_JOB_ID,
+                )

--- a/test/unit/deadline_client/api/test_mcp_logs.py
+++ b/test/unit/deadline_client/api/test_mcp_logs.py
@@ -65,7 +65,7 @@ def test_get_session_and_worker_logs_basic(mock_get_session, mock_session_logs, 
     assert result["worker_logs"]["count"] == 3
 
     mock_get_session.assert_called_once_with(
-        farm_id=MOCK_FARM_ID, queue_id=MOCK_QUEUE_ID, job_id=MOCK_JOB_ID, session_id=MOCK_SESSION_ID
+        farmId=MOCK_FARM_ID, queueId=MOCK_QUEUE_ID, jobId=MOCK_JOB_ID, sessionId=MOCK_SESSION_ID
     )
     mock_worker_logs.assert_called_once_with(
         farm_id=MOCK_FARM_ID, fleet_id=MOCK_FLEET_ID, worker_id=MOCK_WORKER_ID, limit=100


### PR DESCRIPTION
## What

Resolves the API-casing inconsistency reported in #1054.

`deadline.client.api` had two naming conventions across its list/get/search functions:

- `_list_apis.py` (`list_farms`, `list_queues`, `list_jobs`, `list_fleets`, `list_storage_profiles_for_queue`) — camelCase `**kwargs` passed straight through to boto3.
- `_mcp.py` (`get_job`, `get_session`, `list_sessions`, `list_steps`, `list_tasks`, `search_jobs`) — snake_case explicit parameters.

Rather than converting the camelCase functions to snake_case (as the issue floats), this PR standardizes on **camelCase**, matching boto3 and the Deadline Cloud API surface — and the functions that already use it — so the whole `deadline.client.api` list/get/search surface is consistent with the underlying service.

## How

- `_mcp.py`: the six functions now take camelCase parameters (`farmId`, `queueId`, `jobId`, `sessionId`, `stepId`, `queueIds`, `taskRunStatus`, `nameContains`, `pageSize`, `itemOffset`, `maxResults`).
- **Backward compatible this release:** a small `_accept_deprecated_snake_case` decorator keeps accepting the old snake_case keyword arguments, forwards them to their camelCase equivalents, and emits a `DeprecationWarning`. Passing both a camelCase param and its snake_case alias raises `TypeError`.
- The decorator and its alias maps are commented as **slated for removal in the next breaking release**.
- Internal MCP server updated in lockstep: `registry.py` `param_names` are now camelCase, and `tools/logs.py` calls `get_session` with camelCase.
- **Positional callers are unaffected** — parameter order is unchanged.

I checked other `aws-deadline` repos and internal code for callers using the snake_case keyword arguments: none were found. The only consumer of the snake_case contract was this repo's own MCP server (updated here); the one external caller passes positionally and keeps working.

## Testing

- New/updated unit tests cover: the camelCase path, the deprecated snake_case path (warning emitted + translated to boto3 correctly), the guarantee that camelCase does **not** warn, and the mixed-alias `TypeError`.
- Full suite: `2922 passed, 21 skipped`, coverage 76% (≥ threshold). `fmt`, `lint`/mypy, and `build` all clean.

## Note on API-change detection

The `api-change-detection` (griffe) check will flag the parameter rename as a signature change — this is expected for any public-API rename and is called out here as intentional. Runtime behavior stays backward compatible via the deprecation shim described above.

Refs #1054