### PR TITLE
ci: pin openjd-adaptor-runtime to unblock blender submitter UI tests

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -41,7 +41,8 @@ pre-install-commands = [
   "pip install -r requirements-ui-testing.txt",
   "pip install \"moto[server,s3]>=5\" boto3",
   "pip install --no-deps deadline-cloud-for-blender",
-  "pip install deadline-job-attachments openjd-adaptor-runtime",
+  # openjd-adaptor-runtime pinned: 0.9.6 breaks the blender submitter dialog startup. Unpin once fixed upstream.
+  "pip install deadline-job-attachments openjd-adaptor-runtime==0.9.5",
 ]
 
 [envs.blender-ui.scripts]


### PR DESCRIPTION
Fixes: *<insert link to GitHub issue here>*

### What was the problem/requirement? (What/Why)

The three "Blender Submitter UI" CI jobs (Linux/macOS/Windows) began failing across all branches at ~2026-07-21 22:08Z. Blender launches and saves `cube.blend`, but the Deadline Cloud submitter dialog never opens, so the xa11y harness times out:

```
Failed: Submitter dialog not found within 30.0s
```

This is a **new external dependency break, not a code regression**:
- Mainline's own blender job was green at 2026-07-21 00:02Z and mainline hasn't changed since.
- The failure is isolated to the blender-ui environment — a CLI-only PR (no UI code) also fails the blender jobs while its regular "UI Tests" jobs pass.

The `[envs.blender-ui]` environment in `hatch.toml` installs `openjd-adaptor-runtime` **unpinned**. `openjd-adaptor-runtime==0.9.6` was published to PyPI at 2026-07-21 20:52:18Z — squarely inside the pass→fail window (last green 18:02Z, first fail 22:08Z) — and is the only dependency in the blender stack that released then. `deadline-cloud-for-blender` depends on `openjd-adaptor-runtime<0.10,>=0.7`, so the env resolves to 0.9.6, and the submitter's `register()` import chain pulls the adaptor runtime in.

### What was the solution? (How)

Pin `openjd-adaptor-runtime==0.9.5` (the immediate predecessor, released 2026-06-18) in the `[envs.blender-ui]` install line, with a terse comment noting why.

### What is the impact of this change?

Unblocks the Blender Submitter UI CI jobs. Scope is limited to the blender-ui test environment; no runtime/library dependency is changed.

### How was this change tested?

The blender-ui suite requires a real Blender + xa11y GUI harness that does not run on a normal dev machine, so this pin was **not** reproduced end-to-end locally. The diagnosis rests on timing + isolation evidence (above): the 0.9.6 release time falls inside the pass→fail window, it is the only blender-stack dependency that released then, and the failure reproduces on PRs that touch no UI code. **The definitive confirmation is this PR's own CI run** — the Blender Submitter UI jobs should return to green with 0.9.5 pinned.

- Have you run the unit tests? N/A — CI-configuration change only; no source code changed.
- Have you run the integration tests? No.

### Was this change documented?

- The pin carries an inline comment explaining why and when to remove it.
- README.md not affected.

### Follow-up

Unpin `openjd-adaptor-runtime` once a fixed version ships upstream. Consider filing an issue against `OpenJobDescription/openjd-adaptor-runtime-for-python` if 0.9.6 genuinely broke the submitter startup (0.9.6's changes vs 0.9.5 are in the subprocess/stream-logging modules). Note the blender-ui env installs several deps unpinned (`deadline-cloud-for-blender`, PySide6 range) — pinning the whole env would improve reproducibility.

### Does this PR introduce new dependencies?

*   [ ] This PR adds one or more new dependency Python packages.
*   [x] This PR does not add any new dependencies. (Pins an existing dev/test dependency.)

### Is this a breaking change?

No.

### Does this change impact security?

No.
