### PR TITLE
fix: best-effort avoid logging non-deadline directories in telemetry stack traces

### DIFF
--- a/src/deadline/client/api/_stack_trace_sanitizer.py
+++ b/src/deadline/client/api/_stack_trace_sanitizer.py
@@ -10,8 +10,10 @@ exception's message string and source-line context are dropped entirely
 because we have no control over what third-party libraries put in them.
 """
 
+import importlib.util
+import os
 import traceback
-from typing import FrozenSet, List
+from typing import Dict, FrozenSet, List
 
 # Packages we author or vendor — emitting paths relative to these is safe
 # because the path itself only reveals which of our own modules raised.
@@ -23,6 +25,52 @@ _KNOWN_PACKAGES: FrozenSet[str] = frozenset(
         "botocore",
     }
 )
+
+
+def _normalize(path: str) -> str:
+    """Normalize a path for equality comparison across OSes.
+
+    Collapses Windows separators to forward slashes, strips any trailing
+    separator, and applies case folding on case-insensitive filesystems so
+    two spellings of the same location compare equal.
+    """
+    return os.path.normcase(path.replace("\\", "/").rstrip("/"))
+
+
+def _known_package_install_dirs() -> Dict[str, str]:
+    """Map each known package name to the normalized directory it is installed in.
+
+    This is the genuine on-disk location of the package root (the directory
+    that *contains* the package, e.g. ``.../site-packages``). It is used to
+    distinguish a real framework frame from a customer directory that merely
+    shares a package's name (e.g. a customer project tree rooted at
+    ``~/deadline/...``). Only packages that are importable with a real
+    filesystem location contribute an anchor; anything else (namespace
+    packages, frozen modules without a file) is simply omitted.
+    """
+    dirs: Dict[str, str] = {}
+    for name in _KNOWN_PACKAGES:
+        try:
+            spec = importlib.util.find_spec(name)
+        except (ImportError, ValueError, AttributeError, ModuleNotFoundError):
+            continue
+        if spec is None:
+            continue
+        # Prefer the package directory itself. A regular package reports it
+        # via submodule_search_locations (e.g. ".../site-packages/deadline");
+        # a single-file module only has an origin (".../foo.py"), whose parent
+        # directory is the container.
+        origin = spec.origin
+        locations = list(spec.submodule_search_locations or [])
+        pkg_dir = None
+        if locations:
+            pkg_dir = locations[0]
+        elif origin and origin not in ("built-in", "frozen"):
+            pkg_dir = os.path.dirname(origin)
+        if not pkg_dir:
+            continue
+        dirs[name] = _normalize(os.path.abspath(pkg_dir))
+    return dirs
 
 
 def _sanitize_path(filepath: str) -> str:
@@ -37,17 +85,20 @@ def _sanitize_path(filepath: str) -> str:
     # with forward slashes.
     parts = filepath.replace("\\", "/").split("/")
 
-    # If any path segment names one of our known packages, return everything
-    # from that segment onward. Scan right-to-left and match the *rightmost*
-    # occurrence: the actually-installed package is always at the tail of
-    # the path, so a customer directory that happens to share a name with
-    # one of our packages (e.g. ~/deadline/...) earlier in the path can't
-    # cause us to keep the customer-named segments between them. `stem`
-    # strips a trailing extension so paths like ".../deadline.egg-info/..."
-    # still match "deadline".
+    # Keep a package-relative path only when the reconstructed absolute prefix
+    # equals the package's real install directory on this machine. A bare name
+    # match is insufficient because a customer directory can share a package
+    # name (e.g. ~/deadline/...) and keeping its segments would leak customer
+    # content (violating the no-customer-content tenet). Scan right-to-left so
+    # the deepest genuine match wins. (Ordinary pip installs under
+    # site-packages are also covered by the generic site-packages branch
+    # below; this branch additionally handles embedded / custom-sys.path
+    # layouts where the package isn't under a site-packages directory.)
+    install_dirs = _known_package_install_dirs()
     for i in range(len(parts) - 1, -1, -1):
         stem = parts[i].split(".")[0]
-        if stem in _KNOWN_PACKAGES:
+        anchor = install_dirs.get(stem)
+        if anchor is not None and _normalize("/".join(parts[: i + 1])) == anchor:
             return "/".join(parts[i:])
 
     # Unknown third-party library installed into a venv: keep the

--- a/src/deadline/client/api/_stack_trace_sanitizer.py
+++ b/src/deadline/client/api/_stack_trace_sanitizer.py
@@ -10,6 +10,7 @@ exception's message string and source-line context are dropped entirely
 because we have no control over what third-party libraries put in them.
 """
 
