### PR TITLE
chore(dependabot): don't update requirements-installer automatically

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,9 +10,12 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
-    ignore:
-      - dependency-name: "pyside6-essentials"
-        versions: [ "6" ]
+    # requirements-installer.txt pins dependencies (e.g. pyinstaller,
+    # PySide6-Essentials) that we manage deliberately and are particular about,
+    # so exclude the whole file from automatic updates. Dependabot still
+    # maintains pyproject.toml and the other requirements files.
+    exclude-paths:
+      - "requirements-installer.txt"
     commit-message: 
       prefix: "chore(deps):"
     # Combine all minor and patch bumps into a single PR. Major bumps do not


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Dependabot was giving less than desirable updates for pyside6-essentials in the installer - https://github.com/aws-deadline/deadline-cloud/pull/1300. We want the library to update and allow for more versions, but we don't want to ship the latest since the installer attempts to match VFX platform.

The current ignore only ignores version 6.0.0, rather than a version range.

### What was the solution? (How)

We're particular about the versions of pyinstaller/pyside6 used for the installer, so we remove those from automatic updates via the exclude-paths.

### What is the impact of this change?

Pyside6 updates in pyproject/gui-testing, but not in the installer

### How was this change tested?

N/A

### Was this change documented?

N/A

### Does this PR introduce new dependencies?

N/A

### Is this a breaking change?

N/A

### Does this change impact security?

N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
