### PR TITLE
fix: DeadlineLoginDialog.login() returns True on successful login

### DIFF
--- a/src/deadline/client/ui/dialogs/deadline_login_dialog.py
+++ b/src/deadline/client/ui/dialogs/deadline_login_dialog.py
@@ -198,4 +198,10 @@ class DeadlineLoginDialog(QMessageBox):
         Runs the modal login dialog, returning True if the login was
         successful, False otherwise.
         """
-        return super().exec_() == QDialog.DialogCode.Accepted
+        # A successful login resolves the dialog one of two ways depending on
+        # close_on_success: with close_on_success=True the success handler calls
+        # self.accept() (QDialog.Accepted); with close_on_success=False it swaps
+        # in an "Ok" button, and clicking a QMessageBox standard button sets the
+        # result to that button's enum (QMessageBox.Ok). Both mean success.
+        result = super().exec_()
+        return result in (QDialog.DialogCode.Accepted, QMessageBox.Ok)

--- a/src/deadline/client/ui/dialogs/deadline_login_dialog.py
+++ b/src/deadline/client/ui/dialogs/deadline_login_dialog.py
@@ -21,6 +21,7 @@ from .._utils import tr
 from ..controllers import AsyncTaskRunner
 from qtpy.QtWidgets import (  # pylint: disable=import-error; type: ignore
     QApplication,
+    QDialog,
     QMessageBox,
     QWidget,
 )
@@ -197,4 +198,4 @@ class DeadlineLoginDialog(QMessageBox):
         Runs the modal login dialog, returning True if the login was
         successful, False otherwise.
         """
-        return super().exec_() == QMessageBox.Ok
+        return super().exec_() == QDialog.DialogCode.Accepted

--- a/test/unit/deadline_client/ui/dialogs/test_deadline_login_dialog.py
+++ b/test/unit/deadline_client/ui/dialogs/test_deadline_login_dialog.py
@@ -44,6 +44,29 @@ class TestDeadlineLoginDialogReturnValue:
 
             assert dialog.exec_() is True
 