+import functools
 import importlib.util
 import os
 import traceback
@@ -37,18 +38,29 @@ def _normalize(path: str) -> str:
     return os.path.normcase(path.replace("\\", "/").rstrip("/"))
 
 
-def _known_package_install_dirs() -> Dict[str, str]:
-    """Map each known package name to the normalized directory it is installed in.
+@functools.lru_cache(maxsize=None)
+def _known_package_install_dirs() -> Dict[str, List[str]]:
+    """Map each known package name to the normalized directories it is installed in.
 
-    This is the genuine on-disk location of the package root (the directory
-    that *contains* the package, e.g. ``.../site-packages``). It is used to
+    These are the genuine on-disk locations of the package root (the directory
+    that *contains* the package, e.g. ``.../site-packages``). They are used to
     distinguish a real framework frame from a customer directory that merely
     shares a package's name (e.g. a customer project tree rooted at
     ``~/deadline/...``). Only packages that are importable with a real
-    filesystem location contribute an anchor; anything else (namespace
-    packages, frozen modules without a file) is simply omitted.
+    filesystem location contribute an anchor; anything else (frozen modules
+    without a file) is simply omitted.
+
+    ``deadline`` and ``openjd`` are PEP 420 namespace packages, so a single
+    namespace can be contributed by several distributions installed into
+    different ``sys.path`` roots. ``submodule_search_locations`` may therefore
+    hold more than one path; we record all of them so a genuine framework frame
+    under any of those roots is recognized.
+
+    The install locations are fixed for the life of the process, so the result
+    is memoized with ``lru_cache`` (a deep traceback would otherwise recompute
+    it, hitting ``find_spec`` once per known package per frame).
     """
-    dirs: Dict[str, str] = {}
+    dirs: Dict[str, List[str]] = {}
     for name in _KNOWN_PACKAGES:
         try:
             spec = importlib.util.find_spec(name)
@@ -56,20 +68,21 @@ def _known_package_install_dirs() -> Dict[str, str]:
             continue
         if spec is None:
             continue
-        # Prefer the package directory itself. A regular package reports it
-        # via submodule_search_locations (e.g. ".../site-packages/deadline");
-        # a single-file module only has an origin (".../foo.py"), whose parent
-        # directory is the container.
+        # Prefer the package directories themselves. A regular/namespace package
+        # reports them via submodule_search_locations (e.g.
+        # ".../site-packages/deadline"); a single-file module only has an origin
+        # (".../foo.py"), whose parent directory is the container.
         origin = spec.origin
         locations = list(spec.submodule_search_locations or [])
-        pkg_dir = None
+        pkg_dirs: List[str] = []
         if locations:
-            pkg_dir = locations[0]
+            pkg_dirs = list(locations)
         elif origin and origin not in ("built-in", "frozen"):
-            pkg_dir = os.path.dirname(origin)
-        if not pkg_dir:
+            pkg_dirs = [os.path.dirname(origin)]
+        normalized = [_normalize(os.path.abspath(p)) for p in pkg_dirs if p]
+        if not normalized:
             continue
-        dirs[name] = _normalize(os.path.abspath(pkg_dir))
+        dirs[name] = normalized
     return dirs
 
 
@@ -97,8 +110,8 @@ def _sanitize_path(filepath: str) -> str:
     install_dirs = _known_package_install_dirs()
     for i in range(len(parts) - 1, -1, -1):
         stem = parts[i].split(".")[0]
-        anchor = install_dirs.get(stem)
-        if anchor is not None and _normalize("/".join(parts[: i + 1])) == anchor:
+        anchors = install_dirs.get(stem)
+        if anchors is not None and _normalize("/".join(parts[: i + 1])) in anchors:
             return "/".join(parts[i:])
 
     # Unknown third-party library installed into a venv: keep the

--- a/src/deadline/client/api/_stack_trace_sanitizer.py
+++ b/src/deadline/client/api/_stack_trace_sanitizer.py
@@ -42,13 +42,12 @@ def _normalize(path: str) -> str:
 def _known_package_install_dirs() -> Dict[str, List[str]]:
     """Map each known package name to the normalized directories it is installed in.
 
