### PR TITLE
chore: remove stale 0.60.3 changelog section from aborted release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,3 @@
-## 0.60.3 (2026-07-24)
-
-### Bug Fixes
-* Fixed a privacy issue where the telemetry stack-trace sanitizer could inadvertently log customer directory paths that happened to share a name with framework packages (e.g. `~/deadline/...`). Such paths are now correctly identified as customer-specific and redacted. (#1295)
-* Bumped the minimum `click` dependency to >= 8.3.3 on Python 3.10+ to address CVE-2026-7246. While deadline-cloud was not directly exploitable, this resolves security scanner warnings. (#1283)
 ## 0.60.2 (2026-07-20)
 
 ### BREAKING CHANGES


### PR DESCRIPTION
## What
Removes the leftover `## 0.60.3 (2026-07-24)` section from CHANGELOG.md.

## Why
The 2026-07-24 release of 0.60.3 failed in `PublishToCodeArtifact` — botocore 1.43.54 added empty-string CA bundle validation that broke two proxy e2e tests (fixed in #1306). Nothing was published to PyPI/CodeArtifact, and the orphaned GitHub release + tag have been deleted so the version number can be reused.

The next `Release: Bump` run will regenerate a complete 0.60.3 section covering all fixes since 0.60.2. Without this cleanup, the regenerated changelog contains duplicate `## 0.60.3` headers (see #1310, closed for this reason).

## Note for reviewers
Merging this touches CHANGELOG.md on mainline, which auto-triggers a `Release: Publish` run. That run will fail fast at the Tag Release author-verification gate (commit author is not the CI bot) without tagging or publishing anything — expected and harmless; it can be cancelled.

After this merges, the plan is: re-run `Release: Bump` → merge the regenerated `chore(release): 0.60.3` PR → release proceeds with the test fix included.