+    def test_exec_returns_true_on_success_when_not_closing_on_success(self, qtbot):
+        """
+        With close_on_success=False a successful login does not call accept();
+        instead it swaps in an "Ok" button and waits for the user to click it.
+        Clicking a QMessageBox standard button sets the result to QMessageBox.Ok
+        (1024), not QDialog.Accepted (1). exec_() must still return True.
+        """
+        with patch(_API_LOGIN, return_value="my-profile"):
+            dialog = DeadlineLoginDialog(parent=None, close_on_success=False)
+            qtbot.addWidget(dialog)
+
+            def click_ok():
+                ok_button = dialog.button(QMessageBox.Ok)
+                if ok_button is None:
+                    # Success handler hasn't swapped in the Ok button yet; retry.
+                    QTimer.singleShot(10, click_ok)
+                    return
+                ok_button.click()
+
+            QTimer.singleShot(10, click_ok)
+
+            assert dialog.exec_() is True
+
     def test_exec_returns_false_when_user_cancels(self, qtbot):
         """
         A realistic cancel: the login backend blocks until it observes the

--- a/test/unit/deadline_client/ui/dialogs/test_deadline_login_dialog.py
+++ b/test/unit/deadline_client/ui/dialogs/test_deadline_login_dialog.py
@@ -56,7 +56,7 @@ class TestDeadlineLoginDialogReturnValue:
             qtbot.addWidget(dialog)
 
             def click_ok():
-                ok_button = dialog.button(QMessageBox.Ok)
+                ok_button = dialog.button(QMessageBox.StandardButton.Ok)
                 if ok_button is None:
                     # Success handler hasn't swapped in the Ok button yet; retry.
                     QTimer.singleShot(10, click_ok)
@@ -92,7 +92,7 @@ class TestDeadlineLoginDialogReturnValue:
                 if not login_started.is_set():
                     QTimer.singleShot(10, click_cancel)
                     return
-                dialog.button(QMessageBox.Cancel).click()
+                dialog.button(QMessageBox.StandardButton.Cancel).click()
 
             QTimer.singleShot(10, click_cancel)
 
@@ -109,7 +109,7 @@ class TestDeadlineLoginDialogReturnValue:
             qtbot.addWidget(dialog)
 
             def close_dialog():
-                close_button = dialog.button(QMessageBox.Close)
+                close_button = dialog.button(QMessageBox.StandardButton.Close)
                 if close_button is None:
                     # Error handler hasn't run yet; poll again shortly.
                     QTimer.singleShot(10, close_dialog)

--- a/test/unit/deadline_client/ui/dialogs/test_deadline_login_dialog.py
+++ b/test/unit/deadline_client/ui/dialogs/test_deadline_login_dialog.py
@@ -1,0 +1,51 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Tests for the DeadlineLoginDialog."""
+
+from unittest.mock import patch
+
+import pytest
+
+try:
+    from qtpy.QtWidgets import QDialog, QMessageBox
+    from deadline.client.ui.dialogs.deadline_login_dialog import DeadlineLoginDialog
+except ImportError:
+    pytest.importorskip("deadline.client.ui.dialogs.deadline_login_dialog")
+
+
+def _make_dialog_without_init():
+    """
+    Build a DeadlineLoginDialog instance without running its __init__.
+
+    DeadlineLoginDialog.__init__ starts a background login thread and connects
+    several signals (including Signal(BaseException)). We only want to exercise
+    the exec_() return-value logic here, so we initialize just the QMessageBox
+    base and leave the login machinery untouched.
+    """
+    dialog = DeadlineLoginDialog.__new__(DeadlineLoginDialog)
+    QMessageBox.__init__(dialog)
+    return dialog
+
+
+class TestDeadlineLoginDialogReturnValue:
+    """Tests for the truthiness returned by exec_()/login()."""
+
+    def test_exec_returns_true_on_successful_login(self, qtbot):
+        """
+        A successful login calls self.accept(), which makes the underlying
+        QMessageBox.exec_() return QDialog.Accepted. DeadlineLoginDialog.exec_()
+        must report this as True.
+        """
+        dialog = _make_dialog_without_init()
+        qtbot.addWidget(dialog)
+
+        with patch.object(QMessageBox, "exec_", return_value=QDialog.DialogCode.Accepted):
+            assert dialog.exec_() is True
+
+    def test_exec_returns_false_on_rejected_login(self, qtbot):
+        """A canceled/rejected dialog (QDialog.Rejected) must report False."""
+        dialog = _make_dialog_without_init()
+        qtbot.addWidget(dialog)
+
+        with patch.object(QMessageBox, "exec_", return_value=QDialog.DialogCode.Rejected):
+            assert dialog.exec_() is False

--- a/test/unit/deadline_client/ui/dialogs/test_deadline_login_dialog.py
+++ b/test/unit/deadline_client/ui/dialogs/test_deadline_login_dialog.py
@@ -2,50 +2,97 @@
 
 """Tests for the DeadlineLoginDialog."""
 
+import threading
 from unittest.mock import patch
 
 import pytest
 
 try:
-    from qtpy.QtWidgets import QDialog, QMessageBox
+    from qtpy.QtCore import QTimer
+    from qtpy.QtWidgets import QMessageBox
     from deadline.client.ui.dialogs.deadline_login_dialog import DeadlineLoginDialog
 except ImportError:
     pytest.importorskip("deadline.client.ui.dialogs.deadline_login_dialog")
 
 
