### PR TITLE
fix: warn about long Windows paths regardless of registry setting

### DIFF
--- a/src/deadline/client/cli/_groups/job_group.py
+++ b/src/deadline/client/cli/_groups/job_group.py
@@ -26,10 +26,7 @@ from ....job_attachments.models import (
     JobAttachmentS3Settings,
     PathFormat,
 )
-from ....job_attachments._utils import (
-    WINDOWS_MAX_PATH_LENGTH,
-    _is_windows_long_path_registry_enabled,
-)
+from ....job_attachments._utils import WINDOWS_MAX_PATH_LENGTH
 from ....job_attachments.progress_tracker import (
     DownloadSummaryStatistics,
     ProgressReportMetadata,
@@ -717,7 +714,10 @@ def _download_job_output(
     def _check_and_warn_long_output_paths(
         output_paths_by_root: dict[str, list[str]],
     ) -> None:
-        if sys.platform == "win32" and not _is_windows_long_path_registry_enabled():
+        # Not gated on the LongPathsEnabled registry setting: that only takes effect for
+        # processes declaring longPathAware in their manifest, so it does not indicate
+        # whether a long path is safe for the applications that will open these files.
+        if sys.platform == "win32":
             for root, paths in output_paths_by_root.items():
                 for output_path in paths:
                     if len(root + output_path) >= WINDOWS_MAX_PATH_LENGTH:

--- a/src/deadline/client/cli/_groups/manifest_group.py
+++ b/src/deadline/client/cli/_groups/manifest_group.py
@@ -27,10 +27,7 @@ from deadline.client.api._session import (
 )
 from deadline.client.config import config_file
 from deadline.job_attachments._diff import pretty_print_cli
-from deadline.job_attachments._utils import (
-    WINDOWS_MAX_PATH_LENGTH,
-    _is_windows_long_path_registry_enabled,
-)
+from deadline.job_attachments._utils import WINDOWS_MAX_PATH_LENGTH
 from deadline.job_attachments.api.manifest import (
     _glob_files,
     _manifest_diff,
@@ -164,11 +161,10 @@ def manifest_snapshot(
         hash_cache_dir=hash_cache_dir,
     )
     if manifest_out:
-        if (
-            sys.platform == "win32"
-            and len(manifest_out.manifest) >= WINDOWS_MAX_PATH_LENGTH
-            and not _is_windows_long_path_registry_enabled()
-        ):
+        # Not gated on the LongPathsEnabled registry setting: that only takes effect for
+        # processes declaring longPathAware in their manifest, so it does not indicate
+        # whether a long path is safe for the tools consuming this one.
+        if sys.platform == "win32" and len(manifest_out.manifest) >= WINDOWS_MAX_PATH_LENGTH:
             long_manifest_path_warning = f"""WARNING: Manifest file path {manifest_out.manifest} exceeds Windows path length limit. This may cause unexpected issues.
 For details and a fix using the registry, see: https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation"""
             logger.echo(

--- a/test/unit/deadline_client/cli/test_cli_long_path_warnings.py
+++ b/test/unit/deadline_client/cli/test_cli_long_path_warnings.py
@@ -1,0 +1,128 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Tests that the CLI's Windows long-path warnings are not suppressed by the
+LongPathsEnabled registry setting.
+
+That setting only takes effect for processes declaring longPathAware in their
+application manifest, so it says nothing about whether a path is safe for the tools
+and applications that ultimately open these files. Gating the warnings on it silenced
+them on exactly the hosts where paths are longest.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import ANY, patch
+
+import pytest
+
+from deadline.client import api
+from deadline.client.cli import main
+from deadline.client.cli._groups import job_group, manifest_group
+from deadline.client.config import set_setting
+from deadline.job_attachments._utils import WINDOWS_MAX_PATH_LENGTH
+from deadline.job_attachments.models import PathFormat
+from click.testing import CliRunner
+
+REGISTRY_HELPER = "_is_windows_long_path_registry_enabled"
+
+MOCK_FARM_ID = "farm-0123456789abcdefabcdefabcdefabcd"
+MOCK_QUEUE_ID = "queue-0123456789abcdefabcdefabcdefabcd"
+MOCK_JOB_ID = "job-0123456789abcdefabcdefabcdefabcd"
+MOCK_GET_QUEUE_RESPONSE = {
+    "queueId": MOCK_QUEUE_ID,
+    "displayName": "Mock Queue",
+    "jobAttachmentSettings": {"s3BucketName": "mock_bucket", "rootPrefix": "mock_deadline"},
+}
+
+
+@pytest.mark.parametrize("module", [job_group, manifest_group], ids=["job", "manifest"])
+def test_registry_helper_no_longer_used(module):
+    """
+    The warnings are unconditional on Windows now, so neither module should still pull in
+    the registry helper. Guards against the check being reintroduced.
+    """
+    assert not hasattr(module, REGISTRY_HELPER)
+
+
+class TestDownloadOutputLongPathWarning:
+    """
+    Exercises `_check_and_warn_long_output_paths` by running the real
+    `deadline job download-output` command with a stubbed downloader.
+    """
+
+    def _invoke(self, fresh_deadline_config, output_paths_by_root, registry_enabled: bool):
+        set_setting("settings.auto_accept", "true")
+
+        with (
+            patch.object(api, "get_boto3_client") as boto3_client_mock,
+            patch.object(job_group, "OutputDownloader") as MockOutputDownloader,
+            patch.object(job_group, "_resolve_storage_profiles", return_value=None),
+            patch.object(job_group.sys, "platform", "win32"),
+            patch(
+                f"deadline.job_attachments._utils.{REGISTRY_HELPER}",
+                return_value=registry_enabled,
+            ),
+        ):
+            downloader = MockOutputDownloader.return_value
+            downloader.get_paths_by_root.return_value = output_paths_by_root
+            downloader.download.return_value = ANY
+
+            boto3_client_mock().get_job.return_value = {
+                "name": "Mock Job",
+                "attachments": {
+                    "manifests": [
+                        {
+                            "rootPath": next(iter(output_paths_by_root)),
+                            "rootPathFormat": PathFormat.WINDOWS,
+                            "outputRelativeDirectories": ["."],
+                        }
+                    ],
+                },
+            }
+            boto3_client_mock().get_queue.side_effect = [MOCK_GET_QUEUE_RESPONSE]
+
+            return CliRunner().invoke(
+                main,
+                [
+                    "job",
+                    "download-output",
+                    "--farm-id",
+                    MOCK_FARM_ID,
+                    "--queue-id",
+                    MOCK_QUEUE_ID,
+                    "--job-id",
+                    MOCK_JOB_ID,
+                ],
+            )
+
+    @pytest.mark.parametrize("registry_enabled", [True, False])
+    def test_long_output_path_warns_regardless_of_registry(
+        self, fresh_deadline_config, registry_enabled
+    ):
+        """
+        The regression test: with the registry setting on, the warning used to be silenced.
+        """
+        root = "C:\\root\\"
+        long_path = "a" * WINDOWS_MAX_PATH_LENGTH
+
+        result = self._invoke(fresh_deadline_config, {root: [long_path]}, registry_enabled)
+
+        assert "exceed Windows path length limit" in result.output
+
+    @pytest.mark.parametrize("registry_enabled", [True, False])
+    def test_short_output_path_does_not_warn(self, fresh_deadline_config, registry_enabled):
+        result = self._invoke(
+            fresh_deadline_config, {"C:\\root\\": ["short.exr"]}, registry_enabled
+        )
+
+        assert "exceed Windows path length limit" not in result.output
+
+
+class TestLongPathMessages:
+    def test_download_warning_message_names_the_problem(self):
+        """The user-facing text should name the problem and point at the fix."""
+        message = job_group._get_long_path_found_message(is_json_format=False)
+
+        assert "exceed Windows path length limit" in message
+        assert "maximum-file-path-limitation" in message


### PR DESCRIPTION
## What changed

Two CLI long-path warnings were gated on the machine-wide `LongPathsEnabled` registry setting:

- `manifest_group.py` — the `deadline manifest snapshot` warning about a long manifest path
- `job_group.py` — `_check_and_warn_long_output_paths` in `deadline job download-output`

Both included `and not _is_windows_long_path_registry_enabled()`, which suppressed the warning whenever that setting was on.

That setting only takes effect for processes declaring `longPathAware` in their application manifest. It says nothing about whether the path is safe for the tools and applications that ultimately open these files — DCC executables such as `AfterEffects.exe` and `Cinema4D.exe` do not declare it and remain capped at `MAX_PATH` regardless.

The result was backwards: the warnings went quiet on exactly the hosts where paths are longest, which are the hosts that have the registry setting enabled. Warn whenever the path exceeds the limit on Windows.

The now-unused `_is_windows_long_path_registry_enabled` import is removed from both modules.

## Relationship to the job attachments fix

Companion to [deadline-cloud-job-attachments#67](https://github.com/aws-deadline/deadline-cloud-job-attachments/pull/67), which removes the same incorrect assumption from `_get_long_path_compatible_path`, where it had a functional rather than cosmetic effect (the `\\?\` prefix was skipped on hosts with the registry setting enabled).

This PR is user-facing messaging only. Nothing fails as a result of the current behaviour; users simply are not told about a path that may cause problems.

Note one interaction: with #67 applied, long paths gain the 4-character `\\?\` prefix, and these warnings measure the resulting length. That makes them marginally more likely to fire. Since they are advisory and the underlying path is genuinely near the limit, that seems acceptable, but flagging it in case reviewers would prefer the checks measure the unprefixed length.

## Tests

New `test/unit/deadline_client/cli/test_cli_long_path_warnings.py`:

- `test_registry_helper_no_longer_used` — parametrized over both modules, guards against the registry check being reintroduced
- `TestDownloadOutputLongPathWarning` — invokes the real `deadline job download-output` command with a stubbed downloader, parametrized over both registry states, asserting the warning fires for long paths and not for short ones
- `TestLongPathMessages` — checks the user-facing text names the problem and links the Microsoft guidance

Verified the tests actually catch the defect: with the source changes stashed, 4 of 7 fail; with them applied, all 7 pass.

## Verification

- Full unit suite: 3114 passed, 21 skipped, 0 failed
- `hatch run fmt`: clean
- `hatch run lint`: ruff clean, mypy clean across 315 source files

Not verified on a real Windows host — the warning paths are `sys.platform`-gated and exercised via mocks.