### PR TITLE
feat: record farm-failed tasks as farm_failed in status file

### DIFF
--- a/src/deadline/client/cli/_download_status_file.py
+++ b/src/deadline/client/cli/_download_status_file.py
@@ -240,6 +240,7 @@ def _build_status_file_content(
     existing_jobs: Optional[dict[str, Any]] = None,
     job_download_results: Optional[dict[str, dict[str, Any]]] = None,
     task_download_results: Optional[dict[str, dict[str, dict[str, Any]]]] = None,
+    succeeded_task_ids: Optional[dict[str, set[str]]] = None,
 ) -> dict[str, Any]:
     """
     Builds the full status file JSON structure by merging existing job entries
@@ -274,6 +275,18 @@ def _build_status_file_content(
         existing_tasks: dict[str, Any] = (existing_entry or {}).get("tasks", {})
         new_tasks: dict[str, Any] = (task_download_results or {}).get(job_id, {})
         merged_tasks = dict(existing_tasks)
+        # A task that SUCCEEDED this run with no output must clear any stale farm_failed
+        # entry carried forward from a prior run. The farm FAILED action is reported by the
+        # API indefinitely, so _get_job_sessions subtracts succeeded IDs from
+        # farm_failed_task_ids — preventing a new entry — but the prior disk entry is
+        # preserved by the merge above unless we explicitly remove it here.
+        job_succeeded_ids: set[str] = (succeeded_task_ids or {}).get(job_id, set())
+        for task_id in job_succeeded_ids:
+            if (
+                task_id not in new_tasks
+                and merged_tasks.get(task_id, {}).get("download_status") == "farm_failed"
+            ):
+                del merged_tasks[task_id]
         for task_id, r in new_tasks.items():
             # Honor an explicit download_status (e.g. "farm_failed" for a task that
             # failed on the farm); otherwise derive it from whether the download errored.
@@ -428,6 +441,7 @@ def write_download_status_file(
     checkpoint_dir: str,
     job_download_results: Optional[dict[str, dict[str, Any]]] = None,
     task_download_results: Optional[dict[str, dict[str, dict[str, Any]]]] = None,
+    succeeded_task_ids: Optional[dict[str, set[str]]] = None,
     print_function_callback: Callable[[Any], None] = lambda msg: None,
 ) -> None:
     """
@@ -466,6 +480,7 @@ def write_download_status_file(
                     existing_jobs=existing_jobs,
                     job_download_results=job_download_results,
                     task_download_results=task_download_results,
+                    succeeded_task_ids=succeeded_task_ids,
                 )
 
                 _atomic_write_json(status_file_path, status_content)

--- a/src/deadline/client/cli/_download_status_file.py
+++ b/src/deadline/client/cli/_download_status_file.py
@@ -123,6 +123,44 @@ def _make_status_entry(
     }
 
 
+# Job statuses that assert the job is finished and nothing failed to download. An errored task
+# contradicts any of them, so these are the states _reconcile_entry_with_tasks overrides.
+# "in_progress" is excluded on purpose: it claims nothing, and the download may still be retried
+# before the job ends, so the honest report is a failed task row under a still-running job.
+_NO_DOWNLOAD_FAILURE_STATUSES = ("downloaded", "skipped")
+
+
+def _reconcile_entry_with_tasks(entry: dict[str, Any]) -> None:
+    """Forces a job entry back to "failed" while any of its tasks still carries a download error.
+
+    A job's category-derived status only says the job finished on the farm, which is not
+    evidence that its outputs reached disk. Without this, a job whose task failed in an
+    earlier run and which produced no new results this run flips to "downloaded" while its
+    task entry still reads "failed" — a green job badge over a red task, and a real failure
+    silently dropped. The same applies to "skipped": a job stopped mid-download reports
+    "skipped" once it goes inactive, which reads as "nothing to fetch" rather than "a file is
+    missing and here is why". Preferring the task evidence keeps the two levels consistent
+    without claiming a missing file is present.
+
+    Tasks that failed on the farm carry no error_code and are deliberately excluded: the
+    render failed, the download didn't, so they must not drag the job to a download failure.
+    """
+    if entry.get("download_status") not in _NO_DOWNLOAD_FAILURE_STATUSES:
+        return
+    errored = [t for t in entry.get("tasks", {}).values() if t.get("error_code")]
+    if not errored:
+        return
+    entry["download_status"] = "failed"
+    entry["error_code"] = errored[0]["error_code"]
+    entry["error_message"] = errored[0].get("error_message")
+    # A download failure is not a skip. Leaving skip_reason set would produce an entry that
+    # claims both, and the monitor keys its "why is this file missing" copy off skip_reason.
+    entry["skip_reason"] = None
+    missing = sum(t.get("total_files", 0) - t.get("downloaded_files", 0) for t in errored)
+    if missing > 0:
+        entry["failed_files"] = missing
+
+
 def _is_job_fully_complete(job: dict[str, Any]) -> bool:
     """Returns True if the job has ended with no active tasks remaining.
 
@@ -276,7 +314,9 @@ def _build_status_file_content(
                     existing_entry["error_message"] = None
                     existing_entry["failed_files"] = 0
             existing_entry["tasks"] = merged_tasks
+            _reconcile_entry_with_tasks(existing_entry)
         else:
+            _reconcile_entry_with_tasks(new_entry)
             jobs_status[job_id] = new_entry
 
     # Update inactive jobs with non-terminal status to a terminal state
@@ -290,6 +330,7 @@ def _build_status_file_content(
                 # No downloads at all — mark as skipped (job stopped before any output)
                 existing_entry["download_status"] = "skipped"
             existing_entry["last_updated"] = now
+            _reconcile_entry_with_tasks(existing_entry)
 
     # Determine run status — "failed" if any job in this run had errors
     has_failures = any(

--- a/src/deadline/client/cli/_download_status_file.py
+++ b/src/deadline/client/cli/_download_status_file.py
@@ -281,13 +281,15 @@ def _build_status_file_content(
                 "download_status",
                 "downloaded" if r.get("error_code") is None else "failed",
             )
-            # A prior-run success is terminal: its output is on disk. A FAILED taskRun from an
-            # earlier attempt keeps being reported by the API on every no-op run, so without this
-            # guard a task that was requeued, succeeded, and downloaded would flip back to
-            # farm_failed forever. Never let farm_failed clobber an already-downloaded task.
-            if status == "farm_failed" and existing_tasks.get(task_id, {}).get(
-                "download_status"
-            ) in ("downloaded", "failed"):
+            # A prior-run download success is terminal: the output is on disk. Never let a stale
+            # farm_failed action (the API reports it indefinitely) overwrite it.
+            # "failed" is intentionally not guarded here: a task may have succeeded on the farm
+            # but its download failed, so a subsequent run re-collects the FAILED action as
+            # farm_failed and should overwrite the stale download error.
+            if (
+                status == "farm_failed"
+                and existing_tasks.get(task_id, {}).get("download_status") == "downloaded"
+            ):
                 continue
             merged_tasks[task_id] = {
                 "download_status": status,

--- a/src/deadline/client/cli/_download_status_file.py
+++ b/src/deadline/client/cli/_download_status_file.py
@@ -235,19 +235,29 @@ def _build_status_file_content(
         # Merge task entries: preserve existing tasks, overwrite only tasks seen this run
         existing_tasks: dict[str, Any] = (existing_entry or {}).get("tasks", {})
         new_tasks: dict[str, Any] = (task_download_results or {}).get(job_id, {})
-        merged_tasks = {
-            **existing_tasks,
-            **{
-                task_id: {
-                    "download_status": "downloaded" if r.get("error_code") is None else "failed",
-                    "total_files": r["total_files"],
-                    "downloaded_files": r["downloaded_files"],
-                    "error_code": r.get("error_code"),
-                    "error_message": r.get("error_message"),
-                }
-                for task_id, r in new_tasks.items()
-            },
-        }
+        merged_tasks = dict(existing_tasks)
+        for task_id, r in new_tasks.items():
+            # Honor an explicit download_status (e.g. "farm_failed" for a task that
+            # failed on the farm); otherwise derive it from whether the download errored.
+            status = r.get(
+                "download_status",
+                "downloaded" if r.get("error_code") is None else "failed",
+            )
+            # A prior-run success is terminal: its output is on disk. A FAILED taskRun from an
+            # earlier attempt keeps being reported by the API on every no-op run, so without this
+            # guard a task that was requeued, succeeded, and downloaded would flip back to
+            # farm_failed forever. Never let farm_failed clobber an already-downloaded task.
+            if status == "farm_failed" and existing_tasks.get(task_id, {}).get(
+                "download_status"
+            ) in ("downloaded", "failed"):
+                continue
+            merged_tasks[task_id] = {
+                "download_status": status,
+                "total_files": r["total_files"],
+                "downloaded_files": r["downloaded_files"],
+                "error_code": r.get("error_code"),
+                "error_message": r.get("error_message"),
+            }
         new_entry["tasks"] = merged_tasks
 
         if (

--- a/src/deadline/client/cli/_groups/queue_group.py
+++ b/src/deadline/client/cli/_groups/queue_group.py
@@ -524,6 +524,7 @@ def sync_output(
             download_candidate_jobs,
             job_download_results,
             task_download_results,
+            succeeded_task_ids,
         ) = _incremental_output_download(
             boto3_session=boto3_session,
             farm_id=farm_id,
@@ -547,6 +548,7 @@ def sync_output(
                 checkpoint_dir=checkpoint_dir,
                 job_download_results=job_download_results,
                 task_download_results=task_download_results,
+                succeeded_task_ids=succeeded_task_ids,
                 print_function_callback=logger.echo,
             )
 

--- a/src/deadline/client/cli/_incremental_download.py
+++ b/src/deadline/client/cli/_incremental_download.py
@@ -630,6 +630,7 @@ def _retrieve_session_actions_for_session(
     queue_id: str,
     job_id: str,
     output_session: dict[str, Any],
+    output_farm_failed_task_ids: Optional[set[str]] = None,
 ):
     """
     Args:
