### PR TITLE
fix: stop bundling awscrt in the installer

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -53,6 +53,13 @@ pre-install-commands = [
 test = "pytest --no-cov -vvv --numprocesses=1 -o \"testpaths=test/blender_submitter_ui\" --confcutdir=test/blender_submitter_ui {args:test/blender_submitter_ui}"
 
 [envs.installer]
+# Pinned explicitly rather than inherited from envs.default: the features here
+# decide what PyInstaller bundles into the shipped installer, so a new extra in
+# the default env must not silently enlarge the signed artifact. "console" is
+# omitted on purpose -- it pulls in awscrt, a compiled wheel that is not in
+# scripts/pyinstaller/allowlist.py. Consumers who need AWS Console sign-in
+# credential refresh install the extra themselves.
+features = ["gui"]
 pre-install-commands = ["pip install -r requirements-installer.txt"]
 
 [envs.installer.scripts]

--- a/test/unit/test_installer_env_features.py
+++ b/test/unit/test_installer_env_features.py
@@ -1,0 +1,52 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Guards what PyInstaller bundles into the shipped installer.
+
+The `installer` Hatch env's features decide which extras are installed when
+`installer:make_exe` runs, and therefore which packages end up inside the signed
+artifact. Hatch envs inherit `features` from `envs.default` when they don't
+declare their own, so adding an extra to the default env silently changes the
+installer's contents -- and `installer:validate_exe` then fails against
+scripts/pyinstaller/allowlist.py, at release time rather than in PR CI.
+"""
+
+from pathlib import Path
+
+import pytest
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python 3.9/3.10
+    import tomli as tomllib  # type: ignore[no-redef]
+
+_HATCH_CONFIG = Path(__file__).absolute().parents[2] / "hatch.toml"
+
+# Extras that must never be bundled, mapped to why. An extra listed here brings in
+# a distribution that scripts/pyinstaller/allowlist.py does not allow.
+_EXTRAS_EXCLUDED_FROM_INSTALLER = {
+    "console": "pulls in awscrt, a compiled wheel absent from the PyInstaller allowlist",
+}
+
+
+@pytest.fixture(scope="module")
+def hatch_envs() -> dict:
+    with open(_HATCH_CONFIG, "rb") as f:
+        return tomllib.load(f)["envs"]
+
+
+def test_installer_env_declares_features_explicitly(hatch_envs: dict) -> None:
+    """Without its own `features`, the installer env inherits envs.default's."""
+    assert "features" in hatch_envs["installer"], (
+        "envs.installer must declare `features` explicitly. Inheriting from "
+        "envs.default lets an extra added there change what PyInstaller bundles "
+        "into the signed installer."
+    )
+
+
+@pytest.mark.parametrize("extra, reason", sorted(_EXTRAS_EXCLUDED_FROM_INSTALLER.items()))
+def test_installer_env_omits_unbundleable_extra(hatch_envs: dict, extra: str, reason: str) -> None:
+    assert extra not in hatch_envs["installer"].get("features", []), (
+        f"envs.installer must not enable the {extra!r} extra: it {reason}. "
+        "Either drop it or add the distribution to scripts/pyinstaller/allowlist.py."
+    )


### PR DESCRIPTION
## Why

`envs.installer` in `hatch.toml` declared no `features`, so Hatch resolved them from `envs.default`. When #1323 added the `console` extra to the default env, the installer build began installing `botocore[crt]`, PyInstaller bundled `awscrt`, and `installer:validate_exe` failed against `scripts/pyinstaller/allowlist.py`:

```
Found file _internal/_awscrt.abi3.so which was not included in the allowlist
Found file deadline/PYZ.pyz/awscrt.auth which was not included in the allowlist
... (+9 more awscrt submodules)
```

This broke `BuildAndStageInstallers` in the 0.60.4 release ([run 31435049529](https://github.com/aws-deadline/deadline-cloud/actions/runs/31435049529)) — macOS failed and Linux/Windows were cancelled by fail-fast, so `Release`, `Publish`, and `PublishToPyPI` never ran. 0.60.4 is not on PyPI.

## What

Pin `features = ["gui"]` on `envs.installer` so an extra added to `envs.default` can no longer change what ships in the signed artifact. `console` is omitted deliberately: `awscrt` is a compiled wheel that isn't allowlisted.

Rejected alternative: adding `awscrt` to the allowlist so the installer ships console sign-in support. That puts a compiled binary into three signed artifacts and needs per-platform allowlist entries — a supply-chain decision worth making deliberately, not as release triage. The allowlist is a deliberate control, so the conservative fix is to keep the bundle as it was.

**No consumer impact.** Console sign-in credential refresh stays available via `pip install "deadline[console]"`. The extra is wheel metadata (`Provides-Extra: console` → `botocore[crt]>=1.42.89`), independent of `hatch.toml`. Verified in a clean venv: adding the extra to an existing install pulls `awscrt`, `botocore.compat.EC` becomes non-`None`, `_check_console_login_dependency` stops raising, and botocore's `login` provider appears in the credential resolver chain.

## Testing

New `test/unit/test_installer_env_features.py` asserts the installer env declares `features` explicitly and omits `console`. It lives in `test/unit/`, so it runs in the existing PR CI matrix. Confirmed it fails against the pre-fix config, not just passes against the new one.

Locally on arm64 macOS / Python 3.13 (matching the failing CodeBuild host):

| Check | Result |
|---|---|
| `awscrt` in installer env | absent |
| `hatch run installer:make_exe` | exit 0 |
| `hatch run installer:validate_exe` | `Validation passed`, 0 allowlist failures |
| `hatch run lint` (ruff + mypy) | clean, 316 files |
| `hatch run test` | 3209 passed, 22 skipped |

## Follow-ups (not in this PR)

- `installer:validate_exe` runs only in the release pipeline, never in PR CI — which is why #1323 merged green and broke at release. This test closes the specific hole; catching the general case means build+validate on PRs touching `hatch.toml`, `pyproject.toml` extras, `requirements-installer.txt`, or `scripts/pyinstaller/`.
- `hatch.toml` `test_build_installer` points at `test/build_installer`, which doesn't exist.
