### PR TITLE
test: prevent OOM crash in archive-safety too-many-entries test

### DIFF
--- a/test/unit/deadline_client/job_bundle/test_repository.py
+++ b/test/unit/deadline_client/job_bundle/test_repository.py
@@ -11,6 +11,7 @@ import os
 import sys
 import zipfile
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 import yaml
@@ -1266,14 +1267,19 @@ class TestArchiveExtractionSafety:
     counts, and extractions that wouldn't fit on disk — always enforced."""
 
     def _fake_zip(self, entries):
-        """entries: list of (file_size, compress_size) tuples."""
+        """entries: list of (file_size, compress_size) tuples.
+
+        Uses lightweight SimpleNamespace entries rather than MagicMock: the
+        too-many-entries test builds MAX_ARCHIVE_ENTRIES + 1 (100_001) infos,
+        and a MagicMock per entry exhausts worker memory (OOM-crashing the
+        pytest-xdist worker). _check_archive_extraction_safety only reads
+        .file_size / .compress_size, which SimpleNamespace provides.
+        """
         zf = MagicMock()
-        infos = []
-        for file_size, compress_size in entries:
-            zi = MagicMock()
-            zi.file_size = file_size
-            zi.compress_size = compress_size
-            infos.append(zi)
+        infos = [
+            SimpleNamespace(file_size=file_size, compress_size=compress_size)
+            for file_size, compress_size in entries
+        ]
         zf.infolist.return_value = infos
         return zf
 


### PR DESCRIPTION
## What

`TestArchiveExtractionSafety._fake_zip` built one `MagicMock` per zip entry. `test_rejects_too_many_entries` constructs `MAX_ARCHIVE_ENTRIES + 1` (**100,001**) entries, so it allocated ~100k `MagicMock` objects — hundreds of MB to multiple GB of RAM.

This is the heaviest test in the suite (**12–48s** even on GitHub runners). On the memory-constrained **single-worker publish CodeBuild container**, it **OOM-killed the pytest-xdist worker** (`replacing crashed worker gw0`). The dead worker dropped its coverage data, total coverage fell to 60.17% (below the 69% `fail-under` gate), and `pipeline/publish.sh` exited 1 — **blocking the release publish** for 0.60.5.

## Fix

Replace the per-entry `MagicMock` with a lightweight `types.SimpleNamespace`. `_check_archive_extraction_safety` only reads `.file_size` / `.compress_size`, which `SimpleNamespace` provides, so all five tests using `_fake_zip` are unaffected and the production `MAX_ARCHIVE_ENTRIES = 100_000` limit is unchanged.

## Testing

The full `TestArchiveExtractionSafety` class (including `test_rejects_too_many_entries`) now passes **under a 2 GB virtual-memory cap in 0.14s** — previously it OOM-crashed the worker.

```
$ ulimit -v 2097152; pytest test/unit/.../test_repository.py::TestArchiveExtractionSafety -v
6 passed in 0.14s
```

## Regression source

Introduced by #1181 (job bundle browser/sharing), which added both the archive-safety check and this test. Since #1181 is the only feature in 0.60.5, its own test currently blocks that release from publishing.