### PR TITLE
fix: prevent config dialog known-path/boolean data loss

### DIFF
--- a/src/deadline/client/ui/dialogs/deadline_config_dialog.py
+++ b/src/deadline/client/ui/dialogs/deadline_config_dialog.py
@@ -506,7 +506,9 @@ class DeadlineWorkstationConfigWidget(QWidget):
                     state = str2bool(config_file.get_setting(setting_name, config=self.config))
                 except ValueError as e:
                     logger.warning(f"{e} for '{setting_name}'")
-                    state = False
+                    # Fall back to the setting's declared default rather than
+                    # blindly coercing a corrupt value to False.
+                    state = str2bool(get_setting_default(setting_name, config=self.config))
                 checkbox.setChecked(state)
 
         self._refresh_callbacks.append(refresh_checkbox)

--- a/src/deadline/client/ui/dialogs/deadline_config_dialog.py
+++ b/src/deadline/client/ui/dialogs/deadline_config_dialog.py
@@ -907,10 +907,13 @@ class DeadlineWorkstationConfigWidget(QWidget):
                         if i != current_row:  # Skip the path being edited
                             current_paths.append(self.known_paths_list.item(i).text())
 
-                    # Only add if not already in list
+                    # Only apply the edit if the new path isn't already in the
+                    # list. Otherwise the rebuilt list excludes the row being
+                    # edited and re-inserting is skipped, so writing it would
+                    # silently drop the original row (config data loss).
                     if path not in current_paths:
                         self.known_paths_list.item(current_row).setText(path)
                         current_paths.insert(current_row, path)
 
-                    self.changes["settings.known_asset_paths"] = os.pathsep.join(current_paths)
-                    self.refresh()
+                        self.changes["settings.known_asset_paths"] = os.pathsep.join(current_paths)
+                        self.refresh()

--- a/test/unit/deadline_client/ui/gui/test_settings_dialogue.py
+++ b/test/unit/deadline_client/ui/gui/test_settings_dialogue.py
@@ -298,6 +298,62 @@ class TestSettingsDialogue:
         assert apply_btn is not None
 
 
+class TestKnownAssetPathEditing:
+    """Regression tests for the known-asset-path edit flow (C11 data loss)."""
+
+    def test_editing_known_path_to_duplicate_does_not_drop_original(self, config_widget):
+        """Editing a known-asset path to a value that already exists must NOT
+        silently delete the original row.
+
+        Regression (C11): ``_on_edit_known_path`` unconditionally staged the
+        rebuilt path list (which excludes the row being edited) even when the
+        re-insert was skipped because the new value duplicated an existing
+        entry. That dropped the original row from the config = data loss. The
+        write/refresh must be guarded on the re-insert actually happening.
+        """
+        import os
+        from qtpy.QtWidgets import QFileDialog
+
+        lw = config_widget.known_paths_list
+        lw.clear()
+        lw.addItems([os.path.normpath("/path/a"), os.path.normpath("/path/b")])
+        lw.setCurrentRow(0)  # editing "/path/a"
+        config_widget.changes.clear()
+
+        # User picks a directory that duplicates the OTHER existing entry.
+        with patch.object(
+            QFileDialog, "getExistingDirectory", return_value=os.path.normpath("/path/b")
+        ):
+            config_widget._on_edit_known_path()
+
+        staged = config_widget.changes.get("settings.known_asset_paths")
+        # The original "/path/a" row must not be silently dropped.
+        assert staged is None or os.path.normpath("/path/a") in staged.split(os.pathsep)
+
+    def test_editing_known_path_to_new_value_updates_config(self, config_widget):
+        """A genuine (non-duplicate) edit still stages the change normally."""
+        import os
+        from qtpy.QtWidgets import QFileDialog
+
+        lw = config_widget.known_paths_list
+        lw.clear()
+        lw.addItems([os.path.normpath("/path/a"), os.path.normpath("/path/b")])
+        lw.setCurrentRow(0)  # editing "/path/a"
+        config_widget.changes.clear()
+
+        with patch.object(
+            QFileDialog, "getExistingDirectory", return_value=os.path.normpath("/path/c")
+        ):
+            config_widget._on_edit_known_path()
+
+        staged = config_widget.changes.get("settings.known_asset_paths")
+        assert staged is not None
+        paths = staged.split(os.pathsep)
+        assert os.path.normpath("/path/c") in paths
+        assert os.path.normpath("/path/b") in paths
+        assert os.path.normpath("/path/a") not in paths
+
+
 def test_profile_switch_preserves_each_profiles_farm_queue(fresh_deadline_config):
     """End-to-end regression for the profile-switch clobber bug.
 

--- a/test/unit/deadline_client/ui/gui/test_settings_dialogue.py
+++ b/test/unit/deadline_client/ui/gui/test_settings_dialogue.py
@@ -354,6 +354,31 @@ class TestKnownAssetPathEditing:
         assert os.path.normpath("/path/a") not in paths
 
 
+class TestCorruptBooleanSetting:
+    """Regression test for corrupt boolean coercion in checkbox refresh."""
+
+    def test_corrupt_boolean_falls_back_to_setting_default(self, config_widget):
+        """A garbage stored boolean must fall back to the setting's declared
+        default, not blindly to False.
+
+        ``settings.submitter_update_notification`` defaults to 'true', so a
+        corrupt stored value must leave the checkbox CHECKED.
+        """
+        import deadline.client.ui.dialogs.deadline_config_dialog as dcd
+
+        dcd.config_file.get_setting.side_effect = lambda name, config=None: (
+            "notabool"
+            if name == "settings.submitter_update_notification"
+            else "(default)"
+            if name == "defaults.aws_profile_name"
+            else ""
+        )
+
+        config_widget.refresh()
+
+        assert config_widget.submitter_update_notification.isChecked() is True
+
+
 def test_profile_switch_preserves_each_profiles_farm_queue(fresh_deadline_config):
     """End-to-end regression for the profile-switch clobber bug.
 

