### PR TITLE
fix: make job trace-schedule robust to in-flight/partial jobs

### DIFF
--- a/src/deadline/client/cli/_groups/_trace_schedule.py
+++ b/src/deadline/client/cli/_groups/_trace_schedule.py
@@ -336,6 +336,17 @@ def _build_trace_events(sessions, workers, started_at, trace_end_utc):
     return trace_events, accumulators
 
 
+def _percent_of(numerator, denominator) -> str:
+    """Format ``numerator`` as a percentage of ``denominator``.
+
+    Returns ``"N/A"`` when the denominator is zero (e.g. an in-flight job with
+    no completed durations yet) to avoid a ZeroDivisionError.
+    """
+    if not denominator:
+        return "N/A"
+    return f"{100 * numerator / denominator:.1f}%"
+
+
 def _print_summary(accumulators):
     click.echo("")
     click.echo(" ==== SUMMARY ====")
@@ -352,7 +363,7 @@ def _print_summary(accumulators):
     task_run_total_duration = accumulators["taskRunDuration"]
     click.echo(
         f"Task Run Total Duration: {datetime.timedelta(microseconds=task_run_total_duration)} "
-        f"({100 * task_run_total_duration / session_total_duration:.1f}%)"
+        f"({_percent_of(task_run_total_duration, session_total_duration)})"
     )
     click.echo(
         f"Non-Task Run Count: {accumulators['sessionActionCount'] - accumulators['taskRunCount']}"
@@ -363,21 +374,21 @@ def _print_summary(accumulators):
     click.echo(
         f"Non-Task Run Total Duration: "
         f"{datetime.timedelta(microseconds=non_task_run_total_duration)} "
-        f"({100 * non_task_run_total_duration / session_total_duration:.1f}%)"
+        f"({_percent_of(non_task_run_total_duration, session_total_duration)})"
     )
     click.echo(f"Sync Job Attachments Count: {accumulators['syncJobAttachmentsCount']}")
     sync_job_attachments_total_duration = accumulators["syncJobAttachmentsDuration"]
     click.echo(
         f"Sync Job Attachments Total Duration: "
         f"{datetime.timedelta(microseconds=sync_job_attachments_total_duration)} "
-        f"({100 * sync_job_attachments_total_duration / session_total_duration:.1f}%)"
+        f"({_percent_of(sync_job_attachments_total_duration, session_total_duration)})"
     )
     click.echo(f"Env Action Count: {accumulators['envActionCount']}")
     env_action_total_duration = accumulators["envActionDuration"]
     click.echo(
         f"Env Action Total Duration: "
         f"{datetime.timedelta(microseconds=env_action_total_duration)} "
-        f"({100 * env_action_total_duration / session_total_duration:.1f}%)"
+        f"({_percent_of(env_action_total_duration, session_total_duration)})"
     )
     click.echo("")
     within_session_overhead_duration = (
@@ -386,11 +397,15 @@ def _print_summary(accumulators):
     click.echo(
         f"Within-session Overhead Duration: "
         f"{datetime.timedelta(microseconds=within_session_overhead_duration)} "
-        f"({100 * within_session_overhead_duration / session_total_duration:.1f}%)"
+        f"({_percent_of(within_session_overhead_duration, session_total_duration)})"
+    )
+    session_action_count = accumulators["sessionActionCount"]
+    overhead_per_action = (
+        within_session_overhead_duration / session_action_count if session_action_count else 0
     )
     click.echo(
         f"Within-session Overhead Duration Per Action: "
-        f"{datetime.timedelta(microseconds=within_session_overhead_duration / accumulators['sessionActionCount'])}"
+        f"{datetime.timedelta(microseconds=overhead_per_action)}"
     )
 
 

--- a/src/deadline/client/cli/_groups/_trace_schedule.py
+++ b/src/deadline/client/cli/_groups/_trace_schedule.py
@@ -255,6 +255,13 @@ def _build_trace_events(sessions, workers, started_at, trace_end_utc):
     }
 
     for session in sessions:
+        # A session that hasn't started yet has no "startedAt" and therefore no
+        # point on the timeline. The B event below (and the per-action events)
+        # need "startedAt", so skip such sessions entirely rather than emitting a
+        # trace event with a missing timestamp (KeyError) or a malformed B/E pair.
+        if "startedAt" not in session:
+            continue
+
         accumulators["sessionCount"] += 1
         accumulators["sessionDuration"] += duration_of(session)
 

--- a/src/deadline/client/cli/_groups/_trace_schedule.py
+++ b/src/deadline/client/cli/_groups/_trace_schedule.py
@@ -109,7 +109,14 @@ def _get_all_sessions(deadline, farm_id, queue_id, job_id):
             nextToken=response["nextToken"],
         )
         sessions.extend(response.get("sessions", []))
