### PR TITLE
fix: anchor known-path containment in job bundle submit

### DIFF
--- a/src/deadline/client/api/_submit_job_bundle.py
+++ b/src/deadline/client/api/_submit_job_bundle.py
@@ -80,6 +80,27 @@ def hashing_telemetry_callback(hashing_summary: SummaryStatistics):
     api.get_deadline_cloud_library_telemetry_client().record_hashing_summary(hashing_summary)
 
 
+def _is_known_path(path: Path | str, known_roots: Iterable[Path | str]) -> bool:
+    """Return True iff ``path`` equals or is a descendant of any root in ``known_roots``.
+
+    Containment is anchored via ``os.path.commonpath`` equality (the same idiom as
+    loader.py): a path is contained only when it shares a whole-component prefix with a
+    root, so a sibling that merely shares a string prefix (root ``/trusted/project`` vs
+    candidate ``/trusted/project-secret``) is outside the root.
+    """
+    norm_candidate = os.path.normpath(str(path))
+    for known_path in known_roots:
+        norm_root = os.path.normpath(str(known_path))
+        try:
+            if os.path.commonpath([norm_root, norm_candidate]) == norm_root:
+                return True
+        except ValueError:
+            # commonpath raises for mixed absolute/relative paths or different Windows
+            # drives; such paths are not contained.
+            continue
+    return False
+
+
 def _summarize_asset_paths(
     input_paths: Collection[Path | str], output_paths: Collection[Path | str], name: str
 ) -> list[str]:
@@ -114,14 +135,11 @@ def _generate_message_for_asset_paths(
 
     # Filter to get the unknown paths
     if known_asset_paths:
-        known_path_regex = re.compile(
-            f"{'|'.join(re.escape(path) for path in known_asset_paths)}.*"
-        )
         unknown_input_paths = {
-            path for path in all_input_paths if not known_path_regex.match(str(path))
+            path for path in all_input_paths if not _is_known_path(path, known_asset_paths)
         }
         unknown_output_paths = {
-            path for path in all_output_paths if not known_path_regex.match(str(path))
+            path for path in all_output_paths if not _is_known_path(path, known_asset_paths)
         }
     else:
         unknown_input_paths = all_input_paths

--- a/test/unit/deadline_client/cli/test_cli_bundle_submit_known_paths.py
+++ b/test/unit/deadline_client/cli/test_cli_bundle_submit_known_paths.py
@@ -95,6 +95,51 @@ def test_filter_redundant_known_paths(input, expected):
         ),
         # No roots -> nothing is contained.
         (os.path.join(os.sep, "trusted", "project"), [], False),
+        # A candidate for which the root is a string prefix with no separator
+        # (/trusted/projectextra) is NOT contained.
+        (
+            os.path.join(os.sep, "trusted", "project") + "extra",
+            [os.path.join(os.sep, "trusted", "project")],
+            False,
+        ),
+        # A '..' traversal that escapes the root is NOT contained.
+        (
+            os.path.join(os.sep, "trusted", "project", "..", "project-secret", "f"),
+            [os.path.join(os.sep, "trusted", "project")],
+            False,
+        ),
+        # A '..' round-trip that stays inside the root IS contained.
+        (
+            os.path.join(os.sep, "trusted", "project", "sub", "..", "f"),
+            [os.path.join(os.sep, "trusted", "project")],
+            True,
+        ),
+        # A trailing separator on the root does not defeat sibling-prefix rejection.
+        (
+            os.path.join(os.sep, "trusted", "project-secret", "f"),
+            [os.path.join(os.sep, "trusted", "project") + os.sep],
+            False,
+        ),
+        # A trailing separator on the root still accepts a genuine descendant.
+        (
+            os.path.join(os.sep, "trusted", "project", "f"),
+            [os.path.join(os.sep, "trusted", "project") + os.sep],
+            True,
+        ),
+        # The parent directory of a root is NOT contained.
+        (
+            os.path.join(os.sep, "trusted"),
+            [os.path.join(os.sep, "trusted", "project")],
+            False,
+        ),
+        # Case-variant alias: os.path.commonpath compares case-insensitively on
+        # Windows (matching the filesystem) and case-sensitively on POSIX, where
+        # the mismatch fails closed (warning still fires).
+        (
+            os.path.join(os.sep, "Trusted", "Project", "f"),
+            [os.path.join(os.sep, "trusted", "project")],
+            os.name == "nt",
+        ),
     ],
 )
 def test_is_known_path(path, roots, expected):

