### PR TITLE
feat: write status file pointer at default path when --ignore-storage-profiles uses a custom --checkpoint-dir

### DIFF
--- a/src/deadline/client/cli/_download_status_file.py
+++ b/src/deadline/client/cli/_download_status_file.py
@@ -13,6 +13,7 @@ from contextlib import contextmanager
 from datetime import datetime, timezone
 from typing import Any, Callable, Generator, Optional
 
+from ..config.config_file import DEFAULT_QUEUE_INCREMENTAL_DOWNLOAD_DIR
 from ._incremental_download import CategorizedJobIds
 
 logger = logging.getLogger(__name__)
@@ -410,7 +411,7 @@ def _get_status_file_paths(
     Determines all paths where the status file should be written.
 
     With storage profile: writes to {each_file_system_location}/.deadline/{queue_id}_download_status.json
-    Without storage profile: writes to ~/.deadline/incremental_download/{queue_id}_ignore-storage-profiles_download_status.json
+    Without storage profile: writes to {checkpoint_dir}/{queue_id}_ignore-storage-profiles_download_status.json
     """
     if local_storage_profile_id and local_storage_profile:
         paths = []
@@ -430,6 +431,98 @@ def _get_status_file_paths(
             checkpoint_dir, f"{queue_id}_ignore-storage-profiles_download_status.json"
         )
         return [status_file_path]
+
+
+def _get_default_pointer_path(queue_id: str) -> str:
+    """Returns the well-known default path where the FE always looks for the status file."""
+    default_dir = os.path.expanduser(DEFAULT_QUEUE_INCREMENTAL_DOWNLOAD_DIR)
+    return os.path.join(default_dir, f"{queue_id}_ignore-storage-profiles_download_status.json")
+
+
+def _write_pointer_if_needed(
+    queue_id: str,
+    checkpoint_dir: str,
+    actual_status_file_path: str,
+    print_function_callback: Callable[[Any], None] = lambda msg: None,
+) -> None:
+    """Writes a pointer file at the default well-known path when the actual status file
+    lives elsewhere (i.e. the user passed a custom --checkpoint-dir).
+
+    The FE always checks the default path. When the file there contains a
+    "status_file_path" key instead of full status data, the FE follows it to the
+    real file. This makes the actual status discoverable regardless of what
+    --checkpoint-dir the user chose, without changing the checkpoint format.
+
+    The pointer write is best-effort: a failure here logs a warning but does not
+    abort — the real status file was written successfully by the caller.
+    """
+    # Compare canonical (symlink-resolved) paths so a custom --checkpoint-dir that is a
+    # symlink or alias of the default dir is recognized as the default — otherwise we could
+    # write a pointer on top of the real status file and destroy the user's downloads.
+    default_dir = os.path.realpath(os.path.expanduser(DEFAULT_QUEUE_INCREMENTAL_DOWNLOAD_DIR))
+    resolved_checkpoint_dir = os.path.realpath(checkpoint_dir)
+    if resolved_checkpoint_dir == default_dir:
+        # Status file is already at the default location — no pointer needed.
+        return
+
+    pointer_path = _get_default_pointer_path(queue_id)
+    try:
+        # Take the same lock a real status-file write to this path would take. A concurrent
+        # sync of this queue that uses the *default* checkpoint dir writes real status data to
+        # this exact path under _status_file_lock; without holding it here, the pointer write
+        # would clobber that data (or vice-versa) — the last-writer-wins race the lock prevents.
+        # The lock also closes the has_real_data read → write TOCTOU window below.
+        with _status_file_lock(pointer_path):
+            # If the real status file and the pointer path resolve to the same physical file
+            # (e.g. the two dirs alias each other in a way the realpath dir check missed),
+            # writing the pointer would clobber the real data. The FE already finds it here — skip.
+            if (
+                os.path.exists(actual_status_file_path)
+                and os.path.exists(pointer_path)
+                and os.path.samefile(actual_status_file_path, pointer_path)
+            ):
+                return
+
+            # If the default path currently holds real status data (not already a pointer),
+            # overwriting it with the pointer intentionally discards that data. This file is a
+            # receipt, not durable history — per-task entries repopulate at the new location as
+            # jobs sync — and we deliberately do not copy it to a backup/history file. Failing
+            # closed (an old Monitor shows "-") beats leaving a stale status file that a Monitor
+            # would read as current. `superseded_path` records where the data was purely as a
+            # reference for the warning below, not as a recoverable location.
+            superseded_path: Optional[str] = None
+            if os.path.exists(pointer_path):
+                try:
+                    with open(pointer_path) as _f:
+                        existing = json.load(_f)
+                    has_real_data = "jobs" in existing
+                except Exception:
+                    # A corrupt or unreadable existing file only affects the warning below; let
+                    # the pointer overwrite it.
+                    has_real_data = False
+                if has_real_data:
+                    superseded_path = pointer_path
+                    warning = (
+                        f"Previous job history at {pointer_path} has been replaced by a pointer to "
+                        f"{actual_status_file_path}. Job statuses will repopulate in the Monitor as "
+                        f"future syncs run."
+                    )
+                    logger.warning(warning)
+                    print_function_callback(f"WARNING: {warning}")
+
+            pointer: dict[str, Any] = {
+                "schema_version": DOWNLOAD_STATUS_FILE_SCHEMA_VERSION,
+                "status_file_path": actual_status_file_path,
+            }
+            if superseded_path:
+                pointer["superseded_path"] = superseded_path
+            _atomic_write_json(pointer_path, pointer)
+    except Exception as e:
+        logger.warning(
+            f"Failed to write status file pointer at {pointer_path}: {e}. "
+            f"The status file was written to {actual_status_file_path} but the monitor "
+            f"may not be able to locate it automatically."
+        )
 
 
 def write_download_status_file(
@@ -467,6 +560,7 @@ def write_download_status_file(
         checkpoint_dir=checkpoint_dir,
     )
 
+    written_paths: list[str] = []
     for status_file_path in status_file_paths:
         try:
             with _status_file_lock(status_file_path):
@@ -484,9 +578,19 @@ def write_download_status_file(
                 )
 
                 _atomic_write_json(status_file_path, status_content)
+            written_paths.append(status_file_path)
             print_function_callback(f"Download status file saved: {status_file_path}")
         except Exception as e:
             logger.warning(f"Failed to write download status file to {status_file_path}: {e}")
             print_function_callback(
                 f"WARNING: Failed to write download status file to {status_file_path}: {e}"
             )
+
+    # When --ignore-storage-profiles is used, the FE has no API-derivable location for the
+    # status file. Write a pointer at the well-known default path so the FE can always find
+    # the real file even when the user passed a custom --checkpoint-dir. Only point at a file
+    # that was actually written — pointing the FE at a missing file is worse than no pointer.
+    if not local_storage_profile_id and written_paths:
+        _write_pointer_if_needed(
+            queue_id, checkpoint_dir, written_paths[0], print_function_callback
+        )

--- a/test/unit/deadline_client/cli/test_cli_download_status_file.py
+++ b/test/unit/deadline_client/cli/test_cli_download_status_file.py
@@ -7,7 +7,10 @@ Tests for the CLI download status file module.
 import json
 import os
 import time
+from contextlib import contextmanager
 from typing import Any, Optional
+
+import pytest
 
 from deadline.client.cli._download_status_file import (
     _atomic_write_json,
@@ -30,6 +33,21 @@ from ..shared_constants import MOCK_QUEUE_ID, MOCK_STORAGE_PROFILE_ID, MOCK_JOB_
 MOCK_JOB_ID_2 = "job-aaaabbbbccccddddeeeeffffaaaabbbb"
 MOCK_JOB_ID_3 = "job-11112222333344445555666677778888"
 MOCK_JOB_ID_4 = "job-99998888777766665555444433332222"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_default_download_dir(tmp_path_factory, monkeypatch):
+    """Redirect the well-known default status-file dir to a temp path for every test.
+
+    write_download_status_file writes a pointer at the default path whenever a job has no
+    storage profile, so without this any --ignore-storage-profiles test would leave a
+    dangling pointer under the developer's real ~/.deadline directory.
+    """
+    default_dir = tmp_path_factory.mktemp("default_download_dir")
+    monkeypatch.setattr(
+        "deadline.client.cli._download_status_file.DEFAULT_QUEUE_INCREMENTAL_DOWNLOAD_DIR",
+        str(default_dir),
+    )
 
 
 def _make_categorized_job_ids(**kwargs) -> CategorizedJobIds:
@@ -610,6 +628,281 @@ class TestWriteDownloadStatusFile:
         assert data["jobs"][MOCK_JOB_ID]["download_status"] == "downloaded"
         assert data["jobs"][MOCK_JOB_ID_2]["download_status"] == "in_progress"
         assert data["jobs"][MOCK_JOB_ID_3]["download_status"] == "skipped"
+
+
+class TestWritePointerIfNeeded:
+    """Tests for _write_pointer_if_needed — the default-path pointer for custom checkpoint dirs."""
+
+    def test_no_pointer_when_checkpoint_dir_is_default(self, tmp_path, monkeypatch):
+        """When checkpoint_dir equals the default, the real file IS at the default location.
+        No pointer file should be written."""
+        from deadline.client.cli._download_status_file import _write_pointer_if_needed
+
+        default_dir = str(tmp_path / "default")
+        monkeypatch.setattr(
+            "deadline.client.cli._download_status_file.DEFAULT_QUEUE_INCREMENTAL_DOWNLOAD_DIR",
+            default_dir,
+        )
+        real_path = os.path.join(
+            default_dir, f"{MOCK_QUEUE_ID}_ignore-storage-profiles_download_status.json"
+        )
+        _write_pointer_if_needed(MOCK_QUEUE_ID, default_dir, real_path)
+
+        # No pointer should be written — the pointer path and real path are the same.
+        pointer_path = os.path.join(
+            default_dir, f"{MOCK_QUEUE_ID}_ignore-storage-profiles_download_status.json"
+        )
+        assert not os.path.exists(pointer_path)
+
+    def test_pointer_written_when_checkpoint_dir_differs(self, tmp_path, monkeypatch):
+        """When checkpoint_dir is different from the default, a pointer JSON is written
+        at the default path so the FE can find the real file."""
+        from deadline.client.cli._download_status_file import _write_pointer_if_needed
+
+        default_dir = str(tmp_path / "default")
+        custom_dir = str(tmp_path / "custom")
+        monkeypatch.setattr(
+            "deadline.client.cli._download_status_file.DEFAULT_QUEUE_INCREMENTAL_DOWNLOAD_DIR",
+            default_dir,
+        )
+        real_path = os.path.join(
+            custom_dir, f"{MOCK_QUEUE_ID}_ignore-storage-profiles_download_status.json"
+        )
+        _write_pointer_if_needed(MOCK_QUEUE_ID, custom_dir, real_path)
+
+        pointer_path = os.path.join(
+            default_dir, f"{MOCK_QUEUE_ID}_ignore-storage-profiles_download_status.json"
+        )
+        assert os.path.exists(pointer_path)
+        with open(pointer_path) as f:
+            data = json.load(f)
+        assert data["status_file_path"] == real_path
+        assert data["schema_version"] == 1
+        assert "superseded_path" not in data
+
+    def test_pointer_write_holds_lock_on_pointer_path(self, tmp_path, monkeypatch):
+        """The pointer write is serialized by _status_file_lock on the pointer path, so a
+        concurrent sync writing real status data to the default path cannot race it."""
+        import deadline.client.cli._download_status_file as mod
+
+        default_dir = str(tmp_path / "default")
+        custom_dir = str(tmp_path / "custom")
+        monkeypatch.setattr(
+            "deadline.client.cli._download_status_file.DEFAULT_QUEUE_INCREMENTAL_DOWNLOAD_DIR",
+            default_dir,
+        )
+        real_path = os.path.join(
+            custom_dir, f"{MOCK_QUEUE_ID}_ignore-storage-profiles_download_status.json"
+        )
+        pointer_path = os.path.join(
+            default_dir, f"{MOCK_QUEUE_ID}_ignore-storage-profiles_download_status.json"
+        )
+
+        locked_paths = []
+        real_lock = mod._status_file_lock
+
+        @contextmanager
+        def _spy_lock(path):
+            locked_paths.append(path)
+            with real_lock(path):
+                yield
+
+        monkeypatch.setattr(mod, "_status_file_lock", _spy_lock)
+        mod._write_pointer_if_needed(MOCK_QUEUE_ID, custom_dir, real_path)
+
+        assert pointer_path in locked_paths, "pointer write did not take the status-file lock"
+
+    def test_pointer_failure_is_silent(self, tmp_path, monkeypatch):
+        """A failure writing the pointer does not raise — it only logs a warning."""
+        from deadline.client.cli._download_status_file import _write_pointer_if_needed
+
+        custom_dir = str(tmp_path / "custom")
+        # Point default dir at a path that can't be created (file in the way).
+        blocker = tmp_path / "blocker"
+        blocker.write_text("not a dir")
+        bad_default = str(blocker / "subdir")
+        monkeypatch.setattr(
+            "deadline.client.cli._download_status_file.DEFAULT_QUEUE_INCREMENTAL_DOWNLOAD_DIR",
+            bad_default,
+        )
+        real_path = os.path.join(
+            custom_dir, f"{MOCK_QUEUE_ID}_ignore-storage-profiles_download_status.json"
+        )
+        # Should not raise.
+        _write_pointer_if_needed(MOCK_QUEUE_ID, custom_dir, real_path)
+
+    def test_write_download_status_file_writes_pointer_for_custom_checkpoint_dir(
+        self, tmp_path, monkeypatch
+    ):
+        """End-to-end: write_download_status_file with a custom checkpoint_dir leaves a pointer
+        at the default path pointing to the real file."""
+        default_dir = str(tmp_path / "default")
+        custom_dir = str(tmp_path / "custom")
+        os.makedirs(custom_dir, exist_ok=True)
+        monkeypatch.setattr(
+            "deadline.client.cli._download_status_file.DEFAULT_QUEUE_INCREMENTAL_DOWNLOAD_DIR",
+            default_dir,
+        )
+
+        cjids = _make_categorized_job_ids(completed={MOCK_JOB_ID})
+        jobs = {MOCK_JOB_ID: _make_job(MOCK_JOB_ID)}
+
+        write_download_status_file(
+            queue_id=MOCK_QUEUE_ID,
+            categorized_job_ids=cjids,
+            download_candidate_jobs=jobs,
+            local_storage_profile_id=None,
+            local_storage_profile=None,
+            checkpoint_dir=custom_dir,
+        )
+
+        # Real file at custom_dir.
+        real_file = os.path.join(
+            custom_dir, f"{MOCK_QUEUE_ID}_ignore-storage-profiles_download_status.json"
+        )
+        assert os.path.exists(real_file)
+        with open(real_file) as f:
+            real_data = json.load(f)
+        assert real_data["jobs"][MOCK_JOB_ID]["download_status"] == "downloaded"
+
+        # Pointer at default_dir.
+        pointer_file = os.path.join(
+            default_dir, f"{MOCK_QUEUE_ID}_ignore-storage-profiles_download_status.json"
+        )
+        assert os.path.exists(pointer_file)
+        with open(pointer_file) as f:
+            pointer_data = json.load(f)
+        assert pointer_data["status_file_path"] == real_file
+        assert pointer_data["schema_version"] == 1
+
+    def test_no_pointer_when_status_file_write_fails(self, tmp_path, monkeypatch):
+        """If the real status-file write fails, no pointer is written — pointing the FE at a
+        file that does not exist on disk is worse than writing no pointer at all."""
+        default_dir = str(tmp_path / "default")
+        monkeypatch.setattr(
+            "deadline.client.cli._download_status_file.DEFAULT_QUEUE_INCREMENTAL_DOWNLOAD_DIR",
+            default_dir,
+        )
+        # Put a file where the custom checkpoint dir should be so the real status-file write
+        # under it fails.
+        blocker = tmp_path / "custom"
+        blocker.write_text("not a dir")
+        custom_dir = str(blocker / "subdir")
+
+        cjids = _make_categorized_job_ids(completed={MOCK_JOB_ID})
+        jobs = {MOCK_JOB_ID: _make_job(MOCK_JOB_ID)}
+
+        write_download_status_file(
+            queue_id=MOCK_QUEUE_ID,
+            categorized_job_ids=cjids,
+            download_candidate_jobs=jobs,
+            local_storage_profile_id=None,
+            local_storage_profile=None,
+            checkpoint_dir=custom_dir,
+        )
+
+        pointer_file = os.path.join(
+            default_dir, f"{MOCK_QUEUE_ID}_ignore-storage-profiles_download_status.json"
+        )
+        assert not os.path.exists(pointer_file)
+
+    def test_superseded_path_recorded_and_warning_surfaced(self, tmp_path, monkeypatch):
+        """When the default path already has real status data (a 'jobs' key), the pointer
+        overwrites it, superseded_path records the prior path as a reference (no backup file
+        is created), and a user-facing warning is emitted through the callback."""
+        from deadline.client.cli._download_status_file import _write_pointer_if_needed
+
+        default_dir = str(tmp_path / "default")
+        custom_dir = str(tmp_path / "custom")
+        os.makedirs(default_dir, exist_ok=True)
+        monkeypatch.setattr(
+            "deadline.client.cli._download_status_file.DEFAULT_QUEUE_INCREMENTAL_DOWNLOAD_DIR",
+            default_dir,
+        )
+        pointer_path = os.path.join(
+            default_dir, f"{MOCK_QUEUE_ID}_ignore-storage-profiles_download_status.json"
+        )
+        old_data = {"schema_version": 1, "jobs": {MOCK_JOB_ID: {"download_status": "downloaded"}}}
+        # Pre-populate the default path with real status data.
+        with open(pointer_path, "w") as f:
+            json.dump(old_data, f)
+
+        real_path = os.path.join(
+            custom_dir, f"{MOCK_QUEUE_ID}_ignore-storage-profiles_download_status.json"
+        )
+        messages: list[str] = []
+        _write_pointer_if_needed(
+            MOCK_QUEUE_ID, custom_dir, real_path, print_function_callback=messages.append
+        )
+
+        # Pointer now lives at the default path, overwriting the old data.
+        with open(pointer_path) as f:
+            data = json.load(f)
+        assert data["status_file_path"] == real_path
+        assert data["schema_version"] == 1
+        assert data["superseded_path"] == pointer_path
+        assert "jobs" not in data
+        # No backup/history file is left behind — the receipt is discarded, not preserved.
+        assert not os.path.exists(pointer_path + ".superseded")
+        # The user was warned through the callback, not just the logger.
+        assert any("WARNING" in msg and pointer_path in msg for msg in messages)
+
+    def test_no_pointer_when_custom_dir_is_symlink_of_default(self, tmp_path, monkeypatch):
+        """A custom --checkpoint-dir that is a symlink of the default dir must be recognized as
+        the default (via realpath) so we never write a pointer on top of the real status file."""
+        from deadline.client.cli._download_status_file import _write_pointer_if_needed
+
+        default_dir = tmp_path / "default"
+        default_dir.mkdir()
+        monkeypatch.setattr(
+            "deadline.client.cli._download_status_file.DEFAULT_QUEUE_INCREMENTAL_DOWNLOAD_DIR",
+            str(default_dir),
+        )
+        # custom_dir is a symlink pointing at the default dir.
+        custom_dir = tmp_path / "custom_link"
+        custom_dir.symlink_to(default_dir)
+
+        real_path = os.path.join(
+            str(default_dir), f"{MOCK_QUEUE_ID}_ignore-storage-profiles_download_status.json"
+        )
+        with open(real_path, "w") as f:
+            json.dump({"schema_version": 1, "jobs": {MOCK_JOB_ID: {}}}, f)
+
+        _write_pointer_if_needed(MOCK_QUEUE_ID, str(custom_dir), real_path)
+
+        # The real status file must be untouched — no pointer written over it.
+        with open(real_path) as f:
+            assert "jobs" in json.load(f)
+
+    def test_no_pointer_written_with_storage_profile(self, tmp_path, monkeypatch):
+        """With a storage profile the file goes to the NAS — no pointer should be written
+        at the default path since the FE discovers the location via the storage profile API."""
+        default_dir = str(tmp_path / "default")
+        renders_dir = tmp_path / "renders"
+        renders_dir.mkdir()
+        monkeypatch.setattr(
+            "deadline.client.cli._download_status_file.DEFAULT_QUEUE_INCREMENTAL_DOWNLOAD_DIR",
+            default_dir,
+        )
+
+        profile = {"fileSystemLocations": [{"name": "renders", "path": str(renders_dir)}]}
+        cjids = _make_categorized_job_ids(completed={MOCK_JOB_ID})
+        jobs = {MOCK_JOB_ID: _make_job(MOCK_JOB_ID)}
+
+        write_download_status_file(
+            queue_id=MOCK_QUEUE_ID,
+            categorized_job_ids=cjids,
+            download_candidate_jobs=jobs,
+            local_storage_profile_id=MOCK_STORAGE_PROFILE_ID,
+            local_storage_profile=profile,
+            checkpoint_dir=str(tmp_path / "checkpoint"),
+        )
+
+        # No pointer at default_dir — FE uses storage profile to find the NAS path.
+        pointer_file = os.path.join(
+            default_dir, f"{MOCK_QUEUE_ID}_ignore-storage-profiles_download_status.json"
+        )
+        assert not os.path.exists(pointer_file)
 
 
 class TestStatusFileLock:


### PR DESCRIPTION
## What was the problem/requirement? (What/Why)

When `deadline queue sync-output` is run with `--ignore-storage-profiles` and a custom `--checkpoint-dir`, the status file is written to the custom directory. The DCM always looks at the well-known default path (`~/.deadline/incremental_download/`), so it could not find the file and showed no download status.

## What was the solution? (How)

After writing the real status file, the CLI now writes a small pointer JSON at the default path when `--checkpoint-dir` differs from the default:

```json
{
  "schema_version": 1,
  "status_file_path": "/custom/path/queue-..._ignore-storage-profiles_download_status.json"
}
```

The DCM detects the `status_file_path` key and follows the redirect to the real file. The pointer write is best-effort — failure logs a warning but does not abort the sync. No change for users with a storage profile or without a custom `--checkpoint-dir`.

## What is the impact of this change?

Users running `--ignore-storage-profiles` with a custom `--checkpoint-dir` will now have their download status visible in the DCM. No impact to other users. Requires a corresponding DCM change to follow the pointer (in progress).

## How was this change tested?

- [x] Unit tests — 6 new tests covering all pointer cases. Full suite: 3161 passed.
- [x] Manual test on gamma — verified pointer written, DCM followed redirect, stale pointer shows blank, switching back to default dir restores real data.
- [ ] Integration tests — not applicable.

## Was this change documented?

- Docstrings updated on new functions.
- No README changes needed.

## Does this PR introduce new dependencies?

- [x] This PR does not add any new dependencies.

## Is this a breaking change?

No. The real status file format and path logic are unchanged.

## Does this change impact security?

The pointer file is written to the same directory as the existing status file using the same atomic write mechanism. The redirect target is validated against path traversal before being followed by the DCM. No new attack surface.
