### PR TITLE
fix: coerce click.Path prompt results to str for mypy 2.3

### DIFF
--- a/src/deadline/client/cli/_groups/job_group.py
+++ b/src/deadline/client/cli/_groups/job_group.py
@@ -541,9 +541,11 @@ def _prompt_for_os_mismatch_roots(
         if PathFormat.get_host_path_format_string() != root_path_format:
             click.echo(_get_mismatch_os_root_warning(asset_root, root_path_format, is_json_format))
             if not is_json_format:
-                new_root = click.prompt(
-                    "> Please enter a new root path",
-                    type=click.Path(exists=False),
+                new_root = str(
+                    click.prompt(
+                        "> Please enter a new root path",
+                        type=click.Path(exists=False),
+                    )
                 )
             else:
                 json_string = click.prompt("", prompt_suffix="", type=str)
@@ -583,10 +585,12 @@ def _prompt_to_confirm_roots(
                 return None
             elif user_choice != "y":
                 index_to_change = int(user_choice)
-                new_root = click.prompt(
-                    "> Please enter the new root directory path, or press Enter to keep it unchanged",
-                    type=click.Path(exists=False),
-                    default=asset_roots[index_to_change],
+                new_root = str(
+                    click.prompt(
+                        "> Please enter the new root directory path, or press Enter to keep it unchanged",
+                        type=click.Path(exists=False),
+                        default=asset_roots[index_to_change],
+                    )
                 )
                 downloader.set_root_path(asset_roots[index_to_change], str(Path(new_root)))
                 paths_by_root = downloader.get_paths_by_root()


### PR DESCRIPTION
## Problem

The `Python (windows-latest, 3.13)` linting job fails on mainline (seen while cutting release #1347):

```
src/deadline/client/cli/_groups/job_group.py:554: error: Argument 2 to "set_root_path" of "_BaseFilterableDownloader" has incompatible type "str | bytes"; expected "str"  [arg-type]
src/deadline/client/cli/_groups/job_group.py:591: error: Argument 1 to "Path" has incompatible type "str | bytes | PathLike[str]"; expected "str | PathLike[str]"  [arg-type]
```

## Cause

Dependency bumps, not a code change. `mypy` was bumped `2.2.* -> 2.3.*` (#1269) and CI now resolves `click` 8.5.0. `click.Path` is typed `ParamType[str | bytes | os.PathLike[str]]`, so `click.prompt(type=click.Path(...))` is inferred as that broad union (`path_type` does not narrow it in the stubs). Passing the result to `set_root_path(str)` and `Path(...)` therefore fails type checking. Earlier mypy/click versions inferred `str`.

## Fix

The prompt value is always a `str` at runtime (a `click.Path` prompt returns the entered string). Coerce it explicitly with `str(...)` at the two call sites — same idiom already used a few lines down (`str(Path(new_root))`). No behavioral change.

## Testing

Verified with the exact CI toolchain (`mypy==2.3.1`, `ruff==0.15.22`, `click==8.5.0`, Python 3.13):

- `mypy src test ...` -> `Success: no issues found in 327 source files`
- `ruff check .` -> all checks passed
- `ruff format --check .` -> 344 files already formatted
- Relevant unit tests (`test_cli_job.py`, `test_cli_job_download_storage_profiles.py`, root/download/confirm paths): 30 passed, 11 skipped