### PR TITLE
fix: route deadline: pre-GUI hook properties to shared values

### DIFF
--- a/src/deadline/client/ui/pre_gui_hooks.py
+++ b/src/deadline/client/ui/pre_gui_hooks.py
@@ -243,14 +243,21 @@ def apply_pre_gui_output(
         # CLI --parameter values take precedence over hook values.
         if param_name in cli_provided_param_names:
             continue
-        if param_name in template_param_names:
+        if param_name.startswith("deadline:"):
+            # Shared job property (priority, initialStatus, maxRetriesPerTask, …). These are
+            # NOT template parameters even though read_job_bundle_parameters keeps them in the
+            # parameters list — the dialog spinner and CreateJob read them from the shared
+            # values dict, so route them there. Checking this before the template-name test
+            # is what lets a pre-GUI hook actually override e.g. deadline:priority.
+            initial_shared_parameter_values[param_name] = param_value
+        elif param_name in template_param_names:
             # Job template parameter — update initial_settings.parameters in-place
             for p in template_parameters:
                 if p["name"] == param_name:
                     p["value"] = param_value
                     break
         else:
-            # Shared job property (deadline: keys, queue parameters, etc.)
+            # Other shared job property (queue parameters, etc.)
             initial_shared_parameter_values[param_name] = param_value
     if "name" in pre_gui_output:
         initial_settings.name = pre_gui_output["name"]

--- a/test/ui/test_bundle_gui_submit_hooks.py
+++ b/test/ui/test_bundle_gui_submit_hooks.py
@@ -4,8 +4,9 @@
 
 These launch the real GUI submitter as a subprocess and drive it through the OS
 accessibility tree (xa11y), against the in-process mock Deadline backend. A preGUI hook
-runs before the dialog opens and pre-fills the job name; the tests assert on the rendered
-``Name`` field to confirm the hook ran (or, when hooks are disabled, that it did not).
+runs before the dialog opens; the tests assert on the rendered ``Name`` field to confirm
+the hook ran (or, when hooks are disabled, that it did not), and that a hook-provided
+``deadline:priority`` reaches both the Priority spinner and the final CreateJob.
 """
 
 from __future__ import annotations
@@ -20,6 +21,14 @@ from helpers import SAMPLE_TEMPLATE, SubmitterDialog, cli_set
 _PRE_GUI_HOOKS_YAML = "version: '1.0'\npreGUI:\n  - command: python3\n    args: [prefill.py]\n"
 _PRE_GUI_SCRIPT = 'import json; print(json.dumps({"name": "PREGUI_RAN"}))\n'
 
+# A preGUI hook that overrides the deadline:priority job property before the dialog opens.
+_PRE_GUI_PRIORITY_HOOKS_YAML = (
+    "version: '1.0'\npreGUI:\n  - command: python3\n    args: [set_priority.py]\n"
+)
+_PRE_GUI_PRIORITY_SCRIPT = (
+    'import json; print(json.dumps({"parameters": {"deadline:priority": 88}}))\n'
+)
+
 
 @pytest.fixture
 def hook_bundle_dir(tmp_path) -> str:
@@ -29,6 +38,28 @@ def hook_bundle_dir(tmp_path) -> str:
     (d / "template.json").write_text(json.dumps(SAMPLE_TEMPLATE))
     (d / "hooks.yaml").write_text(_PRE_GUI_HOOKS_YAML)
     (d / "prefill.py").write_text(_PRE_GUI_SCRIPT)
+    return str(d)
+
+
+@pytest.fixture
+def priority_hook_bundle_dir(tmp_path) -> str:
+    """A job bundle whose preGUI hook overrides ``deadline:priority``.
+
+    The bundle carries a ``parameter_values`` entry for ``deadline:priority`` so that
+    ``read_job_bundle_parameters`` keeps it in ``initial_settings.parameters`` (making it a
+    "template-param name"). This is what reproduces the regression: without it, the old code's
+    fall-through ``else`` branch already routed the hook value to the shared values correctly.
+    With it, the old code wrote the hook value into the unread list entry while the stale
+    bundle value (50) drove the spinner + CreateJob.
+    """
+    d = tmp_path / "bundle"
+    d.mkdir()
+    (d / "template.json").write_text(json.dumps(SAMPLE_TEMPLATE))
+    (d / "parameter_values.json").write_text(
+        json.dumps({"parameterValues": [{"name": "deadline:priority", "value": 50}]})
+    )
+    (d / "hooks.yaml").write_text(_PRE_GUI_PRIORITY_HOOKS_YAML)
+    (d / "set_priority.py").write_text(_PRE_GUI_PRIORITY_SCRIPT)
     return str(d)
 
 
@@ -54,3 +85,32 @@ def test_pre_gui_hook_not_run_when_disabled(hook_bundle_dir, submitter_env):
     with SubmitterDialog.open(hook_bundle_dir, env=env) as app:
         app.wait_farm_resolved()
         assert app.job_name == SAMPLE_TEMPLATE["name"]  # "Test Render Job", unchanged
+
+
+def test_pre_gui_hook_overrides_deadline_priority(
+    priority_hook_bundle_dir, submitter_env, deadline_env
+):
+    """Regression: a preGUI hook returning ``deadline:priority`` reaches both the visible
+    Priority spinner and the final CreateJob, even though the bundle carries a stale value
+    of 50 in its ``parameter_values``.
+
+    Before the fix, the hook value landed in the unread ``initial_settings.parameters`` list
+    entry while the stale 50 drove the spinner and CreateJob, so the job came out priority 50.
+    """
+    backend, _ = deadline_env  # same backend instance the submitter_env fixture seeds
+    env = submitter_env
+    cli_set(env, "settings.allow_bundle_hooks", "true")
+    cli_set(env, "settings.auto_accept", "true")
+
+    with SubmitterDialog.open(priority_hook_bundle_dir, env=env) as app:
+        app.wait_farm_resolved()
+        # The visible spinner reflects the hook's 88, not the bundle's stale 50.
+        assert any(
+            (getattr(sb, "value", "") or "") == "88" for sb in app.elements_by_role("spin_button")
+        ), "Priority spinner did not show the hook-provided value 88"
+        app.submit_and_ok()
+
+    # ...and that value flows all the way to CreateJob, not the bundle's stale 50.
+    assert backend.call_counts.get("CreateJob", 0) == 1, backend.call_counts
+    priorities = [job["priority"] for job in backend.jobs.values()]
+    assert priorities == [88], f"CreateJob priority was not the hook value 88: {priorities}"

--- a/test/unit/deadline_client/ui/test_pregui_hooks.py
+++ b/test/unit/deadline_client/ui/test_pregui_hooks.py
@@ -489,6 +489,38 @@ class TestApplyPreGuiOutput:
         apply_pre_gui_output({"parameters": {"deadline:priority": 90}}, settings, shared)
         assert shared["deadline:priority"] == 90
 
+    def test_deadline_property_in_parameters_list_still_routes_to_shared(self):
+        """Regression: read_job_bundle_parameters keeps ``deadline:*`` values as entries in the
+        parameters list, so ``deadline:priority`` IS a template-param name. It must still be
+        treated as a shared job property (routed to the shared values the spinner + CreateJob
+        read), not written into the unread settings.parameters entry. The dialog seeds a stale
+        50 from the bundle; the hook's 88 must overwrite it."""
+        settings = self._settings(
+            parameters=[{"name": "deadline:priority", "type": "INT", "value": 50}]
+        )
+        shared: dict = {"deadline:priority": 50}  # seeded from the bundle by the submitter
+        apply_pre_gui_output({"parameters": {"deadline:priority": 88}}, settings, shared)
+        # The value the spinner + CreateJob read is overridden to 88...
+        assert shared["deadline:priority"] == 88
+        # ...and the settings.parameters entry is left untouched (nothing reads it for priority).
+        prio = next(p for p in settings.parameters if p["name"] == "deadline:priority")
+        assert prio["value"] == 50
+
+    def test_cli_deadline_property_still_wins_over_hook(self):
+        """CLI --parameter for a deadline: property beats the hook value (the CLI check runs
+        before the deadline: routing)."""
+        settings = self._settings(
+            parameters=[{"name": "deadline:priority", "type": "INT", "value": 50}]
+        )
+        shared: dict = {"deadline:priority": 75}  # CLI-provided value already in shared
+        apply_pre_gui_output(
+            {"parameters": {"deadline:priority": 88}},
+            settings,
+            shared,
+            cli_provided_param_names={"deadline:priority"},
+        )
+        assert shared["deadline:priority"] == 75  # CLI wins, hook's 88 ignored
+
     def test_cli_provided_name_blocks_hook_override(self):
         settings = self._settings(
             parameters=[{"name": "Foo", "type": "STRING", "value": "cli_value"}]


### PR DESCRIPTION
Fixes: *N/A — follow-up to #1255 (the pre-GUI hook feature), caught after it merged.*

### What was the problem/requirement? (What/Why)

A pre-GUI hook that returns a `deadline:`-prefixed job property — e.g.
`{"parameters": {"deadline:priority": 88}}` — was **silently dropped** on the
job-bundle-submitter path (`deadline bundle gui-submit`, used by the DCC submitters).
`name` / `description` and ordinary template parameters applied correctly; only
`deadline:*` job properties (priority, initialStatus, maxRetriesPerTask,
maxFailedTasksCount) were lost.

Why it happened: `read_job_bundle_parameters` keeps `deadline:*` values as entries in the
parameters list (`job_bundle/parameters.py`, "Keep the other parameter values around …
`deadline:*`"). So `deadline:priority` **is** in `template_param_names`, and
`apply_pre_gui_output` routed the hook's value into `initial_settings.parameters` — which
the GUI never reads for priority (`openjd_parameters_widget.py` skips any name containing
`:`) — while the stale bundle value stayed in `initial_shared_parameter_values`, which is
what the dialog spinner and the final CreateJob actually use.

### What was the solution? (How)

In `apply_pre_gui_output`, route `deadline:`-prefixed names to
`initial_shared_parameter_values` **before** the template-name check — they are shared job
properties, not template parameters. The `cli_provided_param_names` check stays ahead of
it, so CLI `--parameter` still wins.

### What is the impact of this change?

Fixes `priority` / `initialStatus` / `maxRetriesPerTask` / `maxFailedTasksCount` overrides
via pre-GUI for **all** DCC submitters at once. DCC settings without a `.parameters` list
were already unaffected. No public API or CLI contract changes.

### How was this change tested?

See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests? **Yes.** Added unit regression tests in
  `test/unit/deadline_client/ui/test_pregui_hooks.py`: a `deadline:priority` present in the
  parameters list (as `read_job_bundle_parameters` leaves it) with a stale seeded shared
  value is overridden by the hook and lands in the shared values; CLI `--parameter` still
  wins over the hook for a `deadline:` property; the non-`deadline:` template-parameter
  branch is unchanged.
- Have you run the integration tests? **Yes (UI/xa11y).** Added an end-to-end xa11y test in
  `test/ui/test_bundle_gui_submit_hooks.py` that drives the real GUI: a pre-GUI hook returns
  `deadline:priority` 88 over a bundle whose `parameter_values` seed a stale 50, and asserts
  the value reaches both the visible Priority spinner and the final CreateJob. Also verified
  manually end-to-end on an After Effects test box before the fix (hook returned 88, spinner
  stayed 50, created job came out `priority: 50`) and after (created job `priority: 88`).

### Was this change documented?

- Are relevant docstrings in the code base updated? **Yes** — the `apply_pre_gui_output`
  docstring/comments now explain the `deadline:*` routing.
- Has the README.md been updated? **N/A** — no CLI arguments or user-facing options changed.

### Does this PR introduce new dependencies?

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?

No. This is a bug fix that restores intended behavior; it does not modify any public
contract in a backwards-incompatible way.

### Does this change impact security?

- Does the change need to be threat modeled? **No** — it does not create or modify
  files/directories or change any trust boundary; it only routes an already-executed hook's
  output to the correct in-memory dict.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
