### PR TITLE
test: clear leaked AWS region env vars in aws_config fixture

### DIFF
--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -90,6 +90,12 @@ def aws_config(monkeypatch):
         monkeypatch.setenv("AWS_CONFIG_FILE", str(temp_file_path))
         monkeypatch.delenv("AWS_DEFAULT_PROFILE", raising=False)
         monkeypatch.delenv("AWS_PROFILE", raising=False)
+        # Also clear the region env vars. Otherwise a leaked AWS_DEFAULT_REGION/AWS_REGION
+        # (e.g. the "us-west-2" that the deadline_mock fixture writes directly to os.environ)
+        # takes precedence over the config-file region, so tests that write a [default] region
+        # to AWS_CONFIG_FILE become order-dependent and flaky.
+        monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
+        monkeypatch.delenv("AWS_REGION", raising=False)
 
         yield temp_file_path
 


### PR DESCRIPTION
## What was happening

The release action's publish step was failing (e.g. [run 29617837217](https://github.com/aws-deadline/deadline-cloud/actions/runs/29617837217)) on two cross-region monitor-URL tests added in #1272:

- `test_get_monitor_subdomain_uses_profile_region_not_farm_region`
- `test_get_job_monitor_url_cross_region_without_injected_client`

Both fail with the URL silently coming back as `None`, tracing to `GetMonitor` raising `ResourceNotFoundException: Monitor not found in us-west-2`.

## Root cause

The autouse `aws_config` fixture (`test/unit/conftest.py`) exists to *sanitize the environment* and already clears `AWS_PROFILE`/`AWS_DEFAULT_PROFILE` — but it left `AWS_DEFAULT_REGION`/`AWS_REGION` untouched.

The shared `deadline_mock` fixture writes `AWS_DEFAULT_REGION=us-west-2` **directly** to `os.environ` (not via monkeypatch, so it's never restored) and leaks into later tests. botocore gives that env var precedence over the config-file region, so the two new tests — which write `[default]\nregion = us-east-1` to `AWS_CONFIG_FILE` and expect that region to win — end up with a `GetMonitor` client scoped to `us-west-2`. The test wire stub then raises `ResourceNotFoundException`, the URL becomes `None`, and the assertion fails. Ordering-dependent → flaky.

## Fix

Clear `AWS_DEFAULT_REGION` and `AWS_REGION` in the `aws_config` fixture alongside the profile vars, so every test starts from a clean region environment. This fixes the whole class of region-leak flakiness at its source rather than patching one test; `deadline_mock` still sets its own `us-west-2` for tests that use it.

## Testing

- Reproduced the failure with `AWS_DEFAULT_REGION=us-west-2` set (simulating the leak) and the fix reverted — both tests fail with `url == None`, matching the CI traceback.
- With the fix applied and the same leaked env, both tests pass. Ran the full `test_monitor_urls.py` + `test_job_monitoring.py` (56 tests) under the leaked env — all pass.
- `hatch run fmt` and `hatch run lint` (ruff + mypy) clean.