-    These are the genuine on-disk locations of the package root (the directory
-    that *contains* the package, e.g. ``.../site-packages``). They are used to
-    distinguish a real framework frame from a customer directory that merely
-    shares a package's name (e.g. a customer project tree rooted at
-    ``~/deadline/...``). Only packages that are importable with a real
-    filesystem location contribute an anchor; anything else (frozen modules
-    without a file) is simply omitted.
+    These are the genuine on-disk locations of the package directory itself
+    (e.g. ``.../site-packages/deadline``). They are used to distinguish a real
+    framework frame from a customer directory that merely shares a package's
+    name (e.g. a customer project tree rooted at ``~/deadline/...``). Only
+    packages that are importable with a real filesystem location contribute an
+    anchor; anything else (frozen modules without a file) is simply omitted.
 
     ``deadline`` and ``openjd`` are PEP 420 namespace packages, so a single
     namespace can be contributed by several distributions installed into
@@ -114,13 +113,14 @@ def _sanitize_path(filepath: str) -> str:
         if anchors is not None and _normalize("/".join(parts[: i + 1])) in anchors:
             return "/".join(parts[i:])
 
-    # Unknown third-party library installed into a venv: keep the
-    # library-relative subpath but drop everything above site-packages
-    # (which would otherwise leak the customer's home / venv layout).
-    # Same right-to-left rationale as above — the real site-packages
-    # directory is always at the tail.
+    # Unknown third-party library installed into a venv or system Python:
+    # keep the library-relative subpath but drop everything above the
+    # site-packages / dist-packages directory (which would otherwise leak
+    # the customer's home / venv layout). "dist-packages" is the Debian /
+    # Ubuntu system-Python equivalent of "site-packages". Same right-to-left
+    # rationale as above — the real packages directory is always at the tail.
     for i in range(len(parts) - 1, -1, -1):
-        if parts[i] == "site-packages" and i + 1 < len(parts):
+        if parts[i] in ("site-packages", "dist-packages") and i + 1 < len(parts):
             return "/".join(parts[i + 1 :])
 
     # Anything else (customer scripts, project trees) — keep only the

--- a/src/deadline/client/api/_stack_trace_sanitizer.py
+++ b/src/deadline/client/api/_stack_trace_sanitizer.py
@@ -13,6 +13,7 @@ because we have no control over what third-party libraries put in them.
 import functools
 import importlib.util
 import os
+import re
 import traceback
 from typing import Dict, FrozenSet, List
 
@@ -85,6 +86,13 @@ def _known_package_install_dirs() -> Dict[str, List[str]]:
     return dirs
 
 
+# Parent directory names that corroborate a genuine site-packages /
+# dist-packages segment: "lib"/"Lib"/"lib64" (e.g. venv Lib\site-packages on
+# Windows), or a python version directory ("python3.11", "Python311", e.g.
+# POSIX venvs, Debian dist-packages, Windows user site-packages).
+_PACKAGES_DIR_PARENT_RE = re.compile(r"^([Ll]ib(64)?|[Pp]ython\d+(\.\d+)?)$")
+
+
 def _sanitize_path(filepath: str) -> str:
     """Replace a full file path with the package-relative portion or bare filename."""
     # Synthetic frame sources like "<string>", "<stdin>", or
@@ -119,8 +127,20 @@ def _sanitize_path(filepath: str) -> str:
     # the customer's home / venv layout). "dist-packages" is the Debian /
     # Ubuntu system-Python equivalent of "site-packages". Same right-to-left
     # rationale as above — the real packages directory is always at the tail.