--- a/test/unit/deadline_client/cli/test_cli_bundle_submit_known_paths.py
+++ b/test/unit/deadline_client/cli/test_cli_bundle_submit_known_paths.py
@@ -7,6 +7,7 @@ Tests for the known asset paths functionality in the bundle_submit CLI command.
 import os
 import json
 import tempfile
+from pathlib import Path
 from unittest.mock import patch, ANY, call
 
 import click
@@ -15,7 +16,12 @@ import pytest
 
 from deadline.client import config
 from deadline.client.cli import main
-from deadline.client.api._submit_job_bundle import _filter_redundant_known_paths
+from deadline.client.api._submit_job_bundle import (
+    _filter_redundant_known_paths,
+    _generate_message_for_asset_paths,
+    _is_known_path,
+)
+from deadline.job_attachments.models import AssetRootGroup, AssetUploadGroup
 
 from ..api.test_job_bundle_submission import (
     MOCK_FARM_ID,
@@ -46,6 +52,101 @@ def test_filter_redundant_known_paths(input, expected):
         assert sorted(
             _filter_redundant_known_paths("C:" + path.replace("/", "\\") for path in input)
         ) == ["C:" + path.replace("/", "\\") for path in expected]
+
+
+@pytest.mark.parametrize(
+    "path, roots, expected",
+    [
+        # The root itself is contained.
+        (
+            os.path.join(os.sep, "trusted", "project"),
+            [os.path.join(os.sep, "trusted", "project")],
+            True,
+        ),
+        # A genuine descendant is contained.
+        (
+            os.path.join(os.sep, "trusted", "project", "sub", "file"),
+            [os.path.join(os.sep, "trusted", "project")],
+            True,
+        ),
+        # Core regression: a sibling sharing a string prefix is NOT contained.
+        (
+            os.path.join(os.sep, "trusted", "project-secret", "f"),
+            [os.path.join(os.sep, "trusted", "project")],
+            False,
+        ),
+        # An unrelated path is not contained.
+        (
+            os.path.join(os.sep, "somewhere", "else"),
+            [os.path.join(os.sep, "trusted", "project")],
+            False,
+        ),
+        # Contained by one of several roots.
+        (
+            os.path.join(os.sep, "b", "file"),
+            [os.path.join(os.sep, "a"), os.path.join(os.sep, "b")],
+            True,
+        ),
+        # Mixed absolute/relative (commonpath raises ValueError) -> not contained.
+        (
+            os.path.join("relative", "file"),
+            [os.path.join(os.sep, "trusted", "project")],
+            False,
+        ),
+        # No roots -> nothing is contained.
+        (os.path.join(os.sep, "trusted", "project"), [], False),
+    ],
+)
+def test_is_known_path(path, roots, expected):
+    assert _is_known_path(path, roots) is expected
+
+
+def test_generate_message_for_asset_paths_sibling_prefix_is_unknown():
+    """
+    Security regression test: a known root must NOT "contain" a sibling path that
+    merely shares a string prefix. e.g. known root '/trusted/project' must not
+    suppress the warning for '/trusted/project-secret/file', which lives outside
+    the trusted root. An unanchored prefix match would wrongly treat it as inside.
+    """
+    known_root = os.path.join(os.sep, "trusted", "project")
+    sibling_file = os.path.join(os.sep, "trusted", "project-secret", "file")
+
+    upload_group = AssetUploadGroup(
+        asset_groups=[AssetRootGroup(root_path=known_root, inputs={Path(sibling_file)})],
+        total_input_files=1,
+        total_input_bytes=12,
+    )
+
+    message, no_warnings = _generate_message_for_asset_paths(
+        upload_group, storage_profile=None, known_asset_paths=[known_root]
+    )
+
+    # The sibling file is outside the trusted root, so the warning must fire.
+    assert no_warnings is False, message
+    assert "WARNING: Files were specified outside of known asset paths." in message, message
+    assert sibling_file in message, message
+
+
+def test_generate_message_for_asset_paths_descendant_is_known():
+    """
+    A file that is a genuine descendant of a known root must be treated as inside
+    (no warning), confirming the anchored containment check does not over-reject.
+    """
+    known_root = os.path.join(os.sep, "trusted", "project")
+    inside_file = os.path.join(known_root, "sub", "file")
+
+    upload_group = AssetUploadGroup(
+        asset_groups=[AssetRootGroup(root_path=known_root, inputs={Path(inside_file)})],
+        total_input_files=1,
+        total_input_bytes=12,
+    )
+
+    message, no_warnings = _generate_message_for_asset_paths(
+        upload_group, storage_profile=None, known_asset_paths=[known_root]
+    )
+
+    assert no_warnings is True, message
+    assert "WARNING: Files were specified outside of known asset paths." not in message, message
 
 
 def test_cli_bundle_known_paths_combine(fresh_deadline_config, temp_job_bundle_dir):


### PR DESCRIPTION
Fixes: *<insert link to GitHub issue here>*

### What was the problem/requirement? (What/Why)

The job-bundle submit known-path check used an unanchored regex string-prefix match, so a sibling directory sharing a string prefix was wrongly treated as inside a known root (e.g. root `/trusted/project` "contained" `/trusted/project-secret/file`). That wrongly suppressed the local-file upload warning / safety cancellation for paths outside the declared root.

### What was the solution? (How)

Replace the unanchored prefix match with an anchored path-containment check: a new top-level, pure function `_is_known_path(path, known_roots)` returns `True` only when the path equals or is a descendant of a known root, using the `os.path.commonpath` equality idiom (the same one used in `loader.py`) and treating a `ValueError` (mixed abs/rel or cross-drive) as "not contained".

### What is the impact of this change?

Paths outside a known root are correctly reported as unknown, so the upload warning fires as intended; sibling directories sharing a name prefix are no longer misclassified as inside the root.

### How was this change tested?

Added a parameterized unit test calling `_is_known_path` directly over 7 cases (root itself, descendant, sibling-prefix, unrelated, one-of-several-roots, mixed abs/rel, empty roots), and kept an end-to-end test asserting `_generate_message_for_asset_paths` still suppresses/keeps the right warnings.

- Have you run the unit tests? **Yes** — `test_cli_bundle_submit_known_paths.py` (19 passed).
- Have you run the integration tests? No.

### Was this change documented?

- No public-contract change (internal helper).
- README.md not affected.

### Does this PR introduce new dependencies?

*   [ ] This PR adds one or more new dependency Python packages.
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?

No.

### Does this change impact security?

**Yes — please add the "security" label.** This tightens a containment check that gates a local-file-upload safety warning. Note: symlink/realpath resolution was intentionally deferred (the surrounding module doesn't resolve these caller-supplied path strings; adding realpath is a behavior-sensitive design decision) and is flagged for separate follow-up.


## Testing

Manually verified `_is_known_path` (no live AWS needed) with a 32-case adversarial battery on macOS (POSIX semantics), including real on-disk symlinks. All cases classified as expected — no misclassification found. One platform nuance identified during verification (Windows `commonpath` compares case-insensitively, matching the filesystem) is encoded in the parameterized unit test, which now covers 15 cases including the adversarial ones below.

Truth table (`root = /trusted/project` unless noted; "contained" = treated as known, warning suppressed):

| Adversarial input | Classified | Correct? |
|---|---|---|
| `/trusted/project` (root itself) | contained | yes |
| `/trusted/project/a/b/c` (descendant) | contained | yes |
| `/trusted/project-secret/f` (sibling string-prefix — the original bug) | NOT contained | yes |
| `/trusted/projectextra` (prefix without separator) | NOT contained | yes |
| `/trusted` (parent of root), `/`, unrelated paths | NOT contained | yes |
| `/trusted/project/../project-secret/f` (`..` escape) | NOT contained | yes |
| `/trusted/project/sub/../f` (`..` round-trip inside) | contained | yes |
| Trailing slash on root or candidate, `//` doubles, `./` segments | normalized correctly | yes |
| Relative candidate vs absolute root (and vice versa) | NOT contained (ValueError -> fail closed) | yes |
| `/Trusted/Project/f` (case variant) | POSIX: NOT contained (fail closed); Windows: contained (`commonpath` is case-insensitive, matching the filesystem) | yes |
| Empty candidate, `.`, empty root, empty root list | NOT contained | yes |
| Symlink alias outside root pointing INTO root | NOT contained (fail closed — warning fires; safe) | yes |
| Symlink INSIDE root pointing OUT + `..` through symlink | contained (lexical semantics) | known deferred gap |

The last row is the documented, intentionally deferred symlink/realpath gap (see "Does this change impact security?" above): the check is lexical, matching the surrounding module, so a symlink planted inside a known root can point outside it without triggering the warning. That requires the attacker to already control the trusted root's contents, and is flagged for a separate follow-up rather than silently changing path-resolution behavior here.

Also run: `hatch run fmt`, `hatch run lint` (ruff + mypy) and the full unit test suite — all green.
