### PR TITLE
fix(tests): unset CA bundle env vars instead of blanking them in proxy e2e fixture

### DIFF
--- a/test/cli_e2e/test_proxy_job_attachments.py
+++ b/test/cli_e2e/test_proxy_job_attachments.py
@@ -126,10 +126,13 @@ def s3_proxy_setup(tmp_path: Path, moto_server: str) -> Iterator[tuple]:
         "no_proxy": "",
         "HTTPS_PROXY": "",
         "https_proxy": "",
-        "AWS_CA_BUNDLE": "",
         "AWS_MAX_ATTEMPTS": "1",
         "AWS_RETRY_MODE": "standard",
     }
+    # Remove rather than blank the CA bundle vars: botocore >= 1.43.54 rejects an
+    # empty-string CA bundle with InvalidConfigError.
+    for var in ("AWS_CA_BUNDLE", "REQUESTS_CA_BUNDLE"):
+        env.pop(var, None)
     try:
         yield env, proxy, ca_pem, s3_client
     finally:


### PR DESCRIPTION
botocore 1.43.54 added validation that raises InvalidConfigError when the CA bundle (AWS_CA_BUNDLE / REQUESTS_CA_BUNDLE / ca_bundle / verify) resolves to an empty or whitespace-only string. The s3_proxy_setup fixture set AWS_CA_BUNDLE to an empty string to isolate the test from ambient CA configuration, which now fails every CLI invocation on botocore >= 1.43.54.

Remove the variables from the subprocess environment instead.

Fixes: *<insert link to GitHub issue here>*

### What was the problem/requirement? (What/Why)

### What was the solution? (How)

### What is the impact of this change?

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests?
- Have you run the integration tests?

### Was this change documented?

- Are relevant docstrings in the code base updated?
- Has the README.md been updated? If you modified CLI arguments, for instance.

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatabilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [ ] This PR does not add any new dependencies.

### Is this a breaking change?

A breaking change is one that modifies a public contract in a way that is not backwards compatible. See the 
[Public Contracts](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#public-contracts) section
of the DEVELOPMENT.md for more information on the public contracts.

If so, then please describe the changes that users of this package must make to update their scripts, or Python applications.

### Does this change impact security?

- Does the change need to be threat modeled? For example, does it create or modify files/directories that must only be readable by the process owner?
    - If so, then please label this pull request with the "security" label. We'll work with you to analyze the threats.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
