### PR TITLE
feat: add build_monitor_url helper and surface job URL on submit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,13 @@ option is omitted: `verbose` at an interactive terminal, `json` otherwise
 this with the shared `_resolve_output_format()` helper and the
 `_OUTPUT_FORMAT_HELP` text rather than hand-rolling the default per command.
 
+### Cross-region: two regions are in play
+
+The farm's region (`defaults.farm_region`, used by `get_boto3_client`) can differ
+from the profile/monitor's region. Farm-scoped APIs (CreateJob etc.) need the farm
+region; monitor-scoped APIs (GetMonitor) need the profile region — don't reuse a
+client across that boundary, and test region-sensitive code with the two set differently.
+
 ### CHANGELOG.md is auto-generated — do not edit it
 
 `CHANGELOG.md` is generated automatically from conventional commit messages

--- a/src/deadline/_mcp/tools/job.py
+++ b/src/deadline/_mcp/tools/job.py
@@ -12,6 +12,7 @@ from contextlib import redirect_stdout
 from typing import Any, Dict, Optional
 
 from ...client.api import create_job_from_job_bundle
+from ...client.api._monitor_urls import _get_job_monitor_url
 from ...client.cli._groups.job_group import _download_job_output
 from ...client.config import config_file
 
@@ -117,9 +118,19 @@ def submit_job(
 
     total_time = time.time() - start_time
 
+    # Best-effort monitor URL for the job (only when using Deadline Cloud monitor
+    # credentials); None otherwise.
+    job_url = _get_job_monitor_url(
+        config=config,
+        farm_id=farm_id,
+        queue_id=queue_id,
+        job_id=job_id,
+    )
+
     return {
         "status": "success",
         "job_id": job_id,
+        "job_url": job_url,
         "message": f"Successfully submitted job bundle from {job_bundle_dir}",
         "total_time_seconds": round(total_time, 1),
     }

--- a/src/deadline/client/api/__init__.py
+++ b/src/deadline/client/api/__init__.py
@@ -33,6 +33,7 @@ __all__ = [  # noqa: RUF022  grouped by feature, not sorted
     "check_deadline_api_available",
     "get_credentials_source",
     "get_user_and_identity_store_id",
+    "get_monitor_url",
     "precache_clients",
     "list_farms",
     "list_queues",
@@ -98,6 +99,7 @@ from ._session import (
     get_credentials_source,
     get_user_and_identity_store_id,
 )
+from ._monitor_urls import get_monitor_url
 from ._list_apis import (
     list_farms,
     list_queues,

--- a/src/deadline/client/api/__init__.py
+++ b/src/deadline/client/api/__init__.py
@@ -33,7 +33,7 @@ __all__ = [  # noqa: RUF022  grouped by feature, not sorted
     "check_deadline_api_available",
     "get_credentials_source",
     "get_user_and_identity_store_id",
-    "get_monitor_url",
+    "build_monitor_url",
     "precache_clients",
     "list_farms",
     "list_queues",
@@ -99,7 +99,7 @@ from ._session import (
     get_credentials_source,
     get_user_and_identity_store_id,
 )
-from ._monitor_urls import get_monitor_url
+from ._monitor_urls import build_monitor_url
 from ._list_apis import (
     list_farms,
     list_queues,

--- a/src/deadline/client/api/_monitor_urls.py
+++ b/src/deadline/client/api/_monitor_urls.py
@@ -52,6 +52,7 @@ def build_monitor_url(
     task_id: Optional[str] = None,
     *,
     monitor_region: Optional[str] = None,
+    host: Optional[str] = None,
     config: Optional[ConfigParser] = None,
 ) -> str:
     """
@@ -110,7 +111,14 @@ def build_monitor_url(
         task_id (str, optional): The task to select. Requires ``step_id``.
         monitor_region (str, optional): The region the monitor itself lives in, used
             in the host. Defaults to ``region`` (single-region case). Pass this when
-            the farm is in a different region than the monitor.
+            the farm is in a different region than the monitor. Ignored when ``host``
+            is supplied.
+        host (str, optional): The monitor host to use verbatim (scheme + netloc, e.g.
+            ``https://mymonitor.us-east-1.deadlinecloud.amazonaws.com``), such as the
+            ``url`` returned by ``deadline:GetMonitor``. When given, it is used as-is
+            instead of reconstructing the host from ``subdomain`` + region + the
+            commercial domain -- necessary for non-commercial partitions (aws-us-gov,
+            aws-cn) whose hosts differ. A trailing slash is stripped.
         config (ConfigParser, optional): The AWS Deadline Cloud configuration object
             to use when resolving the region.
 
@@ -140,11 +148,18 @@ def build_monitor_url(
             "A region is required to build a monitor URL. Pass region= explicitly or "
             "configure defaults.farm_region."
         )
-    # The host uses the monitor's own region, which may differ from the farm's
-    # (cross-region). Default to the farm region for the common single-region case.
-    host_region = monitor_region or resolved_region
-
-    host = f"https://{subdomain}.{host_region}.{_MONITOR_DOMAIN}"
+    # Prefer an authoritative host when the caller has one (the ``url`` from
+    # ``deadline:GetMonitor``). Reconstructing from the hardcoded commercial domain
+    # would produce a wrong host in other partitions (aws-us-gov, aws-cn), where the
+    # real monitor host does not end in ``deadlinecloud.amazonaws.com``. When no host
+    # is supplied, fall back to building one from the monitor's own region -- which
+    # may differ from the farm's (cross-region) -- defaulting to the farm region for
+    # the common single-region case.
+    if host:
+        host = host.rstrip("/")
+    else:
+        host_region = monitor_region or resolved_region
+        host = f"https://{subdomain}.{host_region}.{_MONITOR_DOMAIN}"
 
     # No farm -> the "all farms" list, which is not region-scoped in the path.
     if not farm_id:
@@ -186,32 +201,48 @@ def _parse_monitor_host(url: Optional[str]) -> tuple[Optional[str], Optional[str
     return subdomain, region
 
 
+def _monitor_host_of(url: Optional[str]) -> Optional[str]:
+    """
+    Extract the ``scheme://netloc`` host from a monitor ``url``, or ``None`` when the
+    url is missing or has no host. Unlike :func:`_parse_monitor_host` this makes no
+    assumptions about the domain, so it works in every partition (aws-us-gov, aws-cn).
+    """
+    if not url:
+        return None
+    parts = urlsplit(url)
+    if not parts.scheme or not parts.netloc:
+        return None
+    return f"{parts.scheme}://{parts.netloc}"
+
+
 def _get_monitor_subdomain(
     config: Optional[ConfigParser] = None,
     deadline_client: Optional[BaseClient] = None,
-) -> tuple[Optional[str], Optional[str]]:
+) -> tuple[Optional[str], Optional[str], Optional[str]]:
     """
-    Best-effort lookup of the monitor ``(subdomain, monitor_region)`` for the
+    Best-effort lookup of the monitor ``(subdomain, monitor_region, host)`` for the
     current profile.
 
-    Returns the subdomain and the monitor's own region only when the credentials
-    were written by Deadline Cloud monitor (so a monitor exists to link to) and the
-    ``deadline:GetMonitor`` call returns a usable ``subdomain``. Returns
-    ``(None, None)`` otherwise. The region is parsed from the monitor's ``url`` and
-    may be ``None`` if that field is absent or malformed. Never raises.
+    Returns these only when the credentials were written by Deadline Cloud monitor (so
+    a monitor exists to link to) and the ``deadline:GetMonitor`` call returns a usable
+    ``subdomain``. Returns ``(None, None, None)`` otherwise. ``host`` is the
+    authoritative ``scheme://netloc`` from the monitor's ``url`` (preferred over a
+    reconstructed host); ``monitor_region`` is parsed from that same url. Either may be
+    ``None`` if the ``url`` field is absent or malformed. Never raises.
     """
     if get_credentials_source(config=config) != AwsCredentialsSource.DEADLINE_CLOUD_MONITOR_LOGIN:
-        return None, None
+        return None, None, None
     monitor_id = get_monitor_id(config=config)
     if not monitor_id:
-        return None, None
+        return None, None, None
     client = deadline_client or get_boto3_client("deadline", config=config)
     monitor = client.get_monitor(monitorId=monitor_id)
     subdomain = monitor.get("subdomain")
     if not subdomain:
-        return None, None
-    _, monitor_region = _parse_monitor_host(monitor.get("url"))
-    return subdomain, monitor_region
+        return None, None, None
+    url = monitor.get("url")
+    _, monitor_region = _parse_monitor_host(url)
+    return subdomain, monitor_region, _monitor_host_of(url)
 
 
 def _get_job_monitor_url(
@@ -231,7 +262,7 @@ def _get_job_monitor_url(
     itself.
     """
     try:
-        subdomain, monitor_region = _get_monitor_subdomain(
+        subdomain, monitor_region, monitor_host = _get_monitor_subdomain(
             config=config, deadline_client=deadline_client
         )
         if not subdomain:
@@ -240,6 +271,9 @@ def _get_job_monitor_url(
         # back to the monitor's own region (correct for the common single-region
         # case, where farm_region is often not configured at all).
         resource_region = _resolve_region(config=config) or monitor_region
+        # Prefer the authoritative host from GetMonitor so the URL is correct in every
+        # partition (aws-us-gov, aws-cn); build_monitor_url falls back to reconstructing
+        # it from subdomain + region when the monitor url was absent/malformed.
         return build_monitor_url(
             subdomain,
             region=resource_region,
@@ -247,6 +281,7 @@ def _get_job_monitor_url(
             queue_id=queue_id,
             job_id=job_id,
             monitor_region=monitor_region,
+            host=monitor_host,
             config=config,
         )
     except Exception:

--- a/src/deadline/client/api/_monitor_urls.py
+++ b/src/deadline/client/api/_monitor_urls.py
@@ -30,9 +30,10 @@ from botocore.client import BaseClient  # type: ignore[import]
 from ._session import (
     AwsCredentialsSource,
     _resolve_region,
-    get_boto3_client,
+    get_boto3_session,
     get_credentials_source,
     get_monitor_id,
+    get_session_client,
 )
 
 __all__ = ["build_monitor_url"]
@@ -215,9 +216,20 @@ def _monitor_host_of(url: Optional[str]) -> Optional[str]:
     return f"{parts.scheme}://{parts.netloc}"
 
 
+def _get_monitor_client(config: Optional[ConfigParser] = None) -> BaseClient:
+    """
+    A deadline client for calling ``deadline:GetMonitor``, scoped to the profile's own
+    region -- where Deadline Cloud monitor wrote the profile, i.e. the monitor's home
+    region. Deliberately not ``get_boto3_client``, whose region resolution prefers
+    ``defaults.farm_region``: a monitor is a regional resource, and in a cross-region
+    setup a farm-region endpoint would report the monitor as not found.
+    """
+    session = get_boto3_session(config=config)
+    return get_session_client(session=session, service_name="deadline")
+
+
 def _get_monitor_subdomain(
     config: Optional[ConfigParser] = None,
-    deadline_client: Optional[BaseClient] = None,
 ) -> tuple[Optional[str], Optional[str], Optional[str]]:
     """
     Best-effort lookup of the monitor ``(subdomain, monitor_region, host)`` for the
@@ -235,8 +247,7 @@ def _get_monitor_subdomain(
     monitor_id = get_monitor_id(config=config)
     if not monitor_id:
         return None, None, None
-    client = deadline_client or get_boto3_client("deadline", config=config)
-    monitor = client.get_monitor(monitorId=monitor_id)
+    monitor = _get_monitor_client(config=config).get_monitor(monitorId=monitor_id)
     subdomain = monitor.get("subdomain")
     if not subdomain:
         return None, None, None
@@ -250,7 +261,6 @@ def _get_job_monitor_url(
     farm_id: Optional[str] = None,
     queue_id: Optional[str] = None,
     job_id: Optional[str] = None,
-    deadline_client: Optional[BaseClient] = None,
 ) -> Optional[str]:
     """
     Best-effort monitor URL for a just-submitted job.
@@ -260,11 +270,13 @@ def _get_job_monitor_url(
     ``deadline:GetMonitor`` call fails or returns no subdomain, or a region can't be
     resolved. This keeps URL generation from ever interfering with job submission
     itself.
+
+    Note there is deliberately no way to supply a deadline client: the ``GetMonitor``
+    lookup must run against the monitor's home region (the profile region), while
+    clients used for submission are scoped to the farm's region, which can differ.
     """
     try:
-        subdomain, monitor_region, monitor_host = _get_monitor_subdomain(
-            config=config, deadline_client=deadline_client
-        )
+        subdomain, monitor_region, monitor_host = _get_monitor_subdomain(config=config)
         if not subdomain:
             return None
         # Resource (path) region: the configured farm region if set, otherwise fall

--- a/src/deadline/client/api/_monitor_urls.py
+++ b/src/deadline/client/api/_monitor_urls.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 from configparser import ConfigParser
 from typing import Optional
-from urllib.parse import quote, urlencode
+from urllib.parse import quote, urlencode, urlsplit
 
 from botocore.client import BaseClient  # type: ignore[import]
 
@@ -51,6 +51,7 @@ def get_monitor_url(
     step_id: Optional[str] = None,
     task_id: Optional[str] = None,
     *,
+    monitor_region: Optional[str] = None,
     config: Optional[ConfigParser] = None,
 ) -> str:
     """
@@ -61,6 +62,12 @@ def get_monitor_url(
     ``<subdomain>.<region>.deadlinecloud.amazonaws.com`` and can be read from the
     ``deadline:GetMonitor`` API (its ``subdomain`` field) or the Deadline Cloud
     console.
+
+    Two regions are involved and may differ for a cross-region farm: the
+    *monitor* region appears in the host, while the *farm* (resource) region
+    appears in the path. ``monitor_region`` controls the host; ``region``
+    controls the path. When ``monitor_region`` is omitted it defaults to
+    ``region`` -- the common single-region case, where both are the same.
 
     The resource identifiers form a hierarchy -- ``queue_id`` requires ``farm_id``,
     ``job_id`` requires ``queue_id``, ``step_id`` requires ``job_id``, and
@@ -82,18 +89,28 @@ def get_monitor_url(
             farm_id="farm-1234", queue_id="queue-5678",
             job_id="job-9abc", step_id="step-def0", task_id="task-def0-2",
         )
+
+        # Cross-region: a monitor in us-east-1 linking to a farm in eu-west-1
+        get_monitor_url(
+            "mymonitor", "eu-west-1", farm_id="farm-1234", monitor_region="us-east-1"
+        )
+        # 'https://mymonitor.us-east-1.deadlinecloud.amazonaws.com/eu-west-1/farms/farm-1234'
         ```
 
     Args:
         subdomain (str): The monitor subdomain (required).
-        region (str, optional): The AWS region of the resource. When omitted, it is
-            resolved the same way as elsewhere in the client: an explicit value wins,
-            otherwise the ``defaults.farm_region`` setting is used.
+        region (str, optional): The AWS region of the resource (farm). Used in the
+            URL path. When omitted, it is resolved the same way as elsewhere in the
+            client: an explicit value wins, otherwise the ``defaults.farm_region``
+            setting is used.
         farm_id (str, optional): The farm to link to.
         queue_id (str, optional): The queue to link to. Requires ``farm_id``.
         job_id (str, optional): The job to select. Requires ``queue_id``.
         step_id (str, optional): The step to select. Requires ``job_id``.
         task_id (str, optional): The task to select. Requires ``step_id``.
+        monitor_region (str, optional): The region the monitor itself lives in, used
+            in the host. Defaults to ``region`` (single-region case). Pass this when
+            the farm is in a different region than the monitor.
         config (ConfigParser, optional): The AWS Deadline Cloud configuration object
             to use when resolving the region.
 
@@ -123,8 +140,11 @@ def get_monitor_url(
             "A region is required to build a monitor URL. Pass region= explicitly or "
             "configure defaults.farm_region."
         )
+    # The host uses the monitor's own region, which may differ from the farm's
+    # (cross-region). Default to the farm region for the common single-region case.
+    host_region = monitor_region or resolved_region
 
-    host = f"https://{subdomain}.{resolved_region}.{_MONITOR_DOMAIN}"
+    host = f"https://{subdomain}.{host_region}.{_MONITOR_DOMAIN}"
 
     # No farm -> the "all farms" list, which is not region-scoped in the path.
     if not farm_id:
@@ -145,25 +165,53 @@ def get_monitor_url(
     return host + path
 
 
+def _parse_monitor_host(url: Optional[str]) -> tuple[Optional[str], Optional[str]]:
+    """
+    Parse ``(subdomain, region)`` out of a monitor URL of the form
+    ``https://<subdomain>.<region>.deadlinecloud.amazonaws.com``.
+
+    Returns ``(None, None)`` if the URL is missing or doesn't match that shape.
+    """
+    if not url:
+        return None, None
+    host = urlsplit(url).netloc or url
+    suffix = "." + _MONITOR_DOMAIN
+    if not host.endswith(suffix):
+        return None, None
+    label = host[: -len(suffix)]
+    # label is "<subdomain>.<region>"
+    subdomain, _, region = label.partition(".")
+    if not subdomain or not region:
+        return None, None
+    return subdomain, region
+
+
 def _get_monitor_subdomain(
     config: Optional[ConfigParser] = None,
     deadline_client: Optional[BaseClient] = None,
-) -> Optional[str]:
+) -> tuple[Optional[str], Optional[str]]:
     """
-    Best-effort lookup of the monitor subdomain for the current profile.
+    Best-effort lookup of the monitor ``(subdomain, monitor_region)`` for the
+    current profile.
 
-    Returns the subdomain only when the credentials were written by Deadline Cloud
-    monitor (so a monitor exists to link to) and the ``deadline:GetMonitor`` call
-    succeeds. Returns ``None`` otherwise. Never raises.
+    Returns the subdomain and the monitor's own region only when the credentials
+    were written by Deadline Cloud monitor (so a monitor exists to link to) and the
+    ``deadline:GetMonitor`` call returns a usable ``subdomain``. Returns
+    ``(None, None)`` otherwise. The region is parsed from the monitor's ``url`` and
+    may be ``None`` if that field is absent or malformed. Never raises.
     """
     if get_credentials_source(config=config) != AwsCredentialsSource.DEADLINE_CLOUD_MONITOR_LOGIN:
-        return None
+        return None, None
     monitor_id = get_monitor_id(config=config)
     if not monitor_id:
-        return None
+        return None, None
     client = deadline_client or get_boto3_client("deadline", config=config)
     monitor = client.get_monitor(monitorId=monitor_id)
-    return monitor.get("subdomain")
+    subdomain = monitor.get("subdomain")
+    if not subdomain:
+        return None, None
+    _, monitor_region = _parse_monitor_host(monitor.get("url"))
+    return subdomain, monitor_region
 
 
 def _get_job_monitor_url(
@@ -178,18 +226,27 @@ def _get_job_monitor_url(
 
     Returns ``None`` (rather than raising) whenever the URL can't be built -- for
     example when the credentials didn't come from Deadline Cloud monitor, the
-    ``deadline:GetMonitor`` call fails, or a region can't be resolved. This keeps
-    URL generation from ever interfering with job submission itself.
+    ``deadline:GetMonitor`` call fails or returns no subdomain, or a region can't be
+    resolved. This keeps URL generation from ever interfering with job submission
+    itself.
     """
     try:
-        subdomain = _get_monitor_subdomain(config=config, deadline_client=deadline_client)
+        subdomain, monitor_region = _get_monitor_subdomain(
+            config=config, deadline_client=deadline_client
+        )
         if not subdomain:
             return None
+        # Resource (path) region: the configured farm region if set, otherwise fall
+        # back to the monitor's own region (correct for the common single-region
+        # case, where farm_region is often not configured at all).
+        resource_region = _resolve_region(config=config) or monitor_region
         return get_monitor_url(
             subdomain,
+            region=resource_region,
             farm_id=farm_id,
             queue_id=queue_id,
             job_id=job_id,
+            monitor_region=monitor_region,
             config=config,
         )
     except Exception:

--- a/src/deadline/client/api/_monitor_urls.py
+++ b/src/deadline/client/api/_monitor_urls.py
@@ -1,0 +1,196 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Helpers for constructing AWS Deadline Cloud monitor (web console) URLs.
+
+The primary entry point, :func:`get_monitor_url`, is a pure URL *formatter*: it
+takes the pieces of a resource path and returns the corresponding monitor URL.
+It never makes network calls -- the caller must supply the monitor ``subdomain``
+(available from the ``deadline:GetMonitor`` API's ``subdomain``/``url`` fields,
+or the Deadline Cloud console under Monitor details).
+
+The full host of a monitor is ``subdomain.Region.deadlinecloud.amazonaws.com``.
+Resource paths mirror the routes the monitor web app itself uses:
+
+- All farms:  ``/farms``
+- Farm:       ``/<region>/farms/<farm_id>``
+- Queue:      ``/<region>/farms/<farm_id>/queues/<queue_id>``
+- A job/step/task is selected on the queue page via ``jobId``/``stepId``/``taskId``
+  query parameters.
+"""
+
+from __future__ import annotations
+
+from configparser import ConfigParser
+from typing import Optional
+from urllib.parse import quote, urlencode
+
+from botocore.client import BaseClient  # type: ignore[import]
+
+from ._session import (
+    AwsCredentialsSource,
+    _resolve_region,
+    get_boto3_client,
+    get_credentials_source,
+    get_monitor_id,
+)
+
+__all__ = ["get_monitor_url"]
+
+# The parent domain shared by every Deadline Cloud monitor. The full monitor
+# host is "<subdomain>.<region>.<_MONITOR_DOMAIN>".
+_MONITOR_DOMAIN = "deadlinecloud.amazonaws.com"
+
+
+def get_monitor_url(
+    subdomain: str,
+    region: Optional[str] = None,
+    farm_id: Optional[str] = None,
+    queue_id: Optional[str] = None,
+    job_id: Optional[str] = None,
+    step_id: Optional[str] = None,
+    task_id: Optional[str] = None,
+    *,
+    config: Optional[ConfigParser] = None,
+) -> str:
+    """
+    Builds the AWS Deadline Cloud monitor URL for a resource.
+
+    This is a pure formatter and makes no network calls. The ``subdomain`` is
+    required; it is the monitor-specific label in the host
+    ``<subdomain>.<region>.deadlinecloud.amazonaws.com`` and can be read from the
+    ``deadline:GetMonitor`` API (its ``subdomain`` field) or the Deadline Cloud
+    console.
+
+    The resource identifiers form a hierarchy -- ``queue_id`` requires ``farm_id``,
+    ``job_id`` requires ``queue_id``, ``step_id`` requires ``job_id``, and
+    ``task_id`` requires ``step_id``. Supplying a lower-level id without its
+    parent (for example a ``queue_id`` with no ``farm_id``) raises ``ValueError``.
+    With ``farm_id`` omitted the URL points at the "all farms" list.
+
+    Example:
+        ```python
+        from deadline.client.api import get_monitor_url
+
+        # Queue URL
+        get_monitor_url("mymonitor", "us-east-1", farm_id="farm-1234", queue_id="queue-5678")
+        # 'https://mymonitor.us-east-1.deadlinecloud.amazonaws.com/us-east-1/farms/farm-1234/queues/queue-5678'
+
+        # Task URL (job + step + task selected on the queue page)
+        get_monitor_url(
+            "mymonitor", "us-east-1",
+            farm_id="farm-1234", queue_id="queue-5678",
+            job_id="job-9abc", step_id="step-def0", task_id="task-def0-2",
+        )
+        ```
+
+    Args:
+        subdomain (str): The monitor subdomain (required).
+        region (str, optional): The AWS region of the resource. When omitted, it is
+            resolved the same way as elsewhere in the client: an explicit value wins,
+            otherwise the ``defaults.farm_region`` setting is used.
+        farm_id (str, optional): The farm to link to.
+        queue_id (str, optional): The queue to link to. Requires ``farm_id``.
+        job_id (str, optional): The job to select. Requires ``queue_id``.
+        step_id (str, optional): The step to select. Requires ``job_id``.
+        task_id (str, optional): The task to select. Requires ``step_id``.
+        config (ConfigParser, optional): The AWS Deadline Cloud configuration object
+            to use when resolving the region.
+
+    Returns:
+        str: The fully-qualified monitor URL.
+
+    Raises:
+        ValueError: If ``subdomain`` is empty, the resource hierarchy is violated,
+            or no region can be resolved.
+    """
+    if not subdomain:
+        raise ValueError("A monitor subdomain is required to build a monitor URL.")
+
+    # Validate the resource hierarchy: each id requires its parent.
+    if queue_id and not farm_id:
+        raise ValueError("queue_id requires farm_id to build a monitor URL.")
+    if job_id and not queue_id:
+        raise ValueError("job_id requires queue_id to build a monitor URL.")
+    if step_id and not job_id:
+        raise ValueError("step_id requires job_id to build a monitor URL.")
+    if task_id and not step_id:
+        raise ValueError("task_id requires step_id to build a monitor URL.")
+
+    resolved_region = _resolve_region(config=config, region=region)
+    if not resolved_region:
+        raise ValueError(
+            "A region is required to build a monitor URL. Pass region= explicitly or "
+            "configure defaults.farm_region."
+        )
+
+    host = f"https://{subdomain}.{resolved_region}.{_MONITOR_DOMAIN}"
+
+    # No farm -> the "all farms" list, which is not region-scoped in the path.
+    if not farm_id:
+        return f"{host}/farms"
+
+    path = f"/{resolved_region}/farms/{quote(farm_id)}"
+    if queue_id:
+        path += f"/queues/{quote(queue_id)}"
+        # A job/step/task is selected on the queue page via query parameters.
+        query = [
+            (key, value)
+            for key, value in (("jobId", job_id), ("stepId", step_id), ("taskId", task_id))
+            if value
+        ]
+        if query:
+            path += "?" + urlencode(query)
+
+    return host + path
+
+
+def _get_monitor_subdomain(
+    config: Optional[ConfigParser] = None,
+    deadline_client: Optional[BaseClient] = None,
+) -> Optional[str]:
+    """
+    Best-effort lookup of the monitor subdomain for the current profile.
+
+    Returns the subdomain only when the credentials were written by Deadline Cloud
+    monitor (so a monitor exists to link to) and the ``deadline:GetMonitor`` call
+    succeeds. Returns ``None`` otherwise. Never raises.
+    """
+    if get_credentials_source(config=config) != AwsCredentialsSource.DEADLINE_CLOUD_MONITOR_LOGIN:
+        return None
+    monitor_id = get_monitor_id(config=config)
+    if not monitor_id:
+        return None
+    client = deadline_client or get_boto3_client("deadline", config=config)
+    monitor = client.get_monitor(monitorId=monitor_id)
+    return monitor.get("subdomain")
+
+
+def _get_job_monitor_url(
+    config: Optional[ConfigParser] = None,
+    farm_id: Optional[str] = None,
+    queue_id: Optional[str] = None,
+    job_id: Optional[str] = None,
+    deadline_client: Optional[BaseClient] = None,
+) -> Optional[str]:
+    """
+    Best-effort monitor URL for a just-submitted job.
+
+    Returns ``None`` (rather than raising) whenever the URL can't be built -- for
+    example when the credentials didn't come from Deadline Cloud monitor, the
+    ``deadline:GetMonitor`` call fails, or a region can't be resolved. This keeps
+    URL generation from ever interfering with job submission itself.
+    """
+    try:
+        subdomain = _get_monitor_subdomain(config=config, deadline_client=deadline_client)
+        if not subdomain:
+            return None
+        return get_monitor_url(
+            subdomain,
+            farm_id=farm_id,
+            queue_id=queue_id,
+            job_id=job_id,
+            config=config,
+        )
+    except Exception:
+        return None

--- a/src/deadline/client/api/_monitor_urls.py
+++ b/src/deadline/client/api/_monitor_urls.py
@@ -3,7 +3,7 @@
 """
 Helpers for constructing AWS Deadline Cloud monitor (web console) URLs.
 
-The primary entry point, :func:`get_monitor_url`, is a pure URL *formatter*: it
+The primary entry point, :func:`build_monitor_url`, is a pure URL *formatter*: it
 takes the pieces of a resource path and returns the corresponding monitor URL.
 It never makes network calls -- the caller must supply the monitor ``subdomain``
 (available from the ``deadline:GetMonitor`` API's ``subdomain``/``url`` fields,
@@ -35,14 +35,14 @@ from ._session import (
     get_monitor_id,
 )
 
-__all__ = ["get_monitor_url"]
+__all__ = ["build_monitor_url"]
 
 # The parent domain shared by every Deadline Cloud monitor. The full monitor
 # host is "<subdomain>.<region>.<_MONITOR_DOMAIN>".
 _MONITOR_DOMAIN = "deadlinecloud.amazonaws.com"
 
 
-def get_monitor_url(
+def build_monitor_url(
     subdomain: str,
     region: Optional[str] = None,
     farm_id: Optional[str] = None,
@@ -77,21 +77,21 @@ def get_monitor_url(
 
     Example:
         ```python
-        from deadline.client.api import get_monitor_url
+        from deadline.client.api import build_monitor_url
 
         # Queue URL
-        get_monitor_url("mymonitor", "us-east-1", farm_id="farm-1234", queue_id="queue-5678")
+        build_monitor_url("mymonitor", "us-east-1", farm_id="farm-1234", queue_id="queue-5678")
         # 'https://mymonitor.us-east-1.deadlinecloud.amazonaws.com/us-east-1/farms/farm-1234/queues/queue-5678'
 
         # Task URL (job + step + task selected on the queue page)
-        get_monitor_url(
+        build_monitor_url(
             "mymonitor", "us-east-1",
             farm_id="farm-1234", queue_id="queue-5678",
             job_id="job-9abc", step_id="step-def0", task_id="task-def0-2",
         )
 
         # Cross-region: a monitor in us-east-1 linking to a farm in eu-west-1
-        get_monitor_url(
+        build_monitor_url(
             "mymonitor", "eu-west-1", farm_id="farm-1234", monitor_region="us-east-1"
         )
         # 'https://mymonitor.us-east-1.deadlinecloud.amazonaws.com/eu-west-1/farms/farm-1234'
@@ -240,7 +240,7 @@ def _get_job_monitor_url(
         # back to the monitor's own region (correct for the common single-region
         # case, where farm_region is often not configured at all).
         resource_region = _resolve_region(config=config) or monitor_region
-        return get_monitor_url(
+        return build_monitor_url(
             subdomain,
             region=resource_region,
             farm_id=farm_id,

--- a/src/deadline/client/api/_submit_job_bundle.py
+++ b/src/deadline/client/api/_submit_job_bundle.py
@@ -1078,13 +1078,14 @@ def create_job_from_job_bundle(
 
         # When the credentials came from Deadline Cloud monitor, also surface the
         # monitor URL for the job so it can be shared (e.g. in a notification).
-        # This is best-effort and never affects the submission result.
+        # This is best-effort and never affects the submission result. The submission
+        # client is intentionally not reused here: it is scoped to the farm's region,
+        # while the GetMonitor lookup must go to the monitor's own (profile) region.
         job_url = _get_job_monitor_url(
             config=config,
             farm_id=farm_id,
             queue_id=queue_id,
             job_id=job_id,
-            deadline_client=deadline,
         )
         if job_url:
             print_function_callback(f"Job URL: {job_url}")

--- a/src/deadline/client/api/_submit_job_bundle.py
+++ b/src/deadline/client/api/_submit_job_bundle.py
@@ -65,6 +65,7 @@ from ...job_attachments.progress_tracker import (
 )
 from ...job_attachments.upload import S3AssetManager
 from ._session import session_context
+from ._monitor_urls import _get_job_monitor_url
 from ...job_attachments._path_summarization import (
     human_readable_file_size,
     summarize_path_list,
@@ -1074,6 +1075,19 @@ def create_job_from_job_bundle(
         print_function_callback("Submitted job bundle:")
         print_function_callback(f"   {job_bundle_dir}")
         print_function_callback(status_message + f"\n{job_id}")
+
+        # When the credentials came from Deadline Cloud monitor, also surface the
+        # monitor URL for the job so it can be shared (e.g. in a notification).
+        # This is best-effort and never affects the submission result.
+        job_url = _get_job_monitor_url(
+            config=config,
+            farm_id=farm_id,
+            queue_id=queue_id,
+            job_id=job_id,
+            deadline_client=deadline,
+        )
+        if job_url:
+            print_function_callback(f"Job URL: {job_url}")
 
         # Execute post-submission hooks
         if has_post_submission_hooks:

--- a/src/deadline/client/cli/_groups/bundle_group.py
+++ b/src/deadline/client/cli/_groups/bundle_group.py
@@ -20,6 +20,7 @@ import click
 from botocore.exceptions import ClientError
 
 from ... import api
+from ...api._monitor_urls import _get_job_monitor_url
 from ...config import config_file
 from ...dataclasses import SubmitterInfo
 from ....job_attachments.exceptions import (
@@ -508,11 +509,22 @@ def bundle_gui_submit(
 
         app.exec()
 
+        job_url = None
+        if submitter.job_id:
+            # Best-effort monitor URL (only when using Deadline Cloud monitor
+            # credentials). The GUI submitter uses the default config.
+            job_url = _get_job_monitor_url(
+                farm_id=config_file.get_setting("defaults.farm_id"),
+                queue_id=config_file.get_setting("defaults.queue_id"),
+                job_id=submitter.job_id,
+            )
+
         _print_response(
             output=output,
             job_bundle_dir=job_bundle_dir,
             job_history_bundle_dir=submitter.job_history_bundle_dir,
             job_id=submitter.job_id,
+            job_url=job_url,
         )
 
 
@@ -521,6 +533,7 @@ def _print_response(
     job_bundle_dir: str,
     job_history_bundle_dir: Optional[str],
     job_id: Optional[str],
+    job_url: Optional[str] = None,
 ):
     if output == "json":
         if job_id:
@@ -529,6 +542,8 @@ def _print_response(
                 "jobId": job_id,
                 "jobHistoryBundleDirectory": job_history_bundle_dir,
             }
+            if job_url:
+                response["jobUrl"] = job_url
             click.echo(json.dumps(response))
         else:
             click.echo(json.dumps({"status": "CANCELED"}))
@@ -537,5 +552,7 @@ def _print_response(
             click.echo("Submitted job bundle:")
             click.echo(f"   {job_bundle_dir}")
             click.echo(f"Job ID: {job_id}")
+            if job_url:
+                click.echo(f"Job URL: {job_url}")
         else:
             click.echo("Job submission canceled.")

--- a/test/_common/mock_deadline_backend.py
+++ b/test/_common/mock_deadline_backend.py
@@ -85,6 +85,7 @@ class MockDeadlineBackend:
         self.sessions: dict[tuple, dict] = {}
         self.session_actions: dict[tuple, dict] = {}
         self.storage_profiles: dict[tuple, dict] = {}
+        self.monitors: dict[str, dict] = {}  # monitorId -> monitor
         self.call_counts: dict[str, int] = {}
         self.batch_call_sizes: dict[str, list[int]] = {}
         self._job_environments: dict[str, list[str]] = {}  # job_id -> [env_name, ...]
@@ -106,6 +107,7 @@ class MockDeadlineBackend:
         self.tasks.clear()
         self.sessions.clear()
         self.session_actions.clear()
+        self.monitors.clear()
         self.call_counts.clear()
         self.batch_call_sizes.clear()
         self._job_environments.clear()
@@ -283,6 +285,40 @@ class MockDeadlineBackend:
         params.update(kwargs)
         self._validate("ListFarms", params)
         return {"farms": list(self.farms.values())}
+
+    # ========== Monitor APIs ==========
+
+    def create_monitor(
+        self,
+        *,
+        subdomain: str,
+        region: str = "us-west-2",
+        displayName: str = "Test Monitor",
+        **kwargs,
+    ) -> dict:
+        """Seed a monitor. Not an HTTP route (no CreateMonitor call is made by the
+        client under test); tests use this to set up GetMonitor responses."""
+        monitor_id = self._gen_id("monitor")
+        self.monitors[monitor_id] = {
+            "monitorId": monitor_id,
+            "displayName": displayName,
+            "subdomain": subdomain,
+            "url": f"https://{subdomain}.{region}.deadlinecloud.amazonaws.com",
+            "roleArn": "arn:aws:iam::123456789012:role/MonitorRole",
+            "identityCenterInstanceArn": "arn:aws:sso:::instance/ssoins-mock",
+            "identityCenterApplicationArn": "arn:aws:sso::123456789012:application/ssoins-mock/apl-mock",
+            "createdAt": self._now(),
+            "createdBy": "mock-user",
+            **kwargs,
+        }
+        return self.monitors[monitor_id]
+
+    @route("GET", "/monitors/{monitorId}", "GetMonitor")
+    def get_monitor(self, *, monitorId: str) -> dict:
+        self._validate("GetMonitor", {"monitorId": monitorId})
+        if monitorId not in self.monitors:
+            raise _resource_not_found("monitor", monitorId, "GetMonitor")
+        return self.monitors[monitorId]
 
     # ========== Queue APIs ==========
 

--- a/test/cli_e2e/conftest.py
+++ b/test/cli_e2e/conftest.py
@@ -200,6 +200,34 @@ def seeded_farm_queue(deadline_env, s3_client) -> tuple:
     return backend, farm_id, queue_id, env
 
 
+def set_monitor_profile(env: dict, *, monitor_id: str, region: str = REGION) -> str:
+    """
+    Write a Deadline Cloud monitor-style AWS profile into the subprocess's
+    isolated ``~/.aws/config`` and point the CLI at it.
+
+    The profile carries a ``monitor_id`` (the marker the client uses to detect a
+    Deadline Cloud monitor login). Selecting a named profile disables botocore's
+    env-var credential provider, so the profile also carries the static test
+    credentials inline (a real Deadline Cloud monitor profile would instead use a
+    ``credential_process``). Returns the profile name.
+    """
+    profile_name = "dcm-monitor"
+    aws_dir = Path(env["HOME"]) / ".aws"
+    aws_dir.mkdir(parents=True, exist_ok=True)
+    (aws_dir / "config").write_text(
+        f"[profile {profile_name}]\n"
+        f"region = {region}\n"
+        f"monitor_id = {monitor_id}\n"
+        f"aws_access_key_id = {ACCESS_KEY}\n"
+        f"aws_secret_access_key = {SECRET_KEY}\n"
+        "user_id = user-1234\n"
+        "identity_store_id = d-abcdef0123\n"
+    )
+    r = run_deadline(env, "config", "set", "defaults.aws_profile_name", profile_name)
+    assert r.returncode == 0, f"set aws_profile_name failed: {r.stderr}"
+    return profile_name
+
+
 # ---- helpers exposed to tests ----------------------------------------------
 
 
@@ -236,3 +264,10 @@ def run_cli():
 def configure_cli_defaults():
     """Returns a `configure(env, farm_id=..., queue_id=...)` callable."""
     return configure_defaults
+
+
+@pytest.fixture
+def set_cli_monitor_profile():
+    """Returns a `set(env, monitor_id=..., region=...)` callable that writes a
+    Deadline Cloud monitor AWS profile and selects it."""
+    return set_monitor_profile

--- a/test/cli_e2e/conftest.py
+++ b/test/cli_e2e/conftest.py
@@ -202,8 +202,12 @@ def seeded_farm_queue(deadline_env, s3_client) -> tuple:
 
 def set_monitor_profile(env: dict, *, monitor_id: str, region: str = REGION) -> str:
     """
-    Write a Deadline Cloud monitor-style AWS profile into the subprocess's
-    isolated ``~/.aws/config`` and point the CLI at it.
+    Write a Deadline Cloud monitor-style AWS profile and point the CLI at it.
+
+    The profile is written to an explicit file wired in via ``AWS_CONFIG_FILE``
+    (mutating ``env``) rather than ``~/.aws/config``: boto3 resolves the default
+    location from ``%USERPROFILE%`` on Windows, which the subprocess env doesn't
+    set, so an explicit path is portable across platforms.
 
     The profile carries a ``monitor_id`` (the marker the client uses to detect a
     Deadline Cloud monitor login). Selecting a named profile disables botocore's
@@ -214,7 +218,8 @@ def set_monitor_profile(env: dict, *, monitor_id: str, region: str = REGION) -> 
     profile_name = "dcm-monitor"
     aws_dir = Path(env["HOME"]) / ".aws"
     aws_dir.mkdir(parents=True, exist_ok=True)
-    (aws_dir / "config").write_text(
+    aws_config = aws_dir / "config"
+    aws_config.write_text(
         f"[profile {profile_name}]\n"
         f"region = {region}\n"
         f"monitor_id = {monitor_id}\n"
@@ -223,6 +228,7 @@ def set_monitor_profile(env: dict, *, monitor_id: str, region: str = REGION) -> 
         "user_id = user-1234\n"
         "identity_store_id = d-abcdef0123\n"
     )
+    env["AWS_CONFIG_FILE"] = str(aws_config)
     r = run_deadline(env, "config", "set", "defaults.aws_profile_name", profile_name)
     assert r.returncode == 0, f"set aws_profile_name failed: {r.stderr}"
     return profile_name

--- a/test/cli_e2e/test_bundle.py
+++ b/test/cli_e2e/test_bundle.py
@@ -172,3 +172,104 @@ def test_cli_bundle_submit_with_name_override(seeded_farm_queue, run_cli, tmp_pa
     assert r.returncode == 0, r.stderr or r.stdout
     jobs = [j for (f, q, _), j in backend.jobs.items() if f == farm_id and q == queue_id]
     assert jobs[0]["name"] == "renamed-job"
+
+
+# ---- Monitor URL on submit -------------------------------------------------
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 9),
+    reason="MockDeadlineBackend.create_job requires openjd-model (py>=3.9)",
+)
+def test_cli_bundle_submit_no_monitor_profile_omits_url(seeded_farm_queue, run_cli, tmp_path):
+    """With plain (host-provided) credentials, no monitor URL is printed."""
+    _, _, _, env = seeded_farm_queue
+    bundle_dir = tmp_path / "bundle"
+    bundle_dir.mkdir()
+    (bundle_dir / "template.yaml").write_text(_SIMPLE_TEMPLATE)
+
+    r = run_cli(env, "bundle", "submit", str(bundle_dir), "--yes")
+    assert r.returncode == 0, r.stderr or r.stdout
+    assert "Job URL:" not in r.stdout
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 9),
+    reason="MockDeadlineBackend.create_job requires openjd-model (py>=3.9)",
+)
+def test_cli_bundle_submit_with_monitor_profile_prints_url(
+    seeded_farm_queue, run_cli, set_cli_monitor_profile, tmp_path
+):
+    """With a Deadline Cloud monitor profile, the job's monitor URL is printed
+    and points at the submitted farm/queue/job."""
+    from _constants import REGION
+
+    backend, farm_id, queue_id, env = seeded_farm_queue
+    monitor = backend.create_monitor(subdomain="mymonitor", region=REGION)
+    set_cli_monitor_profile(env, monitor_id=monitor["monitorId"], region=REGION)
+
+    bundle_dir = tmp_path / "bundle"
+    bundle_dir.mkdir()
+    (bundle_dir / "template.yaml").write_text(_SIMPLE_TEMPLATE)
+
+    r = run_cli(env, "bundle", "submit", str(bundle_dir), "--yes")
+    assert r.returncode == 0, r.stderr or r.stdout
+
+    jobs = {
+        j["jobId"]: j for (f, q, _), j in backend.jobs.items() if f == farm_id and q == queue_id
+    }
+    assert len(jobs) == 1
+    job_id = next(iter(jobs))
+
+    expected = (
+        f"Job URL: https://mymonitor.{REGION}.deadlinecloud.amazonaws.com"
+        f"/{REGION}/farms/{farm_id}/queues/{queue_id}?jobId={job_id}"
+    )
+    assert expected in r.stdout, r.stdout
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 9),
+    reason="MockDeadlineBackend.create_job requires openjd-model (py>=3.9)",
+)
+def test_cli_bundle_submit_cross_region_monitor_url(
+    seeded_farm_queue, run_cli, set_cli_monitor_profile, tmp_path
+):
+    """A monitor in one region linking to a farm in another: the host uses the
+    monitor's region while the path uses the farm's region."""
+    from _constants import REGION  # farm/resource region (us-west-2)
+
+    monitor_region = "us-east-1"
+
+    backend, farm_id, queue_id, env = seeded_farm_queue
+    # Monitor lives in us-east-1; the farm/queue are in REGION (us-west-2).
+    monitor = backend.create_monitor(subdomain="mymonitor", region=monitor_region)
+    set_cli_monitor_profile(env, monitor_id=monitor["monitorId"], region=monitor_region)
+    # farm_id/queue_id (and farm_region) are scoped under the selected AWS profile,
+    # so re-assert them now that the monitor profile is active, then pin the farm's
+    # region so the URL path uses it (distinct from the monitor's host region).
+    for key, value in (
+        ("defaults.farm_id", farm_id),
+        ("defaults.queue_id", queue_id),
+        ("defaults.farm_region", REGION),
+    ):
+        r = run_cli(env, "config", "set", key, value)
+        assert r.returncode == 0, r.stderr
+
+    bundle_dir = tmp_path / "bundle"
+    bundle_dir.mkdir()
+    (bundle_dir / "template.yaml").write_text(_SIMPLE_TEMPLATE)
+
+    r = run_cli(env, "bundle", "submit", str(bundle_dir), "--yes")
+    assert r.returncode == 0, r.stderr or r.stdout
+
+    jobs = {
+        j["jobId"]: j for (f, q, _), j in backend.jobs.items() if f == farm_id and q == queue_id
+    }
+    job_id = next(iter(jobs))
+
+    expected = (
+        f"Job URL: https://mymonitor.{monitor_region}.deadlinecloud.amazonaws.com"
+        f"/{REGION}/farms/{farm_id}/queues/{queue_id}?jobId={job_id}"
+    )
+    assert expected in r.stdout, r.stdout

--- a/test/cli_e2e/test_bundle.py
+++ b/test/cli_e2e/test_bundle.py
@@ -4,10 +4,9 @@
 from __future__ import annotations
 
 import shutil
-import sys
 from pathlib import Path
 
-import pytest
+from _constants import REGION
 
 
 _BUNDLE_SRC = (
@@ -32,10 +31,6 @@ steps:
 """
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 9),
-    reason="MockDeadlineBackend.create_job requires openjd-model (py>=3.9)",
-)
 def test_cli_bundle_submit_without_attachments(seeded_farm_queue, run_cli, tmp_path):
     backend, farm_id, queue_id, env = seeded_farm_queue
     bundle_dir = tmp_path / "bundle"
@@ -49,10 +44,6 @@ def test_cli_bundle_submit_without_attachments(seeded_farm_queue, run_cli, tmp_p
     assert len(jobs) == 1
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 9),
-    reason="MockDeadlineBackend.create_job requires openjd-model (py>=3.9)",
-)
 def test_cli_bundle_submit_with_attachments(seeded_farm_queue, run_cli, s3_client, tmp_path):
     from _constants import BUCKET, ROOT_PREFIX
 
@@ -74,10 +65,6 @@ def test_cli_bundle_submit_with_attachments(seeded_farm_queue, run_cli, s3_clien
     assert manifests.get("Contents")
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 9),
-    reason="MockDeadlineBackend.create_job requires openjd-model (py>=3.9)",
-)
 def test_cli_bundle_submit_with_priority_flag(seeded_farm_queue, run_cli, tmp_path):
     backend, farm_id, queue_id, env = seeded_farm_queue
     bundle_dir = tmp_path / "bundle"
@@ -90,10 +77,6 @@ def test_cli_bundle_submit_with_priority_flag(seeded_farm_queue, run_cli, tmp_pa
     assert jobs[0]["priority"] == 75
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 9),
-    reason="MockDeadlineBackend.create_job requires openjd-model (py>=3.9)",
-)
 def test_cli_bundle_submit_with_parameter(seeded_farm_queue, run_cli, tmp_path):
     backend, farm_id, queue_id, env = seeded_farm_queue
     bundle_dir = tmp_path / "bundle"
@@ -158,10 +141,6 @@ def test_cli_bundle_submit_missing_bundle(deadline_env, run_cli, tmp_path):
     assert r.returncode != 0
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 9),
-    reason="MockDeadlineBackend.create_job requires openjd-model (py>=3.9)",
-)
 def test_cli_bundle_submit_with_name_override(seeded_farm_queue, run_cli, tmp_path):
     backend, farm_id, queue_id, env = seeded_farm_queue
     bundle_dir = tmp_path / "bundle"
@@ -177,10 +156,6 @@ def test_cli_bundle_submit_with_name_override(seeded_farm_queue, run_cli, tmp_pa
 # ---- Monitor URL on submit -------------------------------------------------
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 9),
-    reason="MockDeadlineBackend.create_job requires openjd-model (py>=3.9)",
-)
 def test_cli_bundle_submit_no_monitor_profile_omits_url(seeded_farm_queue, run_cli, tmp_path):
     """With plain (host-provided) credentials, no monitor URL is printed."""
     _, _, _, env = seeded_farm_queue
@@ -193,17 +168,11 @@ def test_cli_bundle_submit_no_monitor_profile_omits_url(seeded_farm_queue, run_c
     assert "Job URL:" not in r.stdout
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 9),
-    reason="MockDeadlineBackend.create_job requires openjd-model (py>=3.9)",
-)
 def test_cli_bundle_submit_with_monitor_profile_prints_url(
     seeded_farm_queue, run_cli, set_cli_monitor_profile, tmp_path
 ):
     """With a Deadline Cloud monitor profile, the job's monitor URL is printed
     and points at the submitted farm/queue/job."""
-    from _constants import REGION
-
     backend, farm_id, queue_id, env = seeded_farm_queue
     monitor = backend.create_monitor(subdomain="mymonitor", region=REGION)
     set_cli_monitor_profile(env, monitor_id=monitor["monitorId"], region=REGION)
@@ -228,17 +197,11 @@ def test_cli_bundle_submit_with_monitor_profile_prints_url(
     assert expected in r.stdout, r.stdout
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 9),
-    reason="MockDeadlineBackend.create_job requires openjd-model (py>=3.9)",
-)
 def test_cli_bundle_submit_cross_region_monitor_url(
     seeded_farm_queue, run_cli, set_cli_monitor_profile, tmp_path
 ):
     """A monitor in one region linking to a farm in another: the host uses the
     monitor's region while the path uses the farm's region."""
-    from _constants import REGION  # farm/resource region (us-west-2)
-
     monitor_region = "us-east-1"
 
     backend, farm_id, queue_id, env = seeded_farm_queue

--- a/test/unit/deadline_client/api/test_job_bundle_submission.py
+++ b/test/unit/deadline_client/api/test_job_bundle_submission.py
@@ -351,6 +351,69 @@ def test_create_job_from_job_bundle(
     )
 
 
+def test_create_job_from_job_bundle_prints_monitor_url(fresh_deadline_config, temp_job_bundle_dir):
+    """When a monitor URL is available, create_job_from_job_bundle prints it."""
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+
+    job_template_type, job_template = MOCK_JOB_TEMPLATE_CASES["MINIMAL_JSON"]
+    monitor_url = (
+        f"https://mymonitor.us-east-1.deadlinecloud.amazonaws.com/us-east-1/"
+        f"farms/{MOCK_FARM_ID}/queues/{MOCK_QUEUE_ID}?jobId={MOCK_JOB_ID}"
+    )
+    printed: list[str] = []
+
+    with (
+        patch_calls_for_create_job_from_job_bundle(),
+        patch.object(
+            api._submit_job_bundle, "_get_job_monitor_url", return_value=monitor_url
+        ) as mock_get_url,
+    ):
+        with open(
+            os.path.join(temp_job_bundle_dir, f"template.{job_template_type.lower()}"),
+            "w",
+            encoding="utf8",
+        ) as f:
+            f.write(job_template)
+
+        api.create_job_from_job_bundle(
+            job_bundle_dir=temp_job_bundle_dir,
+            queue_parameter_definitions=[],
+            print_function_callback=lambda msg: printed.append(msg),
+        )
+
+    mock_get_url.assert_called_once()
+    assert f"Job URL: {monitor_url}" in printed
+
+
+def test_create_job_from_job_bundle_no_monitor_url(fresh_deadline_config, temp_job_bundle_dir):
+    """With no monitor URL available, no 'Job URL:' line is printed."""
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+
+    job_template_type, job_template = MOCK_JOB_TEMPLATE_CASES["MINIMAL_JSON"]
+    printed: list[str] = []
+
+    with (
+        patch_calls_for_create_job_from_job_bundle(),
+        patch.object(api._submit_job_bundle, "_get_job_monitor_url", return_value=None),
+    ):
+        with open(
+            os.path.join(temp_job_bundle_dir, f"template.{job_template_type.lower()}"),
+            "w",
+            encoding="utf8",
+        ) as f:
+            f.write(job_template)
+
+        api.create_job_from_job_bundle(
+            job_bundle_dir=temp_job_bundle_dir,
+            queue_parameter_definitions=[],
+            print_function_callback=lambda msg: printed.append(msg),
+        )
+
+    assert not any(msg.startswith("Job URL:") for msg in printed)
+
+
 def test_create_job_from_job_bundle_error_missing_template(
     fresh_deadline_config, temp_job_bundle_dir
 ):

--- a/test/unit/deadline_client/api/test_monitor_urls.py
+++ b/test/unit/deadline_client/api/test_monitor_urls.py
@@ -151,6 +151,24 @@ def test_build_monitor_url_monitor_region_defaults_to_region():
     )
 
 
+def test_build_monitor_url_explicit_host_used_verbatim():
+    """An explicit host is used as-is (with any trailing slash stripped), rather than
+    reconstructed from the commercial domain -- required for non-commercial partitions
+    (aws-us-gov, aws-cn) whose monitor hosts differ."""
+    gov_host = f"https://{SUBDOMAIN}.us-gov-west-1.deadlinecloud.amazonaws-us-gov.com"
+    assert build_monitor_url(
+        SUBDOMAIN, "us-gov-west-1", farm_id=FARM_ID, queue_id=QUEUE_ID, host=gov_host + "/"
+    ) == (f"{gov_host}/us-gov-west-1/farms/{FARM_ID}/queues/{QUEUE_ID}")
+
+
+def test_build_monitor_url_explicit_host_overrides_monitor_region():
+    """When host is supplied, monitor_region is ignored for the host."""
+    host = f"https://{SUBDOMAIN}.cn-north-1.deadlinecloud.amazonaws.com.cn"
+    assert build_monitor_url(
+        SUBDOMAIN, "cn-north-1", farm_id=FARM_ID, monitor_region="us-east-1", host=host
+    ) == (f"{host}/cn-north-1/farms/{FARM_ID}")
+
+
 @pytest.mark.parametrize(
     "url, expected",
     [
@@ -183,11 +201,11 @@ def test_get_monitor_subdomain_returns_none_for_host_creds(fresh_deadline_config
         "get_credentials_source",
         return_value=AwsCredentialsSource.HOST_PROVIDED,
     ):
-        assert _get_monitor_subdomain() == (None, None)
+        assert _get_monitor_subdomain() == (None, None, None)
 
 
 def test_get_monitor_subdomain_calls_get_monitor(fresh_deadline_config):
-    """For DCM credentials, the subdomain and monitor region come from GetMonitor."""
+    """For DCM credentials, the subdomain, region, and host come from GetMonitor."""
     mock_client = MagicMock()
     mock_client.get_monitor.return_value = {
         "subdomain": SUBDOMAIN,
@@ -202,7 +220,11 @@ def test_get_monitor_subdomain_calls_get_monitor(fresh_deadline_config):
         ),
         patch.object(api._monitor_urls, "get_monitor_id", return_value="monitor-abc"),
     ):
-        assert _get_monitor_subdomain(deadline_client=mock_client) == (SUBDOMAIN, "us-east-1")
+        assert _get_monitor_subdomain(deadline_client=mock_client) == (
+            SUBDOMAIN,
+            "us-east-1",
+            f"https://{SUBDOMAIN}.us-east-1.deadlinecloud.amazonaws.com",
+        )
     mock_client.get_monitor.assert_called_once_with(monitorId="monitor-abc")
 
 
@@ -302,6 +324,27 @@ def test_get_job_monitor_url_none_when_no_subdomain(fresh_deadline_config):
             )
             is None
         )
+
+
+def test_get_job_monitor_url_uses_authoritative_host_in_other_partitions(fresh_deadline_config):
+    """In aws-us-gov/aws-cn the monitor host does not end in the commercial domain, so
+    the URL must use the authoritative host from GetMonitor rather than reconstruct it."""
+    config.set_setting("defaults.farm_region", "us-gov-west-1")
+    gov_host = f"https://{SUBDOMAIN}.us-gov-west-1.deadlinecloud.amazonaws-us-gov.com"
+    mock_client = MagicMock()
+    mock_client.get_monitor.return_value = {"subdomain": SUBDOMAIN, "url": gov_host}
+    with (
+        patch.object(
+            api._monitor_urls,
+            "get_credentials_source",
+            return_value=AwsCredentialsSource.DEADLINE_CLOUD_MONITOR_LOGIN,
+        ),
+        patch.object(api._monitor_urls, "get_monitor_id", return_value="monitor-abc"),
+    ):
+        url = _get_job_monitor_url(
+            farm_id=FARM_ID, queue_id=QUEUE_ID, job_id=JOB_ID, deadline_client=mock_client
+        )
+    assert url == f"{gov_host}/us-gov-west-1/farms/{FARM_ID}/queues/{QUEUE_ID}?jobId={JOB_ID}"
 
 
 def test_get_job_monitor_url_falls_back_when_monitor_url_malformed(fresh_deadline_config):

--- a/test/unit/deadline_client/api/test_monitor_urls.py
+++ b/test/unit/deadline_client/api/test_monitor_urls.py
@@ -126,6 +126,54 @@ def test_get_monitor_url_url_encodes_query_values():
     assert "jobId=job+with+spaces%26x%3D1" in url
 
 
+def test_get_monitor_url_cross_region_host_and_path_differ():
+    """A monitor in one region linking to a farm in another: host uses the
+    monitor region, path uses the farm region."""
+    url = get_monitor_url(
+        SUBDOMAIN,
+        "eu-west-1",  # farm/resource region -> path
+        farm_id=FARM_ID,
+        queue_id=QUEUE_ID,
+        monitor_region="us-east-1",  # monitor region -> host
+    )
+    assert url == (
+        f"https://{SUBDOMAIN}.us-east-1.deadlinecloud.amazonaws.com"
+        f"/eu-west-1/farms/{FARM_ID}/queues/{QUEUE_ID}"
+    )
+
+
+def test_get_monitor_url_monitor_region_defaults_to_region():
+    """When monitor_region is omitted, the host uses the resource region."""
+    assert get_monitor_url(SUBDOMAIN, REGION, farm_id=FARM_ID) == (
+        f"https://{SUBDOMAIN}.{REGION}.deadlinecloud.amazonaws.com/{REGION}/farms/{FARM_ID}"
+    )
+
+
+@pytest.mark.parametrize(
+    "url, expected",
+    [
+        (
+            f"https://{SUBDOMAIN}.us-east-1.deadlinecloud.amazonaws.com",
+            (SUBDOMAIN, "us-east-1"),
+        ),
+        # Trailing path is ignored.
+        (
+            f"https://{SUBDOMAIN}.eu-west-1.deadlinecloud.amazonaws.com/eu-west-1/farms",
+            (SUBDOMAIN, "eu-west-1"),
+        ),
+        (None, (None, None)),
+        ("", (None, None)),
+        ("https://example.com", (None, None)),
+        # Missing region label.
+        ("https://deadlinecloud.amazonaws.com", (None, None)),
+    ],
+)
+def test_parse_monitor_host(url, expected):
+    from deadline.client.api._monitor_urls import _parse_monitor_host
+
+    assert _parse_monitor_host(url) == expected
+
+
 def test_get_monitor_subdomain_returns_none_for_host_creds(fresh_deadline_config):
     """Host-provided credentials have no monitor, so there is no subdomain."""
     with patch.object(
@@ -133,13 +181,17 @@ def test_get_monitor_subdomain_returns_none_for_host_creds(fresh_deadline_config
         "get_credentials_source",
         return_value=AwsCredentialsSource.HOST_PROVIDED,
     ):
-        assert _get_monitor_subdomain() is None
+        assert _get_monitor_subdomain() == (None, None)
 
 
 def test_get_monitor_subdomain_calls_get_monitor(fresh_deadline_config):
-    """For DCM credentials, the subdomain is read from deadline:GetMonitor."""
+    """For DCM credentials, the subdomain and monitor region come from GetMonitor."""
     mock_client = MagicMock()
-    mock_client.get_monitor.return_value = {"subdomain": SUBDOMAIN, "monitorId": "monitor-abc"}
+    mock_client.get_monitor.return_value = {
+        "subdomain": SUBDOMAIN,
+        "monitorId": "monitor-abc",
+        "url": f"https://{SUBDOMAIN}.us-east-1.deadlinecloud.amazonaws.com",
+    }
     with (
         patch.object(
             api._monitor_urls,
@@ -148,14 +200,17 @@ def test_get_monitor_subdomain_calls_get_monitor(fresh_deadline_config):
         ),
         patch.object(api._monitor_urls, "get_monitor_id", return_value="monitor-abc"),
     ):
-        assert _get_monitor_subdomain(deadline_client=mock_client) == SUBDOMAIN
+        assert _get_monitor_subdomain(deadline_client=mock_client) == (SUBDOMAIN, "us-east-1")
     mock_client.get_monitor.assert_called_once_with(monitorId="monitor-abc")
 
 
 def test_get_job_monitor_url_happy_path(fresh_deadline_config):
     config.set_setting("defaults.farm_region", REGION)
     mock_client = MagicMock()
-    mock_client.get_monitor.return_value = {"subdomain": SUBDOMAIN}
+    mock_client.get_monitor.return_value = {
+        "subdomain": SUBDOMAIN,
+        "url": HOST,
+    }
     with (
         patch.object(
             api._monitor_urls,
@@ -170,6 +225,31 @@ def test_get_job_monitor_url_happy_path(fresh_deadline_config):
     assert url == f"{HOST}/{REGION}/farms/{FARM_ID}/queues/{QUEUE_ID}?jobId={JOB_ID}"
 
 
+def test_get_job_monitor_url_cross_region(fresh_deadline_config):
+    """Monitor in us-east-1, farm in eu-west-1: host and path regions differ."""
+    config.set_setting("defaults.farm_region", "eu-west-1")
+    mock_client = MagicMock()
+    mock_client.get_monitor.return_value = {
+        "subdomain": SUBDOMAIN,
+        "url": f"https://{SUBDOMAIN}.us-east-1.deadlinecloud.amazonaws.com",
+    }
+    with (
+        patch.object(
+            api._monitor_urls,
+            "get_credentials_source",
+            return_value=AwsCredentialsSource.DEADLINE_CLOUD_MONITOR_LOGIN,
+        ),
+        patch.object(api._monitor_urls, "get_monitor_id", return_value="monitor-abc"),
+    ):
+        url = _get_job_monitor_url(
+            farm_id=FARM_ID, queue_id=QUEUE_ID, job_id=JOB_ID, deadline_client=mock_client
+        )
+    assert url == (
+        f"https://{SUBDOMAIN}.us-east-1.deadlinecloud.amazonaws.com"
+        f"/eu-west-1/farms/{FARM_ID}/queues/{QUEUE_ID}?jobId={JOB_ID}"
+    )
+
+
 def test_get_job_monitor_url_none_without_monitor(fresh_deadline_config):
     """Non-monitor credentials yield None (no URL surfaced)."""
     with patch.object(
@@ -180,8 +260,9 @@ def test_get_job_monitor_url_none_without_monitor(fresh_deadline_config):
         assert _get_job_monitor_url(farm_id=FARM_ID, queue_id=QUEUE_ID, job_id=JOB_ID) is None
 
 
-def test_get_job_monitor_url_swallows_errors(fresh_deadline_config):
-    """Any failure while building the URL results in None, never an exception."""
+def test_get_job_monitor_url_none_when_get_monitor_fails(fresh_deadline_config):
+    """If deadline:GetMonitor raises, we omit the URL rather than propagate."""
+    config.set_setting("defaults.farm_region", REGION)
     mock_client = MagicMock()
     mock_client.get_monitor.side_effect = RuntimeError("boom")
     with (
@@ -198,3 +279,44 @@ def test_get_job_monitor_url_swallows_errors(fresh_deadline_config):
             )
             is None
         )
+
+
+def test_get_job_monitor_url_none_when_no_subdomain(fresh_deadline_config):
+    """If GetMonitor returns no subdomain, we omit the URL."""
+    config.set_setting("defaults.farm_region", REGION)
+    mock_client = MagicMock()
+    mock_client.get_monitor.return_value = {"monitorId": "monitor-abc"}  # no subdomain
+    with (
+        patch.object(
+            api._monitor_urls,
+            "get_credentials_source",
+            return_value=AwsCredentialsSource.DEADLINE_CLOUD_MONITOR_LOGIN,
+        ),
+        patch.object(api._monitor_urls, "get_monitor_id", return_value="monitor-abc"),
+    ):
+        assert (
+            _get_job_monitor_url(
+                farm_id=FARM_ID, queue_id=QUEUE_ID, job_id=JOB_ID, deadline_client=mock_client
+            )
+            is None
+        )
+
+
+def test_get_job_monitor_url_falls_back_when_monitor_url_malformed(fresh_deadline_config):
+    """A subdomain with a missing/garbled monitor url still yields a URL, using the
+    farm region for the host (monitor_region falls back to the resource region)."""
+    config.set_setting("defaults.farm_region", REGION)
+    mock_client = MagicMock()
+    mock_client.get_monitor.return_value = {"subdomain": SUBDOMAIN, "url": "not-a-url"}
+    with (
+        patch.object(
+            api._monitor_urls,
+            "get_credentials_source",
+            return_value=AwsCredentialsSource.DEADLINE_CLOUD_MONITOR_LOGIN,
+        ),
+        patch.object(api._monitor_urls, "get_monitor_id", return_value="monitor-abc"),
+    ):
+        url = _get_job_monitor_url(
+            farm_id=FARM_ID, queue_id=QUEUE_ID, job_id=JOB_ID, deadline_client=mock_client
+        )
+    assert url == f"{HOST}/{REGION}/farms/{FARM_ID}/queues/{QUEUE_ID}?jobId={JOB_ID}"

--- a/test/unit/deadline_client/api/test_monitor_urls.py
+++ b/test/unit/deadline_client/api/test_monitor_urls.py
@@ -1,0 +1,200 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Tests for deadline.client.api._monitor_urls (get_monitor_url and helpers).
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from deadline.client import api, config
+from deadline.client.api import get_monitor_url
+from deadline.client.api._monitor_urls import (
+    _get_job_monitor_url,
+    _get_monitor_subdomain,
+)
+from deadline.client.api._session import AwsCredentialsSource
+
+SUBDOMAIN = "iadproductionsandbox"
+REGION = "us-east-1"
+FARM_ID = "farm-48235bbdf9a8424bbad7e26c6170b074"
+QUEUE_ID = "queue-4847e932013148628fbe9ecb7e29a99c"
+JOB_ID = "job-4d8a9716356340bba8f825745f52d05c"
+STEP_ID = "step-953199a0081448a690c1b039453e11b7"
+TASK_ID = "task-953199a0081448a690c1b039453e11b7-2"
+
+HOST = f"https://{SUBDOMAIN}.{REGION}.deadlinecloud.amazonaws.com"
+
+
+def test_get_monitor_url_all_farms():
+    """With no farm, the URL points at the (non-region-scoped) all-farms list."""
+    assert get_monitor_url(SUBDOMAIN, REGION) == f"{HOST}/farms"
+
+
+def test_get_monitor_url_farm():
+    assert get_monitor_url(SUBDOMAIN, REGION, farm_id=FARM_ID) == f"{HOST}/{REGION}/farms/{FARM_ID}"
+
+
+def test_get_monitor_url_queue():
+    assert (
+        get_monitor_url(SUBDOMAIN, REGION, farm_id=FARM_ID, queue_id=QUEUE_ID)
+        == f"{HOST}/{REGION}/farms/{FARM_ID}/queues/{QUEUE_ID}"
+    )
+
+
+def test_get_monitor_url_job():
+    assert (
+        get_monitor_url(SUBDOMAIN, REGION, farm_id=FARM_ID, queue_id=QUEUE_ID, job_id=JOB_ID)
+        == f"{HOST}/{REGION}/farms/{FARM_ID}/queues/{QUEUE_ID}?jobId={JOB_ID}"
+    )
+
+
+def test_get_monitor_url_step():
+    assert (
+        get_monitor_url(
+            SUBDOMAIN, REGION, farm_id=FARM_ID, queue_id=QUEUE_ID, job_id=JOB_ID, step_id=STEP_ID
+        )
+        == f"{HOST}/{REGION}/farms/{FARM_ID}/queues/{QUEUE_ID}?jobId={JOB_ID}&stepId={STEP_ID}"
+    )
+
+
+def test_get_monitor_url_task():
+    """The full task URL matches the example from the feature request."""
+    assert get_monitor_url(
+        SUBDOMAIN,
+        REGION,
+        farm_id=FARM_ID,
+        queue_id=QUEUE_ID,
+        job_id=JOB_ID,
+        step_id=STEP_ID,
+        task_id=TASK_ID,
+    ) == (
+        f"{HOST}/{REGION}/farms/{FARM_ID}/queues/{QUEUE_ID}"
+        f"?jobId={JOB_ID}&stepId={STEP_ID}&taskId={TASK_ID}"
+    )
+
+
+def test_get_monitor_url_requires_subdomain():
+    with pytest.raises(ValueError, match="subdomain"):
+        get_monitor_url("", REGION, farm_id=FARM_ID)
+
+
+@pytest.mark.parametrize(
+    "kwargs, missing",
+    [
+        (dict(queue_id=QUEUE_ID), "queue_id requires farm_id"),
+        (dict(farm_id=FARM_ID, job_id=JOB_ID), "job_id requires queue_id"),
+        (dict(farm_id=FARM_ID, queue_id=QUEUE_ID, step_id=STEP_ID), "step_id requires job_id"),
+        (
+            dict(farm_id=FARM_ID, queue_id=QUEUE_ID, job_id=JOB_ID, task_id=TASK_ID),
+            "task_id requires step_id",
+        ),
+    ],
+)
+def test_get_monitor_url_hierarchy_violations(kwargs, missing):
+    """A lower-level id without its parent is a ValueError (e.g. queue with no farm)."""
+    with pytest.raises(ValueError, match=missing):
+        get_monitor_url(SUBDOMAIN, REGION, **kwargs)
+
+
+def test_get_monitor_url_region_defaults_from_config(fresh_deadline_config):
+    """When region is omitted it resolves from defaults.farm_region, like elsewhere."""
+    config.set_setting("defaults.farm_region", "eu-west-1")
+    url = get_monitor_url(SUBDOMAIN, farm_id=FARM_ID)
+    assert (
+        url
+        == f"https://{SUBDOMAIN}.eu-west-1.deadlinecloud.amazonaws.com/eu-west-1/farms/{FARM_ID}"
+    )
+
+
+def test_get_monitor_url_requires_region(fresh_deadline_config):
+    """With no explicit region and nothing configured, we raise rather than emit a bad URL."""
+    with pytest.raises(ValueError, match="region is required"):
+        get_monitor_url(SUBDOMAIN, farm_id=FARM_ID)
+
+
+def test_get_monitor_url_url_encodes_query_values():
+    """Query parameter values are URL-encoded."""
+    url = get_monitor_url(
+        SUBDOMAIN,
+        REGION,
+        farm_id=FARM_ID,
+        queue_id=QUEUE_ID,
+        job_id="job with spaces&x=1",
+    )
+    assert "jobId=job+with+spaces%26x%3D1" in url
+
+
+def test_get_monitor_subdomain_returns_none_for_host_creds(fresh_deadline_config):
+    """Host-provided credentials have no monitor, so there is no subdomain."""
+    with patch.object(
+        api._monitor_urls,
+        "get_credentials_source",
+        return_value=AwsCredentialsSource.HOST_PROVIDED,
+    ):
+        assert _get_monitor_subdomain() is None
+
+
+def test_get_monitor_subdomain_calls_get_monitor(fresh_deadline_config):
+    """For DCM credentials, the subdomain is read from deadline:GetMonitor."""
+    mock_client = MagicMock()
+    mock_client.get_monitor.return_value = {"subdomain": SUBDOMAIN, "monitorId": "monitor-abc"}
+    with (
+        patch.object(
+            api._monitor_urls,
+            "get_credentials_source",
+            return_value=AwsCredentialsSource.DEADLINE_CLOUD_MONITOR_LOGIN,
+        ),
+        patch.object(api._monitor_urls, "get_monitor_id", return_value="monitor-abc"),
+    ):
+        assert _get_monitor_subdomain(deadline_client=mock_client) == SUBDOMAIN
+    mock_client.get_monitor.assert_called_once_with(monitorId="monitor-abc")
+
+
+def test_get_job_monitor_url_happy_path(fresh_deadline_config):
+    config.set_setting("defaults.farm_region", REGION)
+    mock_client = MagicMock()
+    mock_client.get_monitor.return_value = {"subdomain": SUBDOMAIN}
+    with (
+        patch.object(
+            api._monitor_urls,
+            "get_credentials_source",
+            return_value=AwsCredentialsSource.DEADLINE_CLOUD_MONITOR_LOGIN,
+        ),
+        patch.object(api._monitor_urls, "get_monitor_id", return_value="monitor-abc"),
+    ):
+        url = _get_job_monitor_url(
+            farm_id=FARM_ID, queue_id=QUEUE_ID, job_id=JOB_ID, deadline_client=mock_client
+        )
+    assert url == f"{HOST}/{REGION}/farms/{FARM_ID}/queues/{QUEUE_ID}?jobId={JOB_ID}"
+
+
+def test_get_job_monitor_url_none_without_monitor(fresh_deadline_config):
+    """Non-monitor credentials yield None (no URL surfaced)."""
+    with patch.object(
+        api._monitor_urls,
+        "get_credentials_source",
+        return_value=AwsCredentialsSource.HOST_PROVIDED,
+    ):
+        assert _get_job_monitor_url(farm_id=FARM_ID, queue_id=QUEUE_ID, job_id=JOB_ID) is None
+
+
+def test_get_job_monitor_url_swallows_errors(fresh_deadline_config):
+    """Any failure while building the URL results in None, never an exception."""
+    mock_client = MagicMock()
+    mock_client.get_monitor.side_effect = RuntimeError("boom")
+    with (
+        patch.object(
+            api._monitor_urls,
+            "get_credentials_source",
+            return_value=AwsCredentialsSource.DEADLINE_CLOUD_MONITOR_LOGIN,
+        ),
+        patch.object(api._monitor_urls, "get_monitor_id", return_value="monitor-abc"),
+    ):
+        assert (
+            _get_job_monitor_url(
+                farm_id=FARM_ID, queue_id=QUEUE_ID, job_id=JOB_ID, deadline_client=mock_client
+            )
+            is None
+        )

--- a/test/unit/deadline_client/api/test_monitor_urls.py
+++ b/test/unit/deadline_client/api/test_monitor_urls.py
@@ -7,6 +7,8 @@ Tests for deadline.client.api._monitor_urls (build_monitor_url and helpers).
 from unittest.mock import MagicMock, patch
 
 import pytest
+from botocore.client import BaseClient
+from botocore.exceptions import ClientError
 
 from deadline.client import api, config
 from deadline.client.api import build_monitor_url
@@ -219,13 +221,27 @@ def test_get_monitor_subdomain_calls_get_monitor(fresh_deadline_config):
             return_value=AwsCredentialsSource.DEADLINE_CLOUD_MONITOR_LOGIN,
         ),
         patch.object(api._monitor_urls, "get_monitor_id", return_value="monitor-abc"),
+        patch.object(api._monitor_urls, "_get_monitor_client", return_value=mock_client),
     ):
-        assert _get_monitor_subdomain(deadline_client=mock_client) == (
+        assert _get_monitor_subdomain() == (
             SUBDOMAIN,
             "us-east-1",
             f"https://{SUBDOMAIN}.us-east-1.deadlinecloud.amazonaws.com",
         )
     mock_client.get_monitor.assert_called_once_with(monitorId="monitor-abc")
+
+
+def _patch_dcm_monitor(mock_client):
+    """Patch the module so credentials look like a Deadline Cloud monitor login whose
+    GetMonitor call is served by ``mock_client``."""
+    return patch.multiple(
+        api._monitor_urls,
+        get_credentials_source=MagicMock(
+            return_value=AwsCredentialsSource.DEADLINE_CLOUD_MONITOR_LOGIN
+        ),
+        get_monitor_id=MagicMock(return_value="monitor-abc"),
+        _get_monitor_client=MagicMock(return_value=mock_client),
+    )
 
 
 def test_get_job_monitor_url_happy_path(fresh_deadline_config):
@@ -235,17 +251,8 @@ def test_get_job_monitor_url_happy_path(fresh_deadline_config):
         "subdomain": SUBDOMAIN,
         "url": HOST,
     }
-    with (
-        patch.object(
-            api._monitor_urls,
-            "get_credentials_source",
-            return_value=AwsCredentialsSource.DEADLINE_CLOUD_MONITOR_LOGIN,
-        ),
-        patch.object(api._monitor_urls, "get_monitor_id", return_value="monitor-abc"),
-    ):
-        url = _get_job_monitor_url(
-            farm_id=FARM_ID, queue_id=QUEUE_ID, job_id=JOB_ID, deadline_client=mock_client
-        )
+    with _patch_dcm_monitor(mock_client):
+        url = _get_job_monitor_url(farm_id=FARM_ID, queue_id=QUEUE_ID, job_id=JOB_ID)
     assert url == f"{HOST}/{REGION}/farms/{FARM_ID}/queues/{QUEUE_ID}?jobId={JOB_ID}"
 
 
@@ -257,17 +264,8 @@ def test_get_job_monitor_url_cross_region(fresh_deadline_config):
         "subdomain": SUBDOMAIN,
         "url": f"https://{SUBDOMAIN}.us-east-1.deadlinecloud.amazonaws.com",
     }
-    with (
-        patch.object(
-            api._monitor_urls,
-            "get_credentials_source",
-            return_value=AwsCredentialsSource.DEADLINE_CLOUD_MONITOR_LOGIN,
-        ),
-        patch.object(api._monitor_urls, "get_monitor_id", return_value="monitor-abc"),
-    ):
-        url = _get_job_monitor_url(
-            farm_id=FARM_ID, queue_id=QUEUE_ID, job_id=JOB_ID, deadline_client=mock_client
-        )
+    with _patch_dcm_monitor(mock_client):
+        url = _get_job_monitor_url(farm_id=FARM_ID, queue_id=QUEUE_ID, job_id=JOB_ID)
     assert url == (
         f"https://{SUBDOMAIN}.us-east-1.deadlinecloud.amazonaws.com"
         f"/eu-west-1/farms/{FARM_ID}/queues/{QUEUE_ID}?jobId={JOB_ID}"
@@ -289,20 +287,8 @@ def test_get_job_monitor_url_none_when_get_monitor_fails(fresh_deadline_config):
     config.set_setting("defaults.farm_region", REGION)
     mock_client = MagicMock()
     mock_client.get_monitor.side_effect = RuntimeError("boom")
-    with (
-        patch.object(
-            api._monitor_urls,
-            "get_credentials_source",
-            return_value=AwsCredentialsSource.DEADLINE_CLOUD_MONITOR_LOGIN,
-        ),
-        patch.object(api._monitor_urls, "get_monitor_id", return_value="monitor-abc"),
-    ):
-        assert (
-            _get_job_monitor_url(
-                farm_id=FARM_ID, queue_id=QUEUE_ID, job_id=JOB_ID, deadline_client=mock_client
-            )
-            is None
-        )
+    with _patch_dcm_monitor(mock_client):
+        assert _get_job_monitor_url(farm_id=FARM_ID, queue_id=QUEUE_ID, job_id=JOB_ID) is None
 
 
 def test_get_job_monitor_url_none_when_no_subdomain(fresh_deadline_config):
@@ -310,20 +296,8 @@ def test_get_job_monitor_url_none_when_no_subdomain(fresh_deadline_config):
     config.set_setting("defaults.farm_region", REGION)
     mock_client = MagicMock()
     mock_client.get_monitor.return_value = {"monitorId": "monitor-abc"}  # no subdomain
-    with (
-        patch.object(
-            api._monitor_urls,
-            "get_credentials_source",
-            return_value=AwsCredentialsSource.DEADLINE_CLOUD_MONITOR_LOGIN,
-        ),
-        patch.object(api._monitor_urls, "get_monitor_id", return_value="monitor-abc"),
-    ):
-        assert (
-            _get_job_monitor_url(
-                farm_id=FARM_ID, queue_id=QUEUE_ID, job_id=JOB_ID, deadline_client=mock_client
-            )
-            is None
-        )
+    with _patch_dcm_monitor(mock_client):
+        assert _get_job_monitor_url(farm_id=FARM_ID, queue_id=QUEUE_ID, job_id=JOB_ID) is None
 
 
 def test_get_job_monitor_url_uses_authoritative_host_in_other_partitions(fresh_deadline_config):
@@ -333,7 +307,47 @@ def test_get_job_monitor_url_uses_authoritative_host_in_other_partitions(fresh_d
     gov_host = f"https://{SUBDOMAIN}.us-gov-west-1.deadlinecloud.amazonaws-us-gov.com"
     mock_client = MagicMock()
     mock_client.get_monitor.return_value = {"subdomain": SUBDOMAIN, "url": gov_host}
+    with _patch_dcm_monitor(mock_client):
+        url = _get_job_monitor_url(farm_id=FARM_ID, queue_id=QUEUE_ID, job_id=JOB_ID)
+    assert url == f"{gov_host}/us-gov-west-1/farms/{FARM_ID}/queues/{QUEUE_ID}?jobId={JOB_ID}"
+
+
+def _get_monitor_wire_stub(monitor_region: str, monitor: dict):
+    """
+    Patch the boto wire so ``deadline:GetMonitor`` behaves like the real service:
+    it succeeds only when called through a client scoped to the monitor's home
+    region, and raises ``ResourceNotFoundException`` from any other regional
+    endpoint (a monitor is a regional resource).
+    """
+
+    def _make_api_call(self, operation_name, api_params):
+        assert operation_name == "GetMonitor"
+        if self.meta.region_name != monitor_region:
+            raise ClientError(
+                {
+                    "Error": {
+                        "Code": "ResourceNotFoundException",
+                        "Message": f"Monitor not found in {self.meta.region_name}",
+                    }
+                },
+                operation_name,
+            )
+        return monitor
+
+    return patch.object(BaseClient, "_make_api_call", _make_api_call)
+
+
+def test_get_monitor_subdomain_uses_profile_region_not_farm_region(
+    fresh_deadline_config, aws_config
+):
+    """The GetMonitor call must go to the monitor's home region -- the region of the
+    AWS profile that Deadline Cloud monitor wrote -- not defaults.farm_region. In a
+    cross-region setup a farm-region client hits the wrong endpoint and finds no
+    monitor."""
+    aws_config.write_text("[default]\nregion = us-east-1\n")
+    config.set_setting("defaults.farm_region", "eu-west-1")
     with (
+        _get_monitor_wire_stub("us-east-1", {"subdomain": SUBDOMAIN, "url": HOST}),
         patch.object(
             api._monitor_urls,
             "get_credentials_source",
@@ -341,10 +355,28 @@ def test_get_job_monitor_url_uses_authoritative_host_in_other_partitions(fresh_d
         ),
         patch.object(api._monitor_urls, "get_monitor_id", return_value="monitor-abc"),
     ):
-        url = _get_job_monitor_url(
-            farm_id=FARM_ID, queue_id=QUEUE_ID, job_id=JOB_ID, deadline_client=mock_client
-        )
-    assert url == f"{gov_host}/us-gov-west-1/farms/{FARM_ID}/queues/{QUEUE_ID}?jobId={JOB_ID}"
+        assert _get_monitor_subdomain() == (SUBDOMAIN, REGION, HOST)
+
+
+def test_get_job_monitor_url_cross_region_without_injected_client(
+    fresh_deadline_config, aws_config
+):
+    """End-to-end cross-region: monitor (and profile) in us-east-1, farm in eu-west-1.
+    The URL must still be produced -- GetMonitor must not be attempted in the farm's
+    region, where it would raise ResourceNotFoundException and silently yield None."""
+    aws_config.write_text("[default]\nregion = us-east-1\n")
+    config.set_setting("defaults.farm_region", "eu-west-1")
+    with (
+        _get_monitor_wire_stub("us-east-1", {"subdomain": SUBDOMAIN, "url": HOST}),
+        patch.object(
+            api._monitor_urls,
+            "get_credentials_source",
+            return_value=AwsCredentialsSource.DEADLINE_CLOUD_MONITOR_LOGIN,
+        ),
+        patch.object(api._monitor_urls, "get_monitor_id", return_value="monitor-abc"),
+    ):
+        url = _get_job_monitor_url(farm_id=FARM_ID, queue_id=QUEUE_ID, job_id=JOB_ID)
+    assert url == (f"{HOST}/eu-west-1/farms/{FARM_ID}/queues/{QUEUE_ID}?jobId={JOB_ID}")
 
 
 def test_get_job_monitor_url_falls_back_when_monitor_url_malformed(fresh_deadline_config):
@@ -353,15 +385,6 @@ def test_get_job_monitor_url_falls_back_when_monitor_url_malformed(fresh_deadlin
     config.set_setting("defaults.farm_region", REGION)
     mock_client = MagicMock()
     mock_client.get_monitor.return_value = {"subdomain": SUBDOMAIN, "url": "not-a-url"}
-    with (
-        patch.object(
-            api._monitor_urls,
-            "get_credentials_source",
-            return_value=AwsCredentialsSource.DEADLINE_CLOUD_MONITOR_LOGIN,
-        ),
-        patch.object(api._monitor_urls, "get_monitor_id", return_value="monitor-abc"),
-    ):
-        url = _get_job_monitor_url(
-            farm_id=FARM_ID, queue_id=QUEUE_ID, job_id=JOB_ID, deadline_client=mock_client
-        )
+    with _patch_dcm_monitor(mock_client):
+        url = _get_job_monitor_url(farm_id=FARM_ID, queue_id=QUEUE_ID, job_id=JOB_ID)
     assert url == f"{HOST}/{REGION}/farms/{FARM_ID}/queues/{QUEUE_ID}?jobId={JOB_ID}"

--- a/test/unit/deadline_client/api/test_monitor_urls.py
+++ b/test/unit/deadline_client/api/test_monitor_urls.py
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 """
-Tests for deadline.client.api._monitor_urls (get_monitor_url and helpers).
+Tests for deadline.client.api._monitor_urls (build_monitor_url and helpers).
 """
 
 from unittest.mock import MagicMock, patch
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from deadline.client import api, config
-from deadline.client.api import get_monitor_url
+from deadline.client.api import build_monitor_url
 from deadline.client.api._monitor_urls import (
     _get_job_monitor_url,
     _get_monitor_subdomain,
@@ -27,41 +27,43 @@ TASK_ID = "task-953199a0081448a690c1b039453e11b7-2"
 HOST = f"https://{SUBDOMAIN}.{REGION}.deadlinecloud.amazonaws.com"
 
 
-def test_get_monitor_url_all_farms():
+def test_build_monitor_url_all_farms():
     """With no farm, the URL points at the (non-region-scoped) all-farms list."""
-    assert get_monitor_url(SUBDOMAIN, REGION) == f"{HOST}/farms"
+    assert build_monitor_url(SUBDOMAIN, REGION) == f"{HOST}/farms"
 
 
-def test_get_monitor_url_farm():
-    assert get_monitor_url(SUBDOMAIN, REGION, farm_id=FARM_ID) == f"{HOST}/{REGION}/farms/{FARM_ID}"
-
-
-def test_get_monitor_url_queue():
+def test_build_monitor_url_farm():
     assert (
-        get_monitor_url(SUBDOMAIN, REGION, farm_id=FARM_ID, queue_id=QUEUE_ID)
+        build_monitor_url(SUBDOMAIN, REGION, farm_id=FARM_ID) == f"{HOST}/{REGION}/farms/{FARM_ID}"
+    )
+
+
+def test_build_monitor_url_queue():
+    assert (
+        build_monitor_url(SUBDOMAIN, REGION, farm_id=FARM_ID, queue_id=QUEUE_ID)
         == f"{HOST}/{REGION}/farms/{FARM_ID}/queues/{QUEUE_ID}"
     )
 
 
-def test_get_monitor_url_job():
+def test_build_monitor_url_job():
     assert (
-        get_monitor_url(SUBDOMAIN, REGION, farm_id=FARM_ID, queue_id=QUEUE_ID, job_id=JOB_ID)
+        build_monitor_url(SUBDOMAIN, REGION, farm_id=FARM_ID, queue_id=QUEUE_ID, job_id=JOB_ID)
         == f"{HOST}/{REGION}/farms/{FARM_ID}/queues/{QUEUE_ID}?jobId={JOB_ID}"
     )
 
 
-def test_get_monitor_url_step():
+def test_build_monitor_url_step():
     assert (
-        get_monitor_url(
+        build_monitor_url(
             SUBDOMAIN, REGION, farm_id=FARM_ID, queue_id=QUEUE_ID, job_id=JOB_ID, step_id=STEP_ID
         )
         == f"{HOST}/{REGION}/farms/{FARM_ID}/queues/{QUEUE_ID}?jobId={JOB_ID}&stepId={STEP_ID}"
     )
 
 
-def test_get_monitor_url_task():
+def test_build_monitor_url_task():
     """The full task URL matches the example from the feature request."""
-    assert get_monitor_url(
+    assert build_monitor_url(
         SUBDOMAIN,
         REGION,
         farm_id=FARM_ID,
@@ -75,9 +77,9 @@ def test_get_monitor_url_task():
     )
 
 
-def test_get_monitor_url_requires_subdomain():
+def test_build_monitor_url_requires_subdomain():
     with pytest.raises(ValueError, match="subdomain"):
-        get_monitor_url("", REGION, farm_id=FARM_ID)
+        build_monitor_url("", REGION, farm_id=FARM_ID)
 
 
 @pytest.mark.parametrize(
@@ -92,31 +94,31 @@ def test_get_monitor_url_requires_subdomain():
         ),
     ],
 )
-def test_get_monitor_url_hierarchy_violations(kwargs, missing):
+def test_build_monitor_url_hierarchy_violations(kwargs, missing):
     """A lower-level id without its parent is a ValueError (e.g. queue with no farm)."""
     with pytest.raises(ValueError, match=missing):
-        get_monitor_url(SUBDOMAIN, REGION, **kwargs)
+        build_monitor_url(SUBDOMAIN, REGION, **kwargs)
 
 
-def test_get_monitor_url_region_defaults_from_config(fresh_deadline_config):
+def test_build_monitor_url_region_defaults_from_config(fresh_deadline_config):
     """When region is omitted it resolves from defaults.farm_region, like elsewhere."""
     config.set_setting("defaults.farm_region", "eu-west-1")
-    url = get_monitor_url(SUBDOMAIN, farm_id=FARM_ID)
+    url = build_monitor_url(SUBDOMAIN, farm_id=FARM_ID)
     assert (
         url
         == f"https://{SUBDOMAIN}.eu-west-1.deadlinecloud.amazonaws.com/eu-west-1/farms/{FARM_ID}"
     )
 
 
-def test_get_monitor_url_requires_region(fresh_deadline_config):
+def test_build_monitor_url_requires_region(fresh_deadline_config):
     """With no explicit region and nothing configured, we raise rather than emit a bad URL."""
     with pytest.raises(ValueError, match="region is required"):
-        get_monitor_url(SUBDOMAIN, farm_id=FARM_ID)
+        build_monitor_url(SUBDOMAIN, farm_id=FARM_ID)
 
 
-def test_get_monitor_url_url_encodes_query_values():
+def test_build_monitor_url_url_encodes_query_values():
     """Query parameter values are URL-encoded."""
-    url = get_monitor_url(
+    url = build_monitor_url(
         SUBDOMAIN,
         REGION,
         farm_id=FARM_ID,
@@ -126,10 +128,10 @@ def test_get_monitor_url_url_encodes_query_values():
     assert "jobId=job+with+spaces%26x%3D1" in url
 
 
-def test_get_monitor_url_cross_region_host_and_path_differ():
+def test_build_monitor_url_cross_region_host_and_path_differ():
     """A monitor in one region linking to a farm in another: host uses the
     monitor region, path uses the farm region."""
-    url = get_monitor_url(
+    url = build_monitor_url(
         SUBDOMAIN,
         "eu-west-1",  # farm/resource region -> path
         farm_id=FARM_ID,
@@ -142,9 +144,9 @@ def test_get_monitor_url_cross_region_host_and_path_differ():
     )
 
 
-def test_get_monitor_url_monitor_region_defaults_to_region():
+def test_build_monitor_url_monitor_region_defaults_to_region():
     """When monitor_region is omitted, the host uses the resource region."""
-    assert get_monitor_url(SUBDOMAIN, REGION, farm_id=FARM_ID) == (
+    assert build_monitor_url(SUBDOMAIN, REGION, farm_id=FARM_ID) == (
         f"https://{SUBDOMAIN}.{REGION}.deadlinecloud.amazonaws.com/{REGION}/farms/{FARM_ID}"
     )
 

--- a/test/unit/deadline_client/cli/test_cli_bundle_print_response.py
+++ b/test/unit/deadline_client/cli/test_cli_bundle_print_response.py
@@ -1,0 +1,66 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Tests for the bundle gui-submit response formatter (_print_response), focused on
+the monitor URL (jobUrl / "Job URL:").
+"""
+
+import json
+
+from deadline.client.cli._groups.bundle_group import _print_response
+
+JOB_ID = "job-0123456789abcdefabcdefabcdefabcd"
+JOB_URL = (
+    "https://mymonitor.us-east-1.deadlinecloud.amazonaws.com/us-east-1/"
+    "farms/farm-1234/queues/queue-5678?jobId=" + JOB_ID
+)
+
+
+def test_print_response_json_includes_job_url(capsys):
+    _print_response(
+        output="json",
+        job_bundle_dir="/tmp/bundle",
+        job_history_bundle_dir="/tmp/history",
+        job_id=JOB_ID,
+        job_url=JOB_URL,
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "SUBMITTED"
+    assert payload["jobId"] == JOB_ID
+    assert payload["jobUrl"] == JOB_URL
+
+
+def test_print_response_json_omits_job_url_when_absent(capsys):
+    _print_response(
+        output="json",
+        job_bundle_dir="/tmp/bundle",
+        job_history_bundle_dir="/tmp/history",
+        job_id=JOB_ID,
+        job_url=None,
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert "jobUrl" not in payload
+
+
+def test_print_response_verbose_includes_job_url(capsys):
+    _print_response(
+        output="verbose",
+        job_bundle_dir="/tmp/bundle",
+        job_history_bundle_dir="/tmp/history",
+        job_id=JOB_ID,
+        job_url=JOB_URL,
+    )
+    out = capsys.readouterr().out
+    assert f"Job URL: {JOB_URL}" in out
+
+
+def test_print_response_verbose_omits_job_url_when_absent(capsys):
+    _print_response(
+        output="verbose",
+        job_bundle_dir="/tmp/bundle",
+        job_history_bundle_dir="/tmp/history",
+        job_id=JOB_ID,
+        job_url=None,
+    )
+    out = capsys.readouterr().out
+    assert "Job URL:" not in out

--- a/test/unit/deadline_mcp/test_mcp_job.py
+++ b/test/unit/deadline_mcp/test_mcp_job.py
@@ -1,0 +1,52 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Tests for deadline._mcp.tools.job.submit_job, focused on the monitor URL in the
+response.
+"""
+
+from unittest.mock import patch
+
+from deadline._mcp.tools import job as job_tool
+
+FARM_ID = "farm-1234"
+QUEUE_ID = "queue-5678"
+JOB_ID = "job-9abc"
+JOB_URL = "https://mymonitor.us-east-1.deadlinecloud.amazonaws.com/us-east-1/farms/farm-1234/queues/queue-5678?jobId=job-9abc"
+
+
+def _run_submit(tmp_path, job_url):
+    bundle_dir = str(tmp_path)
+    with (
+        patch.object(job_tool, "create_job_from_job_bundle", return_value=JOB_ID),
+        patch.object(job_tool, "_get_job_monitor_url", return_value=job_url) as mock_url,
+    ):
+        result = job_tool.submit_job(
+            job_bundle_dir=bundle_dir,
+            farm_id=FARM_ID,
+            queue_id=QUEUE_ID,
+        )
+    return result, mock_url
+
+
+def test_submit_job_includes_job_url(tmp_path):
+    """When a monitor URL is available it is returned as job_url."""
+    result, mock_url = _run_submit(tmp_path, JOB_URL)
+
+    assert result["status"] == "success"
+    assert result["job_id"] == JOB_ID
+    assert result["job_url"] == JOB_URL
+    # URL helper is called with the resolved farm/queue/job.
+    _, kwargs = mock_url.call_args
+    assert kwargs["farm_id"] == FARM_ID
+    assert kwargs["queue_id"] == QUEUE_ID
+    assert kwargs["job_id"] == JOB_ID
+
+
+def test_submit_job_job_url_none_when_not_monitor(tmp_path):
+    """Non-monitor credentials -> job_url is present but None."""
+    result, _ = _run_submit(tmp_path, None)
+
+    assert result["status"] == "success"
+    assert result["job_id"] == JOB_ID
+    assert result["job_url"] is None

--- a/test/unit/deadline_mcp/test_mcp_job.py
+++ b/test/unit/deadline_mcp/test_mcp_job.py
@@ -7,6 +7,7 @@ response.
 
 from unittest.mock import patch
 
+from deadline.client import config
 from deadline._mcp.tools import job as job_tool
 
 FARM_ID = "farm-1234"
@@ -16,6 +17,11 @@ JOB_URL = "https://mymonitor.us-east-1.deadlinecloud.amazonaws.com/us-east-1/far
 
 
 def _run_submit(tmp_path, job_url):
+    # submit_job reads/writes a literal "[defaults]" config section. Seed it as a
+    # configured workstation would: setting aws_profile_name (which has no
+    # profile-scoping dependency) materializes that section in the isolated config.
+    config.set_setting("defaults.aws_profile_name", "(default)")
+
     bundle_dir = str(tmp_path)
     with (
         patch.object(job_tool, "create_job_from_job_bundle", return_value=JOB_ID),
@@ -29,7 +35,7 @@ def _run_submit(tmp_path, job_url):
     return result, mock_url
 
 
-def test_submit_job_includes_job_url(tmp_path):
+def test_submit_job_includes_job_url(fresh_deadline_config, tmp_path):
     """When a monitor URL is available it is returned as job_url."""
     result, mock_url = _run_submit(tmp_path, JOB_URL)
 
@@ -43,7 +49,7 @@ def test_submit_job_includes_job_url(tmp_path):
     assert kwargs["job_id"] == JOB_ID
 
 
-def test_submit_job_job_url_none_when_not_monitor(tmp_path):
+def test_submit_job_job_url_none_when_not_monitor(fresh_deadline_config, tmp_path):
     """Non-monitor credentials -> job_url is present but None."""
     result, _ = _run_submit(tmp_path, None)
 


### PR DESCRIPTION
## What

Implements the request in #627: return the monitor URL for a job so it can be shared (e.g. in a Slack notification) after submission.

### 1. New `build_monitor_url()` helper (`deadline.client.api`)

A pure URL builder — it assembles the URL from its parts and makes no network calls:

```python
from deadline.client.api import build_monitor_url

build_monitor_url("mymonitor", "us-east-1", farm_id="farm-…", queue_id="queue-…")
# https://mymonitor.us-east-1.deadlinecloud.amazonaws.com/us-east-1/farms/farm-…/queues/queue-…
```

- Signature: `build_monitor_url(subdomain, region=None, farm_id=None, queue_id=None, job_id=None, step_id=None, task_id=None, *, monitor_region=None, config=None)`.
- `subdomain` is required (available from `deadline:GetMonitor`'s `subdomain` field); the full host is `subdomain.Region.deadlinecloud.amazonaws.com`.
- `region` defaults from `defaults.farm_region` (same resolution used elsewhere in the client), or can be passed explicitly.
- `monitor_region` controls the region in the host (the monitor's own region); it defaults to `region`. Pass it for cross-region farms, where the monitor and farm live in different regions.
- Enforces the resource hierarchy: a queue requires a farm, a job requires a queue, a step requires a job, a task requires a step. `build_monitor_url(sub, region, queue_id=…)` with no farm raises `ValueError`.
- With no farm it returns the all-farms list URL; job/step/task are added as `jobId`/`stepId`/`taskId` query params on the queue page. Routes mirror the monitor web app.

### 2. Surface the job URL after submission

When credentials came from Deadline Cloud monitor, the job's URL is looked up (via `GetMonitor`) and surfaced:

- **Text**: `create_job_from_job_bundle` prints a `Job URL: …` line (covers `deadline bundle submit`).
- **JSON**: `deadline bundle gui-submit --output json` gains a `jobUrl` field.
- **MCP**: the `submit_job` tool response gains a `job_url` field.

This is best-effort and never affects submission — a missing monitor, a failed `GetMonitor` call, or host-provided credentials simply result in no URL. `create_job_from_job_bundle` still returns the job id string (non-breaking); programmatic callers can use `build_monitor_url()` directly.

## Testing

- New `test/unit/deadline_client/api/test_monitor_urls.py` covering every route level (the task URL asserts an exact match to the example in #627), hierarchy violations, region defaulting/requirement, cross-region host vs. path regions, URL-encoding, and the best-effort helper.
- New tests for the MCP `submit_job` `job_url` field, the `gui-submit` `jobUrl`/`Job URL:` output, and the `create_job_from_job_bundle` text line.
- `hatch run fmt`, `hatch run lint` (ruff + mypy), full `hatch run test`, and `hatch build` all pass.

Closes #627