### PR TITLE
fix: avoid crashes in job bundle submission edge cases

### DIFF
--- a/src/deadline/client/api/_submit_job_bundle.py
+++ b/src/deadline/client/api/_submit_job_bundle.py
@@ -1158,9 +1158,9 @@ def wait_for_create_job_to_complete(
             time.sleep(delay)
             delay = min(delay * 2, max_delay)
         elif current_status in failure_statuses:
-            return False, job["lifecycleStatusMessage"]
+            return False, job.get("lifecycleStatusMessage", "")
         else:
-            return True, job["lifecycleStatusMessage"]
+            return True, job.get("lifecycleStatusMessage", "")
 
     raise TimeoutError(
         f"Timed out after {timeout_seconds} seconds while waiting for Job to be created: {job_id}"

--- a/src/deadline/client/api/_submit_job_bundle.py
+++ b/src/deadline/client/api/_submit_job_bundle.py
@@ -309,11 +309,13 @@ def _filter_redundant_known_paths(known_asset_paths: Iterable[str]) -> list[str]
 def _save_debug_snapshot(
     debug_snapshot_dir: str,
     create_job_args: dict,
-    asset_manager: S3AssetManager,
+    asset_manager: Optional[S3AssetManager],
     queue: dict,
     storage_profile_id: str,
     storage_profile: Optional[StorageProfile],
 ):
+    # ``asset_manager`` is only dereferenced when the create_job args carry
+    # attachments; a snapshot with no attachments passes None here.
     # Save the full set of arguments for passing to the deadline.create_job API
     with open(
         os.path.join(debug_snapshot_dir, "create_job_args.json"), "w", encoding="utf-8"
@@ -821,6 +823,9 @@ def create_job_from_job_bundle(
 
     # Hash and upload job attachments if there are any
     files_processed = False
+    # Only assigned when there are attachments to process, but referenced
+    # unconditionally by the debug-snapshot path below, so initialize it here.
+    asset_manager: Optional[S3AssetManager] = None
     if asset_references and "jobAttachmentSettings" in queue:
         # Extend input_filenames with all the files in the input_directories
         missing_directories: set[str] = set()

--- a/src/deadline/client/api/_submit_job_bundle.py
+++ b/src/deadline/client/api/_submit_job_bundle.py
@@ -954,6 +954,7 @@ def create_job_from_job_bundle(
                     asset_manifests,
                     print_function_callback,
                     upload_progress_callback,
+                    config=config,
                     from_gui=from_gui,
                     force_s3_check=force_s3_check,
                 )
@@ -964,6 +965,7 @@ def create_job_from_job_bundle(
                     asset_manifests,
                     print_function_callback,
                     upload_progress_callback,
+                    config=config,
                     from_gui=from_gui,
                 )
 

--- a/test/unit/deadline_client/api/test_job_bundle_submission.py
+++ b/test/unit/deadline_client/api/test_job_bundle_submission.py
@@ -20,15 +20,17 @@ from deadline.job_attachments.exceptions import MisconfiguredInputsError
 from deadline.job_attachments.models import (
     AssetRootGroup,
     AssetUploadGroup,
+    Attachments,
     FileSystemLocation,
     FileSystemLocationType,
     JobAttachmentsFileSystem,
+    ManifestProperties,
     PathFormat,
     StorageProfile,
     StorageProfileOperatingSystemFamily,
 )
 from deadline.job_attachments.upload import S3AssetManager
-from deadline.job_attachments.progress_tracker import ProgressReportMetadata
+from deadline.job_attachments.progress_tracker import ProgressReportMetadata, SummaryStatistics
 
 from ..testing_utilities import patch_calls_for_create_job_from_job_bundle, write_test_asset_files
 from ..shared_constants import (
@@ -1336,3 +1338,94 @@ def test_create_job_from_job_bundle_debug_snapshot_no_attachments(
     mock.get_boto3_client().create_job.assert_not_called()
     # The snapshot files were written.
     assert os.path.isfile(os.path.join(str(tmp_path), "create_job_args.json"))
+    # No attachments means no "aws s3 cp" upload commands in the generated script.
+    with open(os.path.join(str(tmp_path), "submit_job.sh"), encoding="utf-8") as f:
+        submit_script = f.read()
+    assert "aws s3 cp" not in submit_script
+    assert "aws deadline create-job" in submit_script
+
+
+def test_create_job_from_job_bundle_debug_snapshot_with_attachments(
+    fresh_deadline_config, temp_job_bundle_dir, temp_assets_dir, tmp_path
+):
+    """
+    A debug snapshot of a bundle WITH job attachments must snapshot the assets
+    (via _snapshot_attachments, forwarding the caller's config for telemetry),
+    pass the bound asset_manager to _save_debug_snapshot, and include the
+    "aws s3 cp" upload commands in the generated submit scripts.
+
+    This is the other side of making ``asset_manager`` Optional: the attachments
+    branch must keep working with a real (non-None) asset manager.
+    """
+    custom_config = config.config_file.read_config()
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID, config=custom_config)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID, config=custom_config)
+
+    snapshot_assets_return = (
+        SummaryStatistics(),
+        Attachments(
+            [
+                ManifestProperties(
+                    rootPath="/mnt/root/path1",
+                    rootPathFormat=PathFormat.POSIX,
+                    inputManifestPath="mock-manifest",
+                    inputManifestHash="mock-manifest-hash",
+                    outputRelativeDirectories=["."],
+                ),
+            ],
+        ),
+    )
+
+    with (
+        patch_calls_for_create_job_from_job_bundle() as mock,
+        patch.object(
+            api._submit_job_bundle,
+            "_snapshot_attachments",
+            wraps=api._submit_job_bundle._snapshot_attachments,
+        ) as mock_snapshot_attachments,
+        patch.object(
+            S3AssetManager, "snapshot_assets", return_value=snapshot_assets_return
+        ) as mock_snapshot_assets,
+    ):
+        # Write a JSON template
+        with open(os.path.join(temp_job_bundle_dir, "template.json"), "w", encoding="utf8") as f:
+            f.write(MOCK_JOB_TEMPLATE_CASES["MINIMAL_JSON"][1])
+
+        # Create asset files and reference them so the attachments path runs.
+        asset_contents = {"asset-1.txt": "This is asset 1"}
+        write_test_asset_files(temp_assets_dir, asset_contents)
+        asset_references = {
+            "inputs": {"filenames": [os.path.join(temp_assets_dir, "asset-1.txt")]},
+        }
+        with open(
+            os.path.join(temp_job_bundle_dir, "asset_references.json"), "w", encoding="utf8"
+        ) as f:
+            json.dump({"assetReferences": asset_references}, f)
+
+        response = api.create_job_from_job_bundle(
+            temp_job_bundle_dir,
+            config=custom_config,
+            queue_parameter_definitions=[],
+            known_asset_paths=[temp_assets_dir],
+            debug_snapshot_dir=str(tmp_path),
+        )
+
+    # No job is submitted and no upload happens when creating a debug snapshot.
+    assert response is None
+    mock.get_boto3_client().create_job.assert_not_called()
+    mock.upload_assets.assert_not_called()
+    mock_snapshot_assets.assert_called_once()
+
+    # The snapshot path was used and received the caller's config.
+    mock_snapshot_attachments.assert_called_once()
+    _, call_kwargs = mock_snapshot_attachments.call_args
+    assert call_kwargs.get("config") is custom_config
+
+    # The snapshot includes the attachments and the s3 upload commands.
+    with open(os.path.join(str(tmp_path), "create_job_args.json"), encoding="utf-8") as f:
+        create_job_args = json.load(f)
+    assert "attachments" in create_job_args
+    with open(os.path.join(str(tmp_path), "submit_job.sh"), encoding="utf-8") as f:
+        submit_script = f.read()
+    assert "aws s3 cp" in submit_script
+    assert "aws deadline create-job" in submit_script

--- a/test/unit/deadline_client/api/test_job_bundle_submission.py
+++ b/test/unit/deadline_client/api/test_job_bundle_submission.py
@@ -1105,6 +1105,42 @@ def test_wait_for_create_job_to_complete(responses, final_status):
     assert status_message == MOCK_STATUS_MESSAGE
 
 
+@pytest.mark.parametrize(
+    "final_status, expected_success",
+    [
+        pytest.param("READY", True, id="SucceededNoStatusMessage"),
+        pytest.param("CREATE_FAILED", False, id="FailedNoStatusMessage"),
+    ],
+)
+def test_wait_for_create_job_to_complete_missing_status_message(final_status, expected_success):
+    """
+    A get_job response may omit lifecycleStatusMessage. Reading it without a
+    fallback raises KeyError, which makes a successful submit look like a crash.
+    The waiter must tolerate the missing key and return an empty message.
+    """
+
+    def mock_continue_callback() -> bool:
+        return True
+
+    deadline_client = Mock()
+    # Response intentionally omits "lifecycleStatusMessage".
+    deadline_client.get_job.side_effect = [
+        {"lifecycleStatus": "CREATE_IN_PROGRESS", "lifecycleStatusMessage": MOCK_STATUS_MESSAGE},
+        {"lifecycleStatus": final_status},
+    ]
+
+    with patch.object(time, "sleep"):
+        success, status_message = api.wait_for_create_job_to_complete(
+            farm_id=MOCK_FARM_ID,
+            queue_id=MOCK_QUEUE_ID,
+            job_id=MOCK_JOB_ID,
+            deadline_client=deadline_client,
+            continue_callback=mock_continue_callback,
+        )
+    assert success == expected_success
+    assert status_message == ""
+
+
 def test_wait_for_create_job_to_complete_timeout():
     """
     Test the waiter for calling CreateJob when it times out.

--- a/test/unit/deadline_client/api/test_job_bundle_submission.py
+++ b/test/unit/deadline_client/api/test_job_bundle_submission.py
@@ -598,6 +598,56 @@ def test_create_job_from_job_bundle_job_attachments(
         ]
 
 
+def test_create_job_from_job_bundle_forwards_config_to_upload_attachments(
+    fresh_deadline_config, temp_job_bundle_dir, temp_assets_dir
+):
+    """
+    When a caller passes an explicit config object, it must be forwarded to
+    _upload_attachments so upload telemetry uses that config (rather than the
+    default config loaded from disk).
+    """
+    custom_config = config.config_file.read_config()
+
+    with (
+        patch_calls_for_create_job_from_job_bundle() as mock,
+        patch.object(
+            api._submit_job_bundle,
+            "_upload_attachments",
+            wraps=api._submit_job_bundle._upload_attachments,
+        ) as mock_upload_attachments,
+    ):
+        config.set_setting("defaults.farm_id", MOCK_FARM_ID, config=custom_config)
+        config.set_setting("defaults.queue_id", MOCK_QUEUE_ID, config=custom_config)
+
+        # Write a JSON template
+        with open(os.path.join(temp_job_bundle_dir, "template.json"), "w", encoding="utf8") as f:
+            f.write(MOCK_JOB_TEMPLATE_CASES["MINIMAL_JSON"][1])
+
+        # Create asset files and reference them so the upload path runs.
+        asset_contents = {"asset-1.txt": "This is asset 1"}
+        write_test_asset_files(temp_assets_dir, asset_contents)
+        asset_references = {
+            "inputs": {"filenames": [os.path.join(temp_assets_dir, "asset-1.txt")]},
+        }
+        with open(
+            os.path.join(temp_job_bundle_dir, "asset_references.json"), "w", encoding="utf8"
+        ) as f:
+            json.dump({"assetReferences": asset_references}, f)
+
+        api.create_job_from_job_bundle(
+            temp_job_bundle_dir,
+            config=custom_config,
+            queue_parameter_definitions=[],
+            known_asset_paths=[temp_assets_dir],
+        )
+
+    mock_upload_attachments.assert_called_once()
+    _, call_kwargs = mock_upload_attachments.call_args
+    assert call_kwargs.get("config") is custom_config
+    # Sanity check the flow actually reached upload.
+    mock.upload_assets.assert_called_once()
+
+
 def test_create_job_from_job_bundle_empty_job_attachments(
     fresh_deadline_config, temp_job_bundle_dir, temp_assets_dir
 ):

--- a/test/unit/deadline_client/api/test_job_bundle_submission.py
+++ b/test/unit/deadline_client/api/test_job_bundle_submission.py
@@ -1212,3 +1212,41 @@ def test_create_job_from_job_bundle_force_s3_check(
             assert call_kwargs.get("force_s3_check") == force_s3_check_param
         else:
             assert call_kwargs.get("force_s3_check") is None
+
+
+def test_create_job_from_job_bundle_debug_snapshot_no_attachments(
+    fresh_deadline_config, temp_job_bundle_dir, tmp_path
+):
+    """
+    A debug snapshot of a bundle with no job attachments must not crash.
+
+    The ``asset_manager`` local is only assigned inside the attachments block,
+    but it is passed unconditionally to ``_save_debug_snapshot``. When there are
+    no attachments to process, that local is never bound and referencing it
+    raises UnboundLocalError. Snapshotting must succeed and write the snapshot.
+    """
+    config.set_setting("defaults.farm_id", MOCK_FARM_ID)
+    config.set_setting("defaults.queue_id", MOCK_QUEUE_ID)
+
+    job_template_type, job_template = MOCK_JOB_TEMPLATE_CASES["MINIMAL_JSON"]
+
+    with patch_calls_for_create_job_from_job_bundle() as mock:
+        # Write a template with no asset_references file, so no attachments are processed.
+        with open(
+            os.path.join(temp_job_bundle_dir, f"template.{job_template_type.lower()}"),
+            "w",
+            encoding="utf8",
+        ) as f:
+            f.write(job_template)
+
+        response = api.create_job_from_job_bundle(
+            job_bundle_dir=temp_job_bundle_dir,
+            queue_parameter_definitions=[],
+            debug_snapshot_dir=str(tmp_path),
+        )
+
+    # No job is submitted when creating a debug snapshot.
+    assert response is None
+    mock.get_boto3_client().create_job.assert_not_called()
+    # The snapshot files were written.
+    assert os.path.isfile(os.path.join(str(tmp_path), "create_job_args.json"))


### PR DESCRIPTION
Fixes: *<insert link to GitHub issue here>*

### What was the problem/requirement? (What/Why)

Three crash/robustness bugs in job-bundle submission (`api/_submit_job_bundle.py`):
- `asset_manager` was only assigned inside the attachments block but passed unconditionally to `_save_debug_snapshot` → `UnboundLocalError` when submitting a bundle with no attachments and a debug snapshot.
- `job["lifecycleStatusMessage"]` was read without a fallback → `KeyError` made a successful submit look like a crash.
- `config` wasn't forwarded to `_upload_attachments`/`_snapshot_attachments`, so telemetry used the wrong config.

### What was the solution? (How)

- Initialize `asset_manager = None` before the conditional and accept `Optional[S3AssetManager]` in `_save_debug_snapshot` (it's only dereferenced inside the attachments branch).
- Use `job.get("lifecycleStatusMessage", "")` in both waiter branches.
- Forward `config=config` to both attachment helpers.

### What is the impact of this change?

Debug-snapshot submissions without attachments no longer crash, successful submits report success, and attachment telemetry uses the correct config.

### How was this change tested?

Added red-green unit tests for each: no-attachments debug snapshot, missing `lifecycleStatusMessage`, and config forwarded to the attachment helpers.

- Have you run the unit tests? **Yes** — `test_job_bundle_submission.py` and adjacent bundle-submit tests (58 passed).
- Have you run the integration tests? No.

### Was this change documented?

- No public-contract change.
- README.md not affected.

### Does this PR introduce new dependencies?

*   [ ] This PR adds one or more new dependency Python packages.
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?

No.

### Does this change impact security?

No. (Known-path containment (C-known-path) and the stack-trace sanitizer are handled in separate PRs; the session-context race and debug-snapshot command-injection findings are out of scope here.)


## Testing

All verification is automated unit tests (no live AWS calls; deadline/boto3 clients mocked), each proven red-green against the pre-fix parent commit:

**Fix (a) — `asset_manager` UnboundLocalError:**
- `test_create_job_from_job_bundle_debug_snapshot_no_attachments`: debug snapshot of a bundle with **no** attachments completes cleanly; snapshot files are written, no job is submitted, and the generated `submit_job.sh` contains `aws deadline create-job` but correctly omits `aws s3 cp` lines. Pre-fix failure: `UnboundLocalError: cannot access local variable 'asset_manager'`.
- `test_create_job_from_job_bundle_debug_snapshot_with_attachments` (new): the other side of the `Optional[S3AssetManager]` change — a snapshot **with** attachments uses `_snapshot_attachments` (not `_upload_attachments`) with a bound asset manager, writes `attachments` into `create_job_args.json`, and emits the `aws s3 cp` upload commands in the generated script.

**Fix (b) — missing `lifecycleStatusMessage`:**
- `test_wait_for_create_job_to_complete_missing_status_message`, parametrized over **both** waiter branches: a `get_job` response omitting `lifecycleStatusMessage` returns `(True, "")` for `READY` and `(False, "")` for `CREATE_FAILED`. Pre-fix failure: `KeyError: 'lifecycleStatusMessage'` in each branch. (Note: the shared `MockDeadlineBackend` used by UI/e2e tests always includes `lifecycleStatusMessage`, so this unit test is the permanent coverage for the omission case.)

**Fix (c) — `config` forwarding:**
- `test_create_job_from_job_bundle_forwards_config_to_upload_attachments`: normal submit forwards the caller's `config` object to `_upload_attachments` (verified by identity, `is`). Pre-fix failure: `config` absent from the call kwargs.
- `test_create_job_from_job_bundle_debug_snapshot_with_attachments` (new) verifies the same for `_snapshot_attachments` on the snapshot path; it fails pre-fix with `config` absent.

**Suite runs:** `test_job_bundle_submission.py` (41 tests) plus the full `test/unit/deadline_client/api/` + `test_cli_bundle_submit*.py` suites (578 passed). `hatch run fmt` and `hatch run lint` (ruff check, ruff format, mypy) pass; full CI matrix is green.

**Not covered (manual-only, not automatable):** executing a generated `submit_job.sh`/`submit_job.bat` against a live farm, and observing a real `CreateJob` whose `GetJob` response omits `lifecycleStatusMessage`. These are optional hardening checks; the mocked flows exercise the exact code paths changed.