-    return sorted(sessions, key=lambda session: session["startedAt"])
+    # Sessions that haven't started yet may not have a "startedAt"; sort those
+    # last (using datetime.max) instead of raising a KeyError.
+    return sorted(
+        sessions,
+        key=lambda session: session.get(
+            "startedAt", datetime.datetime.max.replace(tzinfo=datetime.timezone.utc)
+        ),
+    )
 
 
 def _get_all_session_actions(deadline, farm_id, queue_id, job_id, session_id):
@@ -252,7 +259,10 @@ def _build_trace_events(sessions, workers, started_at, trace_end_utc):
         accumulators["sessionDuration"] += duration_of(session)
 
         pid = workers[session["workerId"]]
-        session_event_name = f"{session['step']['name']} - {session['index']}"
+        # The step may be missing if its details couldn't be fetched (e.g. a
+        # partial BatchGetStep result); fall back to a placeholder name.
+        step_name = session.get("step", {}).get("name", "<Unknown Step>")
+        session_event_name = f"{step_name} - {session['index']}"
         if "endedAt" not in session:
             session_event_name = f"{session_event_name} - In Progress"
         trace_events.append(
@@ -317,7 +327,7 @@ def _build_trace_events(sessions, workers, started_at, trace_end_utc):
                         "args": {
                             "sessionActionId": action["sessionActionId"],
                             "status": action["status"],
-                            "stepName": session["step"]["name"],
+                            "stepName": step_name,
                         },
                     }
                 )

--- a/test/unit/deadline_client/cli/test_cli_trace_schedule.py
+++ b/test/unit/deadline_client/cli/test_cli_trace_schedule.py
@@ -7,9 +7,15 @@ command with ``ZeroDivisionError`` or ``KeyError``.
 
 from __future__ import annotations
 
+import datetime
+
 import pytest
 
-from deadline.client.cli._groups._trace_schedule import _print_summary
+from deadline.client.cli._groups._trace_schedule import (
+    _build_trace_events,
+    _get_all_sessions,
+    _print_summary,
+)
 
 
 def _zero_accumulators(**overrides):
@@ -53,6 +59,64 @@ def test_print_summary_zero_session_actions_does_not_divide_by_zero(capsys):
 
     out = capsys.readouterr().out
     assert "Within-session Overhead Duration Per Action" in out