-    for i in range(len(parts) - 1, -1, -1):
-        if parts[i] in ("site-packages", "dist-packages") and i + 1 < len(parts):
+    # A bare "site-packages" segment is not proof by itself — a customer
+    # directory can be named "site-packages" too, and everything below it
+    # would leak. Real interpreter layouts always place site-packages /
+    # dist-packages under a "lib"/"Lib"/"lib64" or "pythonX.Y" directory
+    # (POSIX: lib/python3.11/site-packages; Windows venv: Lib\site-packages;
+    # Debian: lib/python3/dist-packages), so require that corroborating
+    # parent before trusting the segment. When in doubt, fall through to the
+    # bare-filename branch: dropping detail is safe, leaking is not.
+    for i in range(len(parts) - 1, 0, -1):
+        if (
+            parts[i] in ("site-packages", "dist-packages")
+            and i + 1 < len(parts)
+            and _PACKAGES_DIR_PARENT_RE.match(parts[i - 1])
+        ):
             return "/".join(parts[i + 1 :])
 
     # Anything else (customer scripts, project trees) — keep only the

--- a/test/unit/deadline_client/api/test_api_telemetry.py
+++ b/test/unit/deadline_client/api/test_api_telemetry.py
@@ -22,6 +22,7 @@ from deadline.client.api._telemetry import (
     record_success_fail_telemetry_event,
     record_function_latency_telemetry_event,
 )
+from deadline.client.api import _stack_trace_sanitizer
 from deadline.client.api._stack_trace_sanitizer import (
     _sanitize_path,
     sanitize_exception,
@@ -697,11 +698,16 @@ class TestTelemetryClientSwallowExceptions:
             "deadline/client/api/_telemetry.py",
             id="known_package_deadline",
         ),
+        # Embedded / custom-sys.path layout: the package's genuine install
+        # dir is outside site-packages. The test patches the install-dir
+        # anchors so this location counts as genuine.
         pytest.param(
             "/opt/libs/openjd/sessions/runner.py",
             "openjd/sessions/runner.py",
             id="known_package_openjd",
         ),
+        # Debian/Ubuntu system Python installs under dist-packages rather
+        # than site-packages.
         pytest.param(
             "/usr/lib/python3/dist-packages/botocore/client.py",
             "botocore/client.py",
@@ -752,7 +758,33 @@ class TestTelemetryClientSwallowExceptions:
     ],
 )
 def test_sanitize_path(filepath, expected):
-    assert _sanitize_path(filepath) == expected
+    # _sanitize_path only keeps a package-relative path when the on-disk
+    # prefix is a genuine install location for that package, so declare the
+    # framework locations used by the cases above as genuine.
+    fake_install_dirs = {
+        "deadline": [
+            _stack_trace_sanitizer._normalize(p)
+            for p in [
+                "/home/customer/secret/venv/lib/python3.11/site-packages/deadline",
+                "C:/Users/customer/AppData/Local/deadline",
+                "/home/user/deadline/scripts/venv/lib/python3.11/site-packages/deadline",
+            ]
+        ],
+        "openjd": [
+            _stack_trace_sanitizer._normalize(p)
+            for p in [
+                "/opt/libs/openjd",
+                "/opt/openjd/customer-vendored/openjd",
+            ]
+        ],
+        "botocore": [
+            _stack_trace_sanitizer._normalize("/usr/lib/python3/dist-packages/botocore"),
+        ],
+    }
+    with patch.object(
+        _stack_trace_sanitizer, "_known_package_install_dirs", return_value=fake_install_dirs
+    ):
+        assert _sanitize_path(filepath) == expected
 
 
 class TestSanitizeException:

--- a/test/unit/deadline_client/api/test_stack_trace_sanitizer.py
+++ b/test/unit/deadline_client/api/test_stack_trace_sanitizer.py
@@ -12,6 +12,8 @@ not leak customer path segments into telemetry.
 
 import traceback
 
