### PR TITLE
feat: reclaim old task records from the download status file

### DIFF
--- a/src/deadline/client/cli/_download_status_file.py
+++ b/src/deadline/client/cli/_download_status_file.py
@@ -10,7 +10,7 @@ import socket
 import tempfile
 import time
 from contextlib import contextmanager
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, Callable, Generator, Optional
 
 from ..config.config_file import DEFAULT_QUEUE_INCREMENTAL_DOWNLOAD_DIR
@@ -18,7 +18,13 @@ from ._incremental_download import CategorizedJobIds
 
 logger = logging.getLogger(__name__)
 
+# Still 1: trimming only empties a job's tasks dict, which readers already tolerate.
 DOWNLOAD_STATUS_FILE_SCHEMA_VERSION = 1
+
+# Sized against the Monitor parsing this file whole on its 60s poll (~2.4ms/MB); task records at
+# ~230 bytes each dominate the size.
+_TARGET_RETAINED_TASK_RECORDS = 100_000
+
 _STATUS_FILE_LOCK_TTL_SECONDS = 60
 _STATUS_FILE_LOCK_RETRY_INTERVAL_SECONDS = 1
 # MAX_WAIT must be >= TTL so a waiter is willing to wait at least as long as a lock
@@ -128,6 +134,7 @@ def _make_status_entry(
 # contradicts any of them, so these are the states _reconcile_entry_with_tasks overrides.
 # "in_progress" is excluded on purpose: it claims nothing, and the download may still be retried
 # before the job ends, so the honest report is a failed task row under a still-running job.
+# Also gates trimming via _is_history_trimmable: adding a status widens what records get dropped.
 _NO_DOWNLOAD_FAILURE_STATUSES = ("downloaded", "skipped")
 
 
@@ -231,6 +238,112 @@ def _determine_job_download_status(
         return _make_status_entry("in_progress", total_files, downloaded_files)
 
     return _make_status_entry("in_progress", total_files, downloaded_files)
+
+
+_OLDEST_SORT_KEY = datetime.min.replace(tzinfo=timezone.utc)
+# Beyond this, a timestamp is a clock error rather than a newer entry. Affects order only.
+_CLOCK_SKEW_ALLOWANCE = timedelta(minutes=5)
+
+
+def _is_history_trimmable(entry: Any) -> bool:
+    """True if this job's task records may be dropped.
+
+    A "downloaded" job can still hold failed tasks, and the farm_failed guard in
+    _build_status_file_content needs those records on disk to suppress a stale failure.
+    """
+    if not isinstance(entry, dict):
+        return False
+    if entry.get("download_status") not in _NO_DOWNLOAD_FAILURE_STATUSES:
+        return False
+    if entry.get("error_code") is not None or entry.get("failed_files"):
+        return False
+    tasks = entry.get("tasks")
+    if tasks is None:
+        return True
+    if not isinstance(tasks, dict):
+        return False
+    for task in tasks.values():
+        if not isinstance(task, dict):
+            return False
+        if task.get("download_status") != "downloaded" or task.get("error_code") is not None:
+            return False
+    return True
+
+
+def _last_updated_sort_key(entry: Any) -> datetime:
+    """Retention order key, newest first. Undatable entries sort oldest.
+
+    last_updated moves on a status change, not on every sync. Future timestamps are clamped, not
+    demoted, so one fast clock does not make every other writer drop that machine's records first.
+    """
+    if not isinstance(entry, dict):
+        return _OLDEST_SORT_KEY
+    raw = entry.get("last_updated")
+    if not isinstance(raw, str):
+        return _OLDEST_SORT_KEY
+    try:
+        # fromisoformat only accepts a trailing "Z" from 3.11, and this file is written by
+        # whatever client reached it first.
+        parsed = datetime.fromisoformat(raw[:-1] + "+00:00" if raw.endswith("Z") else raw)
+    except ValueError:
+        return _OLDEST_SORT_KEY
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    now = datetime.now(timezone.utc)
+    return min(parsed, now) if parsed > now + _CLOCK_SKEW_ALLOWANCE else parsed
+
+
+def _trim_retained_history(jobs_status: dict[str, Any], candidate_job_ids: set[str]) -> None:
+    """Reclaims task records in place, keeping those of the most recently updated jobs.
+
+    The target is a reclaim budget, not a ceiling: ineligible jobs and this run's candidates keep
+    their records without spending it. Entries are emptied, never removed, because the
+    preserve-counts branch in _build_status_file_content needs the entry. A reclaimed job that is
+    later requeued can report an already-downloaded frame as a farm failure.
+    """
+    ordered = sorted(
+        (
+            (_last_updated_sort_key(entry), position, job_id, entry)
+            for position, (job_id, entry) in enumerate(jobs_status.items())
+        ),
+        key=lambda item: (item[0], item[1]),
+        reverse=True,
+    )
+
+    budget = _TARGET_RETAINED_TASK_RECORDS
+    retained_records = 0
+    dropped_records = 0
+    untrimmable_records = 0
+    live_records = 0
+    for _, _, job_id, entry in ordered:
+        tasks = entry.get("tasks") if isinstance(entry, dict) else None
+        record_count = len(tasks) if isinstance(tasks, dict) else 0
+        if not record_count:
+            continue
+        if not _is_history_trimmable(entry):
+            untrimmable_records += record_count
+            retained_records += record_count
+        elif job_id in candidate_job_ids:
+            live_records += record_count
+            retained_records += record_count
+        elif budget > 0:
+            budget = max(0, budget - record_count)
+            retained_records += record_count
+        else:
+            entry["tasks"] = {}
+            dropped_records += record_count
+
+    if dropped_records:
+        logger.debug(
+            f"Trimmed download status history: dropped {dropped_records} task records, "
+            f"retaining {retained_records}."
+        )
+    if retained_records > _TARGET_RETAINED_TASK_RECORDS:
+        logger.info(
+            f"Download status file retains {retained_records} task records, above the "
+            f"{_TARGET_RETAINED_TASK_RECORDS} target: {untrimmable_records} belong to jobs that "
+            f"are not eligible to be trimmed and {live_records} to jobs this run is still tracking."
+        )
 
 
 def _build_status_file_content(
@@ -347,6 +460,9 @@ def _build_status_file_content(
                 existing_entry["download_status"] = "skipped"
             existing_entry["last_updated"] = now
             _reconcile_entry_with_tasks(existing_entry)
+
+    # Ordered after reconciliation, which reads entry["tasks"].
+    _trim_retained_history(jobs_status, all_job_ids)
 
     # Determine run status — "failed" if any job in this run had errors
     has_failures = any(

--- a/test/unit/deadline_client/cli/test_cli_download_status_file.py
+++ b/test/unit/deadline_client/cli/test_cli_download_status_file.py
@@ -25,7 +25,11 @@ from deadline.client.cli._incremental_download import (
     _FailedJobsTracker,
     _MAX_FAILED_JOB_RETRIES,
 )
-from deadline.client.cli._download_status_file import _is_job_fully_complete
+from deadline.client.cli import _download_status_file as status_file_module
+from deadline.client.cli._download_status_file import (
+    _is_history_trimmable,
+    _is_job_fully_complete,
+)
 
 from ..shared_constants import MOCK_QUEUE_ID, MOCK_STORAGE_PROFILE_ID, MOCK_JOB_ID
 
@@ -2363,3 +2367,399 @@ class TestRetrieveSessionActionsFarmFailures:
 
         # No sessionActions populated (nothing succeeded), no crash.
         assert "sessionActions" not in output_session
+
+
+def _make_history_entry(
+    *,
+    day: int,
+    task_count: int = 0,
+    status: str = "downloaded",
+    task_status: str = "downloaded",
+    task_error_code: Optional[str] = None,
+    failed_files: int = 0,
+    error_code: Optional[str] = None,
+    total_files: Optional[int] = None,
+) -> dict[str, Any]:
+    """Builds a job entry as it would already exist on disk from an earlier run."""
+    counted = task_count if total_files is None else total_files
+    return {
+        "download_status": status,
+        "total_files": counted,
+        "downloaded_files": counted,
+        "failed_files": failed_files,
+        "last_updated": f"2026-01-{day:02d}T00:00:00+00:00",
+        "error_code": error_code,
+        "error_message": None,
+        "skip_reason": None,
+        "tasks": {
+            f"task-{day}-{i}": {
+                "download_status": task_status,
+                "total_files": 1,
+                "downloaded_files": 1 if task_status == "downloaded" else 0,
+                "error_code": task_error_code,
+                "error_message": None,
+            }
+            for i in range(task_count)
+        },
+    }
+
+
+def _build_from_history(existing_jobs: dict[str, Any], **kwargs) -> dict[str, Any]:
+    """Runs the builder over prior state, with no jobs in the current run unless given."""
+    return _build_status_file_content(
+        queue_id=MOCK_QUEUE_ID,
+        storage_profile_id=MOCK_STORAGE_PROFILE_ID,
+        categorized_job_ids=kwargs.pop("categorized_job_ids", _make_categorized_job_ids()),
+        download_candidate_jobs=kwargs.pop("download_candidate_jobs", {}),
+        existing_jobs=existing_jobs,
+        **kwargs,
+    )
+
+
+class TestRetentionTargetValues:
+    """The shipped target, asserted outside the fixture that shrinks it."""
+
+    def test_shipped_target_is_the_intended_value(self):
+        # A dropped digit in the Monitor's size budget would otherwise ship silently.
+        assert status_file_module._TARGET_RETAINED_TASK_RECORDS == 100_000
+
+
+class TestHistoryTrimming:
+    @pytest.fixture(autouse=True)
+    def _small_targets(self, monkeypatch):
+        """Shrink the target so the behaviour is testable without building 100k records."""
+        monkeypatch.setattr(status_file_module, "_TARGET_RETAINED_TASK_RECORDS", 10)
+
+    def test_history_within_targets_is_untouched(self):
+        existing = {
+            "job-a": _make_history_entry(day=3, task_count=4),
+            "job-b": _make_history_entry(day=2, task_count=4),
+        }
+        result = _build_from_history(existing)
+        assert len(result["jobs"]) == 2
+        assert len(result["jobs"]["job-a"]["tasks"]) == 4
+        assert len(result["jobs"]["job-b"]["tasks"]) == 4
+
+    def test_records_are_dropped_once_the_budget_is_spent(self):
+        existing = {
+            "job-new": _make_history_entry(day=9, task_count=6),
+            "job-mid": _make_history_entry(day=5, task_count=4),
+            "job-old": _make_history_entry(day=1, task_count=6),
+        }
+        result = _build_from_history(existing)
+        assert len(result["jobs"]["job-new"]["tasks"]) == 6
+        assert len(result["jobs"]["job-mid"]["tasks"]) == 4
+        assert result["jobs"]["job-old"]["tasks"] == {}
+        assert result["jobs"]["job-old"]["download_status"] == "downloaded"
+        assert result["jobs"]["job-old"]["downloaded_files"] == 6
+
+    def test_newest_job_keeps_its_records_even_when_it_alone_exceeds_the_budget(self):
+        existing = {"job-huge": _make_history_entry(day=9, task_count=14)}
+        result = _build_from_history(existing)
+        assert len(result["jobs"]["job-huge"]["tasks"]) == 14
+
+    def test_an_untrimmable_job_does_not_spend_the_budget(self):
+        existing = {
+            "job-stuck": _make_history_entry(day=9, task_count=14, status="in_progress"),
+            "job-clean": _make_history_entry(day=5, task_count=4),
+        }
+        result = _build_from_history(existing)
+        assert len(result["jobs"]["job-stuck"]["tasks"]) == 14
+        assert len(result["jobs"]["job-clean"]["tasks"]) == 4
+
+    @pytest.mark.parametrize(
+        "task_status,task_error_code",
+        [
+            ("failed", "PERMISSION_DENIED"),
+            ("farm_failed", None),
+            ("in_progress", None),
+            # A record whose status and error fields disagree is still evidence of a failure.
+            ("downloaded", "DISK_FULL"),
+        ],
+    )
+    def test_job_holding_a_non_success_record_is_never_trimmed(self, task_status, task_error_code):
+        existing = {
+            "job-new": _make_history_entry(day=9, task_count=10),
+            "job-old": _make_history_entry(
+                day=1, task_count=4, task_status=task_status, task_error_code=task_error_code
+            ),
+        }
+        result = _build_from_history(existing)
+        assert len(result["jobs"]["job-old"]["tasks"]) == 4
+
+    def test_job_with_failure_counts_is_never_trimmed(self):
+        existing = {
+            "job-new": _make_history_entry(day=9, task_count=10),
+            "job-old": _make_history_entry(day=1, task_count=4, failed_files=2),
+        }
+        result = _build_from_history(existing)
+        assert len(result["jobs"]["job-old"]["tasks"]) == 4
+
+    def test_unfinished_job_is_never_trimmed(self):
+        existing = {
+            "job-new": _make_history_entry(day=9, task_count=10),
+            "job-running": _make_history_entry(day=1, task_count=4, status="in_progress"),
+        }
+        result = _build_from_history(existing)
+        assert len(result["jobs"]["job-running"]["tasks"]) == 4
+
+    def test_no_job_row_is_ever_removed(self):
+        existing = {f"job-{day}": _make_history_entry(day=day, task_count=6) for day in range(1, 9)}
+        existing["job-undated"] = _make_history_entry(day=1, task_count=6)
+        del existing["job-undated"]["last_updated"]
+        result = _build_from_history(existing)
+        assert set(result["jobs"]) == set(existing)
+        # Records were reclaimed, so this is not the trimmer failing to run at all.
+        assert any(e["tasks"] == {} for e in result["jobs"].values())
+
+    def test_ties_in_last_updated_are_broken_by_file_position(self):
+        existing = {
+            "job-first": _make_history_entry(day=4, task_count=10),
+            "job-second": _make_history_entry(day=4, task_count=10),
+        }
+        result = _build_from_history(existing)
+        assert len(result["jobs"]["job-second"]["tasks"]) == 10
+        assert result["jobs"]["job-first"]["tasks"] == {}
+
+    @pytest.mark.parametrize(
+        "last_updated",
+        [
+            pytest.param("__missing__", id="missing"),
+            pytest.param(None, id="null"),
+            pytest.param("not-a-timestamp", id="unparseable"),
+            pytest.param(12345, id="not-a-string"),
+        ],
+    )
+    def test_entry_without_a_usable_timestamp_is_treated_as_oldest(self, last_updated):
+        existing = {
+            "job-dated": _make_history_entry(day=5, task_count=10),
+            "job-undated": _make_history_entry(day=1, task_count=6),
+        }
+        if last_updated == "__missing__":
+            del existing["job-undated"]["last_updated"]
+        else:
+            existing["job-undated"]["last_updated"] = last_updated
+        result = _build_from_history(existing)
+        assert len(result["jobs"]["job-dated"]["tasks"]) == 10
+        assert result["jobs"]["job-undated"]["tasks"] == {}
+
+    def test_naive_timestamp_sorts_by_its_date_not_to_the_bottom(self):
+        existing = {
+            "job-naive": _make_history_entry(day=9, task_count=10),
+            "job-aware": _make_history_entry(day=1, task_count=6),
+        }
+        existing["job-naive"]["last_updated"] = "2026-01-09T00:00:00"
+        result = _build_from_history(existing)
+        assert len(result["jobs"]["job-naive"]["tasks"]) == 10
+        assert result["jobs"]["job-aware"]["tasks"] == {}
+
+    def test_z_suffixed_timestamp_is_understood(self):
+        existing = {
+            "job-zulu": _make_history_entry(day=9, task_count=10),
+            "job-offset": _make_history_entry(day=1, task_count=6),
+        }
+        existing["job-zulu"]["last_updated"] = "2026-01-09T00:00:00Z"
+        result = _build_from_history(existing)
+        assert len(result["jobs"]["job-zulu"]["tasks"]) == 10
+        assert result["jobs"]["job-offset"]["tasks"] == {}
+
+    def test_future_dated_entry_is_clamped_not_treated_as_oldest(self):
+        existing = {
+            "job-skewed": _make_history_entry(day=1, task_count=10),
+            "job-genuinely-old": _make_history_entry(day=2, task_count=6),
+        }
+        existing["job-skewed"]["last_updated"] = "9999-12-31T00:00:00+00:00"
+        result = _build_from_history(existing)
+        assert len(result["jobs"]["job-skewed"]["tasks"]) == 10
+        assert result["jobs"]["job-genuinely-old"]["tasks"] == {}
+
+    def test_records_of_an_inactive_job_are_reclaimed(self):
+        existing = {
+            "job-new": _make_history_entry(day=9, task_count=10),
+            "job-done": _make_history_entry(day=1, task_count=6),
+        }
+        result = _build_from_history(
+            existing, categorized_job_ids=_make_categorized_job_ids(inactive={"job-done"})
+        )
+        assert result["jobs"]["job-done"]["tasks"] == {}
+
+    def test_records_of_a_download_candidate_are_never_emptied(self):
+        existing = {
+            "job-new": _make_history_entry(day=9, task_count=10),
+            "job-live": _make_history_entry(day=1, task_count=4),
+        }
+        current = _make_categorized_job_ids(unchanged={"job-live"})
+        candidates = {"job-live": _make_job("job-live", succeeded=2, total=2, ended=True)}
+        result = _build_from_history(
+            existing, categorized_job_ids=current, download_candidate_jobs=candidates
+        )
+        assert len(result["jobs"]["job-live"]["tasks"]) == 4
+
+    def test_trimmed_records_repopulate_from_a_later_download(self):
+        existing = {
+            "job-new": _make_history_entry(day=9, task_count=10),
+            MOCK_JOB_ID: _make_history_entry(day=1, task_count=6),
+        }
+        first = _build_from_history(existing)
+        assert first["jobs"][MOCK_JOB_ID]["tasks"] == {}
+
+        second = _build_from_history(
+            {MOCK_JOB_ID: first["jobs"][MOCK_JOB_ID]},
+            categorized_job_ids=_make_categorized_job_ids(completed={MOCK_JOB_ID}),
+            download_candidate_jobs={MOCK_JOB_ID: _make_job(MOCK_JOB_ID, succeeded=1, total=1)},
+            task_download_results={
+                MOCK_JOB_ID: {
+                    "task-fresh-0": {
+                        "total_files": 2,
+                        "downloaded_files": 2,
+                        "error_code": None,
+                        "error_message": None,
+                    }
+                }
+            },
+        )
+        tasks = second["jobs"][MOCK_JOB_ID]["tasks"]
+        assert set(tasks) == {"task-fresh-0"}
+        assert tasks["task-fresh-0"]["download_status"] == "downloaded"
+
+    def test_records_kept_on_an_untrimmable_job_still_suppress_a_stale_farm_failure(self):
+        existing = {
+            "job-new": _make_history_entry(day=9, task_count=10),
+            MOCK_JOB_ID: _make_history_entry(
+                day=1, task_count=1, task_status="failed", task_error_code="DISK_FULL"
+            ),
+        }
+        existing[MOCK_JOB_ID]["tasks"]["task-safe-0"] = {
+            "download_status": "downloaded",
+            "total_files": 2,
+            "downloaded_files": 2,
+            "error_code": None,
+            "error_message": None,
+        }
+        result = _build_from_history(
+            existing,
+            categorized_job_ids=_make_categorized_job_ids(completed={MOCK_JOB_ID}),
+            download_candidate_jobs={MOCK_JOB_ID: _make_job(MOCK_JOB_ID, succeeded=1, total=1)},
+            task_download_results={
+                MOCK_JOB_ID: {
+                    "task-safe-0": {
+                        "download_status": "farm_failed",
+                        "total_files": 0,
+                        "downloaded_files": 0,
+                        "error_code": None,
+                        "error_message": None,
+                    }
+                }
+            },
+        )
+        assert (
+            result["jobs"][MOCK_JOB_ID]["tasks"]["task-safe-0"]["download_status"] == "downloaded"
+        )
+
+    @pytest.mark.parametrize(
+        "bad_entry",
+        [
+            pytest.param("not-an-object", id="entry-is-a-string"),
+            pytest.param(
+                {
+                    "download_status": "downloaded",
+                    "last_updated": "2026-01-01T00:00:00+00:00",
+                    "tasks": [],
+                },
+                id="tasks-is-a-list",
+            ),
+            pytest.param(
+                {
+                    "download_status": "downloaded",
+                    "last_updated": "2026-01-01T00:00:00+00:00",
+                    "tasks": {"task-x": "nope"},
+                },
+                id="task-is-a-string",
+            ),
+        ],
+    )
+    def test_malformed_entry_from_another_writer_does_not_stop_the_write(self, tmp_path, bad_entry):
+        """write_download_status_file swallows every exception and only logs, so a shape error in
+        the trim pass would leave the file frozen at its old content forever."""
+        renders_dir = tmp_path / "renders"
+        (renders_dir / ".deadline").mkdir(parents=True)
+        status_file = renders_dir / ".deadline" / f"{MOCK_QUEUE_ID}_download_status.json"
+        with open(status_file, "w") as f:
+            json.dump(
+                {
+                    "schema_version": 1,
+                    "sync_metadata": {},
+                    "jobs": {
+                        "job-bad": bad_entry,
+                        # Enough good rows that the budget runs out before job-bad, where a
+                        # shape assumption would blow up.
+                        **{f"job-ok-{day}": _make_history_entry(day=day) for day in (2, 3, 4, 5)},
+                    },
+                },
+                f,
+            )
+
+        messages: list[str] = []
+        write_download_status_file(
+            queue_id=MOCK_QUEUE_ID,
+            categorized_job_ids=_make_categorized_job_ids(completed={MOCK_JOB_ID}),
+            download_candidate_jobs={MOCK_JOB_ID: _make_job(MOCK_JOB_ID)},
+            local_storage_profile_id=MOCK_STORAGE_PROFILE_ID,
+            local_storage_profile={"fileSystemLocations": [{"path": str(renders_dir)}]},
+            checkpoint_dir=str(tmp_path / "checkpoint"),
+            print_function_callback=messages.append,
+        )
+
+        with open(status_file) as f:
+            data = json.load(f)
+        assert MOCK_JOB_ID in data["jobs"], "the write was abandoned"
+        assert not any("WARNING" in msg for msg in messages)
+
+    def test_write_download_status_file_bounds_the_file_on_disk(self, tmp_path):
+        """Goes through the public entry point and a real read/write cycle."""
+        renders_dir = tmp_path / "renders"
+        (renders_dir / ".deadline").mkdir(parents=True)
+        status_file = renders_dir / ".deadline" / f"{MOCK_QUEUE_ID}_download_status.json"
+        with open(status_file, "w") as f:
+            json.dump(
+                {
+                    "schema_version": 1,
+                    "sync_metadata": {},
+                    "jobs": {
+                        f"job-{day}": _make_history_entry(day=day, task_count=6)
+                        for day in (1, 2, 3, 4, 5)
+                    },
+                },
+                f,
+            )
+
+        write_download_status_file(
+            queue_id=MOCK_QUEUE_ID,
+            categorized_job_ids=_make_categorized_job_ids(completed={MOCK_JOB_ID}),
+            download_candidate_jobs={MOCK_JOB_ID: _make_job(MOCK_JOB_ID)},
+            local_storage_profile_id=MOCK_STORAGE_PROFILE_ID,
+            local_storage_profile={"fileSystemLocations": [{"path": str(renders_dir)}]},
+            checkpoint_dir=str(tmp_path / "checkpoint"),
+        )
+
+        with open(status_file) as f:
+            data = json.load(f)
+        assert MOCK_JOB_ID in data["jobs"]
+        retained = sum(len(e["tasks"]) for e in data["jobs"].values())
+        assert retained <= 12, retained
+
+    def test_is_history_trimmable_requires_a_finished_all_clean_job(self):
+        assert _is_history_trimmable(_make_history_entry(day=1, task_count=2)) is True
+        assert _is_history_trimmable(_make_history_entry(day=1, status="skipped")) is True
+        assert _is_history_trimmable(_make_history_entry(day=1, status="in_progress")) is False
+        assert _is_history_trimmable(_make_history_entry(day=1, error_code="DISK_FULL")) is False
+        assert _is_history_trimmable("not-an-object") is False
+        assert _is_history_trimmable({"download_status": "downloaded", "tasks": []}) is False
+        # An older client may have written a row before the tasks field existed.
+        no_tasks = _make_history_entry(day=1)
+        del no_tasks["tasks"]
+        assert _is_history_trimmable(no_tasks) is True
+        # A record from a client that predates download_status cannot be shown to be a success.
+        entry = _make_history_entry(day=1, task_count=1)
+        del entry["tasks"]["task-1-0"]["download_status"]
+        assert _is_history_trimmable(entry) is False


### PR DESCRIPTION
## What this does

Bounds the growth of the per-queue download-status file, which until now only ever grew. `_build_status_file_content` merges each `deadline queue sync-output` run onto the previous file and nothing was ever removed, so size scaled with the total number of frames ever downloaded through a queue.

Once more than **100,000 task records** are retained, the records of the least recently updated eligible jobs are emptied. Job rows themselves are never removed.

Counterpart change on the reader side, a 64 MiB read ceiling in Deadline Cloud Monitor.

## Why the budget counts frames, not jobs

Task records dominate size. Measured on the pretty-printed file, two independent measurements agreeing within 3%:

| Item | Bytes |
|---|---|
| One task record | 230 to 236 |
| One job row | 329 to 406 |

Capping job count instead would leave size at the mercy of frames-per-job:

| Frames per job | File size under "newest 50 jobs" |
|---|---|
| 100 | 1 MB |
| 1,000 | 11.5 MB |
| 10,000 | **115 MB** |

That last row fails worst for the large-render studios the feature exists to serve.

## What is protected, and why

Two sets of records are never reclaimed.

**Jobs that did not finish cleanly.** A job is eligible only if every task record is a plain success, with no `failed`, no `farm_failed`, and no `error_code`. The Monitor derives a job's partial-failure indicator from the records alone rather than from the job's counts, so dropping them from a partly-failed job would repaint it as a clean success. Job status alone is not sufficient here: a `downloaded` job can legitimately hold failed tasks.

**This run's download candidates.** The `farm_failed` guard in this module reads records from disk to suppress a failure the API replays after a requeue, so emptying them for a job being actively synced would let an already-downloaded frame be recorded as a farm failure.

That second protection deliberately covers the candidate categories only, **not** every job the checkpoint knows about. An inactive job is re-appended to the checkpoint on every run so a later requeue can be detected (`_incremental_download.py:1201`), and `inactive` is recomputed as "in the checkpoint but not a candidate", so a finished job is inactive permanently. Protecting that set would exempt exactly the accumulated history this change exists to reclaim, and the overshoot branch would become the steady state rather than the exception.

## Accepted consequences

- **The file is not bounded.** Job rows accumulate at ~330 bytes each, roughly 33 MB per 100,000 jobs. Only records are reclaimed. See the next section for why rows are left alone.
- **The record target is a reclaim budget, not a ceiling.** Records held by an ineligible job, or by a candidate this run, are kept without spending it, so the retained total can exceed the target. The overshoot is logged at `info` with both figures broken out, so an operator can tell protected records from unreclaimed ones.
- **A reclaimed job that is later requeued can misreport one frame.** With no on-disk record for the `farm_failed` guard to match, a frame whose output was downloaded earlier can be recorded as a farm failure. The same applies to a job another machine is tracking, since one machine cannot see another's candidate set. This is the price of the change reclaiming anything at all; the alternatives were a no-op or zeroed file counts.
- **A queue whose jobs mostly carry failures stays large.** Little is eligible there. Lifting this needs a marker on reclaimed jobs plus new logic in the merge path, left as a follow-up.
- **The first run after this ships still parses the old oversized file in full** inside the lock, since the read precedes any reclaim. Measured at 367 ms for a 101 MB file. One-time, and the file it writes back is smaller.

## Why job rows are never removed

Deleting a row makes the next run rebuild it from scratch with zeroed file counts, because the preserve-counts branch needs the existing entry to be there. Avoiding that requires knowing a job is finished with, and nothing in this file can show it:

- `last_updated` moves only on a status change, never on a sync. A job that finished weeks ago and is still enumerated every run carries an old timestamp while being actively tracked.
- Several machines write this file with independent checkpoints, so one machine's job set proves nothing about what another still tracks.

An age gate on `last_updated` was tried and removed for that reason: it reads "nothing changed recently" as "safe to delete", which is the normal steady state of a healthy finished job. Bounding rows needs a field that advances on every sync. That would also lift the eligibility restriction above, so it belongs in its own change rather than bolted on here.

## Shared-filesystem hazards handled

This file is written by several machines to a shared location, so the retention order cannot trust its contents:

- **A timestamp further ahead than a five-minute skew allowance is clamped to now**, not demoted to oldest. A machine whose clock is fast is writing its newest entries, so treating them as oldest would make every other writer reclaim that machine's records first. The allowance is one-sided by nature: a clock reading in the past produces timestamps indistinguishable from genuinely old ones.
- **`fromisoformat` only accepts a trailing `Z` from Python 3.11**, and `requires-python` is `>=3.9`, so which records were reclaimed first would otherwise depend on the interpreter running the sync. `Z` is now normalised.
- **Entries and records of an unexpected JSON shape are treated as ineligible instead of raising.** `write_download_status_file` swallows every exception and only logs, so a shape error in the reclaim pass would have left that queue's file frozen at its old content indefinitely.

## Why `feat:` and not `feat!:`

Deliberate, and worth a reviewer's disagreement. The schema is unchanged, no CLI subcommand, argument or default changes, and no job row ever disappears. What does change is that an empty `tasks` dict can now mean "records reclaimed" as well as "nothing downloaded", which is called out on the schema-version constant.

## Testing

- `hatch run test`: **3842 passed, 22 skipped, 0 failures**. Coverage 77.67% against the 69% gate; the changed module is at 95%, with the remaining uncovered lines pre-existing.
- `hatch run fmt`, `hatch run lint` (ruff + mypy), `hatch build`: all clean.
- 21 new tests plus 7 parametrized cases, including one that goes through the public `write_download_status_file` path with a real read/write cycle rather than only the internal builder.
- **Every guard was verified by removing it and confirming its test fails.** That check caught three tests of mine that passed for reasons unrelated to what they were written to check, including one whose subject was unreachable because a recently-settled row sorts to the front rather than into the tail.
- Not run: the integration suite. Nothing was measured against a real network share, so any timing figure here is CPU only.
