### PR TITLE
fix: constrain MCP dependency to v1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ gui = [
   "PySide6-essentials >= 6.6,< 6.11",
 ]
 mcp = [
-  "mcp >= 1.13.0",
+  "mcp >= 1.13.0, < 2",
 ]
 
 [project.scripts]

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -6,4 +6,4 @@ mkdocs-click
 # griffe version will match whichever griffelib mkdocstrings uses
 griffe
 # MCP (Model Context Protocol) library for MCP CLI command
-mcp >= 1.13.0; python_version >= '3.10'
+mcp >= 1.13.0, < 2; python_version >= '3.10'

--- a/requirements-integ-testing.txt
+++ b/requirements-integ-testing.txt
@@ -1,4 +1,4 @@
 deadline-cloud-test-fixtures
 # MCP (Model Context Protocol) library for MCP server integration tests
-mcp >= 1.13.0
+mcp >= 1.13.0, < 2
 pytest-asyncio == 1.*

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -15,7 +15,7 @@ moto[server] == 5.*
 jsondiff == 2.*
 pyinstrument == 5.*
 # MCP (Model Context Protocol) library for MCP unit tests
-mcp >= 1.13.0; python_version >= '3.10'
+mcp >= 1.13.0, < 2; python_version >= '3.10'
 # OpenJD model library for job template parsing in mock backend
 openjd-model >= 0.11.0
 


### PR DESCRIPTION
Fixes: N/A (no GitHub issue filed)

### What was the problem/requirement? (What/Why)

The [MCP integration test workflow](https://github.com/aws-deadline/deadline-cloud/actions/runs/30378862245) began resolving MCP 2.0.0 because the dependency only specified a minimum version (`mcp >= 1.13.0`). MCP 2.0.0 no longer provides `mcp.server.fastmcp`, which the Deadline Cloud MCP server currently imports, so test collection failed with:

```text
ModuleNotFoundError: No module named 'mcp.server.fastmcp'
```

An earlier run of the same commit passed with MCP 1.28.1. This confirmed that the failure was caused by the newly released incompatible major version rather than a source-code regression.

### What was the solution? (How)

Constrain MCP to its compatible v1 release line with `mcp >= 1.13.0, < 2` in every installation path:

- The `mcp` optional dependency in `pyproject.toml`
- Integration test requirements
- Unit test requirements
- Documentation requirements

Migration to the MCP v2 API can be handled separately.

### What is the impact of this change?

Fresh installations now resolve the latest compatible MCP v1 release instead of the incompatible v2 release. This restores MCP server imports and integration test collection without changing any CLI behavior or public Deadline Cloud APIs.

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests? **Yes.** `hatch run test` passed with 3,059 tests passed and 21 skipped. The focused MCP unit and CLI suite also passed all 54 tests.
- Have you run the integration tests? **Collection only.** `hatch run integ:test --collect-only test/integ/deadline_mcp/test_mcp_server_integration.py` resolved MCP 1.29.0 and collected all six tests successfully. The tests were not executed against live AWS resources.

Additional verification:

- `hatch run fmt`
- `hatch run lint`
- `hatch build`
- `hatch run docs:build`

### Was this change documented?

- Are relevant docstrings in the code base updated? **Not applicable.** No code behavior or API documentation changed.
- Has the README.md been updated? **No.** The dependency declarations document the supported MCP version range, and there are no CLI changes.

### Does this PR introduce new dependencies?

This library is designed to be integrated into third-party applications that have bespoke and customized deployment environments. Adding dependencies will increase the chance of library version conflicts and incompatibilities. Please evaluate the addition of new dependencies. See the [Dependencies](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies) section of DEVELOPMENT.md for more details.

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?

No. This change constrains an existing optional dependency to the major version currently supported by the implementation. It does not modify a public contract.

A breaking change is one that modifies a public contract in a way that is not backwards compatible. See the
[Public Contracts](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#public-contracts) section
of the DEVELOPMENT.md for more information on the public contracts.

### Does this change impact security?

No.

- Does the change need to be threat modeled? For example, does it create or modify files/directories that must only be readable by the process owner?
    - If so, then please label this pull request with the "security" label. We'll work with you to analyze the threats.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