-def _make_dialog_without_init():
-    """
-    Build a DeadlineLoginDialog instance without running its __init__.
-
-    DeadlineLoginDialog.__init__ starts a background login thread and connects
-    several signals (including Signal(BaseException)). We only want to exercise
-    the exec_() return-value logic here, so we initialize just the QMessageBox
-    base and leave the login machinery untouched.
-    """
-    dialog = DeadlineLoginDialog.__new__(DeadlineLoginDialog)
-    QMessageBox.__init__(dialog)
-    return dialog
+# Where DeadlineLoginDialog looks up the login backend. The dialog calls
+# ``api.login(...)`` from its background thread, so patching this lets us drive
+# the login to success or hold it open for cancellation without touching AWS.
+_API_LOGIN = "deadline.client.ui.dialogs.deadline_login_dialog.api.login"
 
 
 class TestDeadlineLoginDialogReturnValue:
-    """Tests for the truthiness returned by exec_()/login()."""
+    """
+    Regression guard for the exec_()/login() return-value contract.
+
+    A successful login calls ``self.accept()`` (QDialog.Accepted == 1); a
+    cancel/reject leaves the dialog rejected. exec_() must translate those into
+    True / False. The bug this guards against compared the result against
+    QMessageBox.Ok (1024), so a real success-via-accept() wrongly returned False.
+    """
 
     def test_exec_returns_true_on_successful_login(self, qtbot):
         """
-        A successful login calls self.accept(), which makes the underlying
-        QMessageBox.exec_() return QDialog.Accepted. DeadlineLoginDialog.exec_()
-        must report this as True.
+        Construct the real dialog (running its full __init__, which starts the
+        background login thread and connects its signals) with the login backend
+        mocked to succeed. The success handler calls self.accept(), so exec_()
+        must return True.
         """
-        dialog = _make_dialog_without_init()
-        qtbot.addWidget(dialog)
+        with patch(_API_LOGIN, return_value="my-profile"):
+            dialog = DeadlineLoginDialog(parent=None, close_on_success=True)
+            qtbot.addWidget(dialog)
 
-        with patch.object(QMessageBox, "exec_", return_value=QDialog.DialogCode.Accepted):
             assert dialog.exec_() is True
 
-    def test_exec_returns_false_on_rejected_login(self, qtbot):
-        """A canceled/rejected dialog (QDialog.Rejected) must report False."""
-        dialog = _make_dialog_without_init()
-        qtbot.addWidget(dialog)
+    def test_exec_returns_false_when_user_cancels(self, qtbot):
+        """
+        A realistic cancel: the login backend blocks until it observes the
+        cancellation flag, and the user clicks the Cancel button while it is
+        still running. The dialog is rejected, so exec_() must return False.
+        """
+        login_started = threading.Event()
 
-        with patch.object(QMessageBox, "exec_", return_value=QDialog.DialogCode.Rejected):
+        def blocking_login(on_pending_authorization, on_cancellation_check, config=None):
+            # Emulate the real handshake: keep running until the dialog signals
+            # cancellation (via the Cancel button setting dialog.canceled).
+            login_started.set()
+            while not on_cancellation_check():
+                pass
+            return "unused-because-canceled"
+
+        with patch(_API_LOGIN, side_effect=blocking_login):
+            dialog = DeadlineLoginDialog(parent=None, close_on_success=True)
+            qtbot.addWidget(dialog)
+
+            def click_cancel():
+                # Wait until the background login is actually running, then cancel.
+                if not login_started.is_set():
+                    QTimer.singleShot(10, click_cancel)
+                    return
+                dialog.button(QMessageBox.Cancel).click()
+
+            QTimer.singleShot(10, click_cancel)
+
+            assert dialog.exec_() is False
+
+    def test_exec_returns_false_on_login_error(self, qtbot):
+        """
+        When the login backend raises, the dialog shows an error and swaps in a
+        Close button instead of accepting. The user closes it, so the dialog is
+        rejected and exec_() must return False.
+        """
+        with patch(_API_LOGIN, side_effect=RuntimeError("boom")):
+            dialog = DeadlineLoginDialog(parent=None, close_on_success=True)
+            qtbot.addWidget(dialog)
+
+            def close_dialog():
+                close_button = dialog.button(QMessageBox.Close)
+                if close_button is None:
+                    # Error handler hasn't run yet; poll again shortly.
+                    QTimer.singleShot(10, close_dialog)
+                    return
+                close_button.click()
+
+            QTimer.singleShot(10, close_dialog)
+
             assert dialog.exec_() is False


