### PR TITLE
fix: use adaptive retries for sync-output metadata API calls

### DIFF
--- a/src/deadline/client/api/_list_jobs_by_filter_expression.py
+++ b/src/deadline/client/api/_list_jobs_by_filter_expression.py
@@ -7,7 +7,7 @@ __all__ = ["_list_jobs_by_filter_expression"]
 from typing import Any, Optional
 import boto3
 
-from deadline.client.api._session import get_session_client
+from deadline.client.api._session import get_session_client, _ADAPTIVE_RETRIES_CLIENT_CONFIG
 from botocore.exceptions import ClientError
 from deadline.client.exceptions import DeadlineOperationError
 
@@ -105,7 +105,9 @@ def _list_jobs_by_filter_expression(
     # This holds {job_id: job_from_search_jobs_call, ...}
     result_jobs = {}
 
-    deadline = get_session_client(boto3_session, "deadline", region=region)
+    deadline = get_session_client(
+        boto3_session, "deadline", region=region, client_config=_ADAPTIVE_RETRIES_CLIENT_CONFIG
+    )
 
     # Sort jobs in ascending order of the timestamp field
     sort_expressions = [{"fieldSort": {"name": "CREATED_AT", "sortOrder": "ASCENDING"}}]

--- a/src/deadline/client/api/_session.py
+++ b/src/deadline/client/api/_session.py
@@ -264,8 +264,26 @@ def apply_proxy_settings(
     return session
 
 
+# Shared botocore Config for code paths that make many API calls in a burst (e.g. one
+# call per job across a large queue). The "adaptive" strategy suits long bursts of
+# repeated calls: it rate-limits client-side and retains backoff state across calls
+# instead of starting fresh each time. The larger attempt budget rides out sustained
+# throttling instead of surfacing a ThrottlingException mid-operation.
+#
+# Defined once at module level because get_session_client caches by the Config
+# instance's identity — reusing this instance is what makes the client cacheable.
+_ADAPTIVE_RETRIES_CLIENT_CONFIG = botocore.config.Config(
+    retries=dict(mode="adaptive", total_max_attempts=10)
+)
+
+
 @lru_cache
-def get_session_client(session: boto3.Session, service_name: str, region: Optional[str] = None):
+def get_session_client(
+    session: boto3.Session,
+    service_name: str,
+    region: Optional[str] = None,
+    client_config: Optional[botocore.config.Config] = None,
+):
     """
     Create and cache a boto3 client for the given session, service name, and region.
 
@@ -289,21 +307,33 @@ def get_session_client(session: boto3.Session, service_name: str, region: Option
         service_name: The name of the AWS service (e.g., 'deadline', 's3')
         region: The AWS region to create the client for. If None, the session's
             default region is used.
+        client_config: Optional botocore Config merged over the default client
+            config (``get_default_client_config``), taking precedence where both
+            set an option. The default config's user-agent tagging is preserved.
+            CAUTION: ``botocore.config.Config`` hashes by object identity, and this
+            argument is part of the lru_cache key — pass a shared (e.g. module-level)
+            instance rather than constructing a new one per call, or every call
+            builds a new client. Pass ``_ADAPTIVE_RETRIES_CLIENT_CONFIG`` for code
+            paths that make many API calls in a burst.
 
     Returns:
         A boto3 client for the specified service
     """
-    if region is None:
-        return session.client(service_name, config=get_default_client_config())
+    resolved_config = get_default_client_config()
+    if client_config is not None:
+        resolved_config = resolved_config.merge(client_config)
 
-    client = session.client(service_name, config=get_default_client_config(), region_name=region)
+    if region is None:
+        return session.client(service_name, config=resolved_config)
+
+    client = session.client(service_name, config=resolved_config, region_name=region)
     resolved = client.meta.endpoint_url
     session_region = session.region_name
     # An override leaked the session's region into a cross-region endpoint.
     if region not in resolved and session_region and session_region in resolved:
         return session.client(
             service_name,
-            config=get_default_client_config(),
+            config=resolved_config,
             region_name=region,
             endpoint_url=resolved.replace(session_region, region, 1),
         )

--- a/src/deadline/client/cli/_groups/queue_group.py
+++ b/src/deadline/client/cli/_groups/queue_group.py
@@ -15,7 +15,11 @@ from botocore.exceptions import ClientError  # type: ignore[import]
 from datetime import datetime, timedelta, timezone
 
 from ... import api
-from ...api._session import get_session_client, _resolve_region
+from ...api._session import (
+    get_session_client,
+    _resolve_region,
+    _ADAPTIVE_RETRIES_CLIENT_CONFIG,
+)
 from ...config import config_file
 from ...exceptions import DeadlineOperationError
 from .._common import (
@@ -373,7 +377,9 @@ def sync_output(
     # This operates within a single farm, so scope the deadline client to that farm's
     # region. _resolve_region returns None when nothing is configured.
     region = _resolve_region(config=config, farm_id=farm_id)
-    deadline = get_session_client(boto3_session, "deadline", region=region)
+    deadline = get_session_client(
+        boto3_session, "deadline", region=region, client_config=_ADAPTIVE_RETRIES_CLIENT_CONFIG
+    )
 
     if ignore_storage_profiles:
         local_storage_profile_id = None

--- a/src/deadline/client/cli/_incremental_download.py
+++ b/src/deadline/client/cli/_incremental_download.py
@@ -24,7 +24,11 @@ import boto3
 from botocore.client import BaseClient  # type: ignore[import]
 from botocore.exceptions import ClientError  # type: ignore[import]
 from ..api._list_jobs_by_filter_expression import _list_jobs_by_filter_expression
-from ..api._session import get_session_client, _resolve_region
+from ..api._session import (
+    get_session_client,
+    _resolve_region,
+    _ADAPTIVE_RETRIES_CLIENT_CONFIG,
+)
 from ...job_attachments.api import summarize_path_list, human_readable_file_size
 from ...job_attachments._aws.aws_clients import get_s3_client as _get_s3_client
 from ...job_attachments._incremental_downloads.incremental_download_state import (
@@ -399,7 +403,9 @@ def _categorize_jobs_in_checkpoint(
         region: The AWS region to scope the deadline client to. When None, the session's
             default region is used.
     """
-    deadline = get_session_client(boto3_session, "deadline", region=region)
+    deadline = get_session_client(
+        boto3_session, "deadline", region=region, client_config=_ADAPTIVE_RETRIES_CLIENT_CONFIG
+    )
     checkpoint_jobs = {job.job_id: job.job for job in checkpoint.jobs}
     checkpoint_job_ids = set(checkpoint_jobs.keys())
 
@@ -783,7 +789,9 @@ def _get_job_sessions(
         if job.session_ended_timestamp is not None
     }
 
-    deadline = get_session_client(boto3_session, "deadline", region=region)
+    deadline = get_session_client(
+        boto3_session, "deadline", region=region, client_config=_ADAPTIVE_RETRIES_CLIENT_CONFIG
+    )
     job_sessions: dict[str, list] = {}
 
     # Retrieve all the sessions with some parallelism
@@ -1251,7 +1259,9 @@ def _incremental_output_download(
     # farm's region. _resolve_region returns None when nothing is configured, preserving
     # the session's default-region behavior.
     region = _resolve_region(config=config, farm_id=farm_id)
-    deadline = get_session_client(boto3_session, "deadline", region=region)
+    deadline = get_session_client(
+        boto3_session, "deadline", region=region, client_config=_ADAPTIVE_RETRIES_CLIENT_CONFIG
+    )
 
     # When this function is done, we will be confident that downloads are complete up to
     # new_completed_timestamp. We subtract a duration from now() that gives a generous amount of

--- a/test/unit/deadline_client/api/test_api_session.py
+++ b/test/unit/deadline_client/api/test_api_session.py
@@ -17,6 +17,7 @@ from deadline.client.api._session import (
     get_session_client,
     precache_clients,
     _resolve_region,
+    _ADAPTIVE_RETRIES_CLIENT_CONFIG,
 )
 
 
@@ -537,6 +538,63 @@ def test_get_session_client_same_region_cached():
     client2 = get_session_client(session, "s3", region="eu-west-1")
 
     assert client1 is client2
+
+
+def test_get_session_client_client_config_merges_over_default():
+    """
+    A caller-supplied client_config is merged over the default config: its options
+    (here the adaptive retry mode) take effect while the default config's
+    user-agent tagging is preserved.
+    """
+    get_session_client.cache_clear()
+    session = boto3.Session()
+
+    client = get_session_client(session, "s3", client_config=_ADAPTIVE_RETRIES_CLIENT_CONFIG)
+    retries = client.meta.config.retries
+    assert retries["mode"] == "adaptive"
+    assert retries["total_max_attempts"] == 10
+    # The default config's user-agent tagging survives the merge
+    assert "app/deadline-client" in client.meta.config.user_agent_extra
+
+    default_client = get_session_client(session, "s3")
+    default_retries = default_client.meta.config.retries or {}
+    assert default_retries.get("mode") != "adaptive"
+
+
+def test_get_session_client_client_config_distinct_cache_entry():
+    """
+    client_config participates in the lru_cache key: passing the shared config
+    yields a different client object than the default, and repeated calls with
+    the same config instance return the same cached client.
+    """
+    get_session_client.cache_clear()
+    session = boto3.Session()
+
+    default_client = get_session_client(session, "s3")
+    adaptive_client = get_session_client(
+        session, "s3", client_config=_ADAPTIVE_RETRIES_CLIENT_CONFIG
+    )
+    assert default_client is not adaptive_client
+
+    adaptive_client2 = get_session_client(
+        session, "s3", client_config=_ADAPTIVE_RETRIES_CLIENT_CONFIG
+    )
+    assert adaptive_client is adaptive_client2
+
+
+def test_get_session_client_client_config_with_region():
+    """
+    client_config composes with the region argument: the region-scoped client
+    carries both the requested region and the merged retry configuration.
+    """
+    get_session_client.cache_clear()
+    session = boto3.Session()
+
+    client = get_session_client(
+        session, "s3", region="us-west-2", client_config=_ADAPTIVE_RETRIES_CLIENT_CONFIG
+    )
+    assert client.meta.region_name == "us-west-2"
+    assert client.meta.config.retries["mode"] == "adaptive"
 
 
 class TestGetSessionClientCrossRegion:

--- a/test/unit/deadline_client/api/test_list_jobs_by_filter_expression.py
+++ b/test/unit/deadline_client/api/test_list_jobs_by_filter_expression.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from deadline.client.api._session import _ADAPTIVE_RETRIES_CLIENT_CONFIG
 from deadline.client.api._list_jobs_by_filter_expression import (
     JobFetchFailure,
     _list_jobs_by_filter_expression,
@@ -289,4 +290,9 @@ def test_list_jobs_by_filter_expression_passes_region(mock_boto3_session, region
             region=region,
         )
 
-    mock_get_session_client.assert_called_once_with(mock_boto3_session, "deadline", region=region)
+    mock_get_session_client.assert_called_once_with(
+        mock_boto3_session,
+        "deadline",
+        region=region,
+        client_config=_ADAPTIVE_RETRIES_CLIENT_CONFIG,
+    )

--- a/test/unit/deadline_client/cli/test_incremental_download_region.py
+++ b/test/unit/deadline_client/cli/test_incremental_download_region.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from deadline.client.api._session import _ADAPTIVE_RETRIES_CLIENT_CONFIG
 from deadline.client.cli import _incremental_download
 from ..shared_constants import MOCK_FARM_ID, MOCK_QUEUE_ID
 
@@ -74,4 +75,9 @@ def test_get_job_sessions_scopes_deadline_client_to_region(region):
             region=region,
         )
 
-    mock_get_session_client.assert_called_once_with(boto3_session, "deadline", region=region)
+    mock_get_session_client.assert_called_once_with(
+        boto3_session,
+        "deadline",
+        region=region,
+        client_config=_ADAPTIVE_RETRIES_CLIENT_CONFIG,
+    )


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

`deadline queue sync-output` keeps a checkpoint of what it has already downloaded. Each run asks the service "what changed since my checkpoint?" and only processes those jobs. In normal operation that delta is small, and the command is fast and reliable. We verified over 1000 consecutive 60-second runs against a queue of 1400 jobs without a single failure.

The problem shows up when a single run has a *large* delta to process — most commonly the first run after a restart, when the checkpoint is fresh or stale and every job in the queue counts as new. For each new job the command calls `GetJob`, then `ListSessions`, then `ListSessionActions` for every session. With 1000+ candidate jobs that's thousands of API calls fired as fast as the command can make them.

The service throttles this call pattern. botocore retries a few times with its default budget, gives up, and raises `ThrottlingException` which is unhandled.

Reproduction (Deadline Cloud farm, queue with 3202 download-candidate jobs, fresh checkpoint):

```
Retrieving sessions for 3202 jobs...
...
botocore.errorfactory.ThrottlingException: An error occurred (ThrottlingException)
when calling the ListSessionActions operation (reached max retries: 4): Too Many Requests
```

A follow-up, not part of this change, is to switch to using deadline:BatchGetJob and other Batch* APIs where possible to speed up the full operation.

### What was the solution? (How)

Use botocore's `adaptive` retry mode for the sync-output metadata calls. Adaptive mode does two things the default mode doesn't: it rate-limits on the client side (measuring how fast the service is willing to go and pacing requests to match, instead of bursting into throttles), and it keeps that pacing state across calls. Combined with a larger attempt budget (`total_max_attempts=10`), sustained throttling becomes a slowdown instead of a crash.

The changes:

* `get_session_client()` gains an optional `client_config` argument, merged over the default client config with `botocore.config.Config.merge()` — caller options take precedence, and the default config's user-agent tagging is preserved.
* A shared module-level `_ADAPTIVE_RETRIES_CLIENT_CONFIG` holds the retry settings. Sharing one instance matters twice: `Config` hashes by identity, so a shared instance is what makes the `lru_cache` on `get_session_client` effective; and the resulting *single shared client* means the adaptive rate-limiter state spans the entire burst, including the threaded session-retrieval phase.
* All five sync-output metadata call sites pass it (`SearchJobs` pagination, per-job `GetJob` categorization, `ListSessions`/`ListSessionActions` retrieval, and the CLI entry point's client).

The scope is limited to sync-output: adaptive client-side rate limiting would add latency to interactive commands, which don't need it. This follows the precedent already in the codebase, where `deadline job requeue` uses an adaptive-retry client for its bulk `UpdateTask` loop.

### What is the impact of this change?

* `deadline queue sync-output` survives large-delta runs (bootstrap, restart after downtime, very busy queues) instead of crashing into a permanent restart loop.
* A/B test against the same live queue (3202 candidate jobs, 25,044 sessions, fresh checkpoint, dry run):
  * **Before:** crashed with `ThrottlingException` ~15 minutes into the session-actions phase; checkpoint never written.
  * **After:** the same phase completed in 43m56s with zero throttling errors surfaced; the run finished cleanly, resolving 192,376 session actions.
* No behavior change for any other command: the adaptive config is opt-in per call site, and clients built with it are separate cache entries from default clients.
* Known limitation (follow-ups planned): this raises the crash threshold, it does not make bootstrap crash-proof — a call throttled through all 10 attempts still fails without saving the checkpoint. Batching the per-job `GetJob` calls (`BatchGetJob`), isolating per-job session-retrieval failures, and saving the checkpoint incrementally are complementary next steps.

### How was this change tested?

- Have you run the unit tests? **Yes.** Full unit suite passes (3052 passed; 9 failures due to local setup constraints). New unit tests cover the `client_config` merge (adaptive options applied, user-agent preserved), the cache-key behavior (shared instance → same client; distinct from default), and composition with the `region` argument.
- Have you run the integration tests? **No** — verified against a live test farm: the A/B reproduction described above, plus 1000+ steady-state runs of the periodic autodownloader during the investigation.
- `ruff format`, `ruff check`, and `mypy` are clean on all changed files.

### Was this change documented?

- Are relevant docstrings in the code base updated? **Yes** — `get_session_client` documents the new argument, the merge semantics, and the identity-based caching caveat (pass a shared `Config` instance, not a fresh one per call).
- Has the README.md been updated? **N/A** — no CLI arguments or user-facing interfaces changed.

### Does this PR introduce new dependencies?

*   [ ] This PR adds one or more new dependency Python packages. I acknowledge I have reviewed the considerations for adding dependencies in [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud/blob/mainline/DEVELOPMENT.md#dependencies).
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?

No.

### Does this change impact security?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