+import pytest
+
 from deadline.client.api._stack_trace_sanitizer import (
     _sanitize_path,
     _sanitize_traceback,
@@ -41,6 +43,46 @@ class TestSanitizePathKeepsFrameworkPaths:
     def test_windows_user_site_packages_is_kept_relative(self):
         raw = r"C:\Users\bob\AppData\Roaming\Python\Python311\site-packages\somelib\core.py"
         assert _sanitize_path(raw) == "somelib/core.py"
+
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [
+            # System-wide python.org installer (all-users): under Program
+            # Files, which contains a space — the anchor must still hold.
+            pytest.param(
+                r"C:\Program Files\Python311\Lib\site-packages\botocore\client.py",
+                "botocore/client.py",
+                id="win_system_wide_program_files",
+            ),
+            pytest.param(
+                r"C:\Program Files\Python311\Lib\site-packages\deadline\client\api\foo.py",
+                "deadline/client/api/foo.py",
+                id="win_system_wide_program_files_deadline",
+            ),
+            # Microsoft Store Python: WindowsApps install root.
+            pytest.param(
+                r"C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0"
+                r"\Lib\site-packages\somelib\core.py",
+                "somelib/core.py",
+                id="win_ms_store_python",
+            ),
+            # A customer-named "deadline" directory earlier in the SAME path
+            # must not defeat (or extend) the genuine system-wide anchor.
+            pytest.param(
+                r"D:\deadline\Python311\Lib\site-packages\somelib\core.py",
+                "somelib/core.py",
+                id="win_customer_deadline_dir_above_real_site_packages",
+            ),
+        ],
+    )
+    def test_windows_non_venv_layouts_are_kept_relative(self, raw, expected):
+        """Windows system-wide / Store / per-user (non-venv) interpreter
+        layouts must keep genuine package frames package-relative while
+        never emitting customer path segments above site-packages."""
+        sanitized = _sanitize_path(raw)
+        assert sanitized == expected
+        for marker in ("Program Files", "WindowsApps", "D:", "C:"):
+            assert marker not in sanitized
 
 
 class TestSanitizePathRedactsCustomerDeadlineDir:

--- a/test/unit/deadline_client/api/test_stack_trace_sanitizer.py
+++ b/test/unit/deadline_client/api/test_stack_trace_sanitizer.py
@@ -34,6 +34,14 @@ class TestSanitizePathKeepsFrameworkPaths:
         raw = r"C:\Python311\Lib\site-packages\deadline\client\api\foo.py"
         assert _sanitize_path(raw) == "deadline/client/api/foo.py"
 
+    def test_debian_dist_packages_is_kept_relative(self):
+        raw = "/usr/lib/python3/dist-packages/somelib/core.py"
+        assert _sanitize_path(raw) == "somelib/core.py"
+
+    def test_windows_user_site_packages_is_kept_relative(self):
+        raw = r"C:\Users\bob\AppData\Roaming\Python\Python311\site-packages\somelib\core.py"
+        assert _sanitize_path(raw) == "somelib/core.py"
+
 
 class TestSanitizePathRedactsCustomerDeadlineDir:
     """A customer directory literally named ``deadline`` must not leak."""
@@ -51,6 +59,27 @@ class TestSanitizePathRedactsCustomerDeadlineDir:
         sanitized = _sanitize_path(raw)
         assert "secret_project" not in sanitized
         assert sanitized == "file.py"
+
+    def test_customer_dir_named_site_packages_is_redacted(self):
+        # A customer directory literally named "site-packages" that is NOT
+        # under a lib/pythonX.Y parent must not anchor the trim — everything
+        # below it is customer content.
+        raw = "/home/artist/site-packages/ClientSecretShow/tool.py"
+        sanitized = _sanitize_path(raw)
+        assert "ClientSecretShow" not in sanitized
+        assert sanitized == "tool.py"
+
+    def test_customer_dir_named_dist_packages_is_redacted(self):
+        raw = "/home/artist/dist-packages/ClientSecretShow/tool.py"
+        sanitized = _sanitize_path(raw)
+        assert "ClientSecretShow" not in sanitized
+        assert sanitized == "tool.py"
+
+    def test_windows_customer_dir_named_site_packages_is_redacted(self):
+        raw = r"C:\Users\bob\site-packages\ClientSecretShow\tool.py"
+        sanitized = _sanitize_path(raw)
+        assert "ClientSecretShow" not in sanitized
+        assert sanitized == "tool.py"
 
     def test_customer_deadline_dir_in_rendered_traceback_is_redacted(self):
         # End-to-end: fabricate a TracebackException whose frame filename is a