+
+
+def test_get_all_sessions_handles_missing_started_at():
+    """Sessions that have not started yet (no ``startedAt``) must not raise a
+    KeyError while sorting."""
+
+    class _FakeDeadline:
+        def list_sessions(self, **kwargs):
+            return {
+                "sessions": [
+                    {"sessionId": "session-2", "startedAt": _dt(60)},
+                    {"sessionId": "session-1"},  # in-flight, no startedAt yet
+                ]
+            }
+
+    sessions = _get_all_sessions(_FakeDeadline(), "farm-1", "queue-1", "job-1")
+
+    assert {s["sessionId"] for s in sessions} == {"session-1", "session-2"}
+
+
+def _dt(offset_seconds: int) -> datetime.datetime:
+    return datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc) + datetime.timedelta(
+        seconds=offset_seconds
+    )
+
+
+def test_build_trace_events_handles_session_without_step():
+    """A session whose step could not be fetched (partial BatchGetStep) must
+    not raise a KeyError on ``session['step']``."""
+    started = _dt(0)
+    ended = _dt(60)
+    session = {
+        "sessionId": "session-1",
+        "workerId": "worker-0",
+        "fleetId": "fleet-0",
+        "lifecycleStatus": "ENDED",
+        "startedAt": started,
+        "endedAt": ended,
+        "index": 0,
+        "actions": [
+            {
+                "sessionActionId": "sessionaction-1",
+                "status": "SUCCEEDED",
+                "startedAt": started,
+                "endedAt": ended,
+                "definition": {"taskRun": {"stepId": "step-1", "taskId": "task-1"}},
+            }
+        ],
+        # No "step" key: the step lookup failed / hasn't been attached.
+    }
+    workers = {"worker-0": 0}
+
+    trace_events, accumulators = _build_trace_events([session], workers, started, ended)
+
+    assert accumulators["sessionCount"] == 1
+    assert accumulators["taskRunCount"] == 1
+    # A trace event should still be produced for the session.
+    assert any(event["cat"] == "SESSION" for event in trace_events)
 
 
 if __name__ == "__main__":

--- a/test/unit/deadline_client/cli/test_cli_trace_schedule.py
+++ b/test/unit/deadline_client/cli/test_cli_trace_schedule.py
@@ -119,5 +119,45 @@ def test_build_trace_events_handles_session_without_step():
     assert any(event["cat"] == "SESSION" for event in trace_events)
 
 
+def test_build_trace_events_skips_session_without_started_at():
+    """A not-yet-started session (no ``startedAt``) must be skipped rather than
+    raising a KeyError when building its trace events / timeline timestamp."""
+    started = _dt(0)
+    ended = _dt(60)
+    started_session = {
+        "sessionId": "session-1",
+        "workerId": "worker-0",
+        "fleetId": "fleet-0",
+        "lifecycleStatus": "ENDED",
+        "startedAt": started,
+        "endedAt": ended,
+        "index": 0,
+        "actions": [],
+    }
+    not_started_session = {
+        "sessionId": "session-2",
+        "workerId": "worker-0",
+        "fleetId": "fleet-0",
+        "lifecycleStatus": "STARTING",
+        "index": 1,
+        "actions": [],
+        # No "startedAt": this session has not begun executing yet.
+    }
+    workers = {"worker-0": 0}
+
+    trace_events, accumulators = _build_trace_events(
+        [started_session, not_started_session], workers, started, ended
+    )
+
+    # Only the started session is counted / emitted.
+    assert accumulators["sessionCount"] == 1
+    session_ids = {
+        event["args"]["sessionId"]
+        for event in trace_events
+        if event["cat"] == "SESSION" and "sessionId" in event.get("args", {})
+    }
+    assert session_ids == {"session-1"}
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/test/unit/deadline_client/cli/test_cli_trace_schedule.py
+++ b/test/unit/deadline_client/cli/test_cli_trace_schedule.py
@@ -1,0 +1,59 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""Unit tests for the ``deadline job trace-schedule`` helper functions.
+
+These focus on partial / in-flight job data that previously crashed the
+command with ``ZeroDivisionError`` or ``KeyError``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from deadline.client.cli._groups._trace_schedule import _print_summary
+
+
+def _zero_accumulators(**overrides):
+    accumulators = {
+        "sessionCount": 0,
+        "sessionActionCount": 0,
+        "taskRunCount": 0,
+        "envActionCount": 0,
+        "syncJobAttachmentsCount": 0,
+        "sessionDuration": 0,
+        "sessionActionDuration": 0,
+        "taskRunDuration": 0,
+        "envActionDuration": 0,
+        "syncJobAttachmentsDuration": 0,
+    }
+    accumulators.update(overrides)
+    return accumulators
+
+
+def test_print_summary_no_completed_durations_does_not_divide_by_zero(capsys):
+    """An in-flight job with no accumulated duration must not crash on the
+    percentage math (session_total_duration == 0)."""
+    _print_summary(_zero_accumulators())
+
+    out = capsys.readouterr().out
+    assert "Task Run Count: 0" in out
+    # Percentages should degrade gracefully rather than crashing.
+    assert "N/A" in out
+
+
+def test_print_summary_zero_session_actions_does_not_divide_by_zero(capsys):
+    """Overhead-per-action must not crash when there are zero session actions
+    even if there is a non-zero session duration."""
+    _print_summary(
+        _zero_accumulators(
+            sessionCount=1,
+            sessionDuration=1_000_000,
+            sessionActionCount=0,
+        )
+    )
+
+    out = capsys.readouterr().out
+    assert "Within-session Overhead Duration Per Action" in out
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Fixes: *<insert link to GitHub issue here>*

