### PR TITLE
docs: revert 'pre-GUI hooks not run by DCC submitters' carve-out from #1242

### DIFF
--- a/docs/submission-hooks.md
+++ b/docs/submission-hooks.md
@@ -40,10 +40,6 @@ export DEADLINE_HOOKS_DIR=/studio/pipeline/hooks/maya
 
 Requires `settings.allow_environment_hooks` to be enabled. Both sources can be active simultaneously — environment hooks run first, then bundle hooks.
 
-> **Note:** In DCC submitters, environment hooks apply to the **pre-submission** and
-> **post-submission** phases only. The pre-GUI phase is not run by in-application
-> submitters — see [Pre-GUI Hooks](#pre-gui-hooks).
-
 ## Hook Types
 
 ### Pre-GUI Hooks
@@ -54,13 +50,6 @@ Run **before** the submission dialog opens. Use these to:
 - Query a project management system for task metadata
 
 Pre-GUI hooks **block the dialog from opening** if they fail (non-zero exit code or timeout).
-
-> **Supported only by `deadline bundle gui-submit`.** Pre-GUI hooks run on the standalone
-> GUI submitter. They do **not** run in in-application (DCC) submitters such as Maya,
-> Nuke, or Blender — those build their submission dialog directly and do not invoke the
-> pre-GUI phase. Pre-submission and post-submission hooks are unaffected and work across
-> all submission methods. (CLI `deadline bundle submit` has no GUI phase, so pre-GUI hooks
-> do not apply there either.)
 
 Output JSON to stdout to modify the initial dialog state:
 
@@ -513,13 +502,11 @@ Failures are logged as warnings but don't affect the submitted job.
 ## Submission methods
 
 Hooks work with these submission methods:
-- `deadline bundle submit` (CLI) — pre-submission and post-submission hooks.
+- `deadline bundle submit` (CLI) — pre-submission and post-submission hooks (there is no pre-GUI phase).
 - `deadline bundle gui-submit` (standalone GUI) — all phases, including pre-GUI.
-- In-application (DCC) submitters — pre-submission and post-submission hooks. The pre-GUI
-  phase is not run by DCC submitters (see [Pre-GUI Hooks](#pre-gui-hooks)).
+- In-application (DCC) submitters — pre-submission and post-submission hooks, plus the pre-GUI phase in submitters that implement it (they call the client's `run_pre_gui_hooks` entry point).
 
-The standalone GUI copies `hooks.yaml` to the job history bundle and resolves script paths
-back to your original bundle directory.
+The standalone GUI copies `hooks.yaml` to the job history bundle and resolves script paths back to your original bundle directory.
 
 ## Best Practices
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

`docs/submission-hooks.md` carried a carve-out — added in #1242 (`d83f1d0`) — stating pre-GUI hooks are **"Supported only by `deadline bundle gui-submit`"** and are **not** run by in-application (DCC) submitters (Maya, Nuke, Blender, …). That is no longer accurate: those DCC submitters now run environment-sourced pre-GUI hooks (from `DEADLINE_HOOKS_DIR`) via the client's `run_pre_gui_hooks` / `apply_pre_gui_output` entry point.

### What was the solution? (How)

Revert the carve-out that #1242 introduced, in the three places it appeared:

- the Environment Hooks **Note**,
- the Pre-GUI Hooks **blockquote** ("Supported only by `deadline bundle gui-submit` …"),
- the submission-methods list (restored to the prior "CLI vs GUI" section).

The unrelated pre-submission `parameters`-output documentation added in the same commit is **preserved** (not reverted). Docs-only, no code changes.

### What is the impact of this change?

Documentation no longer incorrectly states that DCC submitters cannot run pre-GUI hooks. No runtime behavior changes.

### How was this change tested?

N/A — documentation only.

- Have you run the unit tests? N/A (docs only)
- Have you run the integration tests? N/A (docs only)

### Was this change documented?

This change *is* the documentation update.

### Does this PR introduce new dependencies?

*   [x] This PR does not add any new dependencies.

### Is this a breaking change?

No.

### Does this change impact security?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
