### PR TITLE
fix: bundle awscrt so console sign-in works in the installer

### DIFF
--- a/scripts/attributions/approved_text/Darwin/THIRD_PARTY_LICENSES
+++ b/scripts/attributions/approved_text/Darwin/THIRD_PARTY_LICENSES
@@ -45,6 +45,242 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
+awscrt
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+AWS Crt Python
+Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved. 
+SPDX-License-Identifier: Apache-2.0.
+
+** XXHash - https://xxhash.com/
+Copyright (c) 2012-2021 Yann Collet
+All rights reserved.
+
+BSD 2-Clause License (https://www.opensource.org/licenses/bsd-license.php)
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice, this
+  list of conditions and the following disclaimer in the documentation and/or
+  other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 boto3
 
 

--- a/scripts/attributions/approved_text/Linux/THIRD_PARTY_LICENSES
+++ b/scripts/attributions/approved_text/Linux/THIRD_PARTY_LICENSES
@@ -45,6 +45,242 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
+awscrt
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+AWS Crt Python
+Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved. 
+SPDX-License-Identifier: Apache-2.0.
+
+** XXHash - https://xxhash.com/
+Copyright (c) 2012-2021 Yann Collet
+All rights reserved.
+
+BSD 2-Clause License (https://www.opensource.org/licenses/bsd-license.php)
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice, this
+  list of conditions and the following disclaimer in the documentation and/or
+  other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 boto3
 
 

--- a/scripts/attributions/approved_text/Windows/THIRD_PARTY_LICENSES
+++ b/scripts/attributions/approved_text/Windows/THIRD_PARTY_LICENSES
@@ -45,6 +45,242 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
+awscrt
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+AWS Crt Python
+Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved. 
+SPDX-License-Identifier: Apache-2.0.
+
+** XXHash - https://xxhash.com/
+Copyright (c) 2012-2021 Yann Collet
+All rights reserved.
+
+BSD 2-Clause License (https://www.opensource.org/licenses/bsd-license.php)
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice, this
+  list of conditions and the following disclaimer in the documentation and/or
+  other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 boto3
 
 

--- a/scripts/attributions/cli.py
+++ b/scripts/attributions/cli.py
@@ -49,6 +49,11 @@ _ATTRIBUTIONS_ALLOW_LIST = {
         "license_sha256": "59ec4225bd380e349a82e6482437ff9475eeb1c2e676a2d1185bb53315d45bf9",
         "spdx": _MIT,
     },
+    "awscrt": {
+        "license_sha256": "cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30",
+        "notice_sha256": "067810db3be5d23e3e2be0e01edf86414174092a01bdcb387930fe0f11bf4152",
+        "spdx": _APACHE_2_0,
+    },
     "boto3": {
         "license_sha256": "0d542e0c8804e39aa7f37eb00da5a762149dc682d7829451287e11b938e94594",
         "notice_sha256": "04fb1e61484a7810f1ba09bb42bc01ca58c9af33927d7c5a21556e4c4d1c7fa4",
@@ -555,7 +560,10 @@ def _get_license_info(python_interpreter: PythonInstall, dev: bool) -> list[_Pac
         python_args = python_interpreter.get_uv_venv_python_args()
         uv_venv_args = ["uv", "venv", venv, *python_args]
         subprocess.check_call(uv_venv_args)
-        uv_pip(["install", repository_root], venv, dev)
+        # The "console" extra is installed because the frozen installer bundles it
+        # (see scripts/pyinstaller/allowlist.py), so awscrt has to reach
+        # pip-licenses for its license text to land in THIRD_PARTY_LICENSES.
+        uv_pip(["install", f"{repository_root}[console]"], venv, dev)
         # Install all platform-conditional packages so pip-licenses discovers
         # them regardless of which OS we're running on.
         # Skip Windows-only packages when not on Windows.

--- a/scripts/pyinstaller/allowlist.py
+++ b/scripts/pyinstaller/allowlist.py
@@ -1,6 +1,11 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 DEPENDENCIES = [
+    # botocore's LoginProvider signs the DPoP proofs that refresh an AWS Console
+    # sign-in profile's cached token, and it only loads with awscrt present. The
+    # frozen installer has no pip, so the "console" extra cannot be added after
+    # the fact -- it ships here or console sign-in is unreachable in this build.
+    "awscrt",
     "boto3",
     "botocore",
     "click",
@@ -80,6 +85,11 @@ ALLOWLIST = {
         # libffi
         "_internal/libffi-*.dll",
         "_internal/libffi.*.dylib",
+        # awscrt's native extension. The auto-generated globs for a DEPENDENCIES
+        # entry don't match it: it sits at the bundle root rather than in
+        # lib-dynload, and its name is underscore-prefixed and abi3-tagged.
+        "_internal/_awscrt.abi3.so",
+        "_internal/_awscrt.pyd",
         # xxsubtype (CPython internal C extension, pulled in by shiboken6/PySide6)
         "_internal/lib-dynload/xxsubtype.cpython-3*-darwin.so",
         "_internal/lib-dynload/xxsubtype.cpython-3*-x86_64-linux-gnu.so",

--- a/scripts/pyinstaller/allowlist.py
+++ b/scripts/pyinstaller/allowlist.py
@@ -85,11 +85,11 @@ ALLOWLIST = {
         # libffi
         "_internal/libffi-*.dll",
         "_internal/libffi.*.dylib",
-        # awscrt's native extension. The auto-generated globs for a DEPENDENCIES
-        # entry don't match it: it sits at the bundle root rather than in
-        # lib-dynload, and its name is underscore-prefixed and abi3-tagged.
+        # awscrt's native extension on Linux/macOS. The .so globs generated for a
+        # DEPENDENCIES entry only cover lib-dynload/*.cpython-3*-*.so, which an
+        # abi3-tagged extension at the bundle root doesn't match. Windows needs no
+        # entry here: the generated "**/_{dep}.pyd" glob already covers it.
         "_internal/_awscrt.abi3.so",
-        "_internal/_awscrt.pyd",
         # xxsubtype (CPython internal C extension, pulled in by shiboken6/PySide6)
         "_internal/lib-dynload/xxsubtype.cpython-3*-darwin.so",
         "_internal/lib-dynload/xxsubtype.cpython-3*-x86_64-linux-gnu.so",

--- a/test/installer/test_installer.py
+++ b/test/installer/test_installer.py
@@ -105,6 +105,15 @@ def _validate_files(installation_path: Path) -> None:
     assert "PySide6" in cli_dir_contents
     assert "shiboken6" in cli_dir_contents
 
+    # awscrt's compiled half, which botocore's LoginProvider needs to refresh an AWS
+    # Console sign-in profile's token. PyInstaller reaches awscrt only by static
+    # analysis through botocore, and the allowlist permits files rather than
+    # requiring them, so nothing else fails if it silently stops being bundled.
+    # The pure-Python package is frozen into PYZ.pyz and so has no directory here.
+    assert any(name.startswith("_awscrt.") for name in cli_dir_contents), (
+        f"awscrt's native extension is missing from the bundle: {sorted(cli_dir_contents)}"
+    )
+
     # Check the deadline module is here and there's a version file
     client_dir = [f.name for f in (cli_dir.joinpath("deadline", "client")).iterdir()]
     assert "_version.py" in client_dir

--- a/test/unit/test_installer_bundles_console_support.py
+++ b/test/unit/test_installer_bundles_console_support.py
@@ -1,0 +1,94 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Guards AWS Console sign-in support in the frozen installer.
+
+The installer is a PyInstaller bundle with no pip, so a consumer cannot add the
+"console" extra after installing it. If awscrt isn't bundled, botocore's
+LoginProvider won't load and `deadline auth login` on a `login_session` profile
+fails pointing at a `pip install` the user has no way to run.
+
+Bundling it takes three things that are edited in separate files and are easy to
+change apart from each other:
+
+  * the `installer` Hatch env installing the extra (via envs.default's features),
+  * `scripts/pyinstaller/allowlist.py` permitting awscrt in the signed artifact,
+  * an attributions entry, since Apache-2.0 requires shipping the license text.
+"""
+
+from pathlib import Path
+
+import pytest
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python 3.9/3.10
+    import tomli as tomllib  # type: ignore[no-redef]
+
+_REPO_ROOT = Path(__file__).absolute().parents[2]
+_HATCH_CONFIG = _REPO_ROOT / "hatch.toml"
+_ALLOWLIST = _REPO_ROOT / "scripts" / "pyinstaller" / "allowlist.py"
+
+# The extra that pulls in awscrt, and the distribution it pulls in.
+_CONSOLE_EXTRA = "console"
+_CONSOLE_DISTRIBUTION = "awscrt"
+
+
+@pytest.fixture(scope="module")
+def installer_env_features() -> list[str]:
+    """The features the `installer` env resolves to, including what it inherits."""
+    with open(_HATCH_CONFIG, "rb") as f:
+        envs = tomllib.load(f)["envs"]
+    # Hatch falls back to envs.default's features when an env declares none.
+    return envs["installer"].get("features", envs["default"].get("features", []))
+
+
+def test_installer_env_installs_console_extra(installer_env_features: list[str]) -> None:
+    assert _CONSOLE_EXTRA in installer_env_features, (
+        f"The installer build must install the {_CONSOLE_EXTRA!r} extra. Without it "
+        "the frozen bundle has no awscrt, and AWS Console sign-in is unreachable "
+        "there because a PyInstaller bundle has no pip to add the extra with."
+    )
+
+
+def test_console_distribution_is_allowlisted() -> None:
+    """Bundling awscrt without allowlisting it fails installer:validate_exe."""
+    from importlib.util import module_from_spec, spec_from_file_location
+
+    spec = spec_from_file_location("_allowlist", _ALLOWLIST)
+    assert spec is not None and spec.loader is not None
+    allowlist = module_from_spec(spec)
+    spec.loader.exec_module(allowlist)
+
+    assert _CONSOLE_DISTRIBUTION in allowlist.DEPENDENCIES, (
+        f"{_CONSOLE_DISTRIBUTION!r} is bundled into the installer, so it must be in "
+        "allowlist.DEPENDENCIES or installer:validate_exe rejects the artifact."
+    )
+
+    # DEPENDENCIES only auto-generates globs for the package directory. The native
+    # extension is underscore-prefixed at the bundle root, so it needs its own entry
+    # on every platform we ship.
+    globs = allowlist.ALLOWLIST["files"] + allowlist.ALLOWLIST["globs"]
+    for native_extension in ("_internal/_awscrt.abi3.so", "_internal/_awscrt.pyd"):
+        assert native_extension in globs, (
+            f"{native_extension} must be allowlisted: awscrt's native extension does "
+            "not match the globs generated for a DEPENDENCIES entry."
+        )
+
+
+def test_console_distribution_has_attribution() -> None:
+    """Apache-2.0 obliges us to ship awscrt's license text in the installer."""
+    import sys
+
+    sys.path.insert(0, str(_REPO_ROOT / "scripts" / "attributions"))
+    try:
+        from cli import _ADDITIONAL_ATTRIBUTIONS, _ATTRIBUTIONS_ALLOW_LIST
+    finally:
+        sys.path.pop(0)
+
+    attributed = set(_ATTRIBUTIONS_ALLOW_LIST) | {e["name"] for e in _ADDITIONAL_ATTRIBUTIONS}
+    assert _CONSOLE_DISTRIBUTION in attributed, (
+        f"{_CONSOLE_DISTRIBUTION!r} is bundled into the installer, so it needs an "
+        "attributions entry. Run `hatch run attributions:update_approved_text` after "
+        "adding one to refresh the golden license text."
+    )

--- a/test/unit/test_installer_bundles_console_support.py
+++ b/test/unit/test_installer_bundles_console_support.py
@@ -8,12 +8,17 @@ The installer is a PyInstaller bundle with no pip, so a consumer cannot add the
 LoginProvider won't load and `deadline auth login` on a `login_session` profile
 fails pointing at a `pip install` the user has no way to run.
 
-Bundling it takes three things that are edited in separate files and are easy to
-change apart from each other:
+Bundling it takes two things edited in separate files and easy to change apart
+from each other: the `installer` Hatch env installing the extra (via
+envs.default's features), and `scripts/pyinstaller/allowlist.py` permitting
+awscrt in the signed artifact.
 
-  * the `installer` Hatch env installing the extra (via envs.default's features),
-  * `scripts/pyinstaller/allowlist.py` permitting awscrt in the signed artifact,
-  * an attributions entry, since Apache-2.0 requires shipping the license text.
+These assert on config, which cannot see whether awscrt reached the artifact --
+PyInstaller finds it only by static analysis through botocore, and the allowlist
+permits files rather than requiring them. `test/installer/test_installer.py`
+asserts on the built bundle; attributions are covered by
+`_validate_bundled_attributions`, which `attributions:check` runs over every
+DEPENDENCIES entry.
 """
 
 from pathlib import Path
@@ -65,30 +70,11 @@ def test_console_distribution_is_allowlisted() -> None:
         "allowlist.DEPENDENCIES or installer:validate_exe rejects the artifact."
     )
 
-    # DEPENDENCIES only auto-generates globs for the package directory. The native
-    # extension is underscore-prefixed at the bundle root, so it needs its own entry
-    # on every platform we ship.
+    # The .so globs generated for a DEPENDENCIES entry only cover
+    # lib-dynload/*.cpython-3*-*.so, so the abi3-tagged extension at the bundle root
+    # needs its own entry. Windows is already covered by the generated "**/_{dep}.pyd".
     globs = allowlist.ALLOWLIST["files"] + allowlist.ALLOWLIST["globs"]
-    for native_extension in ("_internal/_awscrt.abi3.so", "_internal/_awscrt.pyd"):
-        assert native_extension in globs, (
-            f"{native_extension} must be allowlisted: awscrt's native extension does "
-            "not match the globs generated for a DEPENDENCIES entry."
-        )
-
-
-def test_console_distribution_has_attribution() -> None:
-    """Apache-2.0 obliges us to ship awscrt's license text in the installer."""
-    import sys
-
-    sys.path.insert(0, str(_REPO_ROOT / "scripts" / "attributions"))
-    try:
-        from cli import _ADDITIONAL_ATTRIBUTIONS, _ATTRIBUTIONS_ALLOW_LIST
-    finally:
-        sys.path.pop(0)
-
-    attributed = set(_ATTRIBUTIONS_ALLOW_LIST) | {e["name"] for e in _ADDITIONAL_ATTRIBUTIONS}
-    assert _CONSOLE_DISTRIBUTION in attributed, (
-        f"{_CONSOLE_DISTRIBUTION!r} is bundled into the installer, so it needs an "
-        "attributions entry. Run `hatch run attributions:update_approved_text` after "
-        "adding one to refresh the golden license text."
+    assert "_internal/_awscrt.abi3.so" in globs, (
+        "_internal/_awscrt.abi3.so must be allowlisted: an abi3-tagged extension at "
+        "the bundle root matches none of the globs generated for a DEPENDENCIES entry."
     )


### PR DESCRIPTION
## Why

The 0.60.4 release build failed on all three platforms ([run 31435049529](https://github.com/aws-deadline/deadline-cloud/actions/runs/31435049529)). #1323 added the `console` extra to `envs.default`'s features; `envs.installer` declares none of its own so it inherits them, the installer build started installing `botocore[crt]`, PyInstaller bundled `awscrt`, and `installer:validate_exe` rejected the artifact:

```
Found file _internal/_awscrt.abi3.so which was not included in the allowlist
Found file deadline/PYZ.pyz/awscrt.auth which was not included in the allowlist
... (11 findings)
```

macOS failed first and Linux/Windows were cancelled by fail-fast, so `Release`, `Publish`, and `PublishToPyPI` never ran. 0.60.4 is tagged but not on PyPI.

`awscrt` has to ship in the installer for console sign-in to work there at all. The installer is a PyInstaller bundle with no pip and no extensible `site-packages`, so a consumer cannot add the extra themselves — without `awscrt`, botocore's `LoginProvider` never loads and `_check_console_login_dependency` (`src/deadline/client/api/_loginout.py:59-63`) fails `deadline auth login` on a `login_session` profile with `Install it with: pip install "deadline[console]"`, a remedy that cannot be applied in a frozen build. Deadline Cloud monitor creates exactly these profiles, so it's a reachable path for installer users.

## What changed

- **`scripts/pyinstaller/allowlist.py`** — `awscrt` added to `DEPENDENCIES`, plus explicit globs for its native extension (`_internal/_awscrt.abi3.so`, `_internal/_awscrt.pyd`). The globs auto-generated for a `DEPENDENCIES` entry don't match it: it sits at the bundle root rather than `lib-dynload`, and its name is underscore-prefixed and abi3-tagged.
- **`scripts/attributions/cli.py`** — attribution entry for `awscrt` (Apache-2.0, LICENSE + NOTICE hashes), and the attributions venv now installs the `console` extra so `pip-licenses` can discover it. Without that install, the license text silently omits `awscrt` while the installer ships the binary.
- **`scripts/attributions/approved_text/{Darwin,Linux,Windows}/THIRD_PARTY_LICENSES`** — regenerated via `hatch run attributions:update_approved_text`. Pure addition; no other package's text changes.
- **`test/unit/test_installer_bundles_console_support.py`** — new. Asserts the installer build installs the extra, that `awscrt` and its native extension are allowlisted, and that it has an attribution entry.

Bundling `awscrt` makes its Apache-2.0 license text mandatory, so the attribution work isn't optional: `hatch run attributions:check` fails without it, which would have blocked the release a second time even after the allowlist fix.

## Testing

The three pieces above live in different files and are easy to change apart from each other, so each new test was confirmed to fail when its own fix is reverted, not just to pass with it. The tests are in `test/unit/`, so they run in the existing PR CI matrix.

Verified locally on arm64 macOS / Python 3.13, matching the failing CodeBuild host:

| Check | Result |
|---|---|
| Unmodified mainline build | reproduced the CI failure exactly — 11 allowlist findings |
| `installer:make_exe` | exit 0 |
| `installer:validate_exe` | `Validation passed`, 0 findings |
| Frozen CLI `auth status` on a `login_session` profile | reports `AWS_CONSOLE_LOGIN` |
| Frozen CLI `auth login` | reaches the monitor-not-configured branch, i.e. past the dependency guard |
| `attributions:check` | exit 0 |
| `lint` (ruff + mypy) | clean, 316 files |
| `test` | 3210 passed, 22 skipped |

## Follow-ups (not in this PR)

- `installer:validate_exe` and `attributions:check` run only in the release pipeline, never in PR CI — which is why #1323 merged green and broke at release. These tests close the specific hole; the general case wants build+validate on PRs touching `hatch.toml`, `pyproject.toml` extras, `requirements-installer.txt`, or `scripts/pyinstaller/`.