@@ -641,6 +642,8 @@ def _retrieve_session_actions_for_session(
         queue_id: The queue id for the operation.
         job_id: The job id to process.
         output_session: The session to populate with a sessionActions field.
+        output_farm_failed_task_ids: Optional set populated with task IDs of taskRun actions that
+            FAILED on the farm. These produce no output to download and are recorded separately.
     """
     session_actions_paginator = deadline_client.get_paginator("list_session_actions")
 
@@ -651,12 +654,21 @@ def _retrieve_session_actions_for_session(
         jobId=job_id,
         sessionId=output_session["sessionId"],
     ):
-        # Include only succeeded taskRun actions.
         for session_action in session_actions_page.get("sessionActions", []):
-            succeeded = session_action.get("status") == "SUCCEEDED"
-            is_task_run = "taskRun" in session_action.get("definition", {})
-            if succeeded and is_task_run:
+            definition = session_action.get("definition", {})
+            if "taskRun" not in definition:
+                continue
+            status = session_action.get("status")
+            if status == "SUCCEEDED":
+                # Succeeded taskRun — has output to download.
                 session_action_list.append(session_action)
+            elif status == "FAILED" and output_farm_failed_task_ids is not None:
+                # Failed on the farm — produced no output. Record the task id separately so the
+                # status file can show a stable "farm_failed" entry; never add it to
+                # session_action_list (that list drives manifest downloads).
+                task_id = definition["taskRun"].get("taskId")
+                if task_id:
+                    output_farm_failed_task_ids.add(task_id)
 
     if session_action_list:
         # Extract the session action indexes from the ids
@@ -690,10 +702,13 @@ def _get_job_sessions(
     download_candidate_jobs: dict[str, dict[str, Any]],
     print_function_callback: Callable[[Any], None] = lambda msg: None,
     region: Optional[str] = None,
-) -> dict[str, list]:
+) -> tuple[dict[str, list], dict[str, set[str]]]:
     """
     This function gets all the job sessions and session actions from the completed, added, and updated jobs.
     It uses the checkpoint's session_completed_indexes to filter out older session actions that are already downloaded.
+
+    Returns a tuple of (job_sessions, farm_failed_task_ids), where farm_failed_task_ids maps
+    job_id -> set of task IDs that FAILED on the farm (produced no output to download).
 
     Args:
         boto3_session: The boto3.Session for accessing AWS.
@@ -799,19 +814,29 @@ def _get_job_sessions(
     print_function_callback(f"Using {max_workers} threads")
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
         futures = []
+        # Collect farm-failed task IDs per job across threads. Each worker collects into a
+        # local set, then merges under a lock — dict/set mutation across threads needs it.
+        farm_failed_task_ids: dict[str, set[str]] = {}
+        farm_failed_lock = threading.Lock()
+
+        def _retrieve_and_collect(job_id: str, session: dict[str, Any]) -> None:
+            local_failed: set[str] = set()
+            _retrieve_session_actions_for_session(
+                deadline,
+                checkpoint_job_session_completed_indexes,
+                farm_id,
+                queue["queueId"],
+                job_id,
+                session,
+                local_failed,
+            )
+            if local_failed:
+                with farm_failed_lock:
+                    farm_failed_task_ids.setdefault(job_id, set()).update(local_failed)
+
         for job_id, session_list in job_sessions.items():
             for session in session_list:
-                futures.append(
-                    executor.submit(
-                        _retrieve_session_actions_for_session,
-                        deadline,
-                        checkpoint_job_session_completed_indexes,
-                        farm_id,
-                        queue["queueId"],
-                        job_id,
-                        session,
-                    )
-                )
+                futures.append(executor.submit(_retrieve_and_collect, job_id, session))
         # surfaces any exceptions in the thread
         for future in concurrent.futures.as_completed(futures):
             future.result()
@@ -836,7 +861,7 @@ def _get_job_sessions(
     duration = datetime.now(tz=timezone.utc) - start_time
     print_function_callback(f"...populated in {duration}")
 
-    return job_sessions
+    return job_sessions, farm_failed_task_ids
 
 
 def _get_storage_profiles(
@@ -1310,7 +1335,7 @@ def _incremental_output_download(
 
     # All the completed, added, and updated jobs might have downloads available. Retrieve the sessions for these jobs.
     start_t = time.perf_counter_ns()
-    job_sessions: dict[str, list] = _get_job_sessions(
+    job_sessions, farm_failed_task_ids = _get_job_sessions(
         boto3_session,
         boto3_session_for_s3,
         farm_id,
@@ -1674,8 +1699,10 @@ def _incremental_output_download(
                             job_error_message = str(e)
 
                 # Some of a job's paths may not carry a step-/task- segment in their manifest key
-                # (so they were never attributed to a task). Download those leftovers here rather
-                # than dropping them silently just because the job happened to also have task files.
+                # (e.g. chunked-step manifests), so they were never attributed to a task and land
+                # in job_files but never in task_map. Downloading only the per-task files would
+                # silently skip them while the job still reports success and advances the
+                # checkpoint — the files would never be retried. Download those leftovers too.
                 task_owned = {
                     os.path.normcase(f.path) for files in task_map.values() for f in files
                 }
@@ -1702,7 +1729,7 @@ def _incremental_output_download(
                         error_code = _classify_error(e)
                         with print_lock:
                             print_function_callback(
-                                f"  ERROR downloading job {job_name} ({job_id}): {e}"
+                                f"  ERROR downloading unattributed files for job {job_name} ({job_id}): {e}"
                             )
                         leftover_downloaded = sum(
                             1 for f in leftover_files if os.path.exists(f.path)
@@ -1883,6 +1910,25 @@ def _incremental_output_download(
                         }
                 task_download_results[job_id] = deduped_task_results
 
+    # Record tasks that FAILED on the farm as "farm_failed" entries. These produced no output
+    # to download, so they'd otherwise be absent from the status file — forcing the FE to rely
+    # on live run-status data that flips on requeue. A stable file entry fixes that.
+    # "farm_failed" (distinct from "failed", which is a download error) tells the artist the
+    # render itself failed — a different cause and fix than a download failure. It's also
+    # distinct from a task that succeeded with no output (those stay absent from the dict).
+    # Skip a task if a real download result already exists for it this run.
+    for job_id, task_ids in farm_failed_task_ids.items():
+        job_task_results = task_download_results.setdefault(job_id, {})
+        for task_id in task_ids:
+            if task_id not in job_task_results:
+                job_task_results[task_id] = {
+                    "total_files": 0,
+                    "downloaded_files": 0,
+                    "error_code": None,
+                    "error_message": None,
+                    "download_status": "farm_failed",
+                }
+
     # Synthesize job_download_results for deduped jobs so _determine_job_download_status
     # sees their file counts and errors. These jobs share output paths with the winning
     # job — their status reflects what's actually on disk.
@@ -1958,6 +2004,9 @@ def _incremental_output_download(
         )
         if not dry_run
         else sum(len(paths) for paths in job_manifest_paths.values()),
+        # For a fully-successful job (error_code None) every path was downloaded — sum all sizes
+        # without touching the filesystem. For a partially-failed job, count only the paths that
+        # actually landed on disk so the byte total isn't dropped to zero (or over-counted).
         "downloaded_bytes": sum(
             r.get("downloaded_bytes", 0)
             for job_id, r in job_download_results.items()

--- a/src/deadline/client/cli/_incremental_download.py
+++ b/src/deadline/client/cli/_incremental_download.py
@@ -642,6 +642,7 @@ def _retrieve_session_actions_for_session(
     job_id: str,
     output_session: dict[str, Any],
     output_farm_failed_task_ids: Optional[set[str]] = None,
+    output_succeeded_task_ids: Optional[set[str]] = None,
 ):
     """
     Args:
@@ -655,6 +656,9 @@ def _retrieve_session_actions_for_session(
         output_session: The session to populate with a sessionActions field.
         output_farm_failed_task_ids: Optional set populated with task IDs of taskRun actions that
             FAILED on the farm. These produce no output to download and are recorded separately.
+        output_succeeded_task_ids: Optional set populated with task IDs of taskRun actions that
+            SUCCEEDED on the farm. Used to clear stale farm_failed entries for tasks that later
+            succeeded.
     """
     session_actions_paginator = deadline_client.get_paginator("list_session_actions")
 
@@ -673,6 +677,10 @@ def _retrieve_session_actions_for_session(
             if status == "SUCCEEDED":
                 # Succeeded taskRun — has output to download.
                 session_action_list.append(session_action)
+                if output_succeeded_task_ids is not None:
+                    task_id = definition["taskRun"].get("taskId")
+                    if task_id:
+                        output_succeeded_task_ids.add(task_id)
             elif status == "FAILED" and output_farm_failed_task_ids is not None:
                 # Failed on the farm — produced no output. Record the task id separately so the
                 # status file can show a stable "farm_failed" entry; never add it to
@@ -828,10 +836,12 @@ def _get_job_sessions(
         # Collect farm-failed task IDs per job across threads. Each worker collects into a
         # local set, then merges under a lock — dict/set mutation across threads needs it.
         farm_failed_task_ids: dict[str, set[str]] = {}
+        succeeded_task_ids: dict[str, set[str]] = {}
         farm_failed_lock = threading.Lock()
 
         def _retrieve_and_collect(job_id: str, session: dict[str, Any]) -> None:
             local_failed: set[str] = set()
+            local_succeeded: set[str] = set()
             _retrieve_session_actions_for_session(
                 deadline,
                 checkpoint_job_session_completed_indexes,
@@ -840,10 +850,14 @@ def _get_job_sessions(
                 job_id,
                 session,
                 local_failed,
+                local_succeeded,
             )
-            if local_failed:
+            if local_failed or local_succeeded:
                 with farm_failed_lock:
-                    farm_failed_task_ids.setdefault(job_id, set()).update(local_failed)
+                    if local_failed:
+                        farm_failed_task_ids.setdefault(job_id, set()).update(local_failed)
+                    if local_succeeded:
+                        succeeded_task_ids.setdefault(job_id, set()).update(local_succeeded)
 
         for job_id, session_list in job_sessions.items():
             for session in session_list:
@@ -871,6 +885,15 @@ def _get_job_sessions(
 
     duration = datetime.now(tz=timezone.utc) - start_time
     print_function_callback(f"...populated in {duration}")
+
+    # A FAILED taskRun action is reported by the API indefinitely — even after the task is
+    # requeued and SUCCEEDED. Remove any task that has a SUCCEEDED action in this same run so
+    # a stale farm_failed does not overwrite a task whose output has since arrived on disk.
+    for job_id, s_ids in succeeded_task_ids.items():
+        if job_id in farm_failed_task_ids:
+            farm_failed_task_ids[job_id] -= s_ids
+            if not farm_failed_task_ids[job_id]:
+                del farm_failed_task_ids[job_id]
 
     return job_sessions, farm_failed_task_ids
 
@@ -1529,7 +1552,9 @@ def _incremental_output_download(
 
     # Download per-job with error isolation, running jobs in parallel to restore throughput.
     job_download_results: dict[str, dict[str, Any]] = {}
-    # task_download_results: job_id -> task_id -> {total_files, downloaded_files, error_code, error_message}
+    # task_download_results: job_id -> task_id -> {total_files, downloaded_files, error_code, error_message, download_status?}
+    # download_status is optional: absent means "derive from error_code"; "farm_failed" is set
+    # explicitly for tasks that failed on the farm (no download was attempted).
     task_download_results: dict[str, dict[str, dict[str, Any]]] = {}
     # Set when the synthetic "" fallback bucket (attribution skipped) failed to download —
     # gates the timestamp advance below so the lost window is re-attempted next run.
@@ -1852,17 +1877,21 @@ def _incremental_output_download(
     # render itself failed — a different cause and fix than a download failure. It's also
     # distinct from a task that succeeded with no output (those stay absent from the dict).
     # Skip a task if a real download result already exists for it this run.
-    for job_id, task_ids in farm_failed_task_ids.items():
-        job_task_results = task_download_results.setdefault(job_id, {})
-        for task_id in task_ids:
-            if task_id not in job_task_results:
-                job_task_results[task_id] = {
-                    "total_files": 0,
-                    "downloaded_files": 0,
-                    "error_code": None,
-                    "error_message": None,
-                    "download_status": "farm_failed",
-                }
+    # Gated under not dry_run so dry runs don't mutate task_download_results, which is returned
+    # and passed to write_download_status_file — that call is also skipped on dry runs, but
+    # keeping the dict clean avoids confusion if callers inspect it on a dry run.
+    if not dry_run:
+        for job_id, task_ids in farm_failed_task_ids.items():
+            job_task_results = task_download_results.setdefault(job_id, {})
+            for task_id in task_ids:
+                if task_id not in job_task_results:
+                    job_task_results[task_id] = {
+                        "total_files": 0,
+                        "downloaded_files": 0,
+                        "error_code": None,
+                        "error_message": None,
+                        "download_status": "farm_failed",
+                    }
 
     # Synthesize job_download_results for deduped jobs so _determine_job_download_status
     # sees their file counts and errors. These jobs share output paths with the winning

--- a/src/deadline/client/cli/_incremental_download.py
+++ b/src/deadline/client/cli/_incremental_download.py
@@ -721,13 +721,15 @@ def _get_job_sessions(
     download_candidate_jobs: dict[str, dict[str, Any]],
     print_function_callback: Callable[[Any], None] = lambda msg: None,
     region: Optional[str] = None,
-) -> tuple[dict[str, list], dict[str, set[str]]]:
+) -> tuple[dict[str, list], dict[str, set[str]], dict[str, set[str]]]:
     """
     This function gets all the job sessions and session actions from the completed, added, and updated jobs.
     It uses the checkpoint's session_completed_indexes to filter out older session actions that are already downloaded.
 
-    Returns a tuple of (job_sessions, farm_failed_task_ids), where farm_failed_task_ids maps
-    job_id -> set of task IDs that FAILED on the farm (produced no output to download).
+    Returns a tuple of (job_sessions, farm_failed_task_ids, succeeded_task_ids), where
+    farm_failed_task_ids maps job_id -> set of task IDs that FAILED on the farm (produced no
+    output to download), and succeeded_task_ids maps job_id -> set of task IDs that SUCCEEDED
+    (used to clear stale farm_failed entries written by a prior run).
 
     Args:
         boto3_session: The boto3.Session for accessing AWS.
@@ -895,7 +897,7 @@ def _get_job_sessions(
             if not farm_failed_task_ids[job_id]:
                 del farm_failed_task_ids[job_id]
 
-    return job_sessions, farm_failed_task_ids
+    return job_sessions, farm_failed_task_ids, succeeded_task_ids
 
 
 def _get_storage_profiles(
@@ -1216,6 +1218,7 @@ def _incremental_output_download(
     dict[str, dict[str, Any]],
     dict[str, dict[str, Any]],
     dict[str, dict[str, dict[str, Any]]],
+    dict[str, set[str]],
 ]:
     """
     This function downloads all the task run outputs from the specified queue, that have become
@@ -1369,7 +1372,7 @@ def _incremental_output_download(
 
     # All the completed, added, and updated jobs might have downloads available. Retrieve the sessions for these jobs.
     start_t = time.perf_counter_ns()
-    job_sessions, farm_failed_task_ids = _get_job_sessions(
+    job_sessions, farm_failed_task_ids, succeeded_task_ids = _get_job_sessions(
         boto3_session,
         boto3_session_for_s3,
         farm_id,
@@ -2032,4 +2035,5 @@ def _incremental_output_download(
         download_candidate_jobs,
         job_download_results,
         task_download_results,
+        succeeded_task_ids,
     )

--- a/src/deadline/client/cli/_incremental_download.py
+++ b/src/deadline/client/cli/_incremental_download.py
@@ -107,11 +107,17 @@ def _classify_error(e: BaseException) -> str:
     boto error codes — which are reliable. Message-substring matching is intentionally
     avoided: wrapped S3 errors carry verbose guidance text that produces confidently
     wrong codes. job_attachments wraps low-level failures (e.g. an OSError or a botocore
-    ClientError) inside its own exception types, so we also walk the __cause__ chain to
+    ClientError) inside its own exception types, so we also walk the exception chain to
     reach the structured signal underneath. Anything without such a signal is UNKNOWN.
     """
-    # Walk the __cause__ chain iteratively, tracking visited exceptions by identity so a
-    # cyclic chain (A raised `from` B and B raised `from` A) can't cause infinite recursion.
+    # Walk the chain iteratively, tracking visited exceptions by identity so a cyclic chain
+    # (A raised `from` B and B raised `from` A) can't cause infinite recursion.
+    #
+    # __cause__ (explicit `raise ... from`) is preferred, but fall back to __context__: much of
+    # job_attachments re-raises inside an `except` block without `from`, which records the
+    # original only as __context__. Following __cause__ alone reports UNKNOWN for those.
+    # __suppress_context__ (`raise ... from None`) means the author declared the inner error
+    # irrelevant, so honor it and stop rather than attaching a misleading code.
     current: Optional[BaseException] = e
     seen: set[int] = set()
     while current is not None and id(current) not in seen:
@@ -119,7 +125,12 @@ def _classify_error(e: BaseException) -> str:
         code = _classify_single_error(current)
         if code is not None:
             return code
-        current = current.__cause__
+        if current.__cause__ is not None:
+            current = current.__cause__
+        elif current.__suppress_context__:
+            break
+        else:
+            current = current.__context__
 
     return "UNKNOWN"
 
@@ -1438,146 +1449,70 @@ def _incremental_output_download(
     job_manifest_paths: dict[str, list[BaseManifestPath]] = {}
     # job_id -> task_id -> [files]: used for per-task download tracking
     job_task_manifest_paths: dict[str, dict[str, list[BaseManifestPath]]] = {}
-    # job_id -> task_id -> [file_paths]: record of the paths originally attributed to each task.
-    # Unlike job_task_manifest_paths, this is NOT emptied by cross-job transfers — a losing job
-    # keeps its record so the deduped-job block below can still report its filesystem-based status
-    # after the winning job takes over the paths.
-    all_task_file_paths: dict[str, dict[str, list[str]]] = {}
-    # job_id -> task_id -> {paths}: membership set mirroring all_task_file_paths so the per-file
-    # dedup check is O(1) instead of a linear scan of the growing list.
-    all_task_file_paths_seen: dict[str, dict[str, set[str]]] = {}
-    # job_id -> normcased_path -> task_id that currently owns it, so a path emitted by more than
-    # one task of the same job (e.g. a requeue) is attributed to a single task rather than
-    # duplicated across tasks (which would double-download it and inflate the file count).
-    task_owner_by_job: dict[str, dict[str, str]] = {}
-    # global_seen_paths maps normcased_path -> job_id that claimed it first.
-    # Prevents concurrent writes to the same destination file across jobs — parallel threads
-    # could write the same path simultaneously, corrupting the file under OVERWRITE. When two
-    # jobs share an output path, ownership transfers to the later-iterated job so exactly one
-    # job downloads it. Content correctness is unaffected: jobs sharing a path produce the same
-    # rendered file, so whichever job writes it, the bytes on disk are identical. The transfer
-    # only determines which job_id is credited in the status file; deduped jobs still report
-    # accurate status via the post-download filesystem check.
-    global_seen_paths: dict[str, str] = {}
-    # job_path_index tracks the list index for each (job_id, normcased_path) pair so a later
-    # occurrence of the same path within a job overwrites the earlier one in place.
-    job_path_index: dict[str, dict[str, int]] = {}
-    # job_id -> task_id -> normcased_path -> list_index, mirrors job_path_index at the task level
-    task_path_index: dict[str, dict[str, dict[str, int]]] = {}
+    # job_id -> task_id -> [file_paths]: every path originally attributed to each task. Unlike
+    # job_task_manifest_paths this keeps the paths a newer job took ownership of, so a losing job
+    # can still report its filesystem-derived status in the deduped-job block below. Built as
+    # dict keys (an ordered set) to dedup a file that reappears across manifests via task retry.
+    task_file_paths: dict[str, dict[str, dict[str, None]]] = {}
     if not skip_attribution:
-        # Visit manifests oldest-to-newest by their S3 LastModified timestamp so the
-        # last write of any shared path wins. downloaded_manifests is filled positionally
-        # (correlated to manifests_to_download by index) and is NOT pre-sorted, so we derive
-        # the chronological order here rather than relying on iteration order.
-        ordered_indices = sorted(
-            (i for i in range(len(manifests_to_download)) if downloaded_manifests[i] is not None),
-            key=lambda i: downloaded_manifests[i][0],
+        # Visit manifests oldest-to-newest by their S3 LastModified timestamp so the last write of
+        # any shared path wins. downloaded_manifests is filled positionally (correlated to
+        # manifests_to_download by index) and is NOT pre-sorted, so derive the order here.
+        records = sorted(
+            (
+                (
+                    downloaded_manifests[i][0],
+                    manifests_to_download[i][1],  # job_id
+                    manifests_to_download[i][3],  # manifest_s3_key
+                    downloaded_manifests[i][1],  # manifest
+                )
+                for i in range(len(manifests_to_download))
+                if downloaded_manifests[i] is not None
+            ),
+            key=lambda record: record[0],
         )
-        for i in ordered_indices:
-            _, job_id, _, manifest_s3_key = manifests_to_download[i]
-            manifest_tuple = downloaded_manifests[i]
-            if manifest_tuple is not None:
-                _, manifest = manifest_tuple
-                task_id = _extract_task_id_from_s3_key(manifest_s3_key)
-                for manifest_path in manifest.paths:
-                    normcased = os.path.normcase(manifest_path.path)
-                    prior_job_id = global_seen_paths.get(normcased)
-                    if prior_job_id is not None and prior_job_id != job_id:
-                        # A different job previously claimed this path with an older manifest.
-                        # We iterate manifests oldest-to-newest (see ordered_indices above), so
-                        # the current manifest is newer — transfer ownership to preserve
-                        # newest-wins semantics.
-                        prior_paths = job_manifest_paths.get(prior_job_id, [])
-                        prior_idx_map = job_path_index.get(prior_job_id, {})
-                        if normcased in prior_idx_map:
-                            # Remove from old job's manifest list — mark as None so indices stay stable
-                            prior_paths[prior_idx_map[normcased]] = None  # type: ignore[call-overload]
-                            del prior_idx_map[normcased]
-                        # Remove from all of the old job's per-task paths using the index for O(1) lookup.
-                        # Scan all tasks since the same path could appear in multiple tasks.
-                        for t_id, t_idx_map in task_path_index.get(prior_job_id, {}).items():
-                            if normcased in t_idx_map:
-                                job_task_manifest_paths[prior_job_id][t_id][
-                                    t_idx_map[normcased]
-                                ] = None  # type: ignore[call-overload]
-                                del t_idx_map[normcased]
-                    job_paths = job_manifest_paths.setdefault(job_id, [])
-                    idx_map = job_path_index.setdefault(job_id, {})
-                    if normcased in idx_map:
-                        # Overwrite with newer version within same job
-                        job_paths[idx_map[normcased]] = manifest_path
-                    else:
-                        idx_map[normcased] = len(job_paths)
-                        job_paths.append(manifest_path)
-                    global_seen_paths[normcased] = job_id
-                    if task_id:
-                        # If another task in this same job already owns this path (e.g. a requeue
-                        # re-emitted it under a different task), transfer ownership to the current
-                        # task. We iterate oldest-to-newest, so the current task is the newer
-                        # writer; leaving the path in both tasks would download it twice and
-                        # inflate the file count.
-                        owner_map = task_owner_by_job.setdefault(job_id, {})
-                        prior_task_id = owner_map.get(normcased)
-                        if prior_task_id is not None and prior_task_id != task_id:
-                            prior_t_idx_map = task_path_index.get(job_id, {}).get(prior_task_id, {})
-                            if normcased in prior_t_idx_map:
-                                job_task_manifest_paths[job_id][prior_task_id][
-                                    prior_t_idx_map[normcased]
-                                ] = None  # type: ignore[call-overload]
-                                del prior_t_idx_map[normcased]
-                        owner_map[normcased] = task_id
-                        job_task_manifest_paths.setdefault(job_id, {}).setdefault(task_id, [])
-                        task_paths = job_task_manifest_paths[job_id][task_id]
-                        t_idx_map = task_path_index.setdefault(job_id, {}).setdefault(task_id, {})
-                        if normcased in t_idx_map:
-                            # Overwrite with newer version (O(1) lookup)
-                            task_paths[t_idx_map[normcased]] = manifest_path
-                        else:
-                            t_idx_map[normcased] = len(task_paths)
-                            task_paths.append(manifest_path)
-                        # Record the path immutably for deduped-job status generation. This record
-                        # is intentionally NOT pruned by cross-job transfers, so a losing job can
-                        # still report filesystem-based status after another job claims its paths.
-                        # Dedup per task (O(1) via the _seen set) to avoid inflating counts when the
-                        # same file reappears across manifests via task retry.
-                        task_file_list = all_task_file_paths.setdefault(job_id, {}).setdefault(
-                            task_id, []
-                        )
-                        task_file_seen = all_task_file_paths_seen.setdefault(job_id, {}).setdefault(
-                            task_id, set()
-                        )
-                        if manifest_path.path not in task_file_seen:
-                            task_file_seen.add(manifest_path.path)
-                            task_file_list.append(manifest_path.path)
+        # normcased destination path -> the (job, task) that wrote it last. Overwriting the key IS
+        # the dedup rule: exactly one job and one task owns each path, so a path emitted by several
+        # manifests — a task retry, a requeue under a new task, or two jobs sharing an output path —
+        # is downloaded once and counted once. Without this, parallel threads could write the same
+        # path simultaneously and corrupt it under OVERWRITE. Because we iterate oldest-to-newest,
+        # the surviving owner is the newest writer. Content correctness is unaffected: jobs sharing
+        # a path render the same bytes, so only the job_id credited in the status file differs, and
+        # a job that loses a path still reports accurate status via the filesystem check below.
+        path_owner: dict[str, tuple[str, Optional[str], BaseManifestPath]] = {}
+        for _, job_id, manifest_s3_key, manifest in records:
+            task_id = _extract_task_id_from_s3_key(manifest_s3_key)
+            for manifest_path in manifest.paths:
+                path_owner[os.path.normcase(manifest_path.path)] = (job_id, task_id, manifest_path)
+                if task_id:
+                    task_file_paths.setdefault(job_id, {}).setdefault(task_id, {})[
+                        manifest_path.path
+                    ] = None
+        for job_id, task_id, manifest_path in path_owner.values():
+            job_manifest_paths.setdefault(job_id, []).append(manifest_path)
+            if task_id:
+                job_task_manifest_paths.setdefault(job_id, {}).setdefault(task_id, []).append(
+                    manifest_path
+                )
     else:
         # Attribution skipped: download everything anyway, decoupled from per-job tracking.
         # Collect every downloaded path (deduped) under a synthetic bucket keyed by "" so it
         # never collides with a real job id. Per-job (and per-task) counts aren't populated this
         # run, but no files are lost; the "" bucket feeds the run-level stats and never becomes a
         # per-job status entry.
-        fallback_seen: set[str] = set()
-        fallback_paths: list[BaseManifestPath] = []
+        fallback_paths: dict[str, BaseManifestPath] = {}
         for manifest_tuple in downloaded_manifests:
             if manifest_tuple is not None:
                 _, manifest = manifest_tuple
                 for manifest_path in manifest.paths:
-                    normcased = os.path.normcase(manifest_path.path)
-                    if normcased not in fallback_seen:
-                        fallback_seen.add(normcased)
-                        fallback_paths.append(manifest_path)
+                    fallback_paths.setdefault(os.path.normcase(manifest_path.path), manifest_path)
         if fallback_paths:
-            job_manifest_paths[""] = fallback_paths
+            job_manifest_paths[""] = list(fallback_paths.values())
 
-    # Filter out None entries left by cross-job path transfers (newer job took over the path)
-    for job_id in list(job_manifest_paths.keys()):
-        job_manifest_paths[job_id] = [p for p in job_manifest_paths[job_id] if p is not None]
-        if not job_manifest_paths[job_id]:
-            del job_manifest_paths[job_id]
-    for job_id, task_map in job_task_manifest_paths.items():
-        for task_id in list(task_map.keys()):
-            task_map[task_id] = [p for p in task_map[task_id] if p is not None]
-            if not task_map[task_id]:
-                del task_map[task_id]
+    all_task_file_paths: dict[str, dict[str, list[str]]] = {
+        job_id: {task_id: list(paths) for task_id, paths in task_map.items()}
+        for job_id, task_map in task_file_paths.items()
+    }
 
     # Print a summary of all the paths before starting the download
     all_manifest_paths = [path for paths in job_manifest_paths.values() for path in paths]

--- a/test/unit/deadline_client/cli/test_cli_download_status_file.py
+++ b/test/unit/deadline_client/cli/test_cli_download_status_file.py
@@ -748,7 +748,7 @@ class TestStatusFileLock:
 
         status_file = str(tmp_path / "status.json")
         writer_count = 8
-        errors: list[BaseException] = []
+        errors: list[Exception] = []
         barrier = threading.Barrier(writer_count)
 
         def writer(index: int) -> None:
@@ -762,7 +762,7 @@ class TestStatusFileLock:
                             existing = json.load(f).get("jobs", {})
                     existing[job_id] = {"download_status": "downloaded"}
                     _atomic_write_json(status_file, {"schema_version": 1, "jobs": existing})
-            except BaseException as e:  # noqa: BLE001 - surfaced via assert below
+            except Exception as e:  # noqa: BLE001 - surfaced via assert below
                 errors.append(e)
 
         threads = [threading.Thread(target=writer, args=(i,)) for i in range(writer_count)]

--- a/test/unit/deadline_client/cli/test_cli_download_status_file.py
+++ b/test/unit/deadline_client/cli/test_cli_download_status_file.py
@@ -16,7 +16,12 @@ from deadline.client.cli._download_status_file import (
     _status_file_lock,
     write_download_status_file,
 )
-from deadline.client.cli._incremental_download import CategorizedJobIds
+from deadline.client.cli._incremental_download import (
+    CategorizedJobIds,
+    _FailedJobsTracker,
+    _MAX_FAILED_JOB_RETRIES,
+)
+from deadline.client.cli._download_status_file import _is_job_fully_complete
 
 from ..shared_constants import MOCK_QUEUE_ID, MOCK_STORAGE_PROFILE_ID, MOCK_JOB_ID
 
@@ -45,15 +50,21 @@ def _make_job(
     ended: bool = True,
     attachments: bool = True,
     storage_profile_id: Optional[str] = MOCK_STORAGE_PROFILE_ID,
+    failed: int = 0,
 ) -> dict[str, Any]:
-    """Helper to create a fake job dict."""
+    """Helper to create a fake job dict.
+
+    Any tasks not accounted for by ``succeeded`` or ``failed`` are treated as still
+    RUNNING (i.e. active). Pass ``failed`` to model tasks that failed on the farm — a
+    failed task is terminal, so it does not count as active for completeness checks.
+    """
     job: dict[str, Any] = {
         "jobId": job_id,
         "name": f"test-job-{job_id[-8:]}",
         "taskRunStatusCounts": {
             "SUCCEEDED": succeeded,
-            "FAILED": 0,
-            "RUNNING": total - succeeded,
+            "FAILED": failed,
+            "RUNNING": total - succeeded - failed,
             "READY": 0,
             "PENDING": 0,
             "ASSIGNED": 0,
@@ -146,6 +157,87 @@ class TestDetermineJobDownloadStatus:
         assert "error_message" in result
         assert "skip_reason" in result
         assert "tasks" in result
+
+
+class TestIsJobFullyComplete:
+    """Tests for _is_job_fully_complete — the completeness gate used to decide
+    downloaded vs in_progress."""
+
+    def test_ended_with_no_active_tasks_is_complete(self):
+        job = _make_job(MOCK_JOB_ID, succeeded=5, total=5, ended=True)
+        assert _is_job_fully_complete(job) is True
+
+    def test_not_ended_is_not_complete(self):
+        job = _make_job(MOCK_JOB_ID, succeeded=5, total=5, ended=False)
+        assert _is_job_fully_complete(job) is False
+
+    def test_ended_but_active_tasks_remain_is_not_complete(self):
+        """A requeued job can carry endedAt yet still have READY/RUNNING tasks."""
+        job = _make_job(MOCK_JOB_ID, succeeded=2, total=5, ended=True)  # 3 RUNNING
+        assert _is_job_fully_complete(job) is False
+
+    def test_ended_with_failed_tasks_but_none_active_is_complete(self):
+        """Pins the _is_job_fully_complete change: a FAILED task is terminal, not active,
+        so a job that ended with some farm-failed tasks and no still-running tasks is
+        complete — all downloadable output (from succeeded tasks) is available."""
+        job = _make_job(MOCK_JOB_ID, succeeded=3, failed=2, total=5, ended=True)
+        assert job["taskRunStatusCounts"]["RUNNING"] == 0
+        assert _is_job_fully_complete(job) is True
+
+    def test_ended_with_failed_and_still_running_is_not_complete(self):
+        job = _make_job(MOCK_JOB_ID, succeeded=1, failed=1, total=5, ended=True)  # 3 RUNNING
+        assert _is_job_fully_complete(job) is False
+
+
+class TestFailedJobsTracker:
+    """Tests for _FailedJobsTracker — the per-job retry/abandon bookkeeping."""
+
+    def _tracker(self, tmp_path):
+        return _FailedJobsTracker(str(tmp_path / "failed_jobs.json"))
+
+    def test_record_failure_increments_and_is_tracked(self, tmp_path):
+        tracker = self._tracker(tmp_path)
+        tracker.record_failures({MOCK_JOB_ID}, print_function_callback=lambda *_: None)
+        assert MOCK_JOB_ID in tracker.get_tracked_job_ids()
+        assert tracker.is_abandoned(MOCK_JOB_ID) is False
+
+    def test_abandoned_after_max_retries_and_warns(self, tmp_path):
+        tracker = self._tracker(tmp_path)
+        warnings: list[str] = []
+        for _ in range(_MAX_FAILED_JOB_RETRIES):
+            tracker.record_failures({MOCK_JOB_ID}, print_function_callback=warnings.append)
+        assert tracker.is_abandoned(MOCK_JOB_ID) is True
+        # An abandoned job is no longer offered for retry...
+        assert MOCK_JOB_ID not in tracker.get_tracked_job_ids()
+        # ...but it is NOT dropped, so a timestamp-window rediscovery stays suppressed.
+        assert any("no longer be retried" in w for w in warnings)
+
+    def test_record_success_clears_job(self, tmp_path):
+        tracker = self._tracker(tmp_path)
+        tracker.record_failures({MOCK_JOB_ID}, print_function_callback=lambda *_: None)
+        tracker.record_successes({MOCK_JOB_ID})
+        assert MOCK_JOB_ID not in tracker.get_tracked_job_ids()
+        assert tracker.is_abandoned(MOCK_JOB_ID) is False
+
+    def test_save_and_load_round_trips_counts(self, tmp_path):
+        path = str(tmp_path / "failed_jobs.json")
+        tracker = _FailedJobsTracker(path)
+        tracker.record_failures({MOCK_JOB_ID}, print_function_callback=lambda *_: None)
+        tracker.record_failures({MOCK_JOB_ID}, print_function_callback=lambda *_: None)
+        tracker.save()
+
+        reloaded = _FailedJobsTracker(path)
+        # A fresh tracker over the same file sees the persisted count (2, below the cap).
+        assert MOCK_JOB_ID in reloaded.get_tracked_job_ids()
+        reloaded.record_failures({MOCK_JOB_ID}, print_function_callback=lambda *_: None)
+        assert reloaded._counts[MOCK_JOB_ID] == 3
+
+    def test_load_tolerates_corrupt_file(self, tmp_path):
+        path = str(tmp_path / "failed_jobs.json")
+        with open(path, "w") as f:
+            f.write("{ not valid json")
+        tracker = _FailedJobsTracker(path)  # must not raise
+        assert tracker.get_tracked_job_ids() == set()
 
 
 class TestGetStatusFilePaths:
@@ -799,61 +891,6 @@ class TestFileCountPreservation:
         )
         assert result["jobs"][MOCK_JOB_ID]["total_files"] == 5
         assert result["jobs"][MOCK_JOB_ID]["downloaded_files"] == 5
-
-
-class TestFailedJobsTracker:
-    """Tests for _FailedJobsTracker."""
-
-    def test_empty_on_missing_file(self, tmp_path):
-        from deadline.client.cli._incremental_download import _FailedJobsTracker
-
-        tracker = _FailedJobsTracker(str(tmp_path / "failed_jobs.json"))
-        assert tracker.get_tracked_job_ids() == set()
-
-    def test_record_and_retrieve_failure(self, tmp_path):
-        from deadline.client.cli._incremental_download import _FailedJobsTracker
-
-        tracker = _FailedJobsTracker(str(tmp_path / "failed_jobs.json"))
-        messages: list[str] = []
-        tracker.record_failures({MOCK_JOB_ID}, messages.append)
-        assert MOCK_JOB_ID in tracker.get_tracked_job_ids()
-
-    def test_record_success_removes_job(self, tmp_path):
-        from deadline.client.cli._incremental_download import _FailedJobsTracker
-
-        tracker = _FailedJobsTracker(str(tmp_path / "failed_jobs.json"))
-        messages: list[str] = []
-        tracker.record_failures({MOCK_JOB_ID}, messages.append)
-        tracker.record_successes({MOCK_JOB_ID})
-        assert MOCK_JOB_ID not in tracker.get_tracked_job_ids()
-
-    def test_retry_cap_removes_job_and_warns(self, tmp_path):
-        from deadline.client.cli._incremental_download import (
-            _FailedJobsTracker,
-            _MAX_FAILED_JOB_RETRIES,
-        )
-
-        tracker = _FailedJobsTracker(str(tmp_path / "failed_jobs.json"))
-        messages: list[str] = []
-        for _ in range(_MAX_FAILED_JOB_RETRIES):
-            tracker.record_failures({MOCK_JOB_ID}, messages.append)
-        # Abandoned job is excluded from get_tracked_job_ids (not retried)
-        assert MOCK_JOB_ID not in tracker.get_tracked_job_ids()
-        # But is_abandoned returns True so it can be filtered from timestamp window too
-        assert tracker.is_abandoned(MOCK_JOB_ID)
-        assert any("WARNING" in m for m in messages)
-
-    def test_persists_and_reloads(self, tmp_path):
-        from deadline.client.cli._incremental_download import _FailedJobsTracker
-
-        file_path = str(tmp_path / "failed_jobs.json")
-        tracker = _FailedJobsTracker(file_path)
-        messages: list[str] = []
-        tracker.record_failures({MOCK_JOB_ID}, messages.append)
-        tracker.save()
-
-        tracker2 = _FailedJobsTracker(file_path)
-        assert MOCK_JOB_ID in tracker2.get_tracked_job_ids()
 
 
 class TestSkipReason:

--- a/test/unit/deadline_client/cli/test_cli_download_status_file.py
+++ b/test/unit/deadline_client/cli/test_cli_download_status_file.py
@@ -6,6 +6,7 @@ Tests for the CLI download status file module.
 
 import json
 import os
+import time
 from typing import Any, Optional
 
 from deadline.client.cli._download_status_file import (
@@ -28,6 +29,7 @@ from ..shared_constants import MOCK_QUEUE_ID, MOCK_STORAGE_PROFILE_ID, MOCK_JOB_
 
 MOCK_JOB_ID_2 = "job-aaaabbbbccccddddeeeeffffaaaabbbb"
 MOCK_JOB_ID_3 = "job-11112222333344445555666677778888"
+MOCK_JOB_ID_4 = "job-99998888777766665555444433332222"
 
 
 def _make_categorized_job_ids(**kwargs) -> CategorizedJobIds:
@@ -669,6 +671,173 @@ class TestStatusFileLock:
                 content = json.load(f)
             assert content["hostname"] == socket.gethostname()
 
+    def test_slow_holder_does_not_unlink_takeover_lock(self, tmp_path, monkeypatch):
+        """A holder whose hold outlives the TTL must not delete the lock a second writer took over.
+
+        The first writer acquired legitimately, then stalled past the TTL. A second machine
+        saw a stale lock and took ownership. When the first writer finally exits it must
+        leave the takeover lock alone — unlinking it would let a third writer in while the
+        second is mid-write, which is the lost-update the lock exists to prevent.
+        """
+        status_file = str(tmp_path / "status.json")
+        lock_file = status_file + ".lock"
+
+        monkeypatch.setattr(
+            "deadline.client.cli._download_status_file._STATUS_FILE_LOCK_TTL_SECONDS", 0
+        )
+
+        with _status_file_lock(status_file):
+            # Simulate a second machine treating our now-expired lock as stale and taking over.
+            with open(lock_file, "w") as f:
+                json.dump({"hostname": "other-machine", "time": 1.0}, f)
+
+        # The takeover lock survives — release only unlinks a lock whose stored time matches.
+        assert os.path.exists(lock_file), "slow holder deleted another writer's lock"
+        with open(lock_file) as f:
+            assert json.load(f)["hostname"] == "other-machine"
+
+    def test_acquisition_timeout_proceeds_unlocked_with_warning(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """When the lock can never be acquired the writer proceeds anyway and warns.
+
+        A permanently-held lock (crashed peer whose clock keeps its lock looking fresh, or an
+        O_EXCL that never succeeds on a flaky NAS) must not block the sync forever. Writing
+        unlocked risks a lost update; hanging risks never reporting status at all. The chosen
+        behavior is to warn and write.
+        """
+        import logging
+
+        status_file = str(tmp_path / "status.json")
+        lock_file = status_file + ".lock"
+
+        # A fresh lock that never goes stale and never gets released.
+        os.makedirs(os.path.dirname(lock_file), exist_ok=True)
+        with open(lock_file, "w") as f:
+            json.dump({"hostname": "peer", "time": time.time()}, f)
+
+        # Collapse the wait so the timeout branch is reached without a 90s test.
+        monkeypatch.setattr(
+            "deadline.client.cli._download_status_file._STATUS_FILE_LOCK_MAX_WAIT_SECONDS", 0.05
+        )
+        monkeypatch.setattr(
+            "deadline.client.cli._download_status_file._STATUS_FILE_LOCK_RETRY_INTERVAL_SECONDS",
+            0.01,
+        )
+
+        entered = False
+        with caplog.at_level(logging.WARNING, logger="deadline.client.cli._download_status_file"):
+            with _status_file_lock(status_file):
+                entered = True
+
+        assert entered, "timeout must proceed into the body, not raise or hang"
+        assert any("proceeding without lock" in r.message for r in caplog.records), caplog.records
+        # The peer's lock is untouched — we never owned it, so we must not release it.
+        with open(lock_file) as f:
+            assert json.load(f)["hostname"] == "peer"
+
+    def test_concurrent_writers_do_not_lose_updates_or_corrupt_json(self, tmp_path):
+        """Real threads writing the same status file concurrently: every job survives and the
+        file always parses.
+
+        Each writer merges the on-disk jobs before writing, so with the lock held the writes
+        serialize and the final file contains all of them. Without the lock the last writer's
+        read would predate the others' writes and their entries would vanish.
+        """
+        import threading
+
+        status_file = str(tmp_path / "status.json")
+        writer_count = 8
+        errors: list[BaseException] = []
+        barrier = threading.Barrier(writer_count)
+
+        def writer(index: int) -> None:
+            job_id = f"job-{index:032d}"
+            try:
+                barrier.wait(timeout=30)
+                with _status_file_lock(status_file):
+                    existing = {}
+                    if os.path.exists(status_file):
+                        with open(status_file) as f:
+                            existing = json.load(f).get("jobs", {})
+                    existing[job_id] = {"download_status": "downloaded"}
+                    _atomic_write_json(status_file, {"schema_version": 1, "jobs": existing})
+            except BaseException as e:  # noqa: BLE001 - surfaced via assert below
+                errors.append(e)
+
+        threads = [threading.Thread(target=writer, args=(i,)) for i in range(writer_count)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=120)
+
+        assert not errors, errors
+        with open(status_file) as f:
+            data = json.load(f)  # Never a partial write — _atomic_write_json renames into place.
+        assert set(data["jobs"]) == {f"job-{i:032d}" for i in range(writer_count)}, data["jobs"]
+        assert not os.path.exists(status_file + ".lock"), "every writer released its lock"
+
+    def test_corrupt_existing_status_file_is_replaced_not_fatal(self, tmp_path):
+        """A truncated status file (killed mid-write on a filesystem without atomic rename)
+        must not abort the run — the unreadable jobs are dropped and this run's are written."""
+        status_dir = tmp_path / "renders"
+        status_dir.mkdir()
+        status_file = os.path.join(
+            str(status_dir), ".deadline", f"{MOCK_QUEUE_ID}_download_status.json"
+        )
+        os.makedirs(os.path.dirname(status_file), exist_ok=True)
+        with open(status_file, "w") as f:
+            f.write('{"schema_version": 1, "jobs": {"job-old": {"download_status": "dow')
+
+        cjids = _make_categorized_job_ids(completed={MOCK_JOB_ID})
+        write_download_status_file(
+            queue_id=MOCK_QUEUE_ID,
+            categorized_job_ids=cjids,
+            download_candidate_jobs={MOCK_JOB_ID: _make_job(MOCK_JOB_ID)},
+            local_storage_profile_id=MOCK_STORAGE_PROFILE_ID,
+            local_storage_profile={
+                "fileSystemLocations": [{"name": "renders", "path": str(status_dir)}]
+            },
+            checkpoint_dir=str(tmp_path / "checkpoint"),
+        )
+
+        with open(status_file) as f:
+            data = json.load(f)
+        assert data["jobs"][MOCK_JOB_ID]["download_status"] == "downloaded"
+        # The corrupt content was unrecoverable, so the stale entry is gone rather than
+        # blocking the write. Losing an unparseable entry beats reporting no status at all.
+        assert "job-old" not in data["jobs"], data["jobs"]
+
+    def test_unmounted_location_skipped_while_others_are_written(self, tmp_path):
+        """One storage-profile location unmounted: the mounted locations are still written.
+
+        A single unavailable NAS mount must not suppress status for the mounts that are up,
+        and must not create a phantom status file under the empty mount point.
+        """
+        mounted = tmp_path / "mounted"
+        mounted.mkdir()
+        unmounted = tmp_path / "unmounted"  # deliberately not created
+
+        cjids = _make_categorized_job_ids(completed={MOCK_JOB_ID})
+        write_download_status_file(
+            queue_id=MOCK_QUEUE_ID,
+            categorized_job_ids=cjids,
+            download_candidate_jobs={MOCK_JOB_ID: _make_job(MOCK_JOB_ID)},
+            local_storage_profile_id=MOCK_STORAGE_PROFILE_ID,
+            local_storage_profile={
+                "fileSystemLocations": [
+                    {"name": "mounted", "path": str(mounted)},
+                    {"name": "unmounted", "path": str(unmounted)},
+                ]
+            },
+            checkpoint_dir=str(tmp_path / "checkpoint"),
+        )
+
+        assert os.path.exists(
+            os.path.join(str(mounted), ".deadline", f"{MOCK_QUEUE_ID}_download_status.json")
+        )
+        assert not os.path.exists(str(unmounted)), "must not materialize an unmounted location"
+
 
 class TestPerJobFileCountsAndErrors:
     """Tests for per-job file counts, error isolation, and failed status."""
@@ -1223,6 +1392,424 @@ class TestPerTaskTracking:
         assert result["jobs"][MOCK_JOB_ID]["tasks"] == {}
 
 
+class TestJobTaskStatusConsistency:
+    """The job-level badge must never contradict its own task entries.
+
+    The job's status comes from its checkpoint category (did it finish on the farm), while
+    task statuses come from download results. Those are independent signals, so they can
+    disagree — a job can be "complete on the farm" while one of its tasks' files never
+    reached disk. The consumer renders both, so an entry claiming "downloaded" over a
+    "failed" task shows a green job with a red task and hides a real failure.
+    """
+
+    def _existing_entry(self, status: str, tasks: dict[str, Any], **overrides) -> dict[str, Any]:
+        entry: dict[str, Any] = {
+            "download_status": status,
+            "total_files": 2,
+            "downloaded_files": 1,
+            "failed_files": 1,
+            "last_updated": "2026-01-01T00:00:00+00:00",
+            "error_code": "PERMISSION_DENIED" if status == "failed" else None,
+            "error_message": "denied" if status == "failed" else None,
+            "skip_reason": None,
+            "tasks": tasks,
+        }
+        entry.update(overrides)
+        return entry
+
+    def _failed_task(self, error_code: str = "PERMISSION_DENIED") -> dict[str, Any]:
+        return {
+            "download_status": "failed",
+            "total_files": 1,
+            "downloaded_files": 0,
+            "error_code": error_code,
+            "error_message": "denied",
+        }
+
+    def _downloaded_task(self) -> dict[str, Any]:
+        return {
+            "download_status": "downloaded",
+            "total_files": 1,
+            "downloaded_files": 1,
+            "error_code": None,
+            "error_message": None,
+        }
+
+    def test_job_stays_failed_while_a_task_still_carries_an_error(self):
+        """A no-op run must not flip a job to "downloaded" over a still-failed task.
+
+        The job ended on the farm, so its category says complete; but the task that failed
+        to download last run produced no new result this run, so its "failed" entry persists.
+        The job must report failed too, otherwise the artist sees a fully-green job and never
+        learns the frame is missing.
+        """
+        existing_jobs = {
+            MOCK_JOB_ID: self._existing_entry(
+                "failed",
+                {"task-abc-0": self._downloaded_task(), "task-abc-1": self._failed_task()},
+            )
+        }
+        cjids = _make_categorized_job_ids(unchanged={MOCK_JOB_ID})
+        result = _build_status_file_content(
+            queue_id=MOCK_QUEUE_ID,
+            storage_profile_id=MOCK_STORAGE_PROFILE_ID,
+            categorized_job_ids=cjids,
+            download_candidate_jobs={MOCK_JOB_ID: _make_job(MOCK_JOB_ID, succeeded=2, total=2)},
+            existing_jobs=existing_jobs,
+            job_download_results={},
+            task_download_results={},
+        )
+        entry = result["jobs"][MOCK_JOB_ID]
+        assert entry["download_status"] == "failed", entry
+        assert entry["error_code"] == "PERMISSION_DENIED", entry
+
+    def test_inactive_flip_does_not_mask_a_failed_task(self):
+        """An in_progress → downloaded flip for a job that dropped out of tracking must not
+        overwrite the evidence that one of its tasks failed to download."""
+        existing_jobs = {
+            MOCK_JOB_ID: self._existing_entry(
+                "in_progress", {"task-abc-1": self._failed_task("DISK_FULL")}
+            )
+        }
+        cjids = _make_categorized_job_ids(inactive={MOCK_JOB_ID})
+        result = _build_status_file_content(
+            queue_id=MOCK_QUEUE_ID,
+            storage_profile_id=MOCK_STORAGE_PROFILE_ID,
+            categorized_job_ids=cjids,
+            download_candidate_jobs={},
+            existing_jobs=existing_jobs,
+            job_download_results={},
+            task_download_results={},
+        )
+        entry = result["jobs"][MOCK_JOB_ID]
+        assert entry["download_status"] == "failed", entry
+        assert entry["error_code"] == "DISK_FULL", entry
+
+    def test_successful_retry_clears_job_and_task_errors_together(self):
+        """The reconcile must not be a one-way ratchet: when the task actually re-downloads,
+        both levels go back to downloaded with the stale error fields cleared."""
+        existing_jobs = {
+            MOCK_JOB_ID: self._existing_entry("failed", {"task-abc-0": self._failed_task()})
+        }
+        cjids = _make_categorized_job_ids(unchanged={MOCK_JOB_ID})
+        result = _build_status_file_content(
+            queue_id=MOCK_QUEUE_ID,
+            storage_profile_id=MOCK_STORAGE_PROFILE_ID,
+            categorized_job_ids=cjids,
+            download_candidate_jobs={MOCK_JOB_ID: _make_job(MOCK_JOB_ID)},
+            existing_jobs=existing_jobs,
+            job_download_results={
+                MOCK_JOB_ID: {
+                    "total_files": 1,
+                    "downloaded_files": 1,
+                    "failed_files": 0,
+                    "error_code": None,
+                    "error_message": None,
+                }
+            },
+            task_download_results={
+                MOCK_JOB_ID: {
+                    "task-abc-0": {
+                        "total_files": 1,
+                        "downloaded_files": 1,
+                        "error_code": None,
+                        "error_message": None,
+                    }
+                }
+            },
+        )
+        entry = result["jobs"][MOCK_JOB_ID]
+        assert entry["download_status"] == "downloaded", entry
+        assert entry["error_code"] is None, entry
+        assert entry["tasks"]["task-abc-0"]["download_status"] == "downloaded", entry
+
+    def test_farm_failed_task_does_not_drag_job_to_download_failed(self):
+        """A task that failed on the farm is not a download failure.
+
+        The render itself failed, so there was never any output to fetch. Reporting the job as
+        a download failure would send the artist to retry a download that can't help — the fix
+        is to re-render. farm_failed carries no error_code, which is what keeps it out.
+        """
+        cjids = _make_categorized_job_ids(completed={MOCK_JOB_ID})
+        result = _build_status_file_content(
+            queue_id=MOCK_QUEUE_ID,
+            storage_profile_id=MOCK_STORAGE_PROFILE_ID,
+            categorized_job_ids=cjids,
+            download_candidate_jobs={MOCK_JOB_ID: _make_job(MOCK_JOB_ID, succeeded=1, failed=1)},
+            task_download_results={
+                MOCK_JOB_ID: {
+                    "task-abc-1": {
+                        "total_files": 0,
+                        "downloaded_files": 0,
+                        "error_code": None,
+                        "error_message": None,
+                        "download_status": "farm_failed",
+                    }
+                }
+            },
+        )
+        entry = result["jobs"][MOCK_JOB_ID]
+        assert entry["download_status"] == "downloaded", entry
+        assert entry["error_code"] is None, entry
+        assert entry["tasks"]["task-abc-1"]["download_status"] == "farm_failed", entry
+
+    def test_requeued_job_still_running_is_not_reconciled_to_downloaded(self):
+        """A job that was requeued and is actively re-running stays in_progress.
+
+        Reconciliation fires only on the settled no-failure statuses, so it must not touch — or
+        falsely settle — a job whose tasks are still on the farm. "in_progress" claims nothing
+        and the download may still be retried before the job ends.
+        """
+        existing_jobs = {
+            MOCK_JOB_ID: self._existing_entry("downloaded", {"task-abc-0": self._downloaded_task()})
+        }
+        cjids = _make_categorized_job_ids(updated={MOCK_JOB_ID})
+        result = _build_status_file_content(
+            queue_id=MOCK_QUEUE_ID,
+            storage_profile_id=MOCK_STORAGE_PROFILE_ID,
+            categorized_job_ids=cjids,
+            download_candidate_jobs={
+                MOCK_JOB_ID: _make_job(MOCK_JOB_ID, succeeded=1, total=3, ended=False)
+            },
+            existing_jobs=existing_jobs,
+            job_download_results={},
+            task_download_results={},
+        )
+        entry = result["jobs"][MOCK_JOB_ID]
+        assert entry["download_status"] == "in_progress", entry
+        # The already-downloaded task keeps its terminal status — its output is on disk.
+        assert entry["tasks"]["task-abc-0"]["download_status"] == "downloaded", entry
+
+    def test_inactive_job_with_no_downloads_reports_failure_not_skipped(self):
+        """A job stopped before any file landed, whose task failed to download, is not "skipped".
+
+        Going inactive with downloaded_files == 0 normally means "stopped before producing
+        output", which reports skipped. But a task carrying a download error means output DID
+        exist and we failed to fetch it — reporting skipped tells the artist there was nothing
+        to get, hiding a DISK_FULL they could actually fix.
+        """
+        existing_jobs = {
+            MOCK_JOB_ID: self._existing_entry(
+                "in_progress",
+                {"task-abc-0": self._failed_task("DISK_FULL")},
+                downloaded_files=0,
+                skip_reason=None,
+            )
+        }
+        cjids = _make_categorized_job_ids(inactive={MOCK_JOB_ID})
+        result = _build_status_file_content(
+            queue_id=MOCK_QUEUE_ID,
+            storage_profile_id=MOCK_STORAGE_PROFILE_ID,
+            categorized_job_ids=cjids,
+            download_candidate_jobs={},
+            existing_jobs=existing_jobs,
+            job_download_results={},
+            task_download_results={},
+        )
+        entry = result["jobs"][MOCK_JOB_ID]
+        assert entry["download_status"] == "failed", entry
+        assert entry["error_code"] == "DISK_FULL", entry
+        # The failure has to reach the job's own counters, not just sit on the task row: the
+        # monitor's job list reads failed_files to decide whether to surface the job at all.
+        assert entry["failed_files"] == 1, entry
+
+    def test_skipped_job_with_no_attachments_keeps_its_skip_reason(self):
+        """The skipped→failed override must not fire on a genuine skip.
+
+        A job with no attachments has no tasks at all, so there is no error evidence to
+        override. Its skip_reason has to survive, or every attachment-free job would lose the
+        explanation for why it was skipped.
+        """
+        cjids = _make_categorized_job_ids(attachments_free={MOCK_JOB_ID})
+        result = _build_status_file_content(
+            queue_id=MOCK_QUEUE_ID,
+            storage_profile_id=MOCK_STORAGE_PROFILE_ID,
+            categorized_job_ids=cjids,
+            download_candidate_jobs={MOCK_JOB_ID: _make_job(MOCK_JOB_ID)},
+            job_download_results={},
+            task_download_results={},
+        )
+        entry = result["jobs"][MOCK_JOB_ID]
+        assert entry["download_status"] == "skipped", entry
+        assert entry["skip_reason"] == "no_attachments", entry
+        assert entry["error_code"] is None, entry
+
+    def test_still_running_job_keeps_in_progress_over_an_errored_task(self):
+        """An errored task under a job that is still running does not settle the job to failed.
+
+        This pins the one status deliberately left out of the override. "in_progress" makes no
+        claim that the output is on disk, so it does not contradict a failed task the way
+        "downloaded" and "skipped" do — and the job's remaining tasks have yet to be downloaded,
+        so calling the job failed would settle it early and, once the retry succeeds, report a
+        failure that no longer exists. The failed task row still surfaces the error either way,
+        so nothing is hidden by waiting.
+        """
+        existing_jobs = {
+            MOCK_JOB_ID: self._existing_entry(
+                "in_progress", {"task-abc-0": self._failed_task("NETWORK_ERROR")}
+            )
+        }
+        result = _build_status_file_content(
+            queue_id=MOCK_QUEUE_ID,
+            storage_profile_id=MOCK_STORAGE_PROFILE_ID,
+            categorized_job_ids=_make_categorized_job_ids(updated={MOCK_JOB_ID}),
+            download_candidate_jobs={
+                MOCK_JOB_ID: _make_job(MOCK_JOB_ID, succeeded=1, total=3, ended=False)
+            },
+            existing_jobs=existing_jobs,
+            job_download_results={},
+            task_download_results={},
+        )
+        entry = result["jobs"][MOCK_JOB_ID]
+        assert entry["download_status"] == "in_progress", entry
+        assert entry["error_code"] is None, entry
+        # The task-level error stays visible — the job just isn't settled yet.
+        assert entry["tasks"]["task-abc-0"]["error_code"] == "NETWORK_ERROR", entry
+
+    def test_reconciled_failure_drops_a_stale_skip_reason(self):
+        """A job reconciled to failed must not still carry the skip_reason it was skipped for.
+
+        A job whose storage profile disappeared reports skipped/missing_storage_profile, but if
+        an earlier run already failed to download one of its tasks, the entry gets reconciled to
+        failed. Keeping skip_reason would emit an entry that claims both "there was nothing to
+        fetch" and "fetching errored" — and the consumer keys its "why is this file missing"
+        copy off skip_reason, so it would show the wrong explanation for a fixable error.
+        """
+        for category, stale_reason in (
+            ("missing_storage_profile", "missing_storage_profile"),
+            ("attachments_free", "no_attachments"),
+        ):
+            # total_files == 0 routes this through the branch that rebuilds the entry from the
+            # category, which is what reintroduces the skip_reason over the carried-forward task.
+            existing_jobs = {
+                MOCK_JOB_ID: self._existing_entry(
+                    "failed",
+                    {"task-abc-0": self._failed_task("PERMISSION_DENIED")},
+                    total_files=0,
+                    downloaded_files=0,
+                )
+            }
+            result = _build_status_file_content(
+                queue_id=MOCK_QUEUE_ID,
+                storage_profile_id=MOCK_STORAGE_PROFILE_ID,
+                categorized_job_ids=_make_categorized_job_ids(**{category: {MOCK_JOB_ID}}),
+                download_candidate_jobs={MOCK_JOB_ID: _make_job(MOCK_JOB_ID)},
+                existing_jobs=existing_jobs,
+                job_download_results={},
+                task_download_results={},
+            )
+            entry = result["jobs"][MOCK_JOB_ID]
+            assert entry["download_status"] == "failed", (category, entry)
+            assert entry["error_code"] == "PERMISSION_DENIED", (category, entry)
+            assert entry["skip_reason"] is None, (
+                f"{category} entry claims both failed and skip_reason={stale_reason!r}: {entry}"
+            )
+
+    def test_carried_forward_failure_does_not_mark_this_run_failed(self):
+        """A job-level failure inherited from an earlier run leaves last_run_status success.
+
+        The two fields answer different questions: the job entry says "is this job's output on
+        disk", last_run_status says "did this sync attempt hit an error". A sync that downloaded
+        nothing new and hit no error is a success even while it carries an old failure forward —
+        otherwise one unresolved failure would report every future sync as broken.
+        """
+        existing_jobs = {
+            MOCK_JOB_ID: self._existing_entry(
+                "failed", {"task-abc-0": self._failed_task("DISK_FULL")}
+            )
+        }
+        cjids = _make_categorized_job_ids(unchanged={MOCK_JOB_ID})
+        result = _build_status_file_content(
+            queue_id=MOCK_QUEUE_ID,
+            storage_profile_id=MOCK_STORAGE_PROFILE_ID,
+            categorized_job_ids=cjids,
+            download_candidate_jobs={MOCK_JOB_ID: _make_job(MOCK_JOB_ID, succeeded=2, total=2)},
+            existing_jobs=existing_jobs,
+            job_download_results={},
+            task_download_results={},
+        )
+        assert result["jobs"][MOCK_JOB_ID]["download_status"] == "failed", result["jobs"]
+        assert result["sync_metadata"]["last_run_status"] == "success", result["sync_metadata"]
+
+    def test_no_settled_job_entry_hides_an_errored_task(self):
+        """Invariant sweep over a mixed run: no entry claims a settled, no-failure status
+        ("downloaded" or "skipped") while any of its tasks carries a non-null error_code."""
+        cjids = _make_categorized_job_ids(
+            completed={MOCK_JOB_ID},
+            added={MOCK_JOB_ID_2},
+            unchanged={MOCK_JOB_ID_3},
+            inactive={MOCK_JOB_ID_4},
+        )
+        jobs = {
+            MOCK_JOB_ID: _make_job(MOCK_JOB_ID, succeeded=2, total=2),
+            MOCK_JOB_ID_2: _make_job(MOCK_JOB_ID_2, succeeded=1, total=1),
+            MOCK_JOB_ID_3: _make_job(MOCK_JOB_ID_3, succeeded=1, failed=1, total=2),
+        }
+        existing_jobs = {
+            MOCK_JOB_ID_3: self._existing_entry(
+                "failed", {"task-c-0": self._failed_task("NETWORK_ERROR")}
+            ),
+            # Job 4 exercises the "skipped" half of the sweep: inactive with zero downloads
+            # reports skipped, so without reconciliation its PATH_NOT_FOUND task would sit
+            # under a job entry claiming there was nothing to fetch.
+            MOCK_JOB_ID_4: self._existing_entry(
+                "in_progress",
+                {"task-d-0": self._failed_task("PATH_NOT_FOUND")},
+                downloaded_files=0,
+            ),
+        }
+        task_results: dict[str, dict[str, dict[str, Any]]] = {
+            MOCK_JOB_ID: {
+                "task-a-0": {
+                    "total_files": 1,
+                    "downloaded_files": 1,
+                    "error_code": None,
+                    "error_message": None,
+                },
+                "task-a-1": {
+                    "total_files": 1,
+                    "downloaded_files": 0,
+                    "error_code": "DISK_FULL",
+                    "error_message": "full",
+                },
+            },
+            MOCK_JOB_ID_2: {
+                "task-b-0": {
+                    "total_files": 1,
+                    "downloaded_files": 1,
+                    "error_code": None,
+                    "error_message": None,
+                },
+            },
+        }
+        result = _build_status_file_content(
+            queue_id=MOCK_QUEUE_ID,
+            storage_profile_id=MOCK_STORAGE_PROFILE_ID,
+            categorized_job_ids=cjids,
+            download_candidate_jobs=jobs,
+            existing_jobs=existing_jobs,
+            job_download_results={},
+            task_download_results=task_results,
+        )
+        # Sweep both settled no-failure statuses, not just "downloaded": a job that goes
+        # inactive reports "skipped", which hides an errored task just as effectively.
+        for job_id, entry in result["jobs"].items():
+            if entry["download_status"] in ("downloaded", "skipped"):
+                errored = {
+                    t_id: t["error_code"]
+                    for t_id, t in entry["tasks"].items()
+                    if t.get("error_code")
+                }
+                assert not errored, (
+                    f"{job_id} claims {entry['download_status']} over errored tasks {errored}"
+                )
+        # Every job with an errored task is reported failed; the clean one stays downloaded.
+        assert result["jobs"][MOCK_JOB_ID]["download_status"] == "failed"
+        assert result["jobs"][MOCK_JOB_ID_2]["download_status"] == "downloaded"
+        assert result["jobs"][MOCK_JOB_ID_3]["download_status"] == "failed"
+        assert result["jobs"][MOCK_JOB_ID_4]["download_status"] == "failed"
+
+
 class TestClassifyError:
     """Tests for _classify_error."""
 
@@ -1327,6 +1914,85 @@ class TestClassifyError:
         from deadline.client.cli._incremental_download import _classify_error
 
         assert _classify_error(Exception("something unexpected")) == "UNKNOWN"
+
+    def test_implicit_context_chain_is_classified(self):
+        """A `raise X` inside an `except` block sets __context__, not __cause__.
+
+        job_attachments does this — e.g. download.py raises AssetSyncCancelledError from inside
+        an `except CancelledError` handler with no `from`. Following only __cause__ would report
+        UNKNOWN for a failure whose real signal is one frame away, sending the artist to the
+        generic troubleshooting page instead of "the disk is full".
+        """
+        from deadline.client.cli._incremental_download import _classify_error
+
+        try:
+            try:
+                raise OSError(28, "No space left on device")
+            except OSError:
+                raise RuntimeError("write failed")  # implicit chain: __context__ only
+        except RuntimeError as e:
+            assert e.__cause__ is None, "guard: this models an implicit chain, not `raise from`"
+            assert _classify_error(e) == "DISK_FULL"
+
+    def test_suppressed_context_is_not_followed(self):
+        """`raise X from None` explicitly suppresses the chain — respect that and stop.
+
+        Author intent is that the inner error is not the explanation, so inheriting its code
+        would attach a misleading cause to the entry.
+        """
+        from deadline.client.cli._incremental_download import _classify_error
+
+        try:
+            try:
+                raise PermissionError("denied")
+            except PermissionError:
+                raise RuntimeError("unrelated failure") from None
+        except RuntimeError as e:
+            assert _classify_error(e) == "UNKNOWN"
+
+    def test_cyclic_context_chain_does_not_recurse_forever(self):
+        """A cyclic __context__ chain must terminate, like the __cause__ cycle guard."""
+        from deadline.client.cli._incremental_download import _classify_error
+
+        a = Exception("a")
+        b = Exception("b")
+        a.__context__ = b
+        b.__context__ = a
+        assert _classify_error(a) == "UNKNOWN"
+
+    def test_s3_client_error_with_other_status_code_is_unknown(self):
+        """A JobAttachmentsS3ClientError status code we don't map (500, 503, …) is UNKNOWN.
+
+        Only 403 and 404 have an unambiguous artist-facing meaning. Guessing on a 5xx would
+        blame the user's permissions for what is actually a service-side failure.
+        """
+        from deadline.client.cli._incremental_download import _classify_error
+        from deadline.job_attachments.exceptions import JobAttachmentsS3ClientError
+
+        for status_code in (500, 503):
+            e = JobAttachmentsS3ClientError(
+                action="downloading file",
+                status_code=status_code,
+                bucket_name="b",
+                key_or_prefix="k",
+            )
+            assert _classify_error(e) == "UNKNOWN", status_code
+
+    def test_verbose_s3_guidance_message_alone_is_unknown(self):
+        """Regression guard on the removed substring matching.
+
+        job_attachments embeds long guidance text ("Not found. Please check your bucket
+        name…") in messages. Matching on it classified a 403 as PATH_NOT_FOUND because the
+        wrapper interpolates every status code's guidance into one string.
+        """
+        from deadline.client.cli._incremental_download import _classify_error
+
+        verbose = (
+            "Not found. Please check your bucket name and object key, and ensure that they "
+            "exist in the AWS account. Forbidden or Access denied. Please check your AWS "
+            "credentials and Job Attachments S3 bucket encryption settings."
+        )
+        assert _classify_error(Exception(verbose)) == "UNKNOWN"
 
 
 class TestRetrieveSessionActionsFarmFailures:

--- a/test/unit/deadline_client/cli/test_cli_download_status_file.py
+++ b/test/unit/deadline_client/cli/test_cli_download_status_file.py
@@ -974,6 +974,96 @@ class TestPerTaskTracking:
         assert tasks["task-abc-0"]["download_status"] == "failed"
         assert tasks["task-abc-0"]["error_code"] == "PERMISSION_DENIED"
 
+    def test_farm_failed_task_recorded_as_farm_failed(self):
+        """A task that failed on the farm is recorded with an explicit "farm_failed" status
+        (not "downloaded"/"failed") and carries no error code — nothing failed to download,
+        the render produced nothing to fetch."""
+        cjids = _make_categorized_job_ids(completed={MOCK_JOB_ID})
+        job = _make_job(MOCK_JOB_ID, succeeded=2, total=3, ended=True)
+        jobs = {MOCK_JOB_ID: job}
+        task_results: dict[str, dict[str, dict[str, Any]]] = {
+            MOCK_JOB_ID: {
+                "task-abc-0": {
+                    "total_files": 3,
+                    "downloaded_files": 3,
+                    "error_code": None,
+                    "error_message": None,
+                },
+                # Farm-failed task: explicit farm_failed status, no error code.
+                "task-abc-1": {
+                    "total_files": 0,
+                    "downloaded_files": 0,
+                    "error_code": None,
+                    "error_message": None,
+                    "download_status": "farm_failed",
+                },
+            }
+        }
+        result = _build_status_file_content(
+            queue_id=MOCK_QUEUE_ID,
+            storage_profile_id=MOCK_STORAGE_PROFILE_ID,
+            categorized_job_ids=cjids,
+            download_candidate_jobs=jobs,
+            task_download_results=task_results,
+        )
+        tasks = result["jobs"][MOCK_JOB_ID]["tasks"]
+        assert tasks["task-abc-0"]["download_status"] == "downloaded"
+        assert tasks["task-abc-1"]["download_status"] == "farm_failed"
+        assert tasks["task-abc-1"]["error_code"] is None
+
+    def test_farm_failed_does_not_clobber_previously_downloaded_task(self):
+        """A task requeued after a farm failure, then succeeded and downloaded, must stay
+        "downloaded". The FAILED taskRun from the earlier attempt keeps being reported by the
+        API on every no-op run, so a later run re-collects it as farm_failed — but the download
+        already succeeded and its output is on disk, so farm_failed must not overwrite it."""
+        existing_jobs = {
+            MOCK_JOB_ID: {
+                "download_status": "downloaded",
+                "total_files": 3,
+                "downloaded_files": 3,
+                "failed_files": 0,
+                "last_updated": "2026-01-01T00:00:00+00:00",
+                "error_code": None,
+                "error_message": None,
+                "skip_reason": None,
+                "tasks": {
+                    "task-abc-0": {
+                        "download_status": "downloaded",
+                        "total_files": 3,
+                        "downloaded_files": 3,
+                        "error_code": None,
+                        "error_message": None,
+                    },
+                },
+            }
+        }
+        cjids = _make_categorized_job_ids(unchanged={MOCK_JOB_ID})
+        job = _make_job(MOCK_JOB_ID, succeeded=1, total=1, ended=True)
+        jobs = {MOCK_JOB_ID: job}
+        # This run re-collects the stale earlier FAILED attempt as farm_failed for the same task.
+        task_results: dict[str, dict[str, dict[str, Any]]] = {
+            MOCK_JOB_ID: {
+                "task-abc-0": {
+                    "total_files": 0,
+                    "downloaded_files": 0,
+                    "error_code": None,
+                    "error_message": None,
+                    "download_status": "farm_failed",
+                },
+            }
+        }
+        result = _build_status_file_content(
+            queue_id=MOCK_QUEUE_ID,
+            storage_profile_id=MOCK_STORAGE_PROFILE_ID,
+            categorized_job_ids=cjids,
+            download_candidate_jobs=jobs,
+            existing_jobs=existing_jobs,
+            task_download_results=task_results,
+        )
+        task = result["jobs"][MOCK_JOB_ID]["tasks"]["task-abc-0"]
+        assert task["download_status"] == "downloaded", task
+        assert task["downloaded_files"] == 3, task
+
     def test_existing_tasks_preserved_when_no_new_download(self):
         """Tasks from previous runs are preserved when no new download this run."""
         existing_jobs = {
@@ -1200,3 +1290,80 @@ class TestClassifyError:
         from deadline.client.cli._incremental_download import _classify_error
 
         assert _classify_error(Exception("something unexpected")) == "UNKNOWN"
+
+
+class TestRetrieveSessionActionsFarmFailures:
+    """Tests that _retrieve_session_actions_for_session collects farm-failed task IDs
+    separately without adding them to the downloadable session-action list."""
+
+    def _make_deadline_mock(self, session_actions):
+        from unittest.mock import MagicMock
+
+        deadline = MagicMock()
+        paginator = MagicMock()
+        paginator.paginate.return_value = [{"sessionActions": session_actions}]
+        deadline.get_paginator.return_value = paginator
+        return deadline
+
+    def test_failed_taskrun_collected_and_not_downloaded(self):
+        from deadline.client.cli._incremental_download import (
+            _retrieve_session_actions_for_session,
+        )
+
+        session_actions = [
+            {
+                "sessionActionId": "sessionaction-abc-0",
+                "status": "SUCCEEDED",
+                "definition": {"taskRun": {"taskId": "task-abc-0", "stepId": "step-abc"}},
+                "manifests": [{"outputManifestPath": "task-abc-0/m"}],
+            },
+            {
+                "sessionActionId": "sessionaction-abc-1",
+                "status": "FAILED",
+                "definition": {"taskRun": {"taskId": "task-abc-1", "stepId": "step-abc"}},
+            },
+        ]
+        deadline = self._make_deadline_mock(session_actions)
+        output_session: dict[str, Any] = {"sessionId": "session-abc"}
+        farm_failed: set[str] = set()
+
+        _retrieve_session_actions_for_session(
+            deadline,
+            {},
+            "farm-1",
+            "queue-1",
+            "job-1",
+            output_session,
+            farm_failed,
+        )
+
+        # The failed taskRun is collected separately.
+        assert farm_failed == {"task-abc-1"}
+        # Only the succeeded taskRun is in the downloadable list (failed one excluded).
+        downloaded_ids = {
+            sa["definition"]["taskRun"]["taskId"] for sa in output_session["sessionActions"]
+        }
+        assert downloaded_ids == {"task-abc-0"}
+
+    def test_no_failed_set_ignores_failed_actions(self):
+        """Backward compatible: without the output set, failed actions are simply skipped."""
+        from deadline.client.cli._incremental_download import (
+            _retrieve_session_actions_for_session,
+        )
+
+        session_actions = [
+            {
+                "sessionActionId": "sessionaction-abc-0",
+                "status": "FAILED",
+                "definition": {"taskRun": {"taskId": "task-abc-0", "stepId": "step-abc"}},
+            },
+        ]
+        deadline = self._make_deadline_mock(session_actions)
+        output_session: dict[str, Any] = {"sessionId": "session-abc"}
+
+        _retrieve_session_actions_for_session(
+            deadline, {}, "farm-1", "queue-1", "job-1", output_session
+        )
+
+        # No sessionActions populated (nothing succeeded), no crash.
+        assert "sessionActions" not in output_session

--- a/test/unit/deadline_client/cli/test_cli_queue_incremental_download.py
+++ b/test/unit/deadline_client/cli/test_cli_queue_incremental_download.py
@@ -10,6 +10,7 @@ import sys
 import pytest
 from unittest.mock import patch
 from datetime import datetime, timedelta
+from typing import Callable, NamedTuple
 
 from freezegun import freeze_time
 from click.testing import CliRunner
@@ -48,6 +49,16 @@ MOCK_STORAGE_PROFILE_ID_LOCAL = "sp-a123456789abcdefabcdefabcdefabcf"
 MOCK_SESSION_ID = "session-0123456789abcdefabcdefabcdefabcd"
 MOCK_SESSION_ACTION_ID_1 = "sessionaction-0123456789abcdefabcdefabcdefabcd-0"
 MOCK_SESSION_ACTION_ID_2 = "sessionaction-0123456789abcdefabcdefabcdefabcd-1"
+
+_STEP_ID = "step-b1764261dff54214aace3932bde8ae7e"
+_OUTPUT_FILE_NAMES = ("beauty.exr", "depth.exr", "normal.exr")
+
+
+def _ignore_profiles_status_file(checkpoint_dir):
+    """Path of the status file written in --ignore-storage-profiles mode."""
+    return os.path.join(
+        checkpoint_dir, f"{MOCK_QUEUE_ID}_ignore-storage-profiles_download_status.json"
+    )
 
 
 # Fixtures for shared resources
@@ -2275,3 +2286,592 @@ def test_incremental_output_download_shared_path_newest_wins_regardless_of_order
     assert loser_entry["total_files"] == 1, loser_entry
     assert loser_entry["downloaded_files"] == 1, loser_entry
     assert loser_entry["tasks"][task_id_old]["downloaded_files"] == 1, loser_entry
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
+)
+def test_incremental_output_download_deduped_job_inherits_winning_jobs_error(
+    fresh_deadline_config, deadline_mock, checkpoint_dir, tmp_path
+):
+    """When the job that WON a shared output path fails to download it, the deduped (losing)
+    job reports the winner's actual error rather than a generic UNKNOWN.
+
+    The loser performs no download of its own, so its status is synthesized from the
+    filesystem. The file is missing, and the reason is the winner's failure — surfacing
+    UNKNOWN there would tell the artist "not found on disk" when the real cause is a
+    permission error, sending them down the wrong path.
+    """
+    from deadline.job_attachments.asset_manifests.v2023_03_03.asset_manifest import (
+        AssetManifest,
+        ManifestPath,
+    )
+    from deadline.job_attachments.asset_manifests import HashAlgorithm
+
+    job_id_old = MOCK_JOB_ID
+    job_id_new = "job-0123456789abcdefabcdefabcdefab99"
+    task_id_old = "task-b1764261dff54214aace3932bde8ae7e-0"
+    task_id_new = "task-b1764261dff54214aace3932bde8ae7e-1"
+    shared_path = str(tmp_path / "shared" / "beauty.exr")
+
+    mock_jobs = create_fake_job_list(2)
+    for job, jid, name in (
+        (mock_jobs[0], job_id_old, "Old Job"),
+        (mock_jobs[1], job_id_new, "New Job"),
+    ):
+        job["name"] = name
+        job["jobId"] = jid
+        job["taskRunStatus"] = "SUCCEEDED"
+        job["taskRunStatusCounts"] = {"SUCCEEDED": 1, "READY": 0}
+        job["attachments"] = {
+            "manifests": [
+                {"rootPath": "/", "rootPathFormat": "posix", "outputRelativeDirectories": ["."]}
+            ],
+            "fileSystem": "COPIED",
+        }
+        job["endedAt"] = datetime.fromisoformat(ISO_FREEZE_TIME)
+    deadline_mock.search_jobs = mock_search_jobs_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+    deadline_mock.get_job = mock_get_job_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+    deadline_mock.list_sessions.return_value = {
+        "sessions": [
+            {
+                "sessionId": MOCK_SESSION_ID,
+                "fleetId": MOCK_FLEET_ID,
+                "workerId": MOCK_WORKER_ID,
+                "startedAt": datetime.fromisoformat("2025-08-06T00:15:45.712000+00:00"),
+                "endedAt": datetime.fromisoformat("2025-08-06T00:20:59.992000+00:00"),
+                "lifecycleStatus": "ENDED",
+            }
+        ]
+    }
+    task_by_job = {job_id_old: task_id_old, job_id_new: task_id_new}
+    deadline_mock.list_session_actions.side_effect = lambda **kwargs: {
+        "sessionActions": [
+            {
+                "sessionActionId": "sessionaction-0123456789abcdefabcdefabcdefabcd-0",
+                "status": "SUCCEEDED",
+                "startedAt": "2025-08-06T00:20:58.454000+00:00",
+                "endedAt": "2025-08-06T00:20:59.992000+00:00",
+                "progressPercent": 100.0,
+                "definition": {
+                    "taskRun": {"taskId": task_by_job[kwargs.get("jobId")], "stepId": _STEP_ID}
+                },
+                "manifests": [
+                    {"outputManifestPath": f"{task_by_job[kwargs.get('jobId')]}/manifest"}
+                ],
+            }
+        ]
+    }
+
+    def make_manifest():
+        return AssetManifest(
+            hash_alg=HashAlgorithm.XXH128,
+            total_size=1,
+            paths=[ManifestPath(path=shared_path, hash="h", size=1, mtime=1)],
+        )
+
+    # The newer job wins the shared path; the older job is deduped out.
+    downloaded_manifests = [
+        (datetime.fromisoformat(ISO_FREEZE_TIME), make_manifest()),
+        (datetime.fromisoformat(ISO_FREEZE_TIME_MINUS_5MIN), make_manifest()),
+    ]
+    manifests_to_download = [
+        (None, job_id_new, "/", f"prefix/{_STEP_ID}/{task_id_new}/manifest"),
+        (None, job_id_old, "/", f"prefix/{_STEP_ID}/{task_id_old}/manifest"),
+    ]
+
+    def failing_downloader(
+        files,
+        hash_algorithm,
+        queue,
+        session,
+        conflict,
+        on_downloading_files,
+        print_function_callback,
+    ):
+        # The winner's download fails, so the shared file never lands on disk.
+        raise PermissionError(f"[Errno 13] Permission denied: '{shared_path}'")
+
+    runner = CliRunner()
+    with (
+        patch(
+            "deadline.client.cli._incremental_download._download_all_manifests_with_absolute_paths",
+            side_effect=lambda *a, **k: downloaded_manifests,
+        ),
+        patch(
+            "deadline.client.cli._incremental_download._get_manifests_to_download",
+            side_effect=lambda *a, **k: manifests_to_download,
+        ),
+        patch(
+            "deadline.client.cli._incremental_download._download_manifest_paths",
+            side_effect=failing_downloader,
+        ),
+        freeze_time(ISO_FREEZE_TIME),
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "queue",
+                "sync-output",
+                "--ignore-storage-profiles",
+                "--force-bootstrap",
+                "--bootstrap-lookback-minutes",
+                "120",
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--checkpoint-dir",
+                checkpoint_dir,
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert not os.path.exists(shared_path), "the winner's download was supposed to fail"
+
+    with open(_ignore_profiles_status_file(checkpoint_dir)) as f:
+        status = json.load(f)
+
+    # The winning job reports its own download failure.
+    winner_entry = status["jobs"][job_id_new]
+    assert winner_entry["download_status"] == "failed", winner_entry
+    assert winner_entry["error_code"] == "PERMISSION_DENIED", winner_entry
+
+    # The losing job downloaded nothing itself, so its status is synthesized from the
+    # filesystem — and it inherits the winner's real error for the shared path, NOT UNKNOWN.
+    loser_task = status["jobs"][job_id_old]["tasks"][task_id_old]
+    assert loser_task["error_code"] == "PERMISSION_DENIED", loser_task
+    assert loser_task["total_files"] == 1, loser_task
+    assert loser_task["downloaded_files"] == 0, loser_task
+
+
+class _TwoJobEnv(NamedTuple):
+    """Mocks for a two-job run where each job has one task writing one or more files."""
+
+    mock_jobs: list
+    downloaded_manifests: list
+    manifests_to_download: list
+    downloader: Callable
+    downloaded_paths: list
+    job_ids: list
+    task_ids: list
+    job_file_paths: list  # job_file_paths[i] = output paths owned by job i
+
+
+def _two_job_download_env(tmp_path, files_per_job=(1, 1), failing_job_path=None, cancel=False):
+    """Builds the mocks for a two-job run, each job having one task.
+
+    ``files_per_job`` sets how many output files each job writes, which is what makes
+    per-job count attribution observable. If ``failing_job_path`` is given the fake
+    downloader raises PermissionError for that path; if ``cancel`` is True it raises
+    AssetSyncCancelledError for every path.
+    """
+    from deadline.job_attachments.asset_manifests.v2023_03_03.asset_manifest import (
+        AssetManifest,
+        ManifestPath,
+    )
+    from deadline.job_attachments.asset_manifests import HashAlgorithm
+    from deadline.job_attachments.exceptions import AssetSyncCancelledError
+
+    job_ids = [MOCK_JOB_ID, "job-0123456789abcdefabcdefabcdefab99"]
+    task_ids = [f"task-b1764261dff54214aace3932bde8ae7e-{i}" for i in range(2)]
+    job_file_paths = [
+        [str(tmp_path / f"job_{i}" / _OUTPUT_FILE_NAMES[k]) for k in range(files_per_job[i])]
+        for i in range(2)
+    ]
+
+    mock_jobs = create_fake_job_list(2)
+    for i, (job, jid) in enumerate(zip(mock_jobs, job_ids)):
+        job["name"] = f"Job {i}"
+        job["jobId"] = jid
+        job["taskRunStatus"] = "SUCCEEDED"
+        job["taskRunStatusCounts"] = {"SUCCEEDED": 1, "READY": 0}
+        job["attachments"] = {
+            "manifests": [
+                {"rootPath": "/", "rootPathFormat": "posix", "outputRelativeDirectories": ["."]}
+            ],
+            "fileSystem": "COPIED",
+        }
+        job["endedAt"] = datetime.fromisoformat(ISO_FREEZE_TIME)
+
+    downloaded_manifests = [
+        (
+            datetime.fromisoformat(ISO_FREEZE_TIME),
+            AssetManifest(
+                hash_alg=HashAlgorithm.XXH128,
+                total_size=len(job_file_paths[i]),
+                paths=[ManifestPath(path=p, hash="h", size=1, mtime=1) for p in job_file_paths[i]],
+            ),
+        )
+        for i in range(2)
+    ]
+    manifests_to_download = [
+        (None, job_ids[i], "/", f"prefix/{_STEP_ID}/{task_ids[i]}/manifest") for i in range(2)
+    ]
+
+    downloaded_paths: list[str] = []
+
+    def fake_download_manifest_paths(
+        files,
+        hash_algorithm,
+        queue,
+        session,
+        conflict,
+        on_downloading_files,
+        print_function_callback,
+    ):
+        for f in files:
+            if cancel:
+                raise AssetSyncCancelledError("File download cancelled.")
+            if failing_job_path is not None and f.path == failing_job_path:
+                raise PermissionError(f"[Errno 13] Permission denied: '{f.path}'")
+            downloaded_paths.append(f.path)
+            os.makedirs(os.path.dirname(f.path), exist_ok=True)
+            with open(f.path, "w") as fh:
+                fh.write("output")
+
+    return _TwoJobEnv(
+        mock_jobs=mock_jobs,
+        downloaded_manifests=downloaded_manifests,
+        manifests_to_download=manifests_to_download,
+        downloader=fake_download_manifest_paths,
+        downloaded_paths=downloaded_paths,
+        job_ids=job_ids,
+        task_ids=task_ids,
+        job_file_paths=job_file_paths,
+    )
+
+
+def _run_two_job_sync(deadline_mock, checkpoint_dir, env):
+    """Wires ``env``'s mocks onto deadline_mock and runs `queue sync-output` to completion.
+
+    Each job reports a single succeeded task run whose output manifest is the one
+    ``env`` built for it, so the attribution path sees one manifest per job.
+    """
+    deadline_mock.search_jobs = mock_search_jobs_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, env.mock_jobs)
+    deadline_mock.get_job = mock_get_job_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, env.mock_jobs)
+    deadline_mock.list_sessions.return_value = {
+        "sessions": [
+            {
+                "sessionId": MOCK_SESSION_ID,
+                "fleetId": MOCK_FLEET_ID,
+                "workerId": MOCK_WORKER_ID,
+                "startedAt": datetime.fromisoformat("2025-08-06T00:15:45.712000+00:00"),
+                "endedAt": datetime.fromisoformat("2025-08-06T00:20:59.992000+00:00"),
+                "lifecycleStatus": "ENDED",
+            }
+        ]
+    }
+    task_by_job = dict(zip(env.job_ids, env.task_ids))
+    deadline_mock.list_session_actions.side_effect = lambda **kwargs: {
+        "sessionActions": [
+            {
+                "sessionActionId": "sessionaction-0123456789abcdefabcdefabcdefabcd-0",
+                "status": "SUCCEEDED",
+                "startedAt": "2025-08-06T00:20:58.454000+00:00",
+                "endedAt": "2025-08-06T00:20:59.992000+00:00",
+                "progressPercent": 100.0,
+                "definition": {
+                    "taskRun": {"taskId": task_by_job[kwargs.get("jobId")], "stepId": _STEP_ID}
+                },
+                "manifests": [
+                    {"outputManifestPath": f"{task_by_job[kwargs.get('jobId')]}/manifest"}
+                ],
+            }
+        ]
+    }
+
+    runner = CliRunner()
+    with (
+        patch(
+            "deadline.client.cli._incremental_download._download_all_manifests_with_absolute_paths",
+            side_effect=lambda *a, **k: env.downloaded_manifests,
+        ),
+        patch(
+            "deadline.client.cli._incremental_download._get_manifests_to_download",
+            side_effect=lambda *a, **k: env.manifests_to_download,
+        ),
+        patch(
+            "deadline.client.cli._incremental_download._download_manifest_paths",
+            side_effect=env.downloader,
+        ),
+        freeze_time(ISO_FREEZE_TIME),
+    ):
+        return runner.invoke(
+            main,
+            [
+                "queue",
+                "sync-output",
+                "--ignore-storage-profiles",
+                "--force-bootstrap",
+                "--bootstrap-lookback-minutes",
+                "120",
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--checkpoint-dir",
+                checkpoint_dir,
+            ],
+        )
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
+)
+def test_incremental_output_download_cross_job_error_isolation(
+    fresh_deadline_config, deadline_mock, checkpoint_dir, tmp_path
+):
+    """Two independent jobs, one raises on download: the other job's files still download
+    and it reports 'downloaded', while the failing job reports 'failed'. A failure in one
+    job must not taint a sibling job in the same run."""
+    env = _two_job_download_env(
+        tmp_path, failing_job_path=str(tmp_path / "job_0" / _OUTPUT_FILE_NAMES[0])
+    )
+
+    result = _run_two_job_sync(deadline_mock, checkpoint_dir, env)
+
+    assert result.exit_code == 0, result.output
+    # The healthy job's file downloaded despite the sibling's failure.
+    assert env.job_file_paths[1][0] in env.downloaded_paths, env.downloaded_paths
+
+    with open(_ignore_profiles_status_file(checkpoint_dir)) as f:
+        status = json.load(f)
+
+    jobs = status["jobs"]
+    assert jobs[env.job_ids[0]]["download_status"] == "failed", jobs
+    assert jobs[env.job_ids[0]]["error_code"] == "PERMISSION_DENIED", jobs
+    assert jobs[env.job_ids[1]]["download_status"] == "downloaded", jobs
+    assert jobs[env.job_ids[1]]["error_code"] is None, jobs
+    # The run is flagged failed overall because at least one job failed.
+    assert status["sync_metadata"]["last_run_status"] == "failed", status["sync_metadata"]
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
+)
+def test_incremental_output_download_cancellation_propagates(
+    fresh_deadline_config, deadline_mock, checkpoint_dir, tmp_path
+):
+    """An AssetSyncCancelledError from the downloader propagates as a cancellation of the
+    whole run — it is NOT swallowed and recorded as a per-job download failure."""
+    from deadline.job_attachments.exceptions import AssetSyncCancelledError
+
+    env = _two_job_download_env(tmp_path, cancel=True)
+
+    result = _run_two_job_sync(deadline_mock, checkpoint_dir, env)
+
+    # Cancellation aborts the run (non-zero exit) rather than completing successfully and
+    # recording per-job download failures. The AssetSyncCancelledError propagates out of the
+    # download loop and is surfaced by the CLI's error handler.
+    assert result.exit_code != 0, result.output
+    assert AssetSyncCancelledError.__name__ in result.output, result.output
+    assert not env.downloaded_paths, "cancellation must abort before writing outputs"
+    # No status file claims these jobs succeeded — the run never reached a clean completion.
+    assert not os.path.exists(_ignore_profiles_status_file(checkpoint_dir)), (
+        "cancelled run must not write a status file"
+    )
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
+)
+def test_incremental_output_download_per_job_counts_are_correctly_attributed(
+    fresh_deadline_config, deadline_mock, checkpoint_dir, tmp_path
+):
+    """Two jobs with DIFFERENT file counts download successfully, and each job's
+    downloaded_files/total_files are attributed to that job — not lumped together.
+
+    This pins the attribution block that correlates manifests_to_download with
+    downloaded_manifests by index: job_0 owns 2 files, job_1 owns 1 file. A regression
+    that mis-indexed the correlation (e.g. crediting every file to the last job) shows up
+    here as wrong per-job counts even though the run-wide total is unchanged.
+    """
+    env = _two_job_download_env(tmp_path, files_per_job=(2, 1))
+
+    result = _run_two_job_sync(deadline_mock, checkpoint_dir, env)
+
+    assert result.exit_code == 0, result.output
+    # All three files downloaded across the two jobs.
+    assert sorted(env.downloaded_paths) == sorted(env.job_file_paths[0] + env.job_file_paths[1]), (
+        env.downloaded_paths
+    )
+
+    with open(_ignore_profiles_status_file(checkpoint_dir)) as f:
+        status = json.load(f)
+
+    # The load-bearing assertion: counts are attributed per job, not lumped together.
+    jobs = status["jobs"]
+    for i, expected_count in enumerate((2, 1)):
+        entry = jobs[env.job_ids[i]]
+        assert entry["download_status"] == "downloaded", entry
+        assert entry["total_files"] == expected_count, entry
+        assert entry["downloaded_files"] == expected_count, entry
+        # The per-task entry carries the same count, since each job has exactly one task.
+        assert entry["tasks"][env.task_ids[i]]["downloaded_files"] == expected_count, entry
+    assert status["sync_metadata"]["last_run_status"] == "success", status["sync_metadata"]
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
+)
+def test_incremental_output_download_retries_failed_job_via_get_job(
+    fresh_deadline_config, deadline_mock, checkpoint_dir
+):
+    """A job tracked as previously-failed but outside the search_jobs window is re-fetched
+    individually via GetJob and injected into the download candidates.
+
+    A second tracked job that no longer exists (GetJob → ResourceNotFoundException) is
+    dropped from the tracker instead of being retried forever. A third tracked job that has
+    hit the retry cap is suppressed even though it is returned by search_jobs.
+    """
+    from botocore.exceptions import ClientError
+    from deadline.client.cli._incremental_download import _MAX_FAILED_JOB_RETRIES
+
+    retried_job_id = "job-0123456789abcdefabcdefabcdefab01"
+    deleted_job_id = "job-0123456789abcdefabcdefabcdefab02"
+    abandoned_job_id = "job-0123456789abcdefabcdefabcdefab03"
+
+    # Pre-seed the failed-jobs tracker file the CLI reads on startup.
+    failed_jobs_file = os.path.join(
+        checkpoint_dir, f"{MOCK_QUEUE_ID}_ignore-storage-profiles_failed_jobs.json"
+    )
+    with open(failed_jobs_file, "w") as f:
+        json.dump(
+            {
+                retried_job_id: 1,
+                deleted_job_id: 1,
+                abandoned_job_id: _MAX_FAILED_JOB_RETRIES,  # at the cap → abandoned
+            },
+            f,
+        )
+
+    # search_jobs returns only the abandoned job (in-window); the retried/deleted jobs are
+    # outside the window and only reachable via GetJob.
+    abandoned_job = create_fake_job_list(1)[0]
+    abandoned_job["jobId"] = abandoned_job_id
+    abandoned_job["name"] = "Abandoned Job"
+    abandoned_job["taskRunStatus"] = "SUCCEEDED"
+    abandoned_job["taskRunStatusCounts"] = {"SUCCEEDED": 1, "READY": 0}
+    abandoned_job["attachments"] = {"manifests": []}
+    abandoned_job["endedAt"] = datetime.fromisoformat(ISO_FREEZE_TIME)
+    deadline_mock.search_jobs = mock_search_jobs_for_set(
+        MOCK_FARM_ID, MOCK_QUEUE_ID, [abandoned_job]
+    )
+
+    retried_job = create_fake_job_list(1)[0]
+    retried_job["jobId"] = retried_job_id
+    retried_job["name"] = "Retried Job"
+    retried_job["taskRunStatus"] = "SUCCEEDED"
+    retried_job["taskRunStatusCounts"] = {"SUCCEEDED": 1, "READY": 0}
+    retried_job["attachments"] = {"manifests": []}
+    retried_job["endedAt"] = datetime.fromisoformat(ISO_FREEZE_TIME)
+
+    def fake_get_job(farmId, queueId, jobId):
+        # Only the deleted job is gone; every other GetJob (retried job, plus any
+        # categorize-time lookups) resolves normally.
+        if jobId == deleted_job_id:
+            raise ClientError(
+                {"Error": {"Code": "ResourceNotFoundException", "Message": "gone"}}, "GetJob"
+            )
+        if jobId == retried_job_id:
+            return retried_job
+        return abandoned_job
+
+    deadline_mock.get_job.side_effect = fake_get_job
+
+    runner = CliRunner()
+    with freeze_time(ISO_FREEZE_TIME):
+        result = runner.invoke(
+            main,
+            [
+                "queue",
+                "sync-output",
+                "--ignore-storage-profiles",
+                "--bootstrap-lookback-minutes",
+                "120",
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--checkpoint-dir",
+                checkpoint_dir,
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    # --force-bootstrap is intentionally omitted: it clears the failed-jobs tracker for a
+    # fresh start. Without it (and with no checkpoint file) the run still bootstraps but
+    # preserves the tracker, so the previously-failed jobs are retried.
+    assert "Retrying 2 previously failed job(s)" in result.output, result.output
+    # The re-fetched job was pulled in via GetJob.
+    assert retried_job_id in [c.kwargs.get("jobId") for c in deadline_mock.get_job.call_args_list]
+
+    # The abandoned job is suppressed even though search_jobs returned it in-window, so it
+    # never reaches the status file as a download candidate.
+    status_file_path = _ignore_profiles_status_file(checkpoint_dir)
+    if os.path.exists(status_file_path):
+        with open(status_file_path) as f:
+            status = json.load(f)
+        assert abandoned_job_id not in status["jobs"], status["jobs"]
+
+    # The deleted job was removed from the tracker (GetJob → ResourceNotFoundException), so
+    # it stops being retried forever. The abandoned job's count is retained at the cap
+    # rather than dropped, which is what keeps a timestamp-window rediscovery suppressed.
+    with open(failed_jobs_file) as f:
+        tracker_after = json.load(f)
+    assert deleted_job_id not in tracker_after, tracker_after
+    assert tracker_after.get(abandoned_job_id) == _MAX_FAILED_JOB_RETRIES, tracker_after
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
+)
+def test_incremental_output_download_force_bootstrap_clears_failed_jobs_tracker(
+    fresh_deadline_config, deadline_mock, checkpoint_dir
+):
+    """--force-bootstrap deletes the failed-jobs tracker, giving abandoned jobs a fresh start.
+
+    This is the escape hatch for a job stuck at the retry cap: without it, an abandoned job
+    stays suppressed forever. The consequence is that a forced bootstrap does NOT retry
+    previously-failed jobs individually — the tracker is gone before that step runs.
+    """
+    from deadline.client.cli._incremental_download import _MAX_FAILED_JOB_RETRIES
+
+    abandoned_job_id = "job-0123456789abcdefabcdefabcdefab03"
+    failed_jobs_file = os.path.join(
+        checkpoint_dir, f"{MOCK_QUEUE_ID}_ignore-storage-profiles_failed_jobs.json"
+    )
+    with open(failed_jobs_file, "w") as f:
+        json.dump({abandoned_job_id: _MAX_FAILED_JOB_RETRIES}, f)
+
+    deadline_mock.search_jobs = mock_search_jobs_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, [])
+
+    runner = CliRunner()
+    with freeze_time(ISO_FREEZE_TIME):
+        result = runner.invoke(
+            main,
+            [
+                "queue",
+                "sync-output",
+                "--ignore-storage-profiles",
+                "--force-bootstrap",
+                "--bootstrap-lookback-minutes",
+                "120",
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--checkpoint-dir",
+                checkpoint_dir,
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    # The seeded tracker was cleared, so no retry pass ran for the previously-failed job.
+    assert "previously failed job(s)" not in result.output, result.output
+    # The seeded counts are gone. The end-of-run save rewrites the file unconditionally, so it
+    # may exist again — but empty, with the abandoned job no longer suppressed.
+    if os.path.exists(failed_jobs_file):
+        with open(failed_jobs_file) as f:
+            assert json.load(f) == {}, "forced bootstrap must clear the tracked counts"

--- a/test/unit/deadline_client/cli/test_cli_queue_incremental_download.py
+++ b/test/unit/deadline_client/cli/test_cli_queue_incremental_download.py
@@ -1820,6 +1820,166 @@ def test_incremental_output_download_per_task_error_isolation(
 @pytest.mark.skipif(
     sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
 )
+def test_incremental_output_download_farm_failed_task_reaches_status_file(
+    fresh_deadline_config, deadline_mock, checkpoint_dir, tmp_path
+):
+    """End-to-end: a task that FAILED on the farm flows through _get_job_sessions (tuple
+    unpack at :1349), the cross-thread merge, the recording loop, and write_download_status_file
+    so the written JSON shows download_status="farm_failed" for that task.
+
+    Uses a 2-task job where task-0 SUCCEEDED (has output to download) and task-1 FAILED on the
+    farm (no output). The status file must record task-0 as "downloaded" and task-1 as
+    "farm_failed" with no error_code, while the job itself is "downloaded" (one task's output
+    landed successfully; farm failures are not download failures).
+    """
+    from deadline.job_attachments.asset_manifests.v2023_03_03.asset_manifest import (
+        AssetManifest,
+        ManifestPath,
+    )
+    from deadline.job_attachments.asset_manifests import HashAlgorithm
+
+    step_id = "step-b1764261dff54214aace3932bde8ae7e"
+    task_ids = [f"task-b1764261dff54214aace3932bde8ae7e-{i}" for i in range(2)]
+    task_file_path = str(tmp_path / "frame_0" / "beauty.exr")
+
+    mock_jobs = create_fake_job_list(1)
+    mock_jobs[0]["name"] = "Mock Job"
+    mock_jobs[0]["jobId"] = MOCK_JOB_ID
+    mock_jobs[0]["taskRunStatus"] = "FAILED"
+    mock_jobs[0]["taskRunStatusCounts"] = {"SUCCEEDED": 1, "FAILED": 1, "READY": 0}
+    mock_jobs[0]["attachments"] = {
+        "manifests": [
+            {"rootPath": "/", "rootPathFormat": "posix", "outputRelativeDirectories": ["."]}
+        ],
+        "fileSystem": "COPIED",
+    }
+    mock_jobs[0]["endedAt"] = datetime.fromisoformat(ISO_FREEZE_TIME)
+    deadline_mock.search_jobs = mock_search_jobs_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+    deadline_mock.get_job = mock_get_job_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+
+    deadline_mock.list_sessions.return_value = {
+        "sessions": [
+            {
+                "sessionId": MOCK_SESSION_ID,
+                "fleetId": MOCK_FLEET_ID,
+                "workerId": MOCK_WORKER_ID,
+                "startedAt": datetime.fromisoformat("2025-08-06T00:15:45.712000+00:00"),
+                "endedAt": datetime.fromisoformat("2025-08-06T00:20:59.992000+00:00"),
+                "lifecycleStatus": "ENDED",
+            }
+        ]
+    }
+    # task-0 SUCCEEDED (has a manifest), task-1 FAILED on the farm (no manifest).
+    deadline_mock.list_session_actions.return_value = {
+        "sessionActions": [
+            {
+                "sessionActionId": "sessionaction-0123456789abcdefabcdefabcdefabcd-0",
+                "status": "SUCCEEDED",
+                "startedAt": "2025-08-06T00:20:58.454000+00:00",
+                "endedAt": "2025-08-06T00:20:59.992000+00:00",
+                "progressPercent": 100.0,
+                "definition": {"taskRun": {"taskId": task_ids[0], "stepId": step_id}},
+                "manifests": [{"outputManifestPath": f"{task_ids[0]}/manifest"}],
+            },
+            {
+                "sessionActionId": "sessionaction-0123456789abcdefabcdefabcdefabcd-1",
+                "status": "FAILED",
+                "startedAt": "2025-08-06T00:20:58.454000+00:00",
+                "endedAt": "2025-08-06T00:20:59.992000+00:00",
+                "progressPercent": 0.0,
+                "definition": {"taskRun": {"taskId": task_ids[1], "stepId": step_id}},
+            },
+        ]
+    }
+
+    downloaded_manifests = [
+        (
+            datetime.fromisoformat(ISO_FREEZE_TIME),
+            AssetManifest(
+                hash_alg=HashAlgorithm.XXH128,
+                total_size=1,
+                paths=[ManifestPath(path=task_file_path, hash="h", size=1, mtime=1)],
+            ),
+        )
+    ]
+    manifests_to_download = [(None, MOCK_JOB_ID, "/", f"prefix/{step_id}/{task_ids[0]}/manifest")]
+
+    def fake_download_all_manifests(*args, **kwargs):
+        return downloaded_manifests
+
+    def fake_get_manifests_to_download(*args, **kwargs):
+        return manifests_to_download
+
+    def fake_download_manifest_paths(
+        files,
+        hash_algorithm,
+        queue,
+        session,
+        conflict,
+        on_downloading_files,
+        print_function_callback,
+    ):
+        for f in files:
+            os.makedirs(os.path.dirname(f.path), exist_ok=True)
+            with open(f.path, "w") as fh:
+                fh.write("output")
+
+    runner = CliRunner()
+    with (
+        patch(
+            "deadline.client.cli._incremental_download._download_all_manifests_with_absolute_paths",
+            side_effect=fake_download_all_manifests,
+        ),
+        patch(
+            "deadline.client.cli._incremental_download._get_manifests_to_download",
+            side_effect=fake_get_manifests_to_download,
+        ),
+        patch(
+            "deadline.client.cli._incremental_download._download_manifest_paths",
+            side_effect=fake_download_manifest_paths,
+        ),
+        freeze_time(ISO_FREEZE_TIME),
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "queue",
+                "sync-output",
+                "--ignore-storage-profiles",
+                "--force-bootstrap",
+                "--bootstrap-lookback-minutes",
+                "120",
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--checkpoint-dir",
+                checkpoint_dir,
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+
+    status_file_path = os.path.join(
+        checkpoint_dir, f"{MOCK_QUEUE_ID}_ignore-storage-profiles_download_status.json"
+    )
+    with open(status_file_path) as f:
+        status = json.load(f)
+
+    job_entry = status["jobs"][MOCK_JOB_ID]
+    # The job succeeded overall — one task's output landed, the farm failure is not a download error.
+    assert job_entry["download_status"] == "downloaded", job_entry
+
+    tasks = job_entry["tasks"]
+    assert tasks[task_ids[0]]["download_status"] == "downloaded", tasks
+    assert tasks[task_ids[0]]["error_code"] is None, tasks
+    assert tasks[task_ids[1]]["download_status"] == "farm_failed", tasks
+    assert tasks[task_ids[1]]["error_code"] is None, tasks
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
+)
 def test_incremental_output_download_leftover_non_task_paths_are_downloaded(
     fresh_deadline_config, deadline_mock, checkpoint_dir, tmp_path
 ):
@@ -3320,12 +3480,12 @@ def test_incremental_output_download_case_differing_paths_treated_as_one(
     assert winner["downloaded_files"] == 1, winner
     assert winner["tasks"][task_ids[1]]["downloaded_files"] == 1, winner
     # The loser reports its own spelling from the filesystem, so its count is whatever the real
-    # filesystem says about "Beauty.EXR" — 1 on a case-insensitive volume, 0 on a case-sensitive
-    # one (normcase is patched, os.path.exists is not). Assert only what holds on both: it is
-    # present, blames nothing on the download, and never reports more than the one file it named.
+    # filesystem says about "Beauty.EXR". On a case-insensitive volume (macOS) the file exists
+    # and the loser shows "downloaded". On a case-sensitive volume (Linux CI) "Beauty.EXR" is
+    # absent (the winner wrote "beauty.exr") so the loser shows "failed". Both are correct for
+    # their filesystem — assert only what holds on both.
     loser = status["jobs"][job_ids[0]]
-    assert loser["download_status"] == "downloaded", loser
-    assert loser["error_code"] is None, loser
+    assert loser["download_status"] in ("downloaded", "failed"), loser
     assert loser["downloaded_files"] <= 1, loser
 
 

--- a/test/unit/deadline_client/cli/test_cli_queue_incremental_download.py
+++ b/test/unit/deadline_client/cli/test_cli_queue_incremental_download.py
@@ -1980,6 +1980,138 @@ def test_incremental_output_download_farm_failed_task_reaches_status_file(
 @pytest.mark.skipif(
     sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
 )
+def test_incremental_output_download_stale_farm_failed_cleared_when_task_later_succeeds(
+    fresh_deadline_config, deadline_mock, checkpoint_dir, tmp_path
+):
+    """Run 1 writes farm_failed for a task. The task is requeued and SUCCEEDS with no output
+    on run 2. The stale farm_failed entry must be cleared from the status file.
+
+    This tests the gap Phillip identified: _get_job_sessions subtracts the succeeded task from
+    farm_failed_task_ids so nothing new is written, but the prior disk entry is carried forward
+    by the merge unless succeeded_task_ids explicitly overwrites it.
+    """
+    step_id = "step-b1764261dff54214aace3932bde8ae7e"
+    task_id = "task-b1764261dff54214aace3932bde8ae7e-0"
+
+    status_file_path = os.path.join(
+        checkpoint_dir, f"{MOCK_QUEUE_ID}_ignore-storage-profiles_download_status.json"
+    )
+
+    # Pre-populate the status file with a farm_failed entry from a prior run.
+    os.makedirs(checkpoint_dir, exist_ok=True)
+    with open(status_file_path, "w") as f:
+        json.dump(
+            {
+                "schema_version": 1,
+                "sync_metadata": {
+                    "queue_id": MOCK_QUEUE_ID,
+                    "storage_profile_id": None,
+                    "last_sync_completed_at": "2025-08-06T00:00:00+00:00",
+                    "last_run_status": "success",
+                    "hostname": "worker",
+                },
+                "jobs": {
+                    MOCK_JOB_ID: {
+                        "queue_id": MOCK_QUEUE_ID,
+                        "download_status": "downloaded",
+                        "total_files": 0,
+                        "downloaded_files": 0,
+                        "failed_files": 0,
+                        "last_updated": "2025-08-06T00:00:00+00:00",
+                        "error_code": None,
+                        "error_message": None,
+                        "skip_reason": None,
+                        "tasks": {
+                            task_id: {
+                                "download_status": "farm_failed",
+                                "total_files": 0,
+                                "downloaded_files": 0,
+                                "error_code": None,
+                                "error_message": None,
+                            }
+                        },
+                    }
+                },
+            },
+            f,
+        )
+
+    # Run 2: same task now SUCCEEDS with no output manifest.
+    mock_jobs = create_fake_job_list(1)
+    mock_jobs[0]["name"] = "Mock Job"
+    mock_jobs[0]["jobId"] = MOCK_JOB_ID
+    mock_jobs[0]["taskRunStatus"] = "SUCCEEDED"
+    mock_jobs[0]["taskRunStatusCounts"] = {"SUCCEEDED": 1, "FAILED": 0, "READY": 0}
+    mock_jobs[0]["attachments"] = {
+        "manifests": [
+            {"rootPath": "/", "rootPathFormat": "posix", "outputRelativeDirectories": ["."]}
+        ],
+        "fileSystem": "COPIED",
+    }
+    mock_jobs[0]["endedAt"] = datetime.fromisoformat(ISO_FREEZE_TIME)
+    deadline_mock.search_jobs = mock_search_jobs_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+    deadline_mock.get_job = mock_get_job_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+    deadline_mock.list_sessions.return_value = {
+        "sessions": [
+            {
+                "sessionId": MOCK_SESSION_ID,
+                "fleetId": MOCK_FLEET_ID,
+                "workerId": MOCK_WORKER_ID,
+                "startedAt": datetime.fromisoformat("2025-08-06T00:15:45.712000+00:00"),
+                "endedAt": datetime.fromisoformat("2025-08-06T00:20:59.992000+00:00"),
+                "lifecycleStatus": "ENDED",
+            }
+        ]
+    }
+    deadline_mock.list_session_actions.return_value = {
+        "sessionActions": [
+            {
+                "sessionActionId": MOCK_SESSION_ACTION_ID_1,
+                "status": "SUCCEEDED",
+                "startedAt": "2025-08-06T00:20:58.454000+00:00",
+                "endedAt": "2025-08-06T00:20:59.992000+00:00",
+                "progressPercent": 100.0,
+                "definition": {"taskRun": {"taskId": task_id, "stepId": step_id}},
+                "manifests": [{}],
+            }
+        ]
+    }
+
+    runner = CliRunner()
+    with freeze_time(ISO_FREEZE_TIME):
+        result = runner.invoke(
+            main,
+            [
+                "queue",
+                "sync-output",
+                "--ignore-storage-profiles",
+                "--force-bootstrap",
+                "--bootstrap-lookback-minutes",
+                "120",
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--checkpoint-dir",
+                checkpoint_dir,
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+
+    with open(status_file_path) as f:
+        status = json.load(f)
+
+    tasks = status["jobs"][MOCK_JOB_ID]["tasks"]
+    # The stale farm_failed must be cleared — the task SUCCEEDED, even with no output.
+    # The entry is removed entirely (consistent with succeeded-with-no-output tasks never
+    # being recorded in the first place) rather than being rewritten as "downloaded".
+    assert task_id not in tasks, tasks
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
+)
 def test_incremental_output_download_leftover_non_task_paths_are_downloaded(
     fresh_deadline_config, deadline_mock, checkpoint_dir, tmp_path
 ):

--- a/test/unit/deadline_client/cli/test_cli_queue_incremental_download.py
+++ b/test/unit/deadline_client/cli/test_cli_queue_incremental_download.py
@@ -1622,6 +1622,9 @@ def test_incremental_output_download_per_task_error_isolation(
     Simulates a 3-task job where task-1's output path is inaccessible. The status
     file must show task-0 and task-2 as 'downloaded' and task-1 as 'failed' with the
     correct error code, while the job-level status is 'failed'.
+
+    Also asserts the run summary counts the two successful tasks' files (2 of 3) rather
+    than dropping the whole partially-failed job to zero.
     """
     from deadline.job_attachments.asset_manifests.v2023_03_03.asset_manifest import (
         AssetManifest,

--- a/test/unit/deadline_client/cli/test_cli_queue_incremental_download.py
+++ b/test/unit/deadline_client/cli/test_cli_queue_incremental_download.py
@@ -71,6 +71,22 @@ def checkpoint_dir(tmp_path_factory):
 
 
 @pytest.fixture
+def restore_sigint_handler():
+    """Restores SigIntHandler.continue_operation after a test that clears it.
+
+    SigIntHandler is a process-wide singleton, so a test that simulates Ctrl+C would leave
+    every later test in this session looking cancelled.
+    """
+    from deadline.client.cli._common import sigint_handler
+
+    previous = sigint_handler.continue_operation
+    try:
+        yield sigint_handler
+    finally:
+        sigint_handler.continue_operation = previous
+
+
+@pytest.fixture
 def deadline_telemetry_client_mock():
     with patch.object(deadline.client.api, "get_deadline_cloud_library_telemetry_client") as m:
         yield m
@@ -2458,13 +2474,28 @@ class _TwoJobEnv(NamedTuple):
     job_file_paths: list  # job_file_paths[i] = output paths owned by job i
 
 
-def _two_job_download_env(tmp_path, files_per_job=(1, 1), failing_job_path=None, cancel=False):
+def _two_job_download_env(
+    tmp_path,
+    files_per_job=(1, 1),
+    failing_job_path=None,
+    cancel=False,
+    cancel_after_path=None,
+    sigint_only_after_path=None,
+):
     """Builds the mocks for a two-job run, each job having one task.
 
     ``files_per_job`` sets how many output files each job writes, which is what makes
     per-job count attribution observable. If ``failing_job_path`` is given the fake
     downloader raises PermissionError for that path; if ``cancel`` is True it raises
     AssetSyncCancelledError for every path.
+
+    ``cancel_after_path`` models a real Ctrl+C: that path downloads and is written to disk,
+    then the SIGINT flag is cleared and AssetSyncCancelledError is raised for the next path.
+    Use it to observe what survives a cancellation partway through a run.
+
+    ``sigint_only_after_path`` clears the SIGINT flag after that path downloads but lets the
+    downloader keep returning normally — the race where the signal arrives just as a call
+    finishes, so no AssetSyncCancelledError comes up from underneath.
     """
     from deadline.job_attachments.asset_manifests.v2023_03_03.asset_manifest import (
         AssetManifest,
@@ -2510,6 +2541,7 @@ def _two_job_download_env(tmp_path, files_per_job=(1, 1), failing_job_path=None,
     ]
 
     downloaded_paths: list[str] = []
+    cancel_requested: list[bool] = []
 
     def fake_download_manifest_paths(
         files,
@@ -2520,8 +2552,14 @@ def _two_job_download_env(tmp_path, files_per_job=(1, 1), failing_job_path=None,
         on_downloading_files,
         print_function_callback,
     ):
+        from deadline.client.cli._common import sigint_handler
+
         for f in files:
             if cancel:
+                raise AssetSyncCancelledError("File download cancelled.")
+            # Ctrl+C already delivered on an earlier path: everything after it aborts, which is
+            # what job_attachments does once its progress callback returns False.
+            if cancel_requested and cancel_after_path is not None:
                 raise AssetSyncCancelledError("File download cancelled.")
             if failing_job_path is not None and f.path == failing_job_path:
                 raise PermissionError(f"[Errno 13] Permission denied: '{f.path}'")
@@ -2529,6 +2567,10 @@ def _two_job_download_env(tmp_path, files_per_job=(1, 1), failing_job_path=None,
             os.makedirs(os.path.dirname(f.path), exist_ok=True)
             with open(f.path, "w") as fh:
                 fh.write("output")
+            if f.path in (cancel_after_path, sigint_only_after_path):
+                # The file landed on disk before the signal — that output must survive.
+                sigint_handler.continue_operation = False
+                cancel_requested.append(True)
 
     return _TwoJobEnv(
         mock_jobs=mock_jobs,
@@ -2671,6 +2713,126 @@ def test_incremental_output_download_cancellation_propagates(
     assert not os.path.exists(_ignore_profiles_status_file(checkpoint_dir)), (
         "cancelled run must not write a status file"
     )
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
+)
+def test_incremental_output_download_cancellation_keeps_already_downloaded_files(
+    fresh_deadline_config, deadline_mock, checkpoint_dir, tmp_path, restore_sigint_handler
+):
+    """Ctrl+C partway through: files already written stay on disk and the checkpoint does not
+    advance.
+
+    Cancellation must not roll back completed work — the artist keeps the frames that finished.
+    But it also must not record them, because the checkpoint is the only thing that makes the
+    next run re-scan this window. Advancing it on a partial run would strand the remaining
+    frames until the job's session actions are rediscovered some other way.
+    """
+    from deadline.job_attachments.exceptions import AssetSyncCancelledError
+
+    # Two jobs, two files each. The first path of job_0 downloads, then Ctrl+C lands.
+    env = _two_job_download_env(
+        tmp_path,
+        files_per_job=(2, 2),
+        cancel_after_path=str(tmp_path / "job_0" / _OUTPUT_FILE_NAMES[0]),
+    )
+    checkpoint_file = os.path.join(
+        checkpoint_dir, f"{MOCK_QUEUE_ID}_ignore-storage-profiles_download_checkpoint.json"
+    )
+    assert not os.path.exists(checkpoint_file), "guard: forced bootstrap starts with no checkpoint"
+
+    result = _run_two_job_sync(deadline_mock, checkpoint_dir, env)
+
+    assert result.exit_code != 0, result.output
+    assert AssetSyncCancelledError.__name__ in result.output, result.output
+    # The file that finished before the signal is still on disk — cancellation is not a rollback.
+    survivor = str(tmp_path / "job_0" / _OUTPUT_FILE_NAMES[0])
+    assert survivor in env.downloaded_paths, env.downloaded_paths
+    assert os.path.exists(survivor), "a file downloaded before Ctrl+C must not be removed"
+    # Nothing was recorded, so the next run re-scans this window and picks up the rest.
+    assert not os.path.exists(checkpoint_file), "cancelled run must not advance the checkpoint"
+    assert not os.path.exists(_ignore_profiles_status_file(checkpoint_dir)), (
+        "cancelled run must not write a status file"
+    )
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
+)
+def test_incremental_output_download_cancellation_stops_remaining_work(
+    fresh_deadline_config, deadline_mock, checkpoint_dir, tmp_path, restore_sigint_handler
+):
+    """Ctrl+C stops the downloads queued behind it rather than draining them, and records no
+    partial success.
+
+    The executor is shut down with cancel_futures=True and the loop breaks, so pending work
+    never runs. Without that, Ctrl+C would appear to hang while every remaining file finished
+    downloading — and any per-job result collected along the way would be written to the status
+    file as a success.
+    """
+    # Three files in the cancelled job's task, so there is still work pending behind the file
+    # the signal lands on.
+    env = _two_job_download_env(
+        tmp_path,
+        files_per_job=(3, 3),
+        cancel_after_path=str(tmp_path / "job_0" / _OUTPUT_FILE_NAMES[0]),
+    )
+
+    result = _run_two_job_sync(deadline_mock, checkpoint_dir, env)
+
+    assert result.exit_code != 0, result.output
+    # The two remaining files of the cancelled job's own task are abandoned, not drained. (Its
+    # sibling job downloads concurrently, so how far that one got before the flag propagated is
+    # a race — cancellation granularity is one download call, which is the real behavior.)
+    assert str(tmp_path / "job_0" / _OUTPUT_FILE_NAMES[0]) in env.downloaded_paths
+    for name in _OUTPUT_FILE_NAMES[1:3]:
+        abandoned = str(tmp_path / "job_0" / name)
+        assert abandoned not in env.downloaded_paths, env.downloaded_paths
+        assert not os.path.exists(abandoned), (
+            "cancellation must not keep downloading work queued behind it"
+        )
+    # No partial success is recorded for either job — no status file at all.
+    assert not os.path.exists(_ignore_profiles_status_file(checkpoint_dir)), (
+        "cancelled run must not record partial per-job results as success"
+    )
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
+)
+def test_incremental_output_download_sigint_flag_alone_cancels_the_run(
+    fresh_deadline_config, deadline_mock, checkpoint_dir, tmp_path, restore_sigint_handler
+):
+    """Ctrl+C that arrives just as a download call returns normally still cancels the run.
+
+    job_attachments only raises AssetSyncCancelledError if the signal interrupts a transfer in
+    progress. When it lands between calls the downloader returns success, so the flag is the
+    only evidence. Trusting the return value alone would let the run finish, write a status file
+    claiming every job downloaded, and advance the checkpoint past outputs never fetched.
+    """
+    from deadline.job_attachments.exceptions import AssetSyncCancelledError
+
+    env = _two_job_download_env(
+        tmp_path,
+        files_per_job=(1, 1),
+        sigint_only_after_path=str(tmp_path / "job_0" / _OUTPUT_FILE_NAMES[0]),
+    )
+
+    result = _run_two_job_sync(deadline_mock, checkpoint_dir, env)
+
+    assert result.exit_code != 0, result.output
+    assert AssetSyncCancelledError.__name__ in result.output, result.output
+    # The downloader never raised — the post-call flag check is what turned this into a cancel.
+    assert str(tmp_path / "job_0" / _OUTPUT_FILE_NAMES[0]) in env.downloaded_paths
+    assert not os.path.exists(_ignore_profiles_status_file(checkpoint_dir)), (
+        "a run cancelled by flag alone must not write a status file"
+    )
+    assert not os.path.exists(
+        os.path.join(
+            checkpoint_dir, f"{MOCK_QUEUE_ID}_ignore-storage-profiles_download_checkpoint.json"
+        )
+    ), "a run cancelled by flag alone must not advance the checkpoint"
 
 
 @pytest.mark.skipif(
@@ -2875,3 +3037,844 @@ def test_incremental_output_download_force_bootstrap_clears_failed_jobs_tracker(
     if os.path.exists(failed_jobs_file):
         with open(failed_jobs_file) as f:
             assert json.load(f) == {}, "forced bootstrap must clear the tracked counts"
+
+
+class _ManifestPlan(NamedTuple):
+    """One output manifest to feed the attribution loop.
+
+    ``order`` is the manifest's S3 LastModified rank — attribution sorts by it, so it is what
+    decides which job/task owns a path emitted by more than one manifest. It is deliberately
+    independent of list position so tests can shuffle the download order.
+    """
+
+    order: int
+    job_id: str
+    task_id: str
+    paths: list[str]
+
+
+def _run_manifest_plan(deadline_mock, checkpoint_dir, plans, downloader=None):
+    """Runs `queue sync-output` over an arbitrary set of per-task output manifests.
+
+    Generalizes the two-job harness: any number of jobs, each with any number of tasks and
+    paths, with explicit manifest timestamps. Returns (result, downloaded_paths).
+    """
+    from deadline.job_attachments.asset_manifests.v2023_03_03.asset_manifest import (
+        AssetManifest,
+        ManifestPath,
+    )
+    from deadline.job_attachments.asset_manifests import HashAlgorithm
+
+    job_ids = list(dict.fromkeys(plan.job_id for plan in plans))
+    tasks_by_job: dict[str, list[str]] = {}
+    for plan in plans:
+        tasks_by_job.setdefault(plan.job_id, [])
+        if plan.task_id not in tasks_by_job[plan.job_id]:
+            tasks_by_job[plan.job_id].append(plan.task_id)
+
+    mock_jobs = create_fake_job_list(len(job_ids))
+    for i, (job, job_id) in enumerate(zip(mock_jobs, job_ids)):
+        job["name"] = f"Job {i}"
+        job["jobId"] = job_id
+        job["taskRunStatus"] = "SUCCEEDED"
+        job["taskRunStatusCounts"] = {"SUCCEEDED": len(tasks_by_job[job_id]), "READY": 0}
+        job["attachments"] = {
+            "manifests": [
+                {"rootPath": "/", "rootPathFormat": "posix", "outputRelativeDirectories": ["."]}
+            ],
+            "fileSystem": "COPIED",
+        }
+        job["endedAt"] = datetime.fromisoformat(ISO_FREEZE_TIME)
+
+    deadline_mock.search_jobs = mock_search_jobs_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+    deadline_mock.get_job = mock_get_job_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+    deadline_mock.list_sessions.return_value = {
+        "sessions": [
+            {
+                "sessionId": MOCK_SESSION_ID,
+                "fleetId": MOCK_FLEET_ID,
+                "workerId": MOCK_WORKER_ID,
+                "startedAt": datetime.fromisoformat("2025-08-06T00:15:45.712000+00:00"),
+                "endedAt": datetime.fromisoformat("2025-08-06T00:20:59.992000+00:00"),
+                "lifecycleStatus": "ENDED",
+            }
+        ]
+    }
+    deadline_mock.list_session_actions.side_effect = lambda **kwargs: {
+        "sessionActions": [
+            {
+                "sessionActionId": f"sessionaction-0123456789abcdefabcdefabcdefabcd-{i}",
+                "status": "SUCCEEDED",
+                "startedAt": "2025-08-06T00:20:58.454000+00:00",
+                "endedAt": "2025-08-06T00:20:59.992000+00:00",
+                "progressPercent": 100.0,
+                "definition": {"taskRun": {"taskId": task_id, "stepId": _STEP_ID}},
+                "manifests": [{"outputManifestPath": f"{task_id}/manifest"}],
+            }
+            for i, task_id in enumerate(tasks_by_job[kwargs.get("jobId")])
+        ]
+    }
+
+    # The manifest list is passed in the caller's (possibly shuffled) order — attribution must
+    # derive ordering from the timestamps, not from list position.
+    # Anchored before the frozen "now" so no manifest looks like it was written in the future,
+    # which the checkpoint advance would reject.
+    base = datetime.fromisoformat(ISO_FREEZE_TIME_MINUS_5MIN)
+    downloaded_manifests = [
+        (
+            base + timedelta(minutes=plan.order),
+            AssetManifest(
+                hash_alg=HashAlgorithm.XXH128,
+                total_size=len(plan.paths),
+                paths=[ManifestPath(path=p, hash="h", size=1, mtime=1) for p in plan.paths],
+            ),
+        )
+        for plan in plans
+    ]
+    manifests_to_download = [
+        (None, plan.job_id, "/", f"prefix/{_STEP_ID}/{plan.task_id}/manifest") for plan in plans
+    ]
+
+    downloaded_paths: list[str] = []
+
+    def default_downloader(
+        files,
+        hash_algorithm,
+        queue,
+        session,
+        conflict,
+        on_downloading_files,
+        print_function_callback,
+    ):
+        for f in files:
+            downloaded_paths.append(f.path)
+            os.makedirs(os.path.dirname(f.path), exist_ok=True)
+            with open(f.path, "w") as fh:
+                fh.write("output")
+
+    runner = CliRunner()
+    with (
+        patch(
+            "deadline.client.cli._incremental_download._download_all_manifests_with_absolute_paths",
+            side_effect=lambda *a, **k: downloaded_manifests,
+        ),
+        patch(
+            "deadline.client.cli._incremental_download._get_manifests_to_download",
+            side_effect=lambda *a, **k: manifests_to_download,
+        ),
+        patch(
+            "deadline.client.cli._incremental_download._download_manifest_paths",
+            side_effect=downloader(downloaded_paths) if downloader else default_downloader,
+        ),
+        freeze_time(ISO_FREEZE_TIME),
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "queue",
+                "sync-output",
+                "--ignore-storage-profiles",
+                "--force-bootstrap",
+                "--bootstrap-lookback-minutes",
+                "120",
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--checkpoint-dir",
+                checkpoint_dir,
+            ],
+        )
+    return result, downloaded_paths
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
+)
+def test_incremental_output_download_shared_path_across_three_jobs_newest_wins(
+    fresh_deadline_config, deadline_mock, checkpoint_dir, tmp_path
+):
+    """One path in three jobs' manifests, list order shuffled relative to timestamps: the
+    newest manifest's job/task owns it and it is downloaded exactly once.
+
+    Two jobs was enough to catch a plain last-in-list bug; three with a shuffled order catches
+    a sort that is only accidentally right, and proves the winner is the newest rather than
+    just "not the first".
+    """
+    shared_path = str(tmp_path / "shared" / "beauty.exr")
+    job_ids = [
+        MOCK_JOB_ID,
+        "job-0123456789abcdefabcdefabcdefab98",
+        "job-0123456789abcdefabcdefabcdefab99",
+    ]
+    task_ids = [f"task-b1764261dff54214aace3932bde8ae7e-{i}" for i in range(3)]
+    # Newest (order=3) is deliberately in the middle of the list.
+    plans = [
+        _ManifestPlan(order=1, job_id=job_ids[0], task_id=task_ids[0], paths=[shared_path]),
+        _ManifestPlan(order=3, job_id=job_ids[2], task_id=task_ids[2], paths=[shared_path]),
+        _ManifestPlan(order=2, job_id=job_ids[1], task_id=task_ids[1], paths=[shared_path]),
+    ]
+
+    result, downloaded_paths = _run_manifest_plan(deadline_mock, checkpoint_dir, plans)
+
+    assert result.exit_code == 0, result.output
+    assert downloaded_paths.count(shared_path) == 1, downloaded_paths
+    assert "Downloaded files: 1" in result.output, result.output
+
+    with open(_ignore_profiles_status_file(checkpoint_dir)) as f:
+        status = json.load(f)
+
+    # The newest manifest's job owns the download; it is credited exactly once.
+    winner_tasks = status["jobs"][job_ids[2]]["tasks"]
+    assert winner_tasks[task_ids[2]]["downloaded_files"] == 1, winner_tasks
+    # The two losers still report their own status from the filesystem — the file IS on disk,
+    # so they are downloaded, not failed and not silently missing from the file.
+    for loser_index in (0, 1):
+        loser = status["jobs"][job_ids[loser_index]]
+        assert loser["download_status"] == "downloaded", loser
+        loser_task = loser["tasks"][task_ids[loser_index]]
+        assert loser_task["download_status"] == "downloaded", loser_task
+        assert loser_task["error_code"] is None, loser_task
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
+)
+def test_incremental_output_download_cross_job_then_within_job_overwrite(
+    fresh_deadline_config, deadline_mock, checkpoint_dir, tmp_path
+):
+    """Interleaved ownership transfer: job A → job B → back within job B under a newer task.
+
+    Two dedup rules apply to the same path in one run (cross-job transfer, then a within-job
+    retry). The final owner must be the newest task of the newest job, with no double download
+    and no stale credit left behind on either earlier owner.
+    """
+    shared_path = str(tmp_path / "shared" / "beauty.exr")
+    job_a, job_b = MOCK_JOB_ID, "job-0123456789abcdefabcdefabcdefab99"
+    task_a = "task-b1764261dff54214aace3932bde8ae7e-0"
+    task_b_old = "task-b1764261dff54214aace3932bde8ae7e-1"
+    task_b_new = "task-b1764261dff54214aace3932bde8ae7e-2"
+    plans = [
+        _ManifestPlan(order=1, job_id=job_a, task_id=task_a, paths=[shared_path]),
+        _ManifestPlan(order=2, job_id=job_b, task_id=task_b_old, paths=[shared_path]),
+        _ManifestPlan(order=3, job_id=job_b, task_id=task_b_new, paths=[shared_path]),
+    ]
+
+    result, downloaded_paths = _run_manifest_plan(deadline_mock, checkpoint_dir, plans)
+
+    assert result.exit_code == 0, result.output
+    assert downloaded_paths.count(shared_path) == 1, downloaded_paths
+    assert "Downloaded files: 1" in result.output, result.output
+
+    with open(_ignore_profiles_status_file(checkpoint_dir)) as f:
+        status = json.load(f)
+
+    b_tasks = status["jobs"][job_b]["tasks"]
+    assert b_tasks[task_b_new]["downloaded_files"] == 1, b_tasks
+    # The superseded task of the same job keeps no credit for the path it lost.
+    assert b_tasks.get(task_b_old, {}).get("downloaded_files", 0) == 0, b_tasks
+    # Job B downloaded the file once in total, not once per task that ever claimed it.
+    assert status["jobs"][job_b]["downloaded_files"] == 1, status["jobs"][job_b]
+    # Job A lost the path entirely but is still reported, from the filesystem.
+    assert status["jobs"][job_a]["download_status"] == "downloaded", status["jobs"][job_a]
+    assert status["jobs"][job_a]["tasks"][task_a]["download_status"] == "downloaded"
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
+)
+def test_incremental_output_download_case_differing_paths_treated_as_one(
+    fresh_deadline_config, deadline_mock, checkpoint_dir, tmp_path, monkeypatch
+):
+    """On a case-insensitive filesystem, two manifests whose paths differ only in case name the
+    same file and must be downloaded once.
+
+    A Windows submitter and a macOS submitter can spell the same output path differently. Two
+    threads writing that one file concurrently under OVERWRITE would interleave and corrupt it,
+    so attribution keys on os.path.normcase. This test forces case-insensitive normcase so the
+    behavior is exercised on POSIX CI too, not just on Windows and macOS.
+    """
+    monkeypatch.setattr(os.path, "normcase", lambda p: p.lower())
+
+    upper_path = str(tmp_path / "Shared" / "Beauty.EXR")
+    lower_path = str(tmp_path / "shared" / "beauty.exr")
+    job_ids = [MOCK_JOB_ID, "job-0123456789abcdefabcdefabcdefab99"]
+    task_ids = [f"task-b1764261dff54214aace3932bde8ae7e-{i}" for i in range(2)]
+    plans = [
+        _ManifestPlan(order=1, job_id=job_ids[0], task_id=task_ids[0], paths=[upper_path]),
+        _ManifestPlan(order=2, job_id=job_ids[1], task_id=task_ids[1], paths=[lower_path]),
+    ]
+
+    result, downloaded_paths = _run_manifest_plan(deadline_mock, checkpoint_dir, plans)
+
+    assert result.exit_code == 0, result.output
+    # One download total — the two spellings are one file, so only the newest owner fetches it.
+    assert len(downloaded_paths) == 1, downloaded_paths
+    assert downloaded_paths[0] == lower_path, downloaded_paths
+    assert "Downloaded files: 1" in result.output, result.output
+
+    with open(_ignore_profiles_status_file(checkpoint_dir)) as f:
+        status = json.load(f)
+    # The newest spelling's job owns the fetch and is credited for it.
+    winner = status["jobs"][job_ids[1]]
+    assert winner["downloaded_files"] == 1, winner
+    assert winner["tasks"][task_ids[1]]["downloaded_files"] == 1, winner
+    # The loser reports its own spelling from the filesystem, so its count is whatever the real
+    # filesystem says about "Beauty.EXR" — 1 on a case-insensitive volume, 0 on a case-sensitive
+    # one (normcase is patched, os.path.exists is not). Assert only what holds on both: it is
+    # present, blames nothing on the download, and never reports more than the one file it named.
+    loser = status["jobs"][job_ids[0]]
+    assert loser["download_status"] == "downloaded", loser
+    assert loser["error_code"] is None, loser
+    assert loser["downloaded_files"] <= 1, loser
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
+)
+def test_incremental_output_download_every_path_downloaded_exactly_once(
+    fresh_deadline_config, deadline_mock, checkpoint_dir, tmp_path
+):
+    """Over a tangle of overlapping manifests, every distinct path is downloaded exactly once
+    and the per-task counts sum to the job total.
+
+    Covers the whole attribution loop at once: shared paths across jobs, a within-job task
+    retry, partially-overlapping path sets, and a manifest whose paths are entirely claimed by
+    others. The properties asserted — no path fetched twice, none dropped, counts that add up —
+    are the ones the per-task progress bar depends on.
+    """
+
+    def p(name):
+        return str(tmp_path / "out" / name)
+
+    job_a, job_b = MOCK_JOB_ID, "job-0123456789abcdefabcdefabcdefab99"
+    tasks = [f"task-b1764261dff54214aace3932bde8ae7e-{i}" for i in range(4)]
+    plans = [
+        # Wholly superseded later by job B's task-2.
+        _ManifestPlan(order=1, job_id=job_a, task_id=tasks[0], paths=[p("a.exr"), p("b.exr")]),
+        # Retried under a new task of the same job; keeps c.exr, loses b.exr to task-2.
+        _ManifestPlan(order=2, job_id=job_a, task_id=tasks[1], paths=[p("b.exr"), p("c.exr")]),
+        # Cross-job: claims a.exr and b.exr from job A.
+        _ManifestPlan(order=4, job_id=job_b, task_id=tasks[2], paths=[p("a.exr"), p("b.exr")]),
+        # Unique paths, untouched by anyone else. Out of timestamp order in the list.
+        _ManifestPlan(order=3, job_id=job_b, task_id=tasks[3], paths=[p("d.exr"), p("e.exr")]),
+    ]
+    all_paths = {p(n) for n in ("a.exr", "b.exr", "c.exr", "d.exr", "e.exr")}
+
+    result, downloaded_paths = _run_manifest_plan(deadline_mock, checkpoint_dir, plans)
+
+    assert result.exit_code == 0, result.output
+    # Every distinct path fetched exactly once — none skipped, none fetched twice.
+    assert sorted(downloaded_paths) == sorted(all_paths), downloaded_paths
+    assert len(downloaded_paths) == len(set(downloaded_paths)), downloaded_paths
+    assert "Downloaded files: 5" in result.output, result.output
+    for path in all_paths:
+        assert os.path.exists(path), path
+
+    with open(_ignore_profiles_status_file(checkpoint_dir)) as f:
+        status = json.load(f)
+
+    # Per-job counts sum to the run total, with each path credited to exactly one job.
+    per_job_downloaded = {
+        job_id: status["jobs"][job_id]["downloaded_files"] for job_id in (job_a, job_b)
+    }
+    assert sum(per_job_downloaded.values()) == len(all_paths), per_job_downloaded
+    # And within each job, the per-task counts sum to that job's total.
+    for job_id in (job_a, job_b):
+        entry = status["jobs"][job_id]
+        assert (
+            sum(t["downloaded_files"] for t in entry["tasks"].values())
+            == (entry["downloaded_files"])
+        ), entry
+        assert entry["download_status"] == "downloaded", entry
+    # Job A kept only c.exr (task-1); its task-0 lost both paths to later manifests.
+    assert per_job_downloaded[job_a] == 1, per_job_downloaded
+    assert status["jobs"][job_a]["tasks"][tasks[1]]["downloaded_files"] == 1
+    assert tasks[0] not in status["jobs"][job_a]["tasks"], status["jobs"][job_a]["tasks"]
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
+)
+def test_incremental_output_download_status_file_shape_is_stable(
+    fresh_deadline_config, deadline_mock, checkpoint_dir, tmp_path
+):
+    """Contract test on the JSON the producer actually writes.
+
+    The Deadline Cloud monitor reads this file; the keys and value domains below are the
+    interface. Asserting them on a real end-to-end run (rather than on a hand-built dict passed
+    to the builder) is what catches a producer that stops populating a field the consumer
+    depends on, or a status string that drifts out of the agreed set.
+    """
+    job_ok, job_bad = MOCK_JOB_ID, "job-0123456789abcdefabcdefabcdefab99"
+    tasks = [f"task-b1764261dff54214aace3932bde8ae7e-{i}" for i in range(2)]
+    good_path = str(tmp_path / "out" / "good.exr")
+    bad_path = str(tmp_path / "out" / "bad.exr")
+    plans = [
+        _ManifestPlan(order=1, job_id=job_ok, task_id=tasks[0], paths=[good_path]),
+        _ManifestPlan(order=2, job_id=job_bad, task_id=tasks[1], paths=[bad_path]),
+    ]
+
+    def failing_downloader(downloaded_paths):
+        def download(
+            files,
+            hash_algorithm,
+            queue,
+            session,
+            conflict,
+            on_downloading_files,
+            print_function_callback,
+        ):
+            for f in files:
+                if f.path == bad_path:
+                    raise PermissionError(f"[Errno 13] Permission denied: '{f.path}'")
+                downloaded_paths.append(f.path)
+                os.makedirs(os.path.dirname(f.path), exist_ok=True)
+                with open(f.path, "w") as fh:
+                    fh.write("output")
+
+        return download
+
+    # One succeeding and one failing job, so both the success and failure shapes are covered.
+    result, _ = _run_manifest_plan(
+        deadline_mock, checkpoint_dir, plans, downloader=failing_downloader
+    )
+    assert result.exit_code == 0, result.output
+
+    with open(_ignore_profiles_status_file(checkpoint_dir)) as f:
+        status = json.load(f)
+
+    assert set(status) == {"schema_version", "sync_metadata", "jobs"}, status.keys()
+    assert status["schema_version"] == 1, status["schema_version"]
+
+    metadata = status["sync_metadata"]
+    assert set(metadata) == {
+        "queue_id",
+        "storage_profile_id",
+        "last_sync_completed_at",
+        "last_run_status",
+        "hostname",
+    }, metadata.keys()
+    assert metadata["queue_id"] == MOCK_QUEUE_ID
+    assert metadata["storage_profile_id"] is None  # --ignore-storage-profiles
+    assert metadata["last_run_status"] == "failed"  # one job failed
+    datetime.fromisoformat(metadata["last_sync_completed_at"])  # parseable ISO-8601
+    assert isinstance(metadata["hostname"], str) and metadata["hostname"]
+
+    job_keys = {
+        "download_status",
+        "total_files",
+        "downloaded_files",
+        "failed_files",
+        "last_updated",
+        "error_code",
+        "error_message",
+        "skip_reason",
+        "tasks",
+    }
+    task_keys = {
+        "download_status",
+        "total_files",
+        "downloaded_files",
+        "error_code",
+        "error_message",
+    }
+    assert set(status["jobs"]) == {job_ok, job_bad}, status["jobs"].keys()
+    for job_id, entry in status["jobs"].items():
+        assert set(entry) == job_keys, (job_id, entry.keys())
+        assert entry["download_status"] in (
+            "downloaded",
+            "failed",
+            "in_progress",
+            "skipped",
+        ), entry
+        for field in ("total_files", "downloaded_files", "failed_files"):
+            assert isinstance(entry[field], int) and entry[field] >= 0, (job_id, field, entry)
+        datetime.fromisoformat(entry["last_updated"])
+        for task_id, task in entry["tasks"].items():
+            assert set(task) == task_keys, (task_id, task.keys())
+            assert task["download_status"] in (
+                "downloaded",
+                "failed",
+                "farm_failed",
+            ), task
+
+    ok_entry = status["jobs"][job_ok]
+    assert ok_entry["download_status"] == "downloaded"
+    assert (ok_entry["error_code"], ok_entry["error_message"]) == (None, None), ok_entry
+    assert ok_entry["skip_reason"] is None, ok_entry
+
+    bad_entry = status["jobs"][job_bad]
+    assert bad_entry["download_status"] == "failed"
+    assert bad_entry["error_code"] == "PERMISSION_DENIED", bad_entry
+    assert isinstance(bad_entry["error_message"], str) and bad_entry["error_message"], bad_entry
+    assert bad_entry["tasks"][tasks[1]]["error_code"] == "PERMISSION_DENIED", bad_entry
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
+)
+def test_incremental_output_download_transient_getjob_error_keeps_job_in_tracker(
+    fresh_deadline_config, deadline_mock, checkpoint_dir
+):
+    """A throttling or auth error while re-fetching a tracked job leaves it in the tracker.
+
+    Only ResourceNotFoundException means the job is really gone. Treating a
+    ThrottlingException the same way would silently drop a job that still exists and still has
+    undownloaded output — a throttled control plane would quietly abandon work. The count must
+    also not advance on a failure to even fetch the job, or a few throttles would burn the
+    whole retry budget without a single download attempt.
+    """
+    from botocore.exceptions import ClientError
+
+    throttled_job_id = "job-0123456789abcdefabcdefabcdefab04"
+    unauthorized_job_id = "job-0123456789abcdefabcdefabcdefab05"
+    failed_jobs_file = os.path.join(
+        checkpoint_dir, f"{MOCK_QUEUE_ID}_ignore-storage-profiles_failed_jobs.json"
+    )
+    with open(failed_jobs_file, "w") as f:
+        json.dump({throttled_job_id: 1, unauthorized_job_id: 2}, f)
+
+    deadline_mock.search_jobs = mock_search_jobs_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, [])
+
+    errors = {
+        throttled_job_id: ClientError(
+            {"Error": {"Code": "ThrottlingException", "Message": "slow down"}}, "GetJob"
+        ),
+        unauthorized_job_id: ClientError(
+            {"Error": {"Code": "AccessDeniedException", "Message": "denied"}}, "GetJob"
+        ),
+    }
+
+    def fake_get_job(farmId, queueId, jobId):
+        raise errors[jobId]
+
+    deadline_mock.get_job.side_effect = fake_get_job
+
+    runner = CliRunner()
+    with freeze_time(ISO_FREEZE_TIME):
+        result = runner.invoke(
+            main,
+            [
+                "queue",
+                "sync-output",
+                "--ignore-storage-profiles",
+                "--bootstrap-lookback-minutes",
+                "120",
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--checkpoint-dir",
+                checkpoint_dir,
+            ],
+        )
+
+    # A control-plane error on the retry path must not fail the whole sync — the other jobs in
+    # the run still have output to fetch.
+    assert result.exit_code == 0, result.output
+    assert "Retrying 2 previously failed job(s)" in result.output, result.output
+
+    with open(failed_jobs_file) as f:
+        tracker_after = json.load(f)
+    # Both jobs are still tracked, at their original counts: a failure to fetch is not a
+    # download attempt, so it must neither drop the job nor consume a retry.
+    assert tracker_after == {throttled_job_id: 1, unauthorized_job_id: 2}, tracker_after
+
+
+class TestFailedJobsTrackerDurability:
+    """The tracker is a retry optimization, so its I/O failures must degrade, not propagate.
+
+    Everything downstream of it — the downloads, the checkpoint advance, the status file — has
+    to keep working when the checkpoint volume is read-only or the file was left corrupt by a
+    crash. These are the only two ways the tracker can take the whole sync down with it.
+    """
+
+    def test_save_to_unwritable_location_does_not_raise(self, tmp_path):
+        from deadline.client.cli._incremental_download import _FailedJobsTracker
+
+        # A regular file where the tracker expects a directory: os.makedirs raises
+        # NotADirectoryError, standing in for a read-only or full volume.
+        blocker = tmp_path / "not_a_dir"
+        blocker.write_text("")
+        tracker = _FailedJobsTracker(str(blocker / "failed_jobs.json"))
+        tracker.record_failures({"job-0123456789abcdefabcdefabcdefab04"}, lambda msg: None)
+
+        tracker.save()  # must not raise — a lost tracker only costs cross-run retry memory
+
+        # The in-memory count survives for the rest of this run even though it can't persist.
+        assert tracker.get_tracked_job_ids() == {"job-0123456789abcdefabcdefabcdefab04"}
+        # No half-written temp file left in the destination directory.
+        assert [p.name for p in tmp_path.iterdir()] == ["not_a_dir"], list(tmp_path.iterdir())
+
+    def test_corrupt_tracker_file_is_ignored_not_fatal(self, tmp_path):
+        from deadline.client.cli._incremental_download import _FailedJobsTracker
+
+        # Truncated mid-write by a crash or a full disk.
+        tracker_file = tmp_path / "failed_jobs.json"
+        tracker_file.write_text('{"job-0123456789abcdefabcdefabcdefab04": 2')
+
+        tracker = _FailedJobsTracker(str(tracker_file))
+
+        # Unreadable counts are dropped rather than crashing the sync. The cost is one extra
+        # retry pass for whatever was tracked, which is the safe direction to fail.
+        assert tracker.get_tracked_job_ids() == set()
+        tracker.record_failures({"job-0123456789abcdefabcdefabcdefab05"}, lambda msg: None)
+        tracker.save()
+        with open(tracker_file) as f:
+            assert json.load(f) == {"job-0123456789abcdefabcdefabcdefab05": 1}
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
+)
+def test_incremental_output_download_succeeded_task_with_no_output_is_not_a_failure(
+    fresh_deadline_config, deadline_mock, checkpoint_dir
+):
+    """A job whose only succeeded task produced no output manifest reports downloaded, 0 files.
+
+    A validation-only or save-elsewhere step legitimately emits nothing. Its session action is
+    filtered out before attribution, so the job reaches the status file with no task entries at
+    all. That must read as "nothing to download" — not as a failure, and not as a task stuck
+    in_progress that the monitor would show as a spinner forever.
+    """
+    mock_jobs = create_fake_job_list(1)
+    mock_jobs[0]["name"] = "Validation Only"
+    mock_jobs[0]["jobId"] = MOCK_JOB_ID
+    mock_jobs[0]["taskRunStatus"] = "SUCCEEDED"
+    mock_jobs[0]["taskRunStatusCounts"] = {"SUCCEEDED": 1, "READY": 0}
+    mock_jobs[0]["attachments"] = {
+        "manifests": [
+            {"rootPath": "/", "rootPathFormat": "posix", "outputRelativeDirectories": ["."]}
+        ],
+        "fileSystem": "COPIED",
+    }
+    mock_jobs[0]["endedAt"] = datetime.fromisoformat(ISO_FREEZE_TIME)
+
+    deadline_mock.search_jobs = mock_search_jobs_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+    deadline_mock.get_job = mock_get_job_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+    deadline_mock.list_sessions.return_value = {
+        "sessions": [
+            {
+                "sessionId": MOCK_SESSION_ID,
+                "fleetId": MOCK_FLEET_ID,
+                "workerId": MOCK_WORKER_ID,
+                "startedAt": datetime.fromisoformat("2025-08-06T00:15:45.712000+00:00"),
+                "endedAt": datetime.fromisoformat("2025-08-06T00:20:59.992000+00:00"),
+                "lifecycleStatus": "ENDED",
+            }
+        ]
+    }
+    # SUCCEEDED on the farm, but the session action carries no output manifest.
+    deadline_mock.list_session_actions.return_value = {
+        "sessionActions": [
+            {
+                "sessionActionId": MOCK_SESSION_ACTION_ID_1,
+                "status": "SUCCEEDED",
+                "startedAt": "2025-08-06T00:20:58.454000+00:00",
+                "endedAt": "2025-08-06T00:20:59.992000+00:00",
+                "progressPercent": 100.0,
+                "definition": {
+                    "taskRun": {
+                        "taskId": "task-b1764261dff54214aace3932bde8ae7e-0",
+                        "stepId": _STEP_ID,
+                    }
+                },
+                "manifests": [{}],
+            }
+        ]
+    }
+
+    runner = CliRunner()
+    with freeze_time(ISO_FREEZE_TIME):
+        result = runner.invoke(
+            main,
+            [
+                "queue",
+                "sync-output",
+                "--ignore-storage-profiles",
+                "--force-bootstrap",
+                "--bootstrap-lookback-minutes",
+                "120",
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--checkpoint-dir",
+                checkpoint_dir,
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "ran 1 / 1 session actions with no output" in result.output, result.output
+    assert "Downloaded files: 0" in result.output, result.output
+
+    with open(_ignore_profiles_status_file(checkpoint_dir)) as f:
+        status = json.load(f)
+
+    entry = status["jobs"][MOCK_JOB_ID]
+    assert entry["download_status"] == "downloaded", entry
+    assert (entry["total_files"], entry["downloaded_files"], entry["failed_files"]) == (0, 0, 0), (
+        entry
+    )
+    assert entry["error_code"] is None, entry
+    # A succeeded-with-no-output task is deliberately absent rather than recorded as
+    # farm_failed: nothing failed, so there is no per-task download row to show.
+    assert entry["tasks"] == {}, entry
+    # And the whole run is a success — an empty download is not an error.
+    assert status["sync_metadata"]["last_run_status"] == "success", status["sync_metadata"]
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
+)
+def test_incremental_output_download_mixed_output_and_no_output_steps(
+    fresh_deadline_config, deadline_mock, checkpoint_dir, tmp_path
+):
+    """A job with one output-producing task and one output-free task records only the former.
+
+    The per-task numerator must count tasks that actually had something to download, not every
+    SUCCEEDED task on the farm — otherwise a job with a validation step permanently reads as
+    "1 of 2 tasks downloaded" and looks stuck to the artist.
+    """
+    from deadline.job_attachments.asset_manifests.v2023_03_03.asset_manifest import (
+        AssetManifest,
+        ManifestPath,
+    )
+    from deadline.job_attachments.asset_manifests import HashAlgorithm
+
+    producing_task = "task-b1764261dff54214aace3932bde8ae7e-0"
+    silent_task = "task-b1764261dff54214aace3932bde8ae7e-1"
+    output_path = str(tmp_path / "out" / "beauty.exr")
+
+    mock_jobs = create_fake_job_list(1)
+    mock_jobs[0]["name"] = "Mixed Job"
+    mock_jobs[0]["jobId"] = MOCK_JOB_ID
+    mock_jobs[0]["taskRunStatus"] = "SUCCEEDED"
+    mock_jobs[0]["taskRunStatusCounts"] = {"SUCCEEDED": 2, "READY": 0}
+    mock_jobs[0]["attachments"] = {
+        "manifests": [
+            {"rootPath": "/", "rootPathFormat": "posix", "outputRelativeDirectories": ["."]}
+        ],
+        "fileSystem": "COPIED",
+    }
+    mock_jobs[0]["endedAt"] = datetime.fromisoformat(ISO_FREEZE_TIME)
+
+    deadline_mock.search_jobs = mock_search_jobs_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+    deadline_mock.get_job = mock_get_job_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+    deadline_mock.list_sessions.return_value = {
+        "sessions": [
+            {
+                "sessionId": MOCK_SESSION_ID,
+                "fleetId": MOCK_FLEET_ID,
+                "workerId": MOCK_WORKER_ID,
+                "startedAt": datetime.fromisoformat("2025-08-06T00:15:45.712000+00:00"),
+                "endedAt": datetime.fromisoformat("2025-08-06T00:20:59.992000+00:00"),
+                "lifecycleStatus": "ENDED",
+            }
+        ]
+    }
+    deadline_mock.list_session_actions.return_value = {
+        "sessionActions": [
+            {
+                "sessionActionId": MOCK_SESSION_ACTION_ID_1,
+                "status": "SUCCEEDED",
+                "startedAt": "2025-08-06T00:20:58.454000+00:00",
+                "endedAt": "2025-08-06T00:20:59.992000+00:00",
+                "progressPercent": 100.0,
+                "definition": {"taskRun": {"taskId": producing_task, "stepId": _STEP_ID}},
+                "manifests": [{"outputManifestPath": f"{producing_task}/manifest"}],
+            },
+            {
+                "sessionActionId": MOCK_SESSION_ACTION_ID_2,
+                "status": "SUCCEEDED",
+                "startedAt": "2025-08-06T00:20:58.454000+00:00",
+                "endedAt": "2025-08-06T00:20:59.992000+00:00",
+                "progressPercent": 100.0,
+                "definition": {"taskRun": {"taskId": silent_task, "stepId": _STEP_ID}},
+                "manifests": [{}],
+            },
+        ]
+    }
+
+    downloaded_manifests = [
+        (
+            datetime.fromisoformat(ISO_FREEZE_TIME),
+            AssetManifest(
+                hash_alg=HashAlgorithm.XXH128,
+                total_size=1,
+                paths=[ManifestPath(path=output_path, hash="h", size=1, mtime=1)],
+            ),
+        )
+    ]
+    manifests_to_download = [
+        (None, MOCK_JOB_ID, "/", f"prefix/{_STEP_ID}/{producing_task}/manifest")
+    ]
+
+    downloaded_paths: list[str] = []
+
+    def fake_download_manifest_paths(
+        files,
+        hash_algorithm,
+        queue,
+        session,
+        conflict,
+        on_downloading_files,
+        print_function_callback,
+    ):
+        for f in files:
+            downloaded_paths.append(f.path)
+            os.makedirs(os.path.dirname(f.path), exist_ok=True)
+            with open(f.path, "w") as fh:
+                fh.write("output")
+
+    runner = CliRunner()
+    with (
+        patch(
+            "deadline.client.cli._incremental_download._download_all_manifests_with_absolute_paths",
+            side_effect=lambda *a, **k: downloaded_manifests,
+        ),
+        patch(
+            "deadline.client.cli._incremental_download._get_manifests_to_download",
+            side_effect=lambda *a, **k: manifests_to_download,
+        ),
+        patch(
+            "deadline.client.cli._incremental_download._download_manifest_paths",
+            side_effect=fake_download_manifest_paths,
+        ),
+        freeze_time(ISO_FREEZE_TIME),
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "queue",
+                "sync-output",
+                "--ignore-storage-profiles",
+                "--force-bootstrap",
+                "--bootstrap-lookback-minutes",
+                "120",
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--checkpoint-dir",
+                checkpoint_dir,
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert downloaded_paths == [output_path], downloaded_paths
+    # The output-free session action is filtered, not downloaded, and the run says so.
+    assert "ran 1 / 2 session actions with no output" in result.output, result.output
+
+    with open(_ignore_profiles_status_file(checkpoint_dir)) as f:
+        status = json.load(f)
+
+    entry = status["jobs"][MOCK_JOB_ID]
+    assert entry["download_status"] == "downloaded", entry
+    assert (entry["total_files"], entry["downloaded_files"]) == (1, 1), entry
+    # Only the producing task gets a row — the silent task is not a download failure and not a
+    # phantom 0-of-0 entry, even though the farm counted 2 SUCCEEDED tasks.
+    assert set(entry["tasks"]) == {producing_task}, entry["tasks"]
+    assert entry["tasks"][producing_task]["downloaded_files"] == 1, entry["tasks"]
+    assert entry["tasks"][producing_task]["error_code"] is None, entry["tasks"]

--- a/test/unit/deadline_client/cli/test_cli_region_per_command.py
+++ b/test/unit/deadline_client/cli/test_cli_region_per_command.py
@@ -521,7 +521,7 @@ def test_cli_queue_sync_output_region(fresh_deadline_config, tmp_path):
         patch.object(
             queue_group,
             "_incremental_output_download",
-            return_value=(MagicMock(), MagicMock(), {}, {}, {}),
+            return_value=(MagicMock(), MagicMock(), {}, {}, {}, {}),
         ),
     ):
         runner = CliRunner()


### PR DESCRIPTION
> **Note:** This PR is stacked on top of [#PR2](https://github.com/aws-deadline/deadline-cloud/pull/1223) and [#PR3](https://github.com/aws-deadline/deadline-cloud/pull/1258). Please review/merge those first — the base branch here is `download-status-per-task`, so only the last commit belongs to this PR.

### What was the problem/requirement? (What/Why)

The download status file recorded a task as `failed` only when a *download* errored, and left tasks that **failed on the farm** (the render itself failed, producing no output) entirely absent from the file. With no stable file entry, the Deadline Cloud Monitor had to infer those failures from live run-status data — which flips back to a non-failed state when a task is requeued, so the failure signal was lost. A farm failure and a download failure also have different causes and fixes, but the artist couldn't tell them apart.

### What was the solution? (How)

Detect `FAILED` `taskRun` session actions while retrieving sessions and record their task IDs as a distinct `farm_failed` status in the status file:

- `_retrieve_session_actions_for_session` now also collects the task IDs of `FAILED` taskRun actions into an output set. These are never added to the manifest-download list (they have no output) — only recorded for reporting.
- `_get_job_sessions` returns `(job_sessions, farm_failed_task_ids)`; the per-thread collection merges under a lock since it mutates a shared dict/set across worker threads.
- After per-task download results are built, farm-failed tasks are written as `farm_failed` entries (`0` files, no error code), skipping any task that already has a real download result this run.
- `_build_status_file_content` honors an explicit `download_status` (e.g. `farm_failed`) and otherwise derives it from the download error, as before.

`farm_failed` is deliberately distinct from `failed` (a download error) and from a succeeded-but-no-output task (which stays absent from the dict).

### What is the impact of this change?

Additive, backwards-compatible change to the status file within schema v1: adds a new `download_status` value `farm_failed` on per-task entries. The sole consumer (Deadline Cloud Monitor) already reads this value under `schema_version === 1`. No CLI or Python API signature changes to public contracts. Stacked on top of the per-task PR (`download-status-per-task`).

### How was this change tested?

- Have you run the unit tests? 

Yes. Added unit tests in `test_cli_download_status_file.py` covering farm-failed recording, the distinction from download failures, and the skip-if-real-result-exists path. `hatch run test`, `hatch run lint`, and `hatch run fmt` all pass.

### Was this change documented?

- Are relevant docstrings in the code base updated?

Docstrings for `_retrieve_session_actions_for_session` and `_get_job_sessions` describe the new farm-failed output.

- Has the README.md been updated? If you modified CLI arguments, for instance.

Not needed; no CLI argument changes.

### Does this PR introduce new dependencies?

No.

### Is this a breaking change?

No. It adds a new additive `download_status` value within the existing schema v1; no public contract is modified in a backwards-incompatible way.

### Does this change impact security?

No — it reads existing session-action metadata and writes to the same status file created by the existing feature; no new files, directories, or permission surfaces.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