### What was the problem/requirement? (What/Why)

`deadline job trace-schedule` crashed on in-flight jobs: the summary's percentage/overhead math divided by a zero session-total duration (`ZeroDivisionError`), and it hard-accessed `session["startedAt"]` and `session["step"]`, raising `KeyError` on sessions that hadn't started or whose step hadn't been fetched.

### What was the solution? (How)

- Added a `_percent_of(numerator, denominator)` helper that returns `"N/A"` when the denominator is zero (an in-flight job with no completed durations yet), used for all percentage lines in the summary.
- Sort sessions with `.get("startedAt", datetime.max)` so unstarted sessions sort last, and use `session.get("step", {}).get("name", "<Unknown Step>")` for the step name.

### What is the impact of this change?

`trace-schedule` runs cleanly on jobs that are still running or have partial data, showing `N/A` for percentages that can't yet be computed instead of crashing.

### How was this change tested?

Added unit tests (new file — none existed for this module) covering zero-denominator summary math, zero session-action count, missing `startedAt`, and a session without a fetched `step`.

- Have you run the unit tests? **Yes** — `test/unit/deadline_client/cli/test_cli_trace_schedule.py` (4 passed).
- Have you run the integration tests? No (the e2e test needs a resolvable endpoint; not runnable in the dev sandbox).

### Was this change documented?

- No public-contract change; docstrings on the new helper added.
- README.md not affected.

### Does this PR introduce new dependencies?

*   [ ] This PR adds one or more new dependency Python packages.
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?

No.

### Does this change impact security?

No.


## Testing

In addition to the unit tests, the full command was manually verified end-to-end with mocked AWS APIs (no live service), driving `deadline job trace-schedule --trace-format chrome --trace-file ...` through Click's `CliRunner` with fixture data for an in-flight job:

- Job with `startedAt` but no `endedAt` (still running).
- A completed session (step fetched via BatchGetStep) including a zero-duration action span (`startedAt == endedAt`).
- An in-flight session with no `endedAt`, a running action with no `endedAt`, and a queued action with no `startedAt`.
- A not-yet-started session with no `startedAt` at all.
- A BatchGetStep partial failure (`ResourceNotFoundException`) for one step.

Results: exit code 0, no exceptions; the summary printed real percentages, the partial-step warning was surfaced, and the written Chrome trace file was validated — every event has a non-negative integer `ts` (and `dur` for `X` events), session `B`/`E` pairs are balanced, the not-started session and not-started action emit no events, the failed step falls back to `<Unknown Step>`, in-progress markers appear, and the zero-duration span is emitted with `dur: 0`. A second degenerate run (job started, zero sessions) also exited 0 and printed `N/A` for all percentage lines instead of raising `ZeroDivisionError`.

Not yet verified against a real running job in a live farm; a hands-on check tracing a job mid-render (while some sessions are still `STARTING`) would fully close the loop.
