### PR TITLE
test: fix Blender submitter UI test hang from update-check modal

### DIFF
--- a/test/blender_submitter_ui/test_blender_submitter_ui.py
+++ b/test/blender_submitter_ui/test_blender_submitter_ui.py
@@ -184,6 +184,18 @@ def blender_env(tmp_path, mock_backend, moto_server, s3_client):
         "\n"
         "[profile-(default) settings]\n"
         f"job_history_dir = {tmp_path / 'job_history'}\n"
+        "\n"
+        # The submitter checks a remote manifest
+        # (downloads.deadlinecloud.amazonaws.com/submitters/manifest.json) at
+        # startup and, if it advertises a newer version than the installed one,
+        # pops a BLOCKING modal "update available" dialog. In headless CI nobody
+        # dismisses it, so the submitter dialog never appears and the test times
+        # out. The trigger is server-side (the manifest gaining a new version),
+        # which is why the same commit flips from pass to fail with no change to
+        # any installed package. Disable the notification so the test exercises
+        # the submitter, not the update prompt.
+        "[settings]\n"
+        "submitter_update_notification = false\n"
     )
 
     scene_dir = tmp_path / "scene"
@@ -354,13 +366,18 @@ class TestBlenderSubmitterUI:
             )
             assert len(backend.jobs) == 1, f"Expected 1 job, got {len(backend.jobs)}"
 
-        except Exception:
+        except BaseException:
+            # Catch BaseException, not Exception: the dialog-wait timeout raises
+            # pytest.Failed (a BaseException subclass), so a bare `except Exception`
+            # never fires and the failure diagnostics below are skipped.
             _screenshot("blender_submitter_failure")
             try:
-                apps = xa11y.App.list()
-                for a in apps:
-                    if a.name not in baseline_apps:
-                        _dump_tree(a)
+                # Dump every app tree, not just newly-appeared ones: when the dialog
+                # never opens the baseline set is all we have, and it's the evidence.
+                for a in xa11y.App.list():
+                    origin = "new" if a.name not in baseline_apps else "baseline"
+                    sys.stderr.write(f"--- app ({origin}): {a.name} ---\n")
+                    _dump_tree(a)
             except Exception:
                 pass
             raise
@@ -384,7 +401,7 @@ class TestBlenderSubmitterUI:
                 stderr = proc.stderr.read().decode(errors="replace") if proc.stderr else ""
                 pytest.fail(
                     f"Blender exited early with code {proc.returncode}\n"
-                    f"stdout: {stdout[-2000:]}\nstderr: {stderr[-2000:]}"
+                    f"stdout: {stdout[-8000:]}\nstderr: {stderr[-8000:]}"
                 )
             # Check all apps for the submitter dialog
             for app in xa11y.App.list():
@@ -410,8 +427,8 @@ class TestBlenderSubmitterUI:
         pytest.fail(
             f"Submitter dialog not found within {timeout}s\n"
             f"Apps: {all_trees}\n"
-            f"Blender stdout: {stdout[-2000:]}\n"
-            f"Blender stderr: {stderr[-2000:]}"
+            f"Blender stdout: {stdout[-8000:]}\n"
+            f"Blender stderr: {stderr[-8000:]}"
         )
 
     def _wait_farm_resolved(self, app: xa11y.App, timeout: float = FARM_RESOLVE_TIMEOUT):


### PR DESCRIPTION
Fixes: *<insert link to GitHub issue here>*

### What was the problem/requirement? (What/Why)

The `Blender Submitter UI` integration test began failing in CI with `Submitter dialog not found within 30s`, on all three platforms, deterministically — while the *same commit* had passed hours earlier and no installed package version had changed between the green and red runs.

Root cause: at submitter startup, `check_and_show_update_dialog()` calls `deadline.client.api.safe_check_for_updates()`, which fetches a **remote manifest** from `https://downloads.deadlinecloud.amazonaws.com/submitters/manifest.json` at runtime. When that manifest advertises a version newer than the installed one, the submitter pops a **blocking modal** `UpdateAvailableDialog.exec_()`. In headless CI nobody dismisses it, so the real submitter dialog never opens and the test times out.

The manifest began advertising `deadline-cloud-for-blender` **0.6.6** while PyPI (what CI installs) is still **0.6.5** — so `0.6.5 < 0.6.6` and the modal appears. Because the trigger is **server-side** (the manifest gaining a version), the same commit flips from pass to fail with no change to any installed package, and pinning unrelated dependencies (e.g. `openjd-adaptor-runtime`) has no effect.

Two things kept this hidden: the operator `DEADLINE_CLOUD_OT_open_dialog.execute()` only catches `RuntimeError` (any other exception becomes a silent Blender `{'CANCELLED'}`), and the addon logs only to `~/.deadline/logs/submitters/blender.log`, which CI never captures — so every root cause looked identical ("no window, no stderr").

### What was the solution? (How)

- **Fix:** set `settings.submitter_update_notification = false` in the test's Deadline config, so the test exercises the submitter itself rather than the update prompt. This is the config knob that exists precisely to suppress the startup update check.
- **Harden the failure diagnostics** that made this diagnosable:
  - Catch `BaseException` (not `Exception`) in the test body: the dialog-wait timeout raises `pytest.Failed`, a `BaseException` subclass, so the previous `except Exception:` never fired and no screenshot/tree was ever captured.
  - Dump **all** app accessibility trees on failure, not only newly-appeared apps — when the dialog never opens there are no "new" apps, so the previous filter dumped nothing useful.
  - Widen captured Blender stdout/stderr from 2000 to 8000 chars so a full traceback is not truncated.

### What is the impact of this change?

Test-only; no product code changes. The `Blender Submitter UI` job is green again on Linux, macOS, and Windows, and it no longer depends on a time-varying remote manifest. When the test does fail in the future, CI now captures a screenshot and dumps the accessibility trees so the failure is actionable. The diagnostics run only on the failure path and upload nothing on green runs (the upload step is `if: always()` + `if-no-files-found: ignore`).

### How was this change tested?

- `py_compile` + `ruff check` / `ruff format` clean.
- Behavioral proof in CI: with the fix, the `Blender Submitter UI` jobs pass on all three platforms (Linux, macOS, Windows). The root cause was confirmed by temporarily bypassing the update check, after which the dialog opened and the submission flow reached the mock backend (`ListFarms`, `ListQueues`, `GetQueue`, `AssumeQueueRoleForUser`); the live manifest was verified to advertise 0.6.6 vs PyPI's 0.6.5. That instrumentation was reverted — this PR contains only the config fix and the diagnostics hardening.

- Have you run the unit tests? N/A — change is confined to the `test/blender_submitter_ui` E2E harness; validated with py_compile + lint.
- Have you run the integration tests? Yes — the `Blender Submitter UI` integration workflow runs on this PR and passes on all three platforms.

### Was this change documented?

- Inline comments explain the remote-manifest / blocking-modal root cause, why `BaseException` is caught, and why all trees are dumped.
- README.md not affected.

### Does this PR introduce new dependencies?

*   [ ] This PR adds one or more new dependency Python packages.
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?

No.

### Does this change impact security?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