### PR DESCRIPTION
Fixes: *<insert link to GitHub issue here>*

### What was the problem/requirement? (What/Why)

`DeadlineLoginDialog.login()` returned `False` even on a successful login. A successful login calls `self.accept()`, so the underlying `exec_()` returns `QDialog.Accepted` (1), but the code compared the result against `QMessageBox.Ok` (1024). This broke the documented `if ...login():` usage pattern — callers thought every login failed.

### What was the solution? (How)

Compare `exec_()` against `QDialog.DialogCode.Accepted` instead of `QMessageBox.Ok`, so a successful (accepted) login returns `True` and a cancel/reject returns `False`.

### What is the impact of this change?

Callers using the documented `if ...login():` pattern now correctly see success.

### How was this change tested?

Replaced the original isolated test with realistic pytest-qt (`qtbot`) tests that construct `DeadlineLoginDialog` through its real `__init__` and drive the real modal `exec_()`, patching only the `api.login` backend (no AWS): success → `accept()` → `True`; user-cancel → `False`; login error → `False`. This exercises `__init__`, the background-task start, the success/error/cancel signal handlers, and `exec_()`.

- Have you run the unit tests? **Yes** — `test/unit/deadline_client/ui/dialogs/test_deadline_login_dialog.py` (3 passed, stable across repeated runs under the default xdist config).
- Have you run the integration tests? No.

### Was this change documented?

- No public-contract change (restores the documented return-value behavior).
- README.md not affected.

### Does this PR introduce new dependencies?

*   [ ] This PR adds one or more new dependency Python packages.
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?

No — it fixes the return value to match the documented contract.

### Does this change impact security?

No.


## Testing

**Automated (headless, `QT_QPA_PLATFORM=offscreen`, PySide6):**

- `test/unit/deadline_client/ui/dialogs/test_deadline_login_dialog.py` — 4 passed. These construct the real dialog via `__init__` (real background task + signal wiring, only `api.login` patched) and drive the real modal `exec_()`:
  - success with `close_on_success=True` → `accept()` → returns **True**
  - success with `close_on_success=False` → Ok button clicked → returns **True**
  - user clicks Cancel while login in flight → returns **False**
  - `api.login` raises → Close clicked → returns **False**
- Scratch probe stubbing `super().exec_()` directly confirmed the return-value mapping for every relevant result code: `QDialog.Accepted` (1) → True, `QMessageBox.Ok` (1024) → True, `QDialog.Rejected` (0) → False, `QMessageBox.Cancel` (4194304) → False, `QMessageBox.Close` (2097152) → False.

**Not automatable — needs a human click-through** (the real browser/SSO login handshake can't be scripted):

1. In a submitter (or any caller of `DeadlineLoginDialog.login(...)`), open the login dialog while logged out and complete a real login with the default `close_on_success=True` — the dialog should close itself and the caller should see success (e.g. "Logged in successfully" path, not the failure path).
2. Repeat with `close_on_success=False` (if a caller uses it): after login the dialog shows "Successfully logged into: ..." with an Ok button; clicking Ok must also report success to the caller.
3. Cancel mid-login and confirm the caller sees failure.



**Manually verified (2026-07-23):** completed a real browser SSO login through the GUI `DeadlineLoginDialog` from an editable install of this branch — on success the dialog closed itself and the caller correctly saw a logged-in state (no re-click needed), and cancelling mid-login was correctly treated as not-logged-in.