### PR TITLE
chore: review fix/agents guidance import lint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,23 @@ class _PrivateClass:  # Private
     pass
 ```
 
+### Comments
+
+Prefer clear code over comments — rename, extract, or restructure before adding
+one. Comment only where the code can't be made clear on its own. Comments are
+terse, explain *why* not *what*, and are stateless: no history, past approaches,
+or migrations (git holds that).
+
+```python
+# DON'T
+# previously we used urllib, now we use requests  (history)
+count += 1  # increment count  (restates the code)
+
+# DO
+# STS is eventually consistent right after role creation.
+resp = retry_once(fetch)
+```
+
 ### Commit Messages
 Use [conventional commits](https://www.conventionalcommits.org/):
 - `feat:` - New features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,10 @@ line-length = 100
 
 [tool.ruff.lint]
 # F822 (undefined name in __all__) is on by default; RUF022 keeps __all__ sorted.
-extend-select = ["RUF022"]
+# E402 (imports must be at the top of the file) is pinned explicitly here so it
+# can't silently regress if a future ruff drops it from the defaults; it is
+# build-failing via `hatch run lint`.
+extend-select = ["RUF022", "E402"]
 ignore = ["E501"]
 
 [tool.ruff.lint.isort]


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Agents in this codebase often put imports in functions and write long verbose comments.

### What was the solution? (How)
Add a linter for imports not at the top of the file
Add AGENTS.md guidance about comments

### What is the impact of this change?
Agents produce better code with less feedback.

### How was this change tested?
CI

### Was this change documented?
n/a

### Does this PR introduce new dependencies?
No

### Is this a breaking change?
No

### Does this change impact security?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*


## Testing

Manually verified the new lint config locally (ruff 0.15.22 via `hatch run lint`, macOS):

1. **Rules actually fire**: created a scratch file with a module-level import after executable code (no `noqa`) and an unsorted `__all__`. `hatch run ruff check` flagged both — `E402 Module level import not at top of file` and ``RUF022 `__all__` is not sorted`` — and exited non-zero.
2. **Escape hatch works**: adding `# noqa: E402` to the late import made the file pass, matching the existing suppressions in the tree (e.g. `src/deadline/client/cli/_common.py`, `test/ui/conftest.py`, `test/blender_submitter_ui/*` — deferred/`bpy`-gated imports).
3. **No spurious hits on the real tree**: after removing the scratch file, `hatch run lint` passes clean on the full repo (`ruff check .` — all checks passed; `ruff format --check` — 328 files already formatted; `mypy` — no issues in 311 files).