--- a/test/unit/deadline_client/ui/gui/test_settings_dialogue.py
+++ b/test/unit/deadline_client/ui/gui/test_settings_dialogue.py
@@ -366,15 +366,21 @@ class TestCorruptBooleanSetting:
         """
         import deadline.client.ui.dialogs.deadline_config_dialog as dcd
 
-        dcd.config_file.get_setting.side_effect = lambda name, config=None: (
-            "notabool"
-            if name == "settings.submitter_update_notification"
-            else "(default)"
-            if name == "defaults.aws_profile_name"
-            else ""
-        )
-
-        config_widget.refresh()
+        # ``dcd.config_file`` is a MagicMock here (patched by the mock_api
+        # fixture); patch.object scopes the corrupt-value side_effect to this
+        # test and restores the fixture's side_effect afterward.
+        with patch.object(
+            dcd.config_file,
+            "get_setting",
+            side_effect=lambda name, config=None: (
+                "notabool"
+                if name == "settings.submitter_update_notification"
+                else "(default)"
+                if name == "defaults.aws_profile_name"
+                else ""
+            ),
+        ):
+            config_widget.refresh()
 
         assert config_widget.submitter_update_notification.isChecked() is True
 


### PR DESCRIPTION
Fixes: *<insert link to GitHub issue here>*

### What was the problem/requirement? (What/Why)

Two bugs in the config dialog (`ui/dialogs/deadline_config_dialog.py`):
- Editing a known-asset path to a value that duplicates an existing entry silently deleted the row: the write/refresh happened unconditionally even when the re-insert was skipped as a duplicate → config data loss.
- A corrupt boolean setting coerced to `False` instead of falling back to the setting's declared default.

### What was the solution? (How)

- Move the write/refresh inside the `if path not in current_paths:` guard so the original row is only removed when the re-insert actually happens.
- On a `str2bool` `ValueError`, fall back to `str2bool(get_setting_default(...))` rather than `False`.

### What is the impact of this change?

Editing a known-asset path to a duplicate no longer drops the original row, and a corrupt boolean setting uses its intended default.

### How was this change tested?

Added red-green tests: editing to a duplicate keeps the original row (plus a control that a normal edit still stages), and a corrupt boolean falls back to the setting default.

- Have you run the unit tests? **Yes** — `test_settings_dialogue.py` + `test_deadline_config_dialog.py` (18 passed).
- Have you run the integration tests? No.

### Was this change documented?

- No public-contract change.
- README.md not affected.

### Does this PR introduce new dependencies?

*   [ ] This PR adds one or more new dependency Python packages.
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?

No.

### Does this change impact security?

No.