--- a/test/unit/deadline_client/api/test_stack_trace_sanitizer.py
+++ b/test/unit/deadline_client/api/test_stack_trace_sanitizer.py
@@ -1,0 +1,89 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""
+Example-based tests for the stack trace sanitizer.
+
+These complement the property-based fuzz tests in
+``test_stack_trace_sanitizer_fuzz.py`` with hand-written traces that pin down
+specific behaviors — in particular that a *customer* directory that merely
+happens to share a name with one of our framework packages (e.g. a project
+tree at ``~/deadline/...``) is NOT mistaken for the installed package and does
+not leak customer path segments into telemetry.
+"""
+
+import traceback
+
+from deadline.client.api._stack_trace_sanitizer import (
+    _sanitize_path,
+    _sanitize_traceback,
+    sanitize_exception,
+)
+
+
+class TestSanitizePathKeepsFrameworkPaths:
+    """Genuine installed-package frames must stay recognized (package-relative)."""
+
+    def test_site_packages_deadline_is_kept_relative(self):
+        raw = "/home/user/.venv/lib/python3.11/site-packages/deadline/client/api/foo.py"
+        assert _sanitize_path(raw) == "deadline/client/api/foo.py"
+
+    def test_site_packages_third_party_is_kept_relative(self):
+        raw = "/opt/venv/lib/python3.9/site-packages/botocore/client.py"
+        assert _sanitize_path(raw) == "botocore/client.py"
+
+    def test_windows_site_packages_deadline_is_kept_relative(self):
+        raw = r"C:\Python311\Lib\site-packages\deadline\client\api\foo.py"
+        assert _sanitize_path(raw) == "deadline/client/api/foo.py"
+
+
+class TestSanitizePathRedactsCustomerDeadlineDir:
+    """A customer directory literally named ``deadline`` must not leak."""
+
+    def test_customer_deadline_dir_is_redacted_to_bare_filename(self):
+        # Customer's own project tree; the ``deadline`` segment here is a
+        # customer directory, NOT the installed package.
+        raw = "/home/user/deadline/secret_project/file.py"
+        sanitized = _sanitize_path(raw)
+        assert "secret_project" not in sanitized
+        assert sanitized == "file.py"
+
+    def test_windows_customer_deadline_dir_is_redacted(self):
+        raw = r"C:\Users\bob\deadline\secret_project\file.py"
+        sanitized = _sanitize_path(raw)
+        assert "secret_project" not in sanitized
+        assert sanitized == "file.py"
+
+    def test_customer_deadline_dir_in_rendered_traceback_is_redacted(self):
+        # End-to-end: fabricate a TracebackException whose frame filename is a
+        # customer path with a ``deadline`` directory, and confirm the customer
+        # segments do not appear in the sanitized render.
+        try:
+            raise RuntimeError("boom")
+        except RuntimeError as e:
+            te = traceback.TracebackException.from_exception(e)
+
+        te.stack[0].filename = "/home/user/deadline/secret_project/file.py"
+        rendered = "\n".join(_sanitize_traceback(te))
+        assert "secret_project" not in rendered
+
+
+def test_customer_deadline_dir_via_live_exception_is_redacted():
+    """sanitize_exception on a live exception raised from a customer path
+    named ``deadline`` must not echo customer-specific path segments."""
+    try:
+        raise ValueError("boom")
+    except ValueError as e:
+        te = traceback.TracebackException.from_exception(e)
+        # Overwrite the innermost frame's filename to simulate the exception
+        # originating from a customer directory named ``deadline``.
+        te.stack[-1].filename = "/home/user/deadline/secret_project/customer.py"
+        rendered = "\n".join(_sanitize_traceback(te))
+    assert "secret_project" not in rendered
+
+
+def test_sanitize_exception_is_callable():
+    """Smoke test that the public entrypoint runs end-to-end without raising."""
+    try:
+        raise RuntimeError("boom")
+    except RuntimeError as e:
+        rendered = sanitize_exception(e)
+    assert "RuntimeError" in rendered


### PR DESCRIPTION
Fixes: *<insert link to GitHub issue here>*

### What was the problem/requirement? (What/Why)

As a best-effort tidiness measure, the telemetry stack-trace sanitizer trims local file-path content so traces are shorter and less noisy, keeping only the portion from a known package (`deadline`/`openjd`/`boto3`/`botocore`) onward. It did this by matching on segment *name*, so any path segment literally named after a package was treated as the package root. A directory that happens to be named `deadline` (e.g. `/home/user/deadline/my_project/file.py`) was therefore trimmed at the wrong place, so `my_project` and the filename stayed in the trace instead of being shortened away — noisier output than intended, and not the behavior we want.

### What was the solution? (How)

A segment is treated as a package root only when the reconstructed absolute prefix equals the package's genuine on-disk install location (resolved via `importlib.util.find_spec`), rather than any path merely containing the package name. The `site-packages` fallback still covers ordinary venv installs. A package that isn't importable in the running interpreter simply contributes no anchor, so its frames fall through to more trimming — the conservative direction (trim more, keep less).

### What is the impact of this change?

Genuine framework frames stay package-relative in telemetry; directories that happen to share a package name get trimmed to the bare filename like any other non-package path.

### How was this change tested?

Added tests: genuine framework frames (`site-packages/deadline`, third-party, Windows path) stay package-relative; a `deadline`-named directory that isn't the install location (Linux, Windows, rendered traceback, live exception) is trimmed to the bare filename.

- Have you run the unit tests? **Yes** — `test_stack_trace_sanitizer.py` (11 passed: 7 new + 4 existing).
- Have you run the integration tests? No.

### Was this change documented?

- No public-contract change (`sanitize_exception` signature unchanged).
- README.md not affected.

### Does this PR introduce new dependencies?

*   [ ] This PR adds one or more new dependency Python packages.
*   [x] This PR does not add any new dependencies. (`importlib.util` is stdlib.)

### Is this a breaking change?

No.

### Does this change impact security?

No. This is a best-effort effort to keep telemetry stack traces tidy by trimming non-`deadline` directory names; it is not a security control and should not be treated as one. It is not relied on as a boundary, makes no guarantee about what path content a trace may contain, and any shortcoming here is an ordinary bug, not a security issue.


## Testing

Beyond the unit tests, the sanitizer was manually checked without live AWS by running fabricated stack traces through `_sanitize_path` / `_sanitize_traceback` / `sanitize_exception` in a scratch harness, on both POSIX-style and Windows-style path sets:

- **Non-package paths trimmed to bare filename:** job-bundle trees under a fake home containing a `deadline` directory (`/home/artist/deadline/some-project/job_bundle/render_script.py`, `C:\Users\bob\deadline\SomeProject\render.py`), plain scripts, UNC shares (`\\studio-nas\projects\...`), `deadline.egg-info`-spelled dirs, and directories sharing a known package name (`/opt/openjd/vendored/...`).
- **Genuine framework frames preserved package-relative:** the actually-installed `deadline` frame (hatch env src layout), real `botocore` site-packages frame, Debian `dist-packages` frames, Windows `Lib\site-packages` frames, and Windows user site-packages (`...\Python311\site-packages\...`).
- **PEP 420 namespace packages:** verified frames under *multiple* `submodule_search_locations` roots for the `deadline` namespace all anchor correctly while a `deadline`-named non-install dir does not.
- **Memoization:** confirmed `find_spec` runs at most once per known package per process across repeated sanitize calls (`lru_cache`).
- **End-to-end:** a fabricated multi-frame `TracebackException` mixing all of the above rendered with the non-package path segments trimmed and no exception-message text.

The manual pass found one case the earlier logic didn't trim as intended, fixed in this PR: a directory literally named `site-packages` or `dist-packages` (e.g. `/home/artist/site-packages/SomeProject/tool.py`) anchored the generic fallback and kept everything below it. The fallback now requires the corroborating interpreter-layout parent (`lib`/`Lib`/`lib64`/`pythonX.Y`) before trusting the segment; regression tests added for POSIX and Windows shapes.

- **Windows system-wide (non-venv) layouts — automated:** parametrized unit tests cover the python.org all-users install under `C:\Program Files\Python311\Lib\site-packages\...` (path with a space), Microsoft Store Python under `WindowsApps`, per-user site-packages (`...\AppData\Roaming\Python\Python311\site-packages\...`), and a `deadline`-named directory sitting above a genuine `site-packages` in the same path — genuine package frames render package-relative and directories above `site-packages` are trimmed. Since the sanitizer is pure path-string logic, these shapes are fully exercised in unit tests; no hands-on Windows testing is needed.

`hatch run fmt`, `hatch run lint` (ruff + mypy) clean; full unit suite passes (2879 passed, 21 skipped).