### PR TITLE
feat: restructure queue sync-output progress report

### DIFF
--- a/src/deadline/client/cli/_download_status_file.py
+++ b/src/deadline/client/cli/_download_status_file.py
@@ -15,6 +15,7 @@ from typing import Any, Callable, Generator, Optional
 
 from ..config.config_file import DEFAULT_QUEUE_INCREMENTAL_DOWNLOAD_DIR
 from ._incremental_download import CategorizedJobIds
+from ._sync_output_format import _SyncOutputFormatter, _format_path
 
 logger = logging.getLogger(__name__)
 
@@ -508,7 +509,7 @@ def _write_pointer_if_needed(
                         f"future syncs run."
                     )
                     logger.warning(warning)
-                    print_function_callback(f"WARNING: {warning}")
+                    _SyncOutputFormatter(print_function_callback).warning(warning)
 
             pointer: dict[str, Any] = {
                 "schema_version": DOWNLOAD_STATUS_FILE_SCHEMA_VERSION,
@@ -553,6 +554,7 @@ def write_download_status_file(
         job_download_results: Per-job download results with file counts and error info.
         print_function_callback: Callback for printing output.
     """
+    fmt = _SyncOutputFormatter(print_function_callback)
     status_file_paths = _get_status_file_paths(
         queue_id=queue_id,
         local_storage_profile_id=local_storage_profile_id,
@@ -579,12 +581,11 @@ def write_download_status_file(
 
                 _atomic_write_json(status_file_path, status_content)
             written_paths.append(status_file_path)
-            print_function_callback(f"Download status file saved: {status_file_path}")
+            if not fmt.suppressed:
+                fmt.summary_row("status file", _format_path(status_file_path))
         except Exception as e:
             logger.warning(f"Failed to write download status file to {status_file_path}: {e}")
-            print_function_callback(
-                f"WARNING: Failed to write download status file to {status_file_path}: {e}"
-            )
+            fmt.warning(f"failed to write status file to {_format_path(status_file_path)}: {e}")
 
     # When --ignore-storage-profiles is used, the FE has no API-derivable location for the
     # status file. Write a pointer at the well-known default path so the FE can always find

--- a/src/deadline/client/cli/_groups/queue_group.py
+++ b/src/deadline/client/cli/_groups/queue_group.py
@@ -36,11 +36,61 @@ from .._main import deadline as main
 from .._incremental_download import _incremental_output_download
 from .._download_status_file import write_download_status_file
 from .._pid_file_lock import PidFileLock
+from .._sync_output_format import (
+    _SyncOutputFormatter,
+    _SyncOutputWriter,
+    _format_duration,
+    _format_path,
+    _format_timestamp,
+    _plural,
+)
+from ....job_attachments.api import human_readable_file_size
 from ....job_attachments._incremental_downloads.incremental_download_state import (
     IncrementalDownloadState,
 )
 
 DOWNLOAD_CHECKPOINT_FILE_NAME = "download_checkpoint.json"
+
+
+def _echo_result_line(
+    fmt: _SyncOutputFormatter,
+    stats: dict,
+    job_download_results: dict,
+    dry_run: bool,
+    command_start: float,
+) -> None:
+    """Prints the closing one-line result, so a tail or grep of the log tells the outcome."""
+    elapsed = _format_duration(time.monotonic() - command_start)
+    # The synthetic "" bucket holds paths that could not be attributed to a job, so it is
+    # excluded from the job counts while still contributing to the file and byte totals.
+    failed = [
+        job_id
+        for job_id, result in job_download_results.items()
+        if job_id and result.get("error_code") is not None
+    ]
+    attempted = [job_id for job_id in job_download_results if job_id]
+    size = human_readable_file_size(stats["downloaded_bytes"])
+    files = stats["downloaded_files"]
+
+    if failed:
+        fmt.result(
+            f"{len(failed)} of {len(attempted)} jobs failed after {elapsed}"
+            f" ({files} files, {size} downloaded)",
+            failed=True,
+        )
+    elif dry_run:
+        fmt.result(f"dry run, {files} files ({size}) would be downloaded, checked in {elapsed}")
+    elif files:
+        downloaded_jobs = len(
+            [
+                job_id
+                for job_id, result in job_download_results.items()
+                if job_id and result.get("downloaded_files")
+            ]
+        )
+        fmt.result(f"{files} files, {size}, {_plural(downloaded_jobs, 'job')} in {elapsed}")
+    else:
+        fmt.result(f"nothing to download, checked in {elapsed}")
 
 
 @main.group(name="queue")
@@ -319,6 +369,14 @@ def queue_get(**args):
     help="Perform a dry run of the operation, don't actually download the output files.",
     default=False,
 )
+@click.option(
+    "--verbose",
+    is_flag=True,
+    help="Print the full per-job report even when the run finds nothing new to download.\n"
+    "By default such a run prints a single line, so polling a queue on a schedule does not\n"
+    "fill the log. A run that does find work always prints the full report.",
+    default=False,
+)
 @_handle_error
 @api.record_success_fail_telemetry_event(metric_name="queue_sync_output")
 def sync_output(
@@ -329,6 +387,7 @@ def sync_output(
     ignore_storage_profiles: bool,
     conflict_resolution: str,
     dry_run: bool,
+    verbose: bool,
     **args,
 ):
     """
@@ -354,6 +413,11 @@ def sync_output(
         )
 
     logger: ClickLogger = ClickLogger(is_json=json)
+    # Hold the report back so a run that turns out to have nothing to do can collapse to a
+    # single line. --verbose opts out and prints every section as it happens.
+    writer = _SyncOutputWriter(logger.echo, buffered=not verbose)
+    fmt = _SyncOutputFormatter(writer)
+    command_start = time.monotonic()
 
     # Expand '~' to home directory and create the checkpoint directory if necessary
     checkpoint_dir = os.path.abspath(os.path.expanduser(checkpoint_dir))
@@ -384,7 +448,6 @@ def sync_output(
     if ignore_storage_profiles:
         local_storage_profile_id = None
         local_storage_profile = None
-        logger.echo("Ignoring all storage profiles.")
     else:
         local_storage_profile_id = config_file.get_setting(
             "settings.storage_profile_id", config=config
@@ -428,19 +491,19 @@ def sync_output(
             f"Queue '{queue['displayName']}' does not have job attachments configured."
         )
 
-    logger.echo(f"Started incremental download for queue: {queue['displayName']}")
-    logger.echo(f"Checkpoint: {checkpoint_file_path}")
-    logger.echo()
+    fmt.section(f"Queue sync: {queue['displayName']}")
+    fmt.field("checkpoint", _format_path(checkpoint_file_path))
 
     if local_storage_profile_id:
         assert local_storage_profile is not None
-        logger.echo(
-            f"Mapping job output paths to the local storage profile {local_storage_profile['displayName']} ({local_storage_profile_id})"
+        fmt.field(
+            "storage",
+            f"{local_storage_profile['displayName']} ({local_storage_profile_id})",
         )
-        logger.echo("  File system locations for the storage profile are:")
         for location in local_storage_profile["fileSystemLocations"]:
-            logger.echo(f"    {location['name']}: {location['path']}")
-        logger.echo()
+            fmt.field_continuation(f"{location['name']}: {_format_path(location['path'])}")
+    else:
+        fmt.field("storage", "ignoring all storage profiles")
 
     # Pre-flight validation: warn about inaccessible storage profile locations.
     # Downloads proceed regardless — jobs only map to the locations their outputs fall under,
@@ -449,14 +512,14 @@ def sync_output(
         for location in local_storage_profile["fileSystemLocations"]:
             location_path = location["path"]
             if not os.path.isdir(location_path):
-                logger.echo(
-                    f"WARNING: File system location '{location['name']}' does not exist: {location_path}"
-                    " — status file will not be written to this location."
+                fmt.warning(
+                    f"file system location '{location['name']}' does not exist:"
+                    f" {_format_path(location_path)}, no status file will be written there"
                 )
             elif not os.access(location_path, os.W_OK):
-                logger.echo(
-                    f"WARNING: File system location '{location['name']}' is not writable: {location_path}"
-                    " — status file will not be written to this location."
+                fmt.warning(
+                    f"file system location '{location['name']}' is not writable:"
+                    f" {_format_path(location_path)}, no status file will be written there"
                 )
 
     # Perform incremental download while holding a process id lock
@@ -481,7 +544,11 @@ def sync_output(
 
             # Print the bootstrap time in local time
             if force_bootstrap:
-                logger.echo(f"Bootstrap forced, lookback is {bootstrap_lookback_minutes} minutes")
+                fmt.field(
+                    "state",
+                    f"bootstrap forced from {_format_timestamp(bootstrap_timestamp)}"
+                    f" ({bootstrap_lookback_minutes} minute lookback)",
+                )
                 # Also clear the failed jobs tracker so abandoned jobs get a fresh start
                 storage_profile_key = local_storage_profile_id or "ignore-storage-profiles"
                 failed_jobs_file = os.path.join(
@@ -493,16 +560,14 @@ def sync_output(
                 except OSError:
                     pass  # File doesn't exist — nothing to clear
             else:
-                logger.echo(
-                    f"Checkpoint not found, lookback is {bootstrap_lookback_minutes} minutes"
+                fmt.field(
+                    "state",
+                    f"bootstrapping from {_format_timestamp(bootstrap_timestamp)}"
+                    f" ({bootstrap_lookback_minutes} minute lookback, no checkpoint found)",
                 )
-            logger.echo(f"Initializing from: {bootstrap_timestamp.astimezone().isoformat()}")
         else:
             # Load the incremental download checkpoint file
             checkpoint = IncrementalDownloadState.from_file(checkpoint_file_path)
-
-            # Print the previous download completed time in local time
-            logger.echo("Checkpoint found")
 
             # The checkpoint's local storage profile id must match the CLI option
             if local_storage_profile_id != checkpoint.local_storage_profile_id:
@@ -518,11 +583,11 @@ def sync_output(
                     f"The checkpoint was created with local storage profile {checkpoint.local_storage_profile_id}, but the configured storage profile is {local_storage_profile_id}"
                 )
 
-            logger.echo(
-                f"Continuing from: {checkpoint.downloads_completed_timestamp.astimezone().isoformat()}"
+            fmt.field(
+                "state",
+                "resumed from checkpoint at"
+                f" {_format_timestamp(checkpoint.downloads_completed_timestamp)}",
             )
-
-        logger.echo()
 
         (
             updated_download_state,
@@ -531,6 +596,7 @@ def sync_output(
             job_download_results,
             task_download_results,
             succeeded_task_ids,
+            stats,
         ) = _incremental_output_download(
             boto3_session=boto3_session,
             farm_id=farm_id,
@@ -539,7 +605,7 @@ def sync_output(
             file_conflict_resolution=FileConflictResolution[conflict_resolution],
             checkpoint_dir=checkpoint_dir,
             config=config,
-            print_function_callback=logger.echo,
+            print_function_callback=writer,
             dry_run=dry_run,
         )
 
@@ -555,10 +621,13 @@ def sync_output(
                 job_download_results=job_download_results,
                 task_download_results=task_download_results,
                 succeeded_task_ids=succeeded_task_ids,
-                print_function_callback=logger.echo,
+                print_function_callback=writer,
             )
 
             updated_download_state.save_file(checkpoint_file_path)
-            logger.echo("Checkpoint saved")
-        else:
-            logger.echo("This is a DRY RUN so the checkpoint was not saved")
+
+        # A run with nothing to report has already printed its own one-line result.
+        if not fmt.suppressed:
+            fmt.summary_row("checkpoint", "not saved (dry run)" if dry_run else "saved")
+            fmt.summary_row("elapsed", _format_duration(time.monotonic() - command_start))
+            _echo_result_line(fmt, stats, job_download_results, dry_run, command_start)

--- a/src/deadline/client/cli/_groups/queue_group.py
+++ b/src/deadline/client/cli/_groups/queue_group.py
@@ -8,6 +8,8 @@ import click
 import json
 import time
 import os
+from contextlib import contextmanager
+from typing import Iterator
 from configparser import ConfigParser
 from typing import Optional
 import boto3
@@ -52,6 +54,21 @@ from ....job_attachments._incremental_downloads.incremental_download_state impor
 DOWNLOAD_CHECKPOINT_FILE_NAME = "download_checkpoint.json"
 
 
+@contextmanager
+def _report_on_failure(writer: _SyncOutputWriter) -> Iterator[None]:
+    """Releases a held-back report when the body raises.
+
+    A quiet run buffers its progress lines and normally drops them. On failure they are the
+    only record of what the run had done so far, so an operator reading a scheduled job's log
+    gets the context leading up to the error instead of the traceback alone.
+    """
+    try:
+        yield
+    except BaseException:
+        writer.flush()
+        raise
+
+
 def _echo_result_line(
     fmt: _SyncOutputFormatter,
     stats: dict,
@@ -61,8 +78,12 @@ def _echo_result_line(
 ) -> None:
     """Prints the closing one-line result, so a tail or grep of the log tells the outcome."""
     elapsed = _format_duration(time.monotonic() - command_start)
-    # The synthetic "" bucket holds paths that could not be attributed to a job, so it is
-    # excluded from the job counts while still contributing to the file and byte totals.
+    # The synthetic "" bucket holds paths that could not be attributed to a job. It is not a
+    # job, so it stays out of the job counts, but a failure recorded only there still means
+    # the run failed: it is the sole record of a lost window when attribution was skipped.
+    any_failure = any(
+        result.get("error_code") is not None for result in job_download_results.values()
+    )
     failed = [
         job_id
         for job_id, result in job_download_results.items()
@@ -75,6 +96,12 @@ def _echo_result_line(
     if failed:
         fmt.result(
             f"{len(failed)} of {len(attempted)} jobs failed after {elapsed}"
+            f" ({files} files, {size} downloaded)",
+            failed=True,
+        )
+    elif any_failure:
+        fmt.result(
+            f"download failed after {elapsed}, no job could be identified"
             f" ({files} files, {size} downloaded)",
             failed=True,
         )
@@ -526,9 +553,12 @@ def sync_output(
 
     pid_lock_file_path: str = os.path.join(checkpoint_dir, f"{download_checkpoint_file_name}.pid")
 
-    with PidFileLock(
-        pid_lock_file_path,
-        operation_name="incremental output download",
+    with (
+        PidFileLock(
+            pid_lock_file_path,
+            operation_name="incremental output download",
+        ),
+        _report_on_failure(writer),
     ):
         checkpoint: IncrementalDownloadState
 
@@ -626,8 +656,14 @@ def sync_output(
 
             updated_download_state.save_file(checkpoint_file_path)
 
-        # A run with nothing to report has already printed its own one-line result.
         if not fmt.suppressed:
             fmt.summary_row("checkpoint", "not saved (dry run)" if dry_run else "saved")
             fmt.summary_row("elapsed", _format_duration(time.monotonic() - command_start))
             _echo_result_line(fmt, stats, job_download_results, dry_run, command_start)
+        else:
+            # Quiet run: one line, emitted here so it lands after the checkpoint and status
+            # file are written and therefore below any warning either of them raised.
+            fmt.result(
+                f"{queue['displayName']}: nothing new"
+                f" ({stats['window_summary']}, checked {stats['checked_at']})"
+            )

--- a/src/deadline/client/cli/_incremental_download.py
+++ b/src/deadline/client/cli/_incremental_download.py
@@ -17,7 +17,6 @@ from configparser import ConfigParser
 from typing import Any, Callable
 import time
 import concurrent.futures
-import textwrap
 
 from .. import api
 import boto3
@@ -67,6 +66,15 @@ from ...job_attachments.progress_tracker import (
     ProgressReportMetadata,
 )
 from ._common import _cli_object_repr, sigint_handler
+from ._sync_output_format import (
+    _ENTRY_DETAIL_INDENT,
+    _SyncOutputFormatter,
+    _format_duration,
+    _format_interval,
+    _format_path,
+    _format_timestamp,
+    _plural,
+)
 
 SESSIONS_API_MAX_CONCURRENCY = 3
 
@@ -139,6 +147,30 @@ def _classify_error(e: BaseException) -> str:
     return "UNKNOWN"
 
 
+# Paths that carry no step-/task- segment are collected under a synthetic "" job id, which
+# has neither a display name nor an id worth printing.
+_UNATTRIBUTED_LABEL = "(unattributed paths)"
+
+
+def _job_label(
+    job_id: str,
+    download_candidate_jobs: dict[str, dict[str, Any]],
+    *,
+    with_id: bool = True,
+) -> str:
+    """Names a job for display, including the synthetic bucket that belongs to no job.
+
+    The id is worth repeating on a warning or error, which may be read on its own. Progress
+    lines leave it out, since the job entry above them already carries it.
+    """
+    if not job_id:
+        return _UNATTRIBUTED_LABEL
+    name = download_candidate_jobs.get(job_id, {}).get("name")
+    if not name:
+        return job_id
+    return f"{name} ({job_id})" if with_id else name
+
+
 _MAX_FAILED_JOB_RETRIES = 5
 
 
@@ -197,9 +229,9 @@ class _FailedJobsTracker:
         for job_id in failed_job_ids:
             self._counts[job_id] = self._counts.get(job_id, 0) + 1
             if self._counts[job_id] >= _MAX_FAILED_JOB_RETRIES:
-                print_function_callback(
-                    f"WARNING: Job {job_id} has failed to download {_MAX_FAILED_JOB_RETRIES} "
-                    f"times and will no longer be retried automatically."
+                _SyncOutputFormatter(print_function_callback).warning(
+                    f"job {job_id} failed to download {_MAX_FAILED_JOB_RETRIES} times and will"
+                    " no longer be retried automatically"
                 )
                 # Keep in _counts at the cap value so subsequent timestamp-window rediscoveries
                 # are suppressed — do NOT delete here.
@@ -263,7 +295,7 @@ def _get_download_candidate_jobs(
     Returns:
         A dictionary mapping job id to the job as returned by the deadline.search_jobs API.
     """
-    print_function_callback("Retrieving updated data from Deadline Cloud...")
+    fmt = _SyncOutputFormatter(print_function_callback)
     start_time = datetime.now(tz=timezone.utc)
 
     # Construct the full set of jobs that may have new available downloads.
@@ -297,15 +329,12 @@ def _get_download_candidate_jobs(
             region=region,
         )
     }
-    print(f"DEBUG: Got {len(download_candidate_jobs)} active jobs")
     download_candidate_jobs = {
         job_id: _datetimes_to_str(job)
         for job_id, job in download_candidate_jobs.items()
         if job["taskRunStatusCounts"]["SUCCEEDED"] > 0
     }
-    print(
-        f"DEBUG: Filtered down to {len(download_candidate_jobs)} active jobs based on SUCCEEDED task filter"
-    )
+    active_job_count = len(download_candidate_jobs)
 
     # - Any recently ended job (job went from active to terminal with a taskRunStatus
     #   in SUSPENDED, CANCELED, FAILED, SUCCEEDED, NOT_COMPATIBLE), that has at least
@@ -328,20 +357,23 @@ def _get_download_candidate_jobs(
         },
         region=region,
     )
-    print(
-        f"DEBUG: Got {len(recently_ended_jobs)} jobs with job[endedAt] >= {starting_timestamp.astimezone().isoformat()}"
-    )
     # Filter to jobs where the count of SUCCEEDED tasks is positive.
     recently_ended_jobs = [
         job for job in recently_ended_jobs if job["taskRunStatusCounts"]["SUCCEEDED"] > 0
     ]
-    print(f"DEBUG: Filtered down to {len(recently_ended_jobs)} jobs based on SUCCEEDED task filter")
     download_candidate_jobs.update(
         {job["jobId"]: _datetimes_to_str(job) for job in recently_ended_jobs}
     )
 
     duration = datetime.now(tz=timezone.utc) - start_time
-    print_function_callback(f"...retrieval completed in {duration}")
+    if download_candidate_jobs:
+        fmt.line(
+            f"{_plural(len(download_candidate_jobs), 'candidate job')}"
+            f" ({active_job_count} active, {len(recently_ended_jobs)} recently ended)",
+            duration,
+        )
+    else:
+        fmt.line("no candidate jobs", duration)
 
     return download_candidate_jobs
 
@@ -411,9 +443,11 @@ def _categorize_jobs_in_checkpoint(
 
     download_candidate_job_ids = set(download_candidate_jobs.keys())
 
-    print_function_callback(
-        f"Categorizing {len(checkpoint_jobs)} checkpoint jobs against {len(download_candidate_jobs)} download candidate jobs..."
-    )
+    fmt = _SyncOutputFormatter(print_function_callback)
+    # Per-job lines are buffered so the summary step (which needs the elapsed time) can be
+    # printed above the jobs it describes.
+    buffered_lines: list[Any] = []
+    entries = _SyncOutputFormatter(buffered_lines.append)
     start_time = datetime.now(tz=timezone.utc)
 
     finished_tracking_job_ids = checkpoint_job_ids.difference(download_candidate_job_ids)
@@ -469,7 +503,8 @@ def _categorize_jobs_in_checkpoint(
         if ip_job["taskRunStatusCounts"]["SUCCEEDED"] == dc_job["taskRunStatusCounts"][
             "SUCCEEDED"
         ] and ip_job.get("endedAt") == dc_job.get("endedAt"):
-            print_function_callback(f"UNCHANGED Job: {dc_job['name']} ({job_id})")
+            entries.entry("UNCHANGED", dc_job["name"])
+            entries.entry_detail(job_id)
             unchanged_job_ids.add(job_id)
     updated_job_ids.difference_update(unchanged_job_ids)
 
@@ -485,15 +520,15 @@ def _categorize_jobs_in_checkpoint(
 
         # Print something only if the job is more than a minimal "jobId" tracker
         if set(ip_job.keys()) != {"jobId"}:
-            print_function_callback(f"FINISHED TRACKING Job: {ip_job['name']} ({job_id})")
             if ip_job["attachments"] is None:
-                print_function_callback("  Job without job attachments is no longer active")
+                reason = "no job attachments, no longer active"
             elif ip_succeeded_task_count == ip_total_task_count:
-                print_function_callback("   Job succeeded")
+                reason = "job succeeded"
             else:
-                print_function_callback(
-                    "   Job is not a download candidate anymore (likely suspended, canceled or failed)"
-                )
+                reason = "no longer a download candidate (likely suspended, canceled or failed)"
+            entries.entry("RETIRED", ip_job["name"])
+            entries.entry_detail(job_id)
+            entries.entry_detail(reason)
 
     # Process all the jobs that have updates
     for job_id in updated_job_ids:
@@ -504,13 +539,13 @@ def _categorize_jobs_in_checkpoint(
         dc_succeeded_task_count = dc_job["taskRunStatusCounts"]["SUCCEEDED"]
         dc_total_task_count = sum(value for _, value in dc_job["taskRunStatusCounts"].items())
 
-        print_function_callback(f"EXISTING Job: {ip_job['name']} ({job_id})")
-        print_function_callback(
-            f"  Succeeded tasks (before): {ip_succeeded_task_count} / {ip_total_task_count}"
+        entries.entry(
+            "UPDATED",
+            ip_job["name"],
+            f"({ip_succeeded_task_count} -> {dc_succeeded_task_count}"
+            f"/{dc_total_task_count} tasks succeeded)",
         )
-        print_function_callback(
-            f"  Succeeded tasks (now)   : {dc_succeeded_task_count} / {dc_total_task_count}"
-        )
+        entries.entry_detail(job_id)
 
         # Use the CLI output format to produce a diff of the changes
         ip_job_repr: list[str] = _cli_object_repr(ip_job).splitlines()
@@ -523,7 +558,7 @@ def _categorize_jobs_in_checkpoint(
             tofile="Current update",
             lineterm="",
         ):
-            print_function_callback(f"  {line}")
+            entries.entry_detail(line)
 
         if (
             dc_succeeded_task_count == dc_total_task_count
@@ -547,22 +582,26 @@ def _categorize_jobs_in_checkpoint(
         dc_succeeded_task_count = dc_job["taskRunStatusCounts"]["SUCCEEDED"]
         dc_total_task_count = sum(value for _, value in dc_job["taskRunStatusCounts"].items())
 
-        print_function_callback(f"NEW Job: {dc_job['name']} ({job_id})")
-
         if (
             dc_job["attachments"] is not None
             and dc_job["storageProfileId"] is None
             and checkpoint.local_storage_profile_id is not None
         ):
-            print_function_callback(
-                "  WARNING: THE JOB OUTPUT WILL NOT BE DOWNLOADED, IT HAS NO STORAGE PROFILE."
+            entries.entry("NEW", dc_job["name"])
+            entries.entry_detail(job_id)
+            entries.warning(
+                "no storage profile, this job's output will not be downloaded",
+                indent=_ENTRY_DETAIL_INDENT,
             )
             missing_storage_profile.add(job_id)
             continue
 
-        print_function_callback(
-            f"  Succeeded tasks: {dc_succeeded_task_count} / {dc_total_task_count}"
+        entries.entry(
+            "NEW",
+            dc_job["name"],
+            f"({dc_succeeded_task_count}/{dc_total_task_count} tasks succeeded)",
         )
+        entries.entry_detail(job_id)
         if dc_job["attachments"] is None:
             # If the job does not use job attachments, save a minimal placeholder to avoid
             # repeatedly calling deadline:GetJob.
@@ -572,12 +611,12 @@ def _categorize_jobs_in_checkpoint(
                 "attachments": None,
             }
             attachments_free_job_ids.add(job_id)
-            print_function_callback("  Job does not use job attachments.")
+            entries.entry_detail("does not use job attachments")
         else:
-            print_function_callback("  Manifest file system paths:")
             for manifest in dc_job["attachments"]["manifests"]:
-                print_function_callback(
-                    f"    - {manifest['rootPath']} ({manifest['rootPathFormat']})"
+                entries.entry_detail(
+                    "output root:"
+                    f" {_format_path(manifest['rootPath'])} ({manifest['rootPathFormat']})"
                 )
 
         if (
@@ -600,7 +639,13 @@ def _categorize_jobs_in_checkpoint(
     result.updated = updated_job_ids
 
     duration = datetime.now(tz=timezone.utc) - start_time
-    print_function_callback(f"...categorization completed in {duration}")
+    fmt.line(
+        f"categorized {_plural(len(download_candidate_jobs), 'job')}"
+        f" ({len(checkpoint_jobs)} in checkpoint)",
+        duration,
+    )
+    for line in buffered_lines:
+        print_function_callback(line)
 
     return result
 
@@ -775,10 +820,10 @@ def _get_job_sessions(
             ...
         }
     """
+    fmt = _SyncOutputFormatter(print_function_callback)
     job_ids = categorized_job_ids.completed.union(categorized_job_ids.added).union(
         categorized_job_ids.updated
     )
-    print_function_callback(f"Retrieving sessions for {len(job_ids)} jobs...")
     start_time = datetime.now(tz=timezone.utc)
 
     # The max timestamp of a downloaded session's endedAt provides a lower bound to filter sessions by.
@@ -796,7 +841,6 @@ def _get_job_sessions(
 
     # Retrieve all the sessions with some parallelism
     max_workers = SESSIONS_API_MAX_CONCURRENCY
-    print_function_callback(f"Using {max_workers} threads")
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
         futures = []
         for job_id in job_ids:
@@ -830,17 +874,16 @@ def _get_job_sessions(
             future.result()
 
     duration = datetime.now(tz=timezone.utc) - start_time
-    print_function_callback(f"...retrieval completed in {duration}")
-
-    print_function_callback("")
-    print_function_callback(
-        f"Retrieving session actions for {sum(len(session_list) for session_list in job_sessions.values())} sessions..."
+    session_count = sum(len(session_list) for session_list in job_sessions.values())
+    fmt.line(
+        f"{_plural(session_count, 'session')} across {_plural(len(job_ids), 'job')}",
+        duration,
     )
+
     start_time = datetime.now(tz=timezone.utc)
 
     # Retrieve all the session actions with some parallelism
     max_workers = SESSIONS_API_MAX_CONCURRENCY
-    print_function_callback(f"Using {max_workers} threads")
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
         futures = []
         # Collect farm-failed task IDs per job across threads. Each worker collects into a
@@ -877,10 +920,13 @@ def _get_job_sessions(
             future.result()
 
     duration = datetime.now(tz=timezone.utc) - start_time
-    print_function_callback(f"...retrieval completed in {duration}")
+    session_action_count = sum(
+        len(session.get("sessionActions", []))
+        for session_list in job_sessions.values()
+        for session in session_list
+    )
+    fmt.line(_plural(session_action_count, "succeeded task run"), duration)
 
-    print_function_callback("")
-    print_function_callback("Populating missing manifest S3 keys...")
     start_time = datetime.now(tz=timezone.utc)
 
     _add_missing_output_manifests_to_job_sessions(
@@ -894,7 +940,7 @@ def _get_job_sessions(
     )
 
     duration = datetime.now(tz=timezone.utc) - start_time
-    print_function_callback(f"...populated in {duration}")
+    fmt.line("manifest S3 keys populated", duration)
 
     # A FAILED taskRun action is reported by the API indefinitely — even after the task is
     # requeued and SUCCEEDED. Remove any task that has a SUCCEEDED action in this same run so
@@ -975,15 +1021,22 @@ def _create_path_mapping_rule_appliers(
 
     path_mapping_rule_appliers: dict[str, Optional[_PathMappingRuleApplier]] = {}
 
+    fmt = _SyncOutputFormatter(print_function_callback)
+
     # Create a path mapping rule applier for each storage profile
     local_storage_profile = storage_profiles[checkpoint.local_storage_profile_id]
     local_storage_profile_name = local_storage_profile["displayName"]
-    print_function_callback("")
-    print_function_callback(
-        f"Local storage profile is {local_storage_profile_name} ({checkpoint.local_storage_profile_id})"
+    unmapped_job_count = len(
+        [
+            job
+            for job in download_candidate_jobs.values()
+            if job.get("storageProfileId") == checkpoint.local_storage_profile_id
+        ]
     )
-    print_function_callback(
-        f"  {len([job for job in download_candidate_jobs.values() if job.get('storageProfileId') == checkpoint.local_storage_profile_id])} download candidate jobs have the same storage profile and will be downloaded to their original specified paths"
+    fmt.section("Path mapping")
+    fmt.line(
+        f"{_plural(unmapped_job_count, 'job')} on the local storage profile"
+        f" {local_storage_profile_name}, downloading to their original paths"
     )
     for storage_profile_id, storage_profile in storage_profiles.items():
         storage_profile_name = storage_profile["displayName"]
@@ -994,7 +1047,6 @@ def _create_path_mapping_rule_appliers(
             path_mapping_rule_appliers[storage_profile_id] = _PathMappingRuleApplier(rules)
 
             # Print the path mapping rules for each source storage profile
-            print_function_callback("")
             job_count = len(
                 [
                     job
@@ -1002,22 +1054,20 @@ def _create_path_mapping_rule_appliers(
                     if job.get("storageProfileId") == storage_profile_id
                 ]
             )
-            print_function_callback(
-                f"Path mapping rules for {job_count} download candidate jobs with storage profile {storage_profile_name} ({storage_profile_id})"
-            )
-            print_function_callback(
-                f"  job storage profile: {storage_profile_name} ({storage_profile['osFamily']})"
-            )
-            print_function_callback(
-                f"  local storage profile: {local_storage_profile_name} ({local_storage_profile['osFamily']})"
-            )
             if rules:
+                fmt.line(
+                    f"{_plural(job_count, 'job')} on {storage_profile_name}"
+                    f" ({storage_profile['osFamily']}) -> {local_storage_profile_name}"
+                    f" ({local_storage_profile['osFamily']})"
+                )
                 for rule in rules:
-                    print_function_callback(f"  - from: {rule.source_path}")
-                    print_function_callback(f"    to:   {rule.destination_path}")
+                    fmt.detail(
+                        f"{_format_path(rule.source_path)} -> {_format_path(rule.destination_path)}"
+                    )
             else:
-                print_function_callback(
-                    f"   No rules generated. Storage profiles {local_storage_profile_name} and {storage_profile_name} share no file system location names."
+                fmt.warning(
+                    f"{_plural(job_count, 'job')} on {storage_profile_name} have no mapping:"
+                    f" it shares no file system location names with {local_storage_profile_name}"
                 )
     return path_mapping_rule_appliers
 
@@ -1083,11 +1133,14 @@ def _filter_session_actions_without_manifests_from_job_sessions(
             if total_count != filtered_count:
                 session["sessionActions"] = filtered_session_action_list
         if total_count != filtered_count:
-            print_function_callback(
-                f"WARNING: Job {job['name']} ({job_id}) ran {total_count - filtered_count} / {total_count} session actions with no output."
+            fmt = _SyncOutputFormatter(print_function_callback)
+            fmt.warning(
+                f"{job['name']} ({job_id}) ran {total_count - filtered_count}/{total_count}"
+                " task runs with no output"
             )
-            print_function_callback(
-                "         This may indicate steps in the job that strictly perform validation or save results elsewhere like a shared file system or S3."
+            fmt.detail(
+                "these steps may only validate, or save results elsewhere such as a shared"
+                " file system or S3",
             )
 
 
@@ -1227,6 +1280,7 @@ def _incremental_output_download(
     dict[str, dict[str, Any]],
     dict[str, dict[str, dict[str, Any]]],
     dict[str, set[str]],
+    dict[str, Any],
 ]:
     """
     This function downloads all the task run outputs from the specified queue, that have become
@@ -1252,9 +1306,11 @@ def _incremental_output_download(
 
     Returns:
         A tuple of (updated checkpoint, categorized job IDs, download candidate jobs dict,
-        per-job download results, per-task download results).
+        per-job download results, per-task download results, per-job succeeded task IDs,
+        run statistics).
     """
     durations = IncrementalOutputDownloadLatencies()
+    fmt = _SyncOutputFormatter(print_function_callback)
     # Operations here are within a single farm, so scope the deadline client to that
     # farm's region. _resolve_region returns None when nothing is configured, preserving
     # the session's default-region behavior.
@@ -1281,21 +1337,21 @@ def _incremental_output_download(
         queue_display_name=queue["displayName"],
     )
 
-    print_function_callback("Updating download state across time interval:")
-    print_function_callback(
-        f"    From: {checkpoint.downloads_completed_timestamp.astimezone().isoformat()}"
-    )
-    print_function_callback(f"      To: {current_timestamp.astimezone().isoformat()}")
     update_length = current_timestamp - checkpoint.downloads_completed_timestamp
     eventual_consistency_delta = timedelta(seconds=checkpoint.eventual_consistency_max_seconds)
     if update_length > eventual_consistency_delta:
-        print_function_callback(
-            f"  Length: {update_length - eventual_consistency_delta} + {eventual_consistency_delta} (eventual consistency allowance)"
+        length = (
+            f"{_format_duration(update_length - eventual_consistency_delta)}"
+            f" + {_format_duration(eventual_consistency_delta)} eventual consistency allowance"
         )
     else:
         # Immediately after bootstrapping, this length will be shorter than the eventual consistency window
-        print_function_callback(f"  Length: {update_length}")
-    print_function_callback("")
+        length = _format_duration(update_length)
+    fmt.field(
+        "window",
+        f"{_format_interval(checkpoint.downloads_completed_timestamp, current_timestamp)}"
+        f" ({length})",
+    )
 
     # Save all the jobs' session action indexes from the checkpoint, before we update the checkpoint's jobs list
     checkpoint_job_session_completed_indexes: dict[str, dict[str, int]] = {
@@ -1312,6 +1368,7 @@ def _incremental_output_download(
     failed_jobs_tracker = _FailedJobsTracker(failed_jobs_file)
 
     # Call deadline:SearchJobs to get a set of jobs that includes every job with downloads available.
+    fmt.section("Deadline Cloud")
     start_t = time.perf_counter_ns()
     download_candidate_jobs: dict[str, dict[str, Any]] = _get_download_candidate_jobs(
         boto3_session,
@@ -1326,9 +1383,7 @@ def _incremental_output_download(
     # Inject previously failed jobs that fell outside the timestamp window
     previously_failed_job_ids = failed_jobs_tracker.get_tracked_job_ids()
     if previously_failed_job_ids:
-        print_function_callback(
-            f"Retrying {len(previously_failed_job_ids)} previously failed job(s)..."
-        )
+        fmt.line(f"retrying {_plural(len(previously_failed_job_ids), 'previously failed job')}")
         jobs_not_found: set[str] = set()
         for job_id in previously_failed_job_ids:
             if job_id not in download_candidate_jobs:
@@ -1362,8 +1417,6 @@ def _incremental_output_download(
     for job_id in abandoned_job_ids:
         del download_candidate_jobs[job_id]
 
-    print_function_callback("")
-
     # Compare the download candidates with the previously saved checkpoint state to categorize the jobs
     start_t = time.perf_counter_ns()
     categorized_job_ids: CategorizedJobIds = _categorize_jobs_in_checkpoint(
@@ -1377,8 +1430,6 @@ def _incremental_output_download(
         region=region,
     )
     durations._categorize_jobs_in_checkpoint = time.perf_counter_ns() - start_t
-
-    print_function_callback("")
 
     # All the completed, added, and updated jobs might have downloads available. Retrieve the sessions for these jobs.
     start_t = time.perf_counter_ns()
@@ -1419,8 +1470,20 @@ def _incremental_output_download(
     )
     durations._update_checkpoint_jobs_list = time.perf_counter_ns() - start_t
 
+    # Build per-job file mapping by correlating downloaded manifests with their job IDs.
+    # Resolved before the download so the manifest count can be reported with its timing.
+    manifests_to_download = _get_manifests_to_download(
+        queue["jobAttachmentSettings"]["rootPrefix"],
+        download_candidate_jobs,
+        job_sessions,
+        path_mapping_rule_appliers,
+    )
+
+    fmt.section("Download")
     start_t = time.perf_counter_ns()
     unmapped_paths: dict[str, list[str]] = {}
+    # The callback is suppressed because this helper's only output is a thread count and a
+    # raw timedelta; the equivalent step line is emitted below in this command's own format.
     downloaded_manifests: list[tuple[datetime, BaseAssetManifest]] = (
         _download_all_manifests_with_absolute_paths(
             queue,
@@ -1429,27 +1492,31 @@ def _incremental_output_download(
             path_mapping_rule_appliers,
             unmapped_paths,
             boto3_session_for_s3,
-            print_function_callback,
+            lambda msg: None,
         )
     )
     durations._download_all_manifests_with_absolute_paths = time.perf_counter_ns() - start_t
+    if manifests_to_download:
+        fmt.line(
+            _plural(len(manifests_to_download), "asset manifest"),
+            durations._download_all_manifests_with_absolute_paths / 1_000_000_000,
+        )
 
     # Print warning messages about all the output paths that will not be downloaded due to lack of path mapping.
     if unmapped_paths:
-        print_function_callback("")
-        print_function_callback("WARNING: THE FOLLOWING FILES WILL NOT BE DOWNLOADED")
+        fmt.warning("unmapped output paths, these files will not be downloaded")
         for job_id, unmapped_path_list in unmapped_paths.items():
-            print_function_callback(
-                f"    Job {download_candidate_jobs[job_id]['name']} ({job_id}) has outputs with unmapped paths that will not be downloaded"
-            )
             storage_profile = storage_profiles.get(
                 download_candidate_jobs[job_id].get("storageProfileId", "")
             )
-            if storage_profile is not None:
-                print_function_callback(
-                    f"      Job storage profile is {storage_profile['displayName']} ({storage_profile['storageProfileId']})"
-                )
-            print_function_callback("      Summary of unmapped paths:")
+            note = (
+                f"storage profile {storage_profile['displayName']}"
+                f" ({storage_profile['storageProfileId']})"
+                if storage_profile is not None
+                else None
+            )
+            fmt.entry("UNMAPPED", download_candidate_jobs[job_id]["name"], note=note)
+            fmt.entry_detail(job_id)
             path_format = (
                 PathFormat.WINDOWS
                 if storage_profile is not None
@@ -1459,15 +1526,9 @@ def _incremental_output_download(
             paths_summary = summarize_path_list(
                 unmapped_path_list, max_entries=30, path_format=path_format
             )
-            print_function_callback(textwrap.indent(paths_summary, "      "))
+            for summary_line in paths_summary.splitlines():
+                fmt.entry_detail(summary_line.strip())
 
-    # Build per-job file mapping by correlating downloaded manifests with their job IDs
-    manifests_to_download = _get_manifests_to_download(
-        queue["jobAttachmentSettings"]["rootPrefix"],
-        download_candidate_jobs,
-        job_sessions,
-        path_mapping_rule_appliers,
-    )
     # Correlate manifests_to_download with downloaded_manifests by position to attribute each
     # downloaded manifest to its job (and task). Both lists come from _get_manifests_to_download
     # with identical inputs, so their lengths match in practice. If they ever diverge we skip only
@@ -1477,11 +1538,11 @@ def _incremental_output_download(
     # attribution is best-effort layered on top.)
     skip_attribution = len(manifests_to_download) != len(downloaded_manifests)
     if skip_attribution:
-        print_function_callback(
-            f"WARNING: Manifest list length mismatch ({len(manifests_to_download)} vs "
-            f"{len(downloaded_manifests)}) — per-job and per-task download tracking will not "
-            f"be populated for this run; files will still be downloaded."
+        fmt.warning(
+            f"manifest list length mismatch ({len(manifests_to_download)} vs "
+            f"{len(downloaded_manifests)}), so per-job and per-task tracking is skipped this run"
         )
+        fmt.detail("all files are still downloaded")
     job_manifest_paths: dict[str, list[BaseManifestPath]] = {}
     # job_id -> task_id -> [files]: used for per-task download tracking
     job_task_manifest_paths: dict[str, dict[str, list[BaseManifestPath]]] = {}
@@ -1556,12 +1617,43 @@ def _incremental_output_download(
     file_size_by_path = {
         manifest_path.path: manifest_path.size for manifest_path in all_manifest_paths
     }
-    print_function_callback("")
-    print_function_callback("Summary of paths to download:")
-    print_function_callback(
-        summarize_path_list(local_path_list, total_size_by_path=file_size_by_path, max_entries=30)
-    )
-    print_function_callback("")
+    total_bytes = sum(manifest_path.size for manifest_path in all_manifest_paths)
+    if local_path_list:
+        fmt.line(
+            f"{_plural(len(local_path_list), 'file')},"
+            f" {human_readable_file_size(total_bytes)} to download"
+        )
+        paths_summary = summarize_path_list(
+            local_path_list, total_size_by_path=file_size_by_path, max_entries=30
+        )
+        for summary_line in paths_summary.splitlines():
+            fmt.detail(summary_line.strip())
+    else:
+        fmt.line("nothing new to download")
+
+    # Everything above is buffered when the caller asked for a quiet run. This is the first
+    # point where the outcome is known, so decide here whether the report is worth printing:
+    # a scheduled downloader polls on a timer and most polls find nothing at all. Jobs that
+    # were merely re-seen unchanged do not count as news; a problem always does.
+    if (
+        job_manifest_paths
+        or categorized_job_ids.completed
+        or categorized_job_ids.added
+        or categorized_job_ids.updated
+        or categorized_job_ids.inactive
+        or categorized_job_ids.missing_storage_profile
+        or categorized_job_ids.attachments_free
+        or previously_failed_job_ids
+        or fmt.had_problem
+    ):
+        fmt.flush()
+    else:
+        fmt.discard()
+        fmt.result(
+            f"{queue['displayName']}: nothing new"
+            f" (window {_format_duration(update_length)},"
+            f" checked {_format_timestamp(current_timestamp)})"
+        )
 
     # Download per-job with error isolation, running jobs in parallel to restore throughput.
     job_download_results: dict[str, dict[str, Any]] = {}
@@ -1574,10 +1666,6 @@ def _incremental_output_download(
     fallback_download_failed = False
 
     if not dry_run:
-        total_files = sum(len(paths) for paths in job_manifest_paths.values())
-        print_function_callback(
-            f"Downloading {total_files} files from S3 across {len(job_manifest_paths)} jobs..."
-        )
         start_t = time.perf_counter_ns()
         start_time = datetime.now(tz=timezone.utc)
 
@@ -1588,9 +1676,12 @@ def _incremental_output_download(
         print_lock = threading.Lock()
 
         def _download_job(job_id: str, job_files: list) -> dict[str, Any]:
-            job_name = download_candidate_jobs.get(job_id, {}).get("name", job_id)
+            job_label = _job_label(job_id, download_candidate_jobs)
             with print_lock:
-                print_function_callback(f"  Downloading {len(job_files)} files for job: {job_name}")
+                fmt.detail(
+                    f"{_job_label(job_id, download_candidate_jobs, with_id=False)}:"
+                    f" downloading {_plural(len(job_files), 'file')}"
+                )
 
             MIN_DELAY_BETWEEN_PRINTOUTS = 20
 
@@ -1607,7 +1698,7 @@ def _incremental_output_download(
                     nonlocal last_call_time, printed_100_percent
                     if not printed_100_percent and download_metadata.progress == 100:
                         with print_lock:
-                            print_function_callback(f"    {download_metadata.progressMessage}")
+                            fmt.detail(download_metadata.progressMessage, indent=6)
                         last_call_time = time.time()
                         printed_100_percent = True
                     elif (
@@ -1615,7 +1706,7 @@ def _incremental_output_download(
                         and time.time() - last_call_time > MIN_DELAY_BETWEEN_PRINTOUTS
                     ):
                         with print_lock:
-                            print_function_callback(f"    {download_metadata.progressMessage}")
+                            fmt.detail(download_metadata.progressMessage, indent=6)
                         last_call_time = time.time()
                     return sigint_handler.continue_operation
 
@@ -1641,7 +1732,7 @@ def _incremental_output_download(
                             boto3_session_for_s3,
                             file_conflict_resolution,
                             on_downloading_files=_make_progress_callback(),
-                            print_function_callback=print_function_callback,
+                            print_function_callback=lambda msg: None,
                         )
                         if not sigint_handler.continue_operation:
                             raise AssetSyncCancelledError("File download cancelled.")
@@ -1656,9 +1747,7 @@ def _incremental_output_download(
                     except Exception as e:
                         error_code = _classify_error(e)
                         with print_lock:
-                            print_function_callback(
-                                f"  ERROR downloading task {task_id} for job {job_name}: {e}"
-                            )
+                            fmt.error(f"task {task_id} of job {job_label}: {e}", indent=4)
                         job_task_results[task_id] = {
                             "total_files": len(task_files),
                             "downloaded_files": sum(
@@ -1691,7 +1780,7 @@ def _incremental_output_download(
                             boto3_session_for_s3,
                             file_conflict_resolution,
                             on_downloading_files=_make_progress_callback(),
-                            print_function_callback=print_function_callback,
+                            print_function_callback=lambda msg: None,
                         )
                         if not sigint_handler.continue_operation:
                             raise AssetSyncCancelledError("File download cancelled.")
@@ -1701,9 +1790,7 @@ def _incremental_output_download(
                     except Exception as e:
                         error_code = _classify_error(e)
                         with print_lock:
-                            print_function_callback(
-                                f"  ERROR downloading unattributed files for job {job_name} ({job_id}): {e}"
-                            )
+                            fmt.error(f"unattributed files for {job_label}: {e}", indent=4)
                         leftover_downloaded = sum(
                             1 for f in leftover_files if os.path.exists(f.path)
                         )
@@ -1722,7 +1809,7 @@ def _incremental_output_download(
                         boto3_session_for_s3,
                         file_conflict_resolution,
                         on_downloading_files=_make_progress_callback(),
-                        print_function_callback=print_function_callback,
+                        print_function_callback=lambda msg: None,
                     )
                     if not sigint_handler.continue_operation:
                         raise AssetSyncCancelledError("File download cancelled.")
@@ -1733,9 +1820,7 @@ def _incremental_output_download(
                     job_error_code = _classify_error(e)
                     job_error_message = str(e)
                     with print_lock:
-                        print_function_callback(
-                            f"  ERROR downloading job {job_name} ({job_id}): {e}"
-                        )
+                        fmt.error(f"{job_label}: {e}", indent=4)
 
             if job_task_results:
                 # Per-task path: derive counts from task results directly to avoid
@@ -1823,9 +1908,21 @@ def _incremental_output_download(
 
         durations.download = time.perf_counter_ns() - start_t
         duration = datetime.now(tz=timezone.utc) - start_time
-        print_function_callback(f"...downloaded in {duration}")
-    else:
-        print_function_callback("Skipping downloads due to DRY RUN")
+        downloaded_file_count = sum(
+            r.get("downloaded_files", 0) for r in job_download_results.values()
+        )
+        failed_file_count = sum(r.get("failed_files", 0) for r in job_download_results.values())
+        if not job_manifest_paths:
+            pass  # "nothing new to download" was already reported above
+        elif failed_file_count:
+            fmt.line(
+                f"downloaded {_plural(downloaded_file_count, 'file')}, {failed_file_count} failed",
+                duration,
+            )
+        else:
+            fmt.line(f"downloaded {_plural(downloaded_file_count, 'file')}", duration)
+    elif job_manifest_paths:
+        fmt.line("dry run, no files downloaded")
 
     # For jobs whose paths were entirely claimed by a newer job (cross-job dedup),
     # generate task results based on what's actually on disk. The winning job may have
@@ -2013,31 +2110,10 @@ def _incremental_output_download(
         },
     )
 
-    print_function_callback("")
-    if dry_run:
-        print_function_callback(
-            "Summary of DRY RUN for incremental output download (no files were downloaded to the file system):"
+    if not fmt.suppressed:
+        _print_summary(
+            fmt, stats, dry_run, job_download_results, download_candidate_jobs, unmapped_paths
         )
-    else:
-        print_function_callback("Summary of incremental output download:")
-    print_function_callback(f"  Downloaded session actions: {stats['downloaded_session_actions']}")
-    print_function_callback(f"  Downloaded files: {stats['downloaded_files']}")
-    print_function_callback(
-        f"  Downloaded bytes: {human_readable_file_size(stats['downloaded_bytes'])}"
-    )
-    print_function_callback("  Jobs with downloads:")
-    print_function_callback(f"    completed: {stats['jobs_with_downloads']['completed']}")
-    print_function_callback(f"    added: {stats['jobs_with_downloads']['added']}")
-    print_function_callback(f"    updated: {stats['jobs_with_downloads']['updated']}")
-    print_function_callback("  Jobs without downloads:")
-    print_function_callback(
-        f"    not using job attachments: {stats['jobs_without_downloads']['not_using_job_attachments']}"
-    )
-    print_function_callback(
-        f"    missing storage profile: {stats['jobs_without_downloads']['missing_storage_profile']}"
-    )
-    print_function_callback(f"    unchanged: {stats['jobs_without_downloads']['unchanged']}")
-    print_function_callback(f"    inactive: {stats['jobs_without_downloads']['inactive']}")
 
     return (
         checkpoint,
@@ -2046,4 +2122,65 @@ def _incremental_output_download(
         job_download_results,
         task_download_results,
         succeeded_task_ids,
+        stats,
     )
+
+
+# Job wording follows the download status file's vocabulary (downloaded / in_progress /
+# skipped / failed) so the terminal and the JSON report describe a job the same way.
+_SKIP_REASON_LABELS = {
+    "not_using_job_attachments": "no attachments",
+    "missing_storage_profile": "missing storage profile",
+    "unchanged": "unchanged",
+}
+
+
+def _print_summary(
+    fmt: _SyncOutputFormatter,
+    stats: dict[str, Any],
+    dry_run: bool,
+    job_download_results: dict[str, dict[str, Any]],
+    download_candidate_jobs: dict[str, dict[str, Any]],
+    unmapped_paths: dict[str, list[str]],
+) -> None:
+    """Prints the closing summary block, including every job that failed this run."""
+    fmt.section("Summary (dry run, nothing written to disk)" if dry_run else "Summary")
+    fmt.summary_row(
+        "files",
+        f"{stats['downloaded_files']} downloaded"
+        f", {human_readable_file_size(stats['downloaded_bytes'])}",
+    )
+
+    failures = {
+        job_id: result
+        for job_id, result in job_download_results.items()
+        if result.get("error_code") is not None
+    }
+    in_progress = stats["jobs_with_downloads"]["added"] + stats["jobs_with_downloads"]["updated"]
+    job_parts = [f"{stats['jobs_with_downloads']['completed']} downloaded"]
+    if in_progress:
+        job_parts.append(f"{in_progress} in progress")
+    if stats["jobs_without_downloads"]["inactive"]:
+        job_parts.append(f"{stats['jobs_without_downloads']['inactive']} retired")
+    if failures:
+        job_parts.append(f"{len(failures)} failed")
+    fmt.summary_row("jobs", ", ".join(job_parts))
+
+    fmt.summary_row("task runs", str(stats["downloaded_session_actions"]))
+
+    skipped = ", ".join(
+        f"{count} {label}"
+        for name, label in _SKIP_REASON_LABELS.items()
+        if (count := stats["jobs_without_downloads"][name])
+    )
+    fmt.summary_row("skipped", skipped or "none")
+
+    if unmapped_paths:
+        fmt.summary_row("unmapped", f"{_plural(len(unmapped_paths), 'job')} with unmapped paths")
+
+    # Repeat each failure here so an unattended run does not bury them mid-download.
+    if failures:
+        fmt.summary_row("problems", _plural(len(failures), "job") + " failed")
+        for job_id, result in sorted(failures.items()):
+            label = _job_label(job_id, download_candidate_jobs)
+            fmt.summary_continuation(f"{result['error_code']:<18} {label}")

--- a/src/deadline/client/cli/_incremental_download.py
+++ b/src/deadline/client/cli/_incremental_download.py
@@ -16,6 +16,7 @@ from typing import Optional
 from configparser import ConfigParser
 from typing import Any, Callable
 import time
+import textwrap
 import concurrent.futures
 
 from .. import api
@@ -69,6 +70,7 @@ from ._common import _cli_object_repr, sigint_handler
 from ._sync_output_format import (
     _ENTRY_DETAIL_INDENT,
     _SyncOutputFormatter,
+    _SyncOutputWriter,
     _format_duration,
     _format_interval,
     _format_path,
@@ -335,6 +337,7 @@ def _get_download_candidate_jobs(
         if job["taskRunStatusCounts"]["SUCCEEDED"] > 0
     }
     active_job_count = len(download_candidate_jobs)
+    active_job_ids = set(download_candidate_jobs)
 
     # - Any recently ended job (job went from active to terminal with a taskRunStatus
     #   in SUSPENDED, CANCELED, FAILED, SUCCEEDED, NOT_COMPATIBLE), that has at least
@@ -367,9 +370,10 @@ def _get_download_candidate_jobs(
 
     duration = datetime.now(tz=timezone.utc) - start_time
     if download_candidate_jobs:
+        newly_ended_count = len({job["jobId"] for job in recently_ended_jobs} - active_job_ids)
         fmt.line(
             f"{_plural(len(download_candidate_jobs), 'candidate job')}"
-            f" ({active_job_count} active, {len(recently_ended_jobs)} recently ended)",
+            f" ({active_job_count} active, {newly_ended_count} recently ended)",
             duration,
         )
     else:
@@ -447,7 +451,8 @@ def _categorize_jobs_in_checkpoint(
     # Per-job lines are buffered so the summary step (which needs the elapsed time) can be
     # printed above the jobs it describes.
     buffered_lines: list[Any] = []
-    entries = _SyncOutputFormatter(buffered_lines.append)
+    entries_writer = _SyncOutputWriter(buffered_lines.append)
+    entries = _SyncOutputFormatter(entries_writer)
     start_time = datetime.now(tz=timezone.utc)
 
     finished_tracking_job_ids = checkpoint_job_ids.difference(download_candidate_job_ids)
@@ -646,6 +651,8 @@ def _categorize_jobs_in_checkpoint(
     )
     for line in buffered_lines:
         print_function_callback(line)
+    if entries_writer.had_problem:
+        fmt.mark_problem()
 
     return result
 
@@ -919,13 +926,7 @@ def _get_job_sessions(
         for future in concurrent.futures.as_completed(futures):
             future.result()
 
-    duration = datetime.now(tz=timezone.utc) - start_time
-    session_action_count = sum(
-        len(session.get("sessionActions", []))
-        for session_list in job_sessions.values()
-        for session in session_list
-    )
-    fmt.line(_plural(session_action_count, "succeeded task run"), duration)
+    retrieval_duration = datetime.now(tz=timezone.utc) - start_time
 
     start_time = datetime.now(tz=timezone.utc)
 
@@ -937,6 +938,21 @@ def _get_job_sessions(
         job_sessions,
         download_candidate_jobs,
         print_function_callback,
+    )
+
+    # Counted after the prune so this agrees with the summary's task-runs row, which is
+    # derived from the same session actions once the ones with no output are gone.
+    fmt.line(
+        _plural(
+            sum(
+                len(session.get("sessionActions", []))
+                for session_list in job_sessions.values()
+                for session in session_list
+            ),
+            "task run with output",
+            "task runs with output",
+        ),
+        retrieval_duration,
     )
 
     duration = datetime.now(tz=timezone.utc) - start_time
@@ -1470,15 +1486,6 @@ def _incremental_output_download(
     )
     durations._update_checkpoint_jobs_list = time.perf_counter_ns() - start_t
 
-    # Build per-job file mapping by correlating downloaded manifests with their job IDs.
-    # Resolved before the download so the manifest count can be reported with its timing.
-    manifests_to_download = _get_manifests_to_download(
-        queue["jobAttachmentSettings"]["rootPrefix"],
-        download_candidate_jobs,
-        job_sessions,
-        path_mapping_rule_appliers,
-    )
-
     fmt.section("Download")
     start_t = time.perf_counter_ns()
     unmapped_paths: dict[str, list[str]] = {}
@@ -1496,9 +1503,9 @@ def _incremental_output_download(
         )
     )
     durations._download_all_manifests_with_absolute_paths = time.perf_counter_ns() - start_t
-    if manifests_to_download:
+    if downloaded_manifests:
         fmt.line(
-            _plural(len(manifests_to_download), "asset manifest"),
+            _plural(len(downloaded_manifests), "asset manifest"),
             durations._download_all_manifests_with_absolute_paths / 1_000_000_000,
         )
 
@@ -1527,8 +1534,15 @@ def _incremental_output_download(
                 unmapped_path_list, max_entries=30, path_format=path_format
             )
             for summary_line in paths_summary.splitlines():
-                fmt.entry_detail(summary_line.strip())
+                fmt.entry_detail(summary_line)
 
+    # Build per-job file mapping by correlating downloaded manifests with their job IDs.
+    manifests_to_download = _get_manifests_to_download(
+        queue["jobAttachmentSettings"]["rootPrefix"],
+        download_candidate_jobs,
+        job_sessions,
+        path_mapping_rule_appliers,
+    )
     # Correlate manifests_to_download with downloaded_manifests by position to attribute each
     # downloaded manifest to its job (and task). Both lists come from _get_manifests_to_download
     # with identical inputs, so their lengths match in practice. If they ever diverge we skip only
@@ -1626,8 +1640,8 @@ def _incremental_output_download(
         paths_summary = summarize_path_list(
             local_path_list, total_size_by_path=file_size_by_path, max_entries=30
         )
-        for summary_line in paths_summary.splitlines():
-            fmt.detail(summary_line.strip())
+        for summary_line in textwrap.indent(paths_summary, " " * 4).splitlines():
+            fmt.detail(summary_line, indent=0)
     else:
         fmt.line("nothing new to download")
 
@@ -1649,11 +1663,6 @@ def _incremental_output_download(
         fmt.flush()
     else:
         fmt.discard()
-        fmt.result(
-            f"{queue['displayName']}: nothing new"
-            f" (window {_format_duration(update_length)},"
-            f" checked {_format_timestamp(current_timestamp)})"
-        )
 
     # Download per-job with error isolation, running jobs in parallel to restore throughput.
     job_download_results: dict[str, dict[str, Any]] = {}
@@ -1732,6 +1741,8 @@ def _incremental_output_download(
                             boto3_session_for_s3,
                             file_conflict_resolution,
                             on_downloading_files=_make_progress_callback(),
+                            # Suppressed: this helper's only output is a worker-thread count.
+                            # Suppressed: this helper's only output is a worker-thread count.
                             print_function_callback=lambda msg: None,
                         )
                         if not sigint_handler.continue_operation:
@@ -1780,6 +1791,8 @@ def _incremental_output_download(
                             boto3_session_for_s3,
                             file_conflict_resolution,
                             on_downloading_files=_make_progress_callback(),
+                            # Suppressed: this helper's only output is a worker-thread count.
+                            # Suppressed: this helper's only output is a worker-thread count.
                             print_function_callback=lambda msg: None,
                         )
                         if not sigint_handler.continue_operation:
@@ -1809,6 +1822,7 @@ def _incremental_output_download(
                         boto3_session_for_s3,
                         file_conflict_resolution,
                         on_downloading_files=_make_progress_callback(),
+                        # Suppressed: this helper's only output is a worker-thread count.
                         print_function_callback=lambda msg: None,
                     )
                     if not sigint_handler.continue_operation:
@@ -2109,6 +2123,11 @@ def _incremental_output_download(
             **stats,
         },
     )
+
+    # Values the caller needs for its closing result line, added after the telemetry event so
+    # they stay out of the metric payload.
+    stats["window_summary"] = f"window {_format_duration(update_length)}"
+    stats["checked_at"] = _format_timestamp(current_timestamp)
 
     if not fmt.suppressed:
         _print_summary(

--- a/src/deadline/client/cli/_sync_output_format.py
+++ b/src/deadline/client/cli/_sync_output_format.py
@@ -1,0 +1,253 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Terminal formatting for the `deadline queue sync-output` command.
+
+Output is plain ASCII. Color is used only to flag a problem (yellow for warnings, red
+for errors), matching the rest of the CLI, and structure is carried by indentation so
+the log reads the same when redirected, piped, or collected by a log agent.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "_ENTRY_DETAIL_INDENT",
+    "_SyncOutputFormatter",
+    "_SyncOutputWriter",
+    "_format_duration",
+    "_format_interval",
+    "_format_path",
+    "_format_timestamp",
+    "_plural",
+]
+
+import os
+from datetime import datetime, timedelta
+from typing import Any, Callable, Optional, Union
+
+import click
+
+# Column that right-aligned step timings are flushed to, in characters.
+_TIMING_COLUMN = 56
+
+# Timings below this are noise: a run reports six sub-millisecond bookkeeping steps whose
+# durations say nothing, and hiding them lets the one genuinely slow step stand out.
+_MIN_REPORTED_SECONDS = 1.0
+
+# Width of the label column used by `field()` and `summary_row()`.
+_LABEL_WIDTH = 12
+
+# Layout of the tagged job entries printed beneath a step, e.g. `NEW       my-job`.
+# Continuation lines indent past the tag so they sit under the entry title.
+_ENTRY_INDENT = 4
+_ENTRY_TAG_WIDTH = 9
+_ENTRY_DETAIL_INDENT = _ENTRY_INDENT + _ENTRY_TAG_WIDTH + 1
+
+
+def _format_duration(duration: Union[timedelta, float, int]) -> str:
+    """Renders a duration compactly: `<0.1s`, `0.6s`, `42s`, `10m55s`, `2h05m`."""
+    seconds = duration.total_seconds() if isinstance(duration, timedelta) else float(duration)
+    seconds = max(seconds, 0.0)
+    if seconds < 0.1:
+        return "<0.1s"
+    if seconds < 10:
+        return f"{seconds:.1f}s"
+    if seconds < 60:
+        return f"{seconds:.0f}s"
+    minutes, whole_seconds = divmod(int(round(seconds)), 60)
+    if minutes < 60:
+        return f"{minutes}m" if whole_seconds == 0 else f"{minutes}m{whole_seconds:02d}s"
+    hours, minutes = divmod(minutes, 60)
+    return f"{hours}h" if minutes == 0 else f"{hours}h{minutes:02d}m"
+
+
+def _is_worth_reporting(duration: Union[timedelta, float, int]) -> bool:
+    """Returns True when a step took long enough that its duration is informative."""
+    seconds = duration.total_seconds() if isinstance(duration, timedelta) else float(duration)
+    return seconds >= _MIN_REPORTED_SECONDS
+
+
+def _format_timestamp(when: datetime) -> str:
+    """Renders a timestamp in local time to second precision."""
+    return when.astimezone().strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _format_interval(start: datetime, end: datetime) -> str:
+    """Renders a time interval, collapsing the date on the end when both fall on one day."""
+    start_local = start.astimezone()
+    end_local = end.astimezone()
+    if start_local.date() == end_local.date():
+        return f"{_format_timestamp(start)} to {end_local.strftime('%H:%M:%S')}"
+    return f"{_format_timestamp(start)} to {_format_timestamp(end)}"
+
+
+def _format_path(path: str) -> str:
+    """Collapses the home directory to `~` so long checkpoint paths stay readable.
+
+    Never truncates: these paths are printed so the operator can copy them.
+    """
+    home = os.path.expanduser("~")
+    if home and home != os.sep:
+        if path == home:
+            return "~"
+        if path.startswith(home + os.sep):
+            return "~" + path[len(home) :]
+    return path
+
+
+def _plural(count: int, singular: str, plural: Optional[str] = None) -> str:
+    """Renders `count` with the correctly pluralized noun, e.g. `1 job` / `2 jobs`."""
+    if count == 1:
+        return f"{count} {singular}"
+    return f"{count} {plural if plural is not None else singular + 's'}"
+
+
+class _SyncOutputWriter:
+    """The output sink for one sync-output run: optional buffering, plus a problem flag.
+
+    A run's output is produced from several modules, each of which builds its own
+    formatter around a plain print callback. Routing them all through one writer is what
+    lets the whole report share a single buffer and a single "did anything go wrong" flag.
+
+    While buffering, lines are held rather than printed. The caller then calls `flush()`
+    once it knows the run has something to report, or `discard()` to drop the report in
+    favour of a one-line result. That is what keeps a downloader polling a queue on a
+    schedule from writing a full report every interval when nothing changed.
+
+    Instances are callable, so a writer can be passed anywhere a print callback is taken.
+    """
+
+    def __init__(self, echo: Callable[[Any], None], *, buffered: bool = False) -> None:
+        self._echo = echo
+        self._buffer: Optional[list[Any]] = [] if buffered else None
+        self._suppressed = False
+        self.had_problem = False
+
+    def __call__(self, line: Any = "") -> None:
+        if self._buffer is not None:
+            self._buffer.append(line)
+        else:
+            self._echo(line)
+
+    @property
+    def suppressed(self) -> bool:
+        """True when buffered lines were dropped instead of printed."""
+        return self._suppressed
+
+    def flush(self) -> None:
+        """Prints anything held back and sends later output straight through."""
+        if self._buffer is not None:
+            held, self._buffer = self._buffer, None
+            for line in held:
+                self._echo(line)
+
+    def discard(self) -> None:
+        """Drops anything held back, for a run with nothing worth reporting."""
+        if self._buffer is not None:
+            self._suppressed = True
+            self._buffer = None
+
+
+class _SyncOutputFormatter:
+    """Renders sync-output progress as indented plain-text sections.
+
+    Every line goes through the caller's sink, so JSON mode stays silent and the CLI's
+    logger keeps ownership of the stream. Pass a `_SyncOutputWriter` as the sink to take
+    part in a run's shared buffering; a plain callback also works, and then the buffering
+    controls below are no-ops.
+    """
+
+    def __init__(self, echo: Callable[[Any], None]) -> None:
+        self._echo = echo
+
+    @property
+    def _writer(self) -> Optional[_SyncOutputWriter]:
+        return self._echo if isinstance(self._echo, _SyncOutputWriter) else None
+
+    @property
+    def had_problem(self) -> bool:
+        """True once a warning or error has been reported anywhere in this run."""
+        writer = self._writer
+        return writer.had_problem if writer is not None else False
+
+    @property
+    def suppressed(self) -> bool:
+        """True when the buffered report was dropped in favour of a one-line result."""
+        writer = self._writer
+        return writer.suppressed if writer is not None else False
+
+    def flush(self) -> None:
+        writer = self._writer
+        if writer is not None:
+            writer.flush()
+
+    def discard(self) -> None:
+        writer = self._writer
+        if writer is not None:
+            writer.discard()
+
+    def _emit(self, line: Any) -> None:
+        self._echo(line)
+
+    def _mark_problem(self) -> None:
+        writer = self._writer
+        if writer is not None:
+            writer.had_problem = True
+
+    def blank(self) -> None:
+        self._emit("")
+
+    def section(self, title: str) -> None:
+        """Starts a new section: an unindented heading preceded by a blank line."""
+        self.blank()
+        self._emit(title)
+
+    def field(self, label: str, value: str) -> None:
+        """Prints an aligned `label  value` pair under a heading."""
+        self._emit(f"  {label:<{_LABEL_WIDTH}}{value}")
+
+    def field_continuation(self, value: str) -> None:
+        """Prints an extra value line aligned with the values printed by `field`."""
+        self._emit(f"  {'':<{_LABEL_WIDTH}}{value}")
+
+    def line(self, text: str, duration: Optional[Union[timedelta, float, int]] = None) -> None:
+        """Prints a completed step, with its duration flushed right when slow enough."""
+        if duration is None or not _is_worth_reporting(duration):
+            self._emit(f"  {text}")
+            return
+        padding = max(1, _TIMING_COLUMN - (2 + len(text)))
+        self._emit(f"  {text}{' ' * padding}{_format_duration(duration)}")
+
+    def detail(self, text: str, indent: int = _ENTRY_INDENT) -> None:
+        self._emit(f"{' ' * indent}{text}")
+
+    def entry(self, tag: str, title: str, note: Optional[str] = None) -> None:
+        """Prints a tagged job entry such as `NEW       my-job-name (4/4 tasks succeeded)`."""
+        line = f"{' ' * _ENTRY_INDENT}{tag:<{_ENTRY_TAG_WIDTH}} {title}"
+        if note:
+            line = f"{line} {note}"
+        self._emit(line)
+
+    def entry_detail(self, text: str) -> None:
+        """Prints a line aligned under the title of the entry above it."""
+        self._emit(f"{' ' * _ENTRY_DETAIL_INDENT}{text}")
+
+    def warning(self, text: str, indent: int = 2) -> None:
+        self._mark_problem()
+        self._emit(f"{' ' * indent}{click.style(f'WARNING: {text}', fg='yellow')}")
+
+    def error(self, text: str, indent: int = 2) -> None:
+        self._mark_problem()
+        self._emit(f"{' ' * indent}{click.style(f'ERROR: {text}', fg='red')}")
+
+    def summary_row(self, label: str, value: str) -> None:
+        """Prints an aligned `label  value` row in the closing summary block."""
+        self._emit(f"  {label:<{_LABEL_WIDTH}}{value}")
+
+    def summary_continuation(self, value: str) -> None:
+        """Prints an extra row aligned with the values printed by `summary_row`."""
+        self._emit(f"  {'':<{_LABEL_WIDTH}}{value}")
+
+    def result(self, text: str, *, failed: bool = False) -> None:
+        """Prints the closing one-line result, unindented so it is easy to grep or tail."""
+        self._emit(click.style(f"FAILED  {text}", fg="red") if failed else f"OK  {text}")

--- a/src/deadline/client/cli/_sync_output_format.py
+++ b/src/deadline/client/cli/_sync_output_format.py
@@ -189,6 +189,10 @@ class _SyncOutputFormatter:
     def _emit(self, line: Any) -> None:
         self._echo(line)
 
+    def mark_problem(self) -> None:
+        """Records that a problem happened, for a warning reported through another sink."""
+        self._mark_problem()
+
     def _mark_problem(self) -> None:
         writer = self._writer
         if writer is not None:

--- a/test/unit/deadline_client/cli/test_cli_download_status_file.py
+++ b/test/unit/deadline_client/cli/test_cli_download_status_file.py
@@ -12,6 +12,7 @@ from typing import Any, Optional
 
 import pytest
 
+from deadline.client.cli._sync_output_format import _format_path
 from deadline.client.cli._download_status_file import (
     _atomic_write_json,
     _build_status_file_content,
@@ -513,7 +514,8 @@ class TestWriteDownloadStatusFile:
         with open(status_file) as f:
             data = json.load(f)
         assert data["jobs"][MOCK_JOB_ID]["download_status"] == "downloaded"
-        assert any("status file" in msg and str(renders_dir) in msg for msg in messages)
+        shown = _format_path(str(renders_dir))
+        assert any("status file" in msg and shown in msg for msg in messages)
 
     def test_writes_to_ignore_storage_profiles_path(self, tmp_path):
         checkpoint_dir = tmp_path / "checkpoint"

--- a/test/unit/deadline_client/cli/test_cli_download_status_file.py
+++ b/test/unit/deadline_client/cli/test_cli_download_status_file.py
@@ -513,7 +513,7 @@ class TestWriteDownloadStatusFile:
         with open(status_file) as f:
             data = json.load(f)
         assert data["jobs"][MOCK_JOB_ID]["download_status"] == "downloaded"
-        assert any("saved" in msg for msg in messages)
+        assert any("status file" in msg and str(renders_dir) in msg for msg in messages)
 
     def test_writes_to_ignore_storage_profiles_path(self, tmp_path):
         checkpoint_dir = tmp_path / "checkpoint"
@@ -592,7 +592,7 @@ class TestWriteDownloadStatusFile:
             print_function_callback=messages.append,
         )
 
-        assert any("WARNING" in msg for msg in messages)
+        assert any("failed to write status file" in msg for msg in messages)
 
     def test_json_is_valid_and_parseable(self, tmp_path):
         checkpoint_dir = tmp_path / "checkpoint"

--- a/test/unit/deadline_client/cli/test_cli_queue_incremental_download.py
+++ b/test/unit/deadline_client/cli/test_cli_queue_incremental_download.py
@@ -13,6 +13,7 @@ from datetime import datetime, timedelta
 from typing import Callable, NamedTuple
 
 from freezegun import freeze_time
+import click
 from click.testing import CliRunner
 from deadline.client.cli import main
 import psutil
@@ -112,6 +113,7 @@ def test_incremental_output_download_requires_queue_with_job_attachments(
             [
                 "queue",
                 "sync-output",
+                "--verbose",
                 "--ignore-storage-profiles",
                 "--farm-id",
                 MOCK_FARM_ID,
@@ -156,6 +158,7 @@ def test_incremental_output_download_pid_lock_already_held_error(
             [
                 "queue",
                 "sync-output",
+                "--verbose",
                 "--ignore-storage-profiles",
                 "--farm-id",
                 MOCK_FARM_ID,
@@ -197,6 +200,7 @@ def test_incremental_output_download_storage_profile_options_mutually_exclusive(
             [
                 "queue",
                 "sync-output",
+                "--verbose",
                 "--ignore-storage-profiles",
                 "--storage-profile-id",
                 MOCK_STORAGE_PROFILE_ID,
@@ -214,6 +218,187 @@ def test_incremental_output_download_storage_profile_options_mutually_exclusive(
         "Options '--storage-profile-id' and '--ignore-storage-profiles' cannot be provided together"
         in result.output
     ), result.output
+
+
+def _sync_output_args(checkpoint_dir, *extra):
+    return [
+        "queue",
+        "sync-output",
+        "--ignore-storage-profiles",
+        "--farm-id",
+        MOCK_FARM_ID,
+        "--queue-id",
+        MOCK_QUEUE_ID,
+        "--checkpoint-dir",
+        checkpoint_dir,
+        *extra,
+    ]
+
+
+def _mock_unchanged_job(deadline_mock):
+    """Sets up a single job that is already in the checkpoint and has not changed."""
+    mock_jobs = create_fake_job_list(1)
+    mock_jobs[0]["name"] = "Mock Job"
+    mock_jobs[0]["jobId"] = MOCK_JOB_ID
+    mock_jobs[0]["taskRunStatus"] = "READY"
+    mock_jobs[0]["taskRunStatusCounts"] = {"SUCCEEDED": 1, "READY": 1}
+    mock_jobs[0]["attachments"] = {
+        "manifests": [
+            {"rootPath": "/", "rootPathFormat": "posix", "outputRelativeDirectories": ["."]}
+        ],
+        "fileSystem": "VIRTUAL",
+    }
+    del mock_jobs[0]["endedAt"]
+    deadline_mock.search_jobs = mock_search_jobs_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+    deadline_mock.get_job = mock_get_job_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+    return mock_jobs
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
+)
+def test_incremental_output_download_quiet_when_nothing_new(
+    fresh_deadline_config,
+    deadline_mock,
+    checkpoint_dir,
+):
+    """A run that finds nothing new collapses to one line, so polling on a schedule
+    does not fill the log with a full report every interval."""
+    _mock_unchanged_job(deadline_mock)
+    runner = CliRunner()
+
+    # First run discovers the job, so it has news and prints the full report.
+    with freeze_time(ISO_FREEZE_TIME):
+        first = runner.invoke(main, _sync_output_args(checkpoint_dir))
+    assert first.exit_code == 0, first.output
+    assert "Queue sync: Mock Queue" in first.output, first.output
+
+    # Second run sees the same unchanged job, which is not news.
+    with freeze_time(ISO_FREEZE_TIME_PLUS_3MIN):
+        second = runner.invoke(main, _sync_output_args(checkpoint_dir))
+
+    assert second.exit_code == 0, second.output
+    assert second.output.splitlines() == [
+        "OK  Mock Queue: nothing new (window 3m, checked 2025-05-26 05:03:00)"
+    ], second.output
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
+)
+def test_incremental_output_download_verbose_reports_a_run_with_nothing_new(
+    fresh_deadline_config,
+    deadline_mock,
+    checkpoint_dir,
+):
+    """--verbose prints the full report even when the run has nothing new to say."""
+    _mock_unchanged_job(deadline_mock)
+    runner = CliRunner()
+    with freeze_time(ISO_FREEZE_TIME):
+        runner.invoke(main, _sync_output_args(checkpoint_dir))
+
+    with freeze_time(ISO_FREEZE_TIME_PLUS_3MIN):
+        result = runner.invoke(main, _sync_output_args(checkpoint_dir, "--verbose"))
+
+    assert result.exit_code == 0, result.output
+    assert "Queue sync: Mock Queue" in result.output, result.output
+    assert "UNCHANGED Mock Job" in result.output, result.output
+    assert "skipped     1 unchanged" in result.output, result.output
+    assert "nothing to download" in result.output, result.output
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
+)
+def test_incremental_output_download_output_is_ascii_only(
+    fresh_deadline_config,
+    deadline_mock,
+    checkpoint_dir,
+):
+    """No unicode in the report: redirecting under a legacy Windows codepage must not fail."""
+    _mock_unchanged_job(deadline_mock)
+    runner = CliRunner()
+    with freeze_time(ISO_FREEZE_TIME):
+        result = runner.invoke(main, _sync_output_args(checkpoint_dir, "--verbose"))
+
+    assert result.exit_code == 0, result.output
+    offenders = [line for line in result.output.splitlines() if not line.isascii()]
+    assert not offenders, offenders
+    result.output.encode("cp1252")
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
+)
+def test_incremental_output_download_hides_sub_second_timings(
+    fresh_deadline_config,
+    deadline_mock,
+    checkpoint_dir,
+):
+    """Sub-second step timings are suppressed so a genuinely slow step stands out."""
+    _mock_unchanged_job(deadline_mock)
+    runner = CliRunner()
+    with freeze_time(ISO_FREEZE_TIME):
+        result = runner.invoke(main, _sync_output_args(checkpoint_dir, "--verbose"))
+
+    assert result.exit_code == 0, result.output
+    # Every step in a mocked run is instant, so no step line carries a duration. The
+    # "window" and "elapsed" rows are exempt: a duration is their value, not a timing
+    # annotation, so they always report however small it is.
+    step_lines = [
+        line
+        for line in result.output.splitlines()
+        if line.startswith("  ")
+        and "<0.1s" in line
+        and not line.startswith(("  window", "  elapsed"))
+    ]
+    assert not step_lines, step_lines
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
+)
+def test_incremental_output_download_json_mode_writes_nothing_to_stdout(
+    fresh_deadline_config,
+    deadline_mock,
+    checkpoint_dir,
+):
+    """--json must keep stdout free of progress text so the output stays machine-parseable."""
+    mock_jobs = create_fake_job_list(1)
+    mock_jobs[0]["name"] = "Mock Job"
+    mock_jobs[0]["jobId"] = MOCK_JOB_ID
+    mock_jobs[0]["taskRunStatus"] = "READY"
+    mock_jobs[0]["taskRunStatusCounts"] = {"SUCCEEDED": 1, "READY": 1}
+    mock_jobs[0]["attachments"] = {
+        "manifests": [
+            {"rootPath": "/", "rootPathFormat": "posix", "outputRelativeDirectories": ["."]}
+        ],
+        "fileSystem": "VIRTUAL",
+    }
+    del mock_jobs[0]["endedAt"]
+    deadline_mock.search_jobs = mock_search_jobs_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+    deadline_mock.get_job = mock_get_job_for_set(MOCK_FARM_ID, MOCK_QUEUE_ID, mock_jobs)
+
+    runner = CliRunner()
+    with freeze_time(ISO_FREEZE_TIME):
+        result = runner.invoke(
+            main,
+            [
+                "queue",
+                "sync-output",
+                "--json",
+                "--ignore-storage-profiles",
+                "--farm-id",
+                MOCK_FARM_ID,
+                "--queue-id",
+                MOCK_QUEUE_ID,
+                "--checkpoint-dir",
+                checkpoint_dir,
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert result.output == "", result.output
 
 
 @pytest.mark.skipif(
@@ -259,6 +444,7 @@ def test_incremental_output_download_bootstrap_and_completion(
             [
                 "queue",
                 "sync-output",
+                "--verbose",
             ]
             + storage_profile_options
             + [
@@ -281,33 +467,27 @@ def test_incremental_output_download_bootstrap_and_completion(
 
     # Assert that information is or isn't printed about the storage profile.
     if storage_profile_id is None:
-        assert "Local storage profile is" not in result.output, result.output
-        assert (
-            "download candidate jobs have the same storage profile and will be downloaded to their original specified paths"
-            not in result.output
-        ), result.output
+        assert "on the local storage profile" not in result.output, result.output
+        assert "on the local storage profile" not in result.output, result.output
     else:
-        assert "Local storage profile is" in result.output, result.output
+        assert "on the local storage profile" in result.output, result.output
         assert f"({storage_profile_id})" in result.output, result.output
-        assert (
-            "1 download candidate jobs have the same storage profile and will be downloaded to their original specified paths"
-            in result.output
-        ), result.output
+        assert "1 job on the local storage profile" in result.output, result.output
     # Assert that the output contained information about the bootstrapping and the mocked resources
-    assert "Started incremental download for queue: Mock Queue" in result.output, result.output
+    assert "Queue sync: Mock Queue" in result.output, result.output
     assert (
-        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_' + storage_profile_in_message + '_download_checkpoint.json')}"
+        f"checkpoint  {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_' + storage_profile_in_message + '_download_checkpoint.json')}"
         in result.output
     ), result.output
-    assert "Checkpoint not found, lookback is 0.0 minutes" in result.output, result.output
+    assert "(0.0 minute lookback, no checkpoint found)" in result.output, result.output
     # Need to convert the freeze time to the local time zone for this print assertion
     assert (
-        f"Initializing from: {datetime.fromisoformat(ISO_FREEZE_TIME).astimezone().isoformat()}"
+        f"bootstrapping from {datetime.fromisoformat(ISO_FREEZE_TIME).astimezone().strftime('%Y-%m-%d %H:%M:%S')}"
         in result.output
     ), result.output
-    assert f"NEW Job: Mock Job ({MOCK_JOB_ID})" in result.output, result.output
-    assert "Succeeded tasks: 1 / 2" in result.output, result.output
-    assert "added: 1" in result.output, result.output
+    assert "NEW       Mock Job" in result.output, result.output
+    assert "(1/2 tasks succeeded)" in result.output, result.output
+    assert "jobs        0 downloaded, 1 in progress" in result.output, result.output
 
     # Edit the mock job to complete the task
     mock_jobs[0]["taskRunStatus"] = "SUCCEEDED"
@@ -326,6 +506,7 @@ def test_incremental_output_download_bootstrap_and_completion(
             [
                 "queue",
                 "sync-output",
+                "--verbose",
             ]
             + storage_profile_options
             + [
@@ -342,21 +523,21 @@ def test_incremental_output_download_bootstrap_and_completion(
     assert result.exit_code == 0, result.output
 
     # Assert that the output contained information about loading the checkpoint and the mocked resources
-    assert "Started incremental download for queue: Mock Queue" in result.output, result.output
+    assert "Queue sync: Mock Queue" in result.output, result.output
     assert (
-        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_' + storage_profile_in_message + '_download_checkpoint.json')}"
+        f"checkpoint  {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_' + storage_profile_in_message + '_download_checkpoint.json')}"
         in result.output
     ), result.output
-    assert "Checkpoint found" in result.output, result.output
+    assert "resumed from checkpoint" in result.output, result.output
     # Need to convert the freeze time to the local time zone for this print assertion
     assert (
-        f"Continuing from: {datetime.fromisoformat(ISO_FREEZE_TIME).astimezone().isoformat()}"
+        f"resumed from checkpoint at {datetime.fromisoformat(ISO_FREEZE_TIME).astimezone().strftime('%Y-%m-%d %H:%M:%S')}"
         in result.output
     ), result.output
-    assert f"EXISTING Job: Mock Job ({MOCK_JOB_ID})" in result.output, result.output
-    assert "Succeeded tasks (before): 1 / 2" in result.output, result.output
-    assert "Succeeded tasks (now)   : 2 / 2" in result.output, result.output
-    assert "completed: 1" in result.output, result.output
+    assert "UPDATED   Mock Job" in result.output, result.output
+    assert MOCK_JOB_ID in result.output, result.output
+    assert "2/2 tasks succeeded)" in result.output, result.output
+    assert "jobs        1 downloaded" in result.output, result.output
 
     # RUN 3: Run the CLI command again with a later timestamp to retire the job from the checkpoint
     # 5 minutes later is outside the eventual consistency window.
@@ -366,6 +547,7 @@ def test_incremental_output_download_bootstrap_and_completion(
             [
                 "queue",
                 "sync-output",
+                "--verbose",
             ]
             + storage_profile_options
             + [
@@ -382,20 +564,20 @@ def test_incremental_output_download_bootstrap_and_completion(
     assert result.exit_code == 0, result.output
 
     # Assert that the output contained information about loading the checkpoint and the mocked resources
-    assert "Started incremental download for queue: Mock Queue" in result.output, result.output
+    assert "Queue sync: Mock Queue" in result.output, result.output
     assert (
-        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_' + storage_profile_in_message + '_download_checkpoint.json')}"
+        f"checkpoint  {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_' + storage_profile_in_message + '_download_checkpoint.json')}"
         in result.output
     ), result.output
-    assert "Checkpoint found" in result.output, result.output
+    assert "resumed from checkpoint" in result.output, result.output
     # Need to convert the freeze time to the local time zone for this print assertion
     assert (
-        f"Continuing from: {(datetime.fromisoformat(ISO_FREEZE_TIME_PLUS_3MIN) - timedelta(seconds=EVENTUAL_CONSISTENCY_MAX_SECONDS)).astimezone().isoformat()}"
+        f"resumed from checkpoint at {(datetime.fromisoformat(ISO_FREEZE_TIME_PLUS_3MIN) - timedelta(seconds=EVENTUAL_CONSISTENCY_MAX_SECONDS)).astimezone().strftime('%Y-%m-%d %H:%M:%S')}"
         in result.output
     ), result.output
-    assert f"FINISHED TRACKING Job: Mock Job ({MOCK_JOB_ID})" in result.output, result.output
-    assert "Job succeeded" in result.output, result.output
-    assert "inactive: 1" in result.output, result.output
+    assert "RETIRED   Mock Job" in result.output, result.output
+    assert "job succeeded" in result.output, result.output
+    assert "1 retired" in result.output, result.output
 
     # RUN 4: Run the CLI command again with a later timestamp to see the job stay inactive
     with freeze_time(ISO_FREEZE_TIME_PLUS_7MIN):
@@ -404,6 +586,7 @@ def test_incremental_output_download_bootstrap_and_completion(
             [
                 "queue",
                 "sync-output",
+                "--verbose",
             ]
             + storage_profile_options
             + [
@@ -420,20 +603,20 @@ def test_incremental_output_download_bootstrap_and_completion(
     assert result.exit_code == 0, result.output
 
     # Assert that the output contained information about loading the checkpoint and the mocked resources
-    assert "Started incremental download for queue: Mock Queue" in result.output, result.output
+    assert "Queue sync: Mock Queue" in result.output, result.output
     assert (
-        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_' + storage_profile_in_message + '_download_checkpoint.json')}"
+        f"checkpoint  {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_' + storage_profile_in_message + '_download_checkpoint.json')}"
         in result.output
     ), result.output
-    assert "Checkpoint found" in result.output, result.output
+    assert "resumed from checkpoint" in result.output, result.output
     # Need to convert the freeze time to the local time zone for this print assertion
     assert (
-        f"Continuing from: {(datetime.fromisoformat(ISO_FREEZE_TIME_PLUS_5MIN) - timedelta(seconds=EVENTUAL_CONSISTENCY_MAX_SECONDS)).astimezone().isoformat()}"
+        f"resumed from checkpoint at {(datetime.fromisoformat(ISO_FREEZE_TIME_PLUS_5MIN) - timedelta(seconds=EVENTUAL_CONSISTENCY_MAX_SECONDS)).astimezone().strftime('%Y-%m-%d %H:%M:%S')}"
         in result.output
     ), result.output
     # Because this test didn't model any sessions and session actions, there is no session endedAt
     # timestamp, so no job needs to be further tracked as inactive in this case.
-    assert "inactive: 0" in result.output, result.output
+    assert "skipped     none" in result.output, result.output
 
 
 @pytest.mark.skipif(
@@ -548,6 +731,7 @@ def test_incremental_output_download_storage_profile_path_mapping(
             [
                 "queue",
                 "sync-output",
+                "--verbose",
                 "--storage-profile-id",
                 MOCK_STORAGE_PROFILE_ID_LOCAL,
                 "--farm-id",
@@ -563,37 +747,27 @@ def test_incremental_output_download_storage_profile_path_mapping(
     assert result.exit_code == 0, result.output
 
     # Assert that both storage profiles were retrieved for local and the job
+    assert "on the local storage profile Mock-Storage-Profile-For-Local" in result.output, (
+        result.output
+    )
+    assert "0 jobs on the local storage profile" in result.output, result.output
+    assert "1 job on Mock-Storage-Profile-For-Job (MACOS)" in result.output, result.output
+    assert "on Mock-Storage-Profile-For-Job (MACOS)" in result.output, result.output
     assert (
-        f"Local storage profile is Mock-Storage-Profile-For-Local ({MOCK_STORAGE_PROFILE_ID_LOCAL})"
+        f"Mock-Storage-Profile-For-Local ({StorageProfileOperatingSystemFamily.get_host_os_family().value.upper()})"
         in result.output
     ), result.output
-    assert (
-        "0 download candidate jobs have the same storage profile and will be downloaded to their original specified paths"
-        in result.output
-    ), result.output
-    assert (
-        f"Path mapping rules for 1 download candidate jobs with storage profile Mock-Storage-Profile-For-Job ({MOCK_STORAGE_PROFILE_ID})"
-        in result.output
-    ), result.output
-    assert "job storage profile: Mock-Storage-Profile-For-Job (MACOS)" in result.output, (
+    assert "/Volumes/loc1 " in result.output, result.output
+    assert f"{tmp_path / 'Location1'}" in result.output, result.output
+    assert "/Home/user " in result.output, result.output
+    assert f"{tmp_path / 'Location2'}" in result.output, result.output
+
+    # Assert that it warned about the lack of outputs
+    assert f"Mock Job ({MOCK_JOB_ID}) ran 1/1 task runs with no output" in result.output, (
         result.output
     )
     assert (
-        f"local storage profile: Mock-Storage-Profile-For-Local ({StorageProfileOperatingSystemFamily.get_host_os_family().value.upper()})"
-        in result.output
-    ), result.output
-    assert "- from: /Volumes/loc1" in result.output, result.output
-    assert f" to:   {tmp_path / 'Location1'}" in result.output, result.output
-    assert "- from: /Home/user" in result.output, result.output
-    assert f"to:   {tmp_path / 'Location2'}" in result.output, result.output
-
-    # Assert that it warned about the lack of outputs
-    assert (
-        f"WARNING: Job Mock Job ({MOCK_JOB_ID}) ran 1 / 1 session actions with no output."
-        in result.output
-    ), result.output
-    assert (
-        "This may indicate steps in the job that strictly perform validation or save results elsewhere like a shared file system or S3."
+        "these steps may only validate, or save results elsewhere such as a shared file system or S3"
         in result.output
     ), result.output
 
@@ -625,6 +799,7 @@ def test_incremental_output_download_bootstrap_retire_job_without_attachments(
             [
                 "queue",
                 "sync-output",
+                "--verbose",
                 "--ignore-storage-profiles",
                 "--farm-id",
                 MOCK_FARM_ID,
@@ -639,20 +814,20 @@ def test_incremental_output_download_bootstrap_retire_job_without_attachments(
     assert result.exit_code == 0, result.output
 
     # Assert that the output contained information about the bootstrapping and the mocked resources
-    assert "Started incremental download for queue: Mock Queue" in result.output, result.output
+    assert "Queue sync: Mock Queue" in result.output, result.output
     assert (
-        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_ignore-storage-profiles_download_checkpoint.json')}"
+        f"checkpoint  {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_ignore-storage-profiles_download_checkpoint.json')}"
         in result.output
     ), result.output
-    assert "Checkpoint not found, lookback is 0.0 minutes" in result.output, result.output
+    assert "(0.0 minute lookback, no checkpoint found)" in result.output, result.output
     # Need to convert the freeze time to the local time zone for this print assertion
     assert (
-        f"Initializing from: {datetime.fromisoformat(ISO_FREEZE_TIME).astimezone().isoformat()}"
+        f"bootstrapping from {datetime.fromisoformat(ISO_FREEZE_TIME).astimezone().strftime('%Y-%m-%d %H:%M:%S')}"
         in result.output
     ), result.output
-    assert f"NEW Job: Mock Job ({MOCK_JOB_ID})" in result.output, result.output
-    assert "Succeeded tasks: 1 / 2" in result.output, result.output
-    assert "not using job attachments: 1" in result.output, result.output
+    assert "NEW       Mock Job" in result.output, result.output
+    assert "(1/2 tasks succeeded)" in result.output, result.output
+    assert "skipped     1 no attachments" in result.output, result.output
 
     # Edit the mock job to complete the task
     mock_jobs[0]["taskRunStatus"] = "SUCCEEDED"
@@ -671,6 +846,7 @@ def test_incremental_output_download_bootstrap_retire_job_without_attachments(
             [
                 "queue",
                 "sync-output",
+                "--verbose",
                 "--ignore-storage-profiles",
                 "--farm-id",
                 MOCK_FARM_ID,
@@ -685,18 +861,18 @@ def test_incremental_output_download_bootstrap_retire_job_without_attachments(
     assert result.exit_code == 0, result.output
 
     # Assert that the output contained information about loading the checkpoint and the mocked resources
-    assert "Started incremental download for queue: Mock Queue" in result.output, result.output
+    assert "Queue sync: Mock Queue" in result.output, result.output
     assert (
-        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_ignore-storage-profiles_download_checkpoint.json')}"
+        f"checkpoint  {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_ignore-storage-profiles_download_checkpoint.json')}"
         in result.output
     ), result.output
-    assert "Checkpoint found" in result.output, result.output
+    assert "resumed from checkpoint" in result.output, result.output
     # Need to convert the freeze time to the local time zone for this print assertion
     assert (
-        f"Continuing from: {datetime.fromisoformat(ISO_FREEZE_TIME).astimezone().isoformat()}"
+        f"resumed from checkpoint at {datetime.fromisoformat(ISO_FREEZE_TIME).astimezone().strftime('%Y-%m-%d %H:%M:%S')}"
         in result.output
     ), result.output
-    assert "not using job attachments: 1" in result.output, result.output
+    assert "skipped     1 no attachments" in result.output, result.output
 
     # RUN 3: Run the CLI command again with a later timestamp to retire the job from the checkpoint
     # 5 minutes later is outside the eventual consistency window.
@@ -706,6 +882,7 @@ def test_incremental_output_download_bootstrap_retire_job_without_attachments(
             [
                 "queue",
                 "sync-output",
+                "--verbose",
                 "--ignore-storage-profiles",
                 "--farm-id",
                 MOCK_FARM_ID,
@@ -720,18 +897,18 @@ def test_incremental_output_download_bootstrap_retire_job_without_attachments(
     assert result.exit_code == 0, result.output
 
     # Assert that the output contained information about loading the checkpoint and the mocked resources
-    assert "Started incremental download for queue: Mock Queue" in result.output, result.output
+    assert "Queue sync: Mock Queue" in result.output, result.output
     assert (
-        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_ignore-storage-profiles_download_checkpoint.json')}"
+        f"checkpoint  {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_ignore-storage-profiles_download_checkpoint.json')}"
         in result.output
     ), result.output
-    assert "Checkpoint found" in result.output, result.output
+    assert "resumed from checkpoint" in result.output, result.output
     # Need to convert the freeze time to the local time zone for this print assertion
     assert (
-        f"Continuing from: {(datetime.fromisoformat(ISO_FREEZE_TIME_PLUS_3MIN) - timedelta(seconds=EVENTUAL_CONSISTENCY_MAX_SECONDS)).astimezone().isoformat()}"
+        f"resumed from checkpoint at {(datetime.fromisoformat(ISO_FREEZE_TIME_PLUS_3MIN) - timedelta(seconds=EVENTUAL_CONSISTENCY_MAX_SECONDS)).astimezone().strftime('%Y-%m-%d %H:%M:%S')}"
         in result.output
     ), result.output
-    assert "inactive: 1" in result.output, result.output
+    assert "1 retired" in result.output, result.output
 
 
 @pytest.mark.skipif(
@@ -767,6 +944,7 @@ def test_incremental_output_download_job_unchanged(
             [
                 "queue",
                 "sync-output",
+                "--verbose",
                 "--ignore-storage-profiles",
                 "--farm-id",
                 MOCK_FARM_ID,
@@ -781,20 +959,20 @@ def test_incremental_output_download_job_unchanged(
     assert result.exit_code == 0, result.output
 
     # Assert that the output contained information about the bootstrapping and the mocked resources
-    assert "Started incremental download for queue: Mock Queue" in result.output, result.output
+    assert "Queue sync: Mock Queue" in result.output, result.output
     assert (
-        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_ignore-storage-profiles_download_checkpoint.json')}"
+        f"checkpoint  {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_ignore-storage-profiles_download_checkpoint.json')}"
         in result.output
     ), result.output
-    assert "Checkpoint not found, lookback is 0.0 minutes" in result.output, result.output
+    assert "(0.0 minute lookback, no checkpoint found)" in result.output, result.output
     # Need to convert the freeze time to the local time zone for this print assertion
     assert (
-        f"Initializing from: {datetime.fromisoformat(ISO_FREEZE_TIME).astimezone().isoformat()}"
+        f"bootstrapping from {datetime.fromisoformat(ISO_FREEZE_TIME).astimezone().strftime('%Y-%m-%d %H:%M:%S')}"
         in result.output
     ), result.output
-    assert f"NEW Job: Mock Job ({MOCK_JOB_ID})" in result.output, result.output
-    assert "Succeeded tasks: 1 / 2" in result.output, result.output
-    assert "added: 1" in result.output, result.output
+    assert "NEW       Mock Job" in result.output, result.output
+    assert "(1/2 tasks succeeded)" in result.output, result.output
+    assert "jobs        0 downloaded, 1 in progress" in result.output, result.output
 
     # RUN 2: Run the CLI command again to see that the job is unchanged
     with freeze_time(ISO_FREEZE_TIME_PLUS_3MIN):
@@ -803,6 +981,7 @@ def test_incremental_output_download_job_unchanged(
             [
                 "queue",
                 "sync-output",
+                "--verbose",
                 "--ignore-storage-profiles",
                 "--farm-id",
                 MOCK_FARM_ID,
@@ -817,19 +996,19 @@ def test_incremental_output_download_job_unchanged(
     assert result.exit_code == 0, result.output
 
     # Assert that the output contained information about loading the checkpoint and the mocked resources
-    assert "Started incremental download for queue: Mock Queue" in result.output, result.output
+    assert "Queue sync: Mock Queue" in result.output, result.output
     assert (
-        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_ignore-storage-profiles_download_checkpoint.json')}"
+        f"checkpoint  {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_ignore-storage-profiles_download_checkpoint.json')}"
         in result.output
     ), result.output
-    assert "Checkpoint found" in result.output, result.output
+    assert "resumed from checkpoint" in result.output, result.output
     # Need to convert the freeze time to the local time zone for this print assertion
     assert (
-        f"Continuing from: {datetime.fromisoformat(ISO_FREEZE_TIME).astimezone().isoformat()}"
+        f"resumed from checkpoint at {datetime.fromisoformat(ISO_FREEZE_TIME).astimezone().strftime('%Y-%m-%d %H:%M:%S')}"
         in result.output
     ), result.output
-    assert f"UNCHANGED Job: Mock Job ({MOCK_JOB_ID})" in result.output, result.output
-    assert "unchanged: 1" in result.output, result.output
+    assert "UNCHANGED Mock Job" in result.output, result.output
+    assert "skipped     1 unchanged" in result.output, result.output
 
 
 @pytest.mark.skipif(
@@ -865,6 +1044,7 @@ def test_incremental_output_download_job_canceled(
             [
                 "queue",
                 "sync-output",
+                "--verbose",
                 "--ignore-storage-profiles",
                 "--farm-id",
                 MOCK_FARM_ID,
@@ -879,20 +1059,20 @@ def test_incremental_output_download_job_canceled(
     assert result.exit_code == 0, result.output
 
     # Assert that the output contained information about the bootstrapping and the mocked resources
-    assert "Started incremental download for queue: Mock Queue" in result.output, result.output
+    assert "Queue sync: Mock Queue" in result.output, result.output
     assert (
-        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_ignore-storage-profiles_download_checkpoint.json')}"
+        f"checkpoint  {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_ignore-storage-profiles_download_checkpoint.json')}"
         in result.output
     ), result.output
-    assert "Checkpoint not found, lookback is 0.0 minutes" in result.output, result.output
+    assert "(0.0 minute lookback, no checkpoint found)" in result.output, result.output
     # Need to convert the freeze time to the local time zone for this print assertion
     assert (
-        f"Initializing from: {datetime.fromisoformat(ISO_FREEZE_TIME).astimezone().isoformat()}"
+        f"bootstrapping from {datetime.fromisoformat(ISO_FREEZE_TIME).astimezone().strftime('%Y-%m-%d %H:%M:%S')}"
         in result.output
     ), result.output
-    assert f"NEW Job: Mock Job ({MOCK_JOB_ID})" in result.output, result.output
-    assert "Succeeded tasks: 1 / 2" in result.output, result.output
-    assert "added: 1" in result.output, result.output
+    assert "NEW       Mock Job" in result.output, result.output
+    assert "(1/2 tasks succeeded)" in result.output, result.output
+    assert "jobs        0 downloaded, 1 in progress" in result.output, result.output
 
     # RUN 2: Run the CLI command again to see that the job is canceled
     mock_jobs[0]["taskRunStatus"] = "CANCELED"
@@ -906,6 +1086,7 @@ def test_incremental_output_download_job_canceled(
             [
                 "queue",
                 "sync-output",
+                "--verbose",
                 "--ignore-storage-profiles",
                 "--farm-id",
                 MOCK_FARM_ID,
@@ -920,23 +1101,22 @@ def test_incremental_output_download_job_canceled(
     assert result.exit_code == 0, result.output
 
     # Assert that the output contained information about loading the checkpoint and the mocked resources
-    assert "Started incremental download for queue: Mock Queue" in result.output, result.output
+    assert "Queue sync: Mock Queue" in result.output, result.output
     assert (
-        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_ignore-storage-profiles_download_checkpoint.json')}"
+        f"checkpoint  {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_ignore-storage-profiles_download_checkpoint.json')}"
         in result.output
     ), result.output
-    assert "Checkpoint found" in result.output, result.output
+    assert "resumed from checkpoint" in result.output, result.output
     # Need to convert the freeze time to the local time zone for this print assertion
     assert (
-        f"Continuing from: {datetime.fromisoformat(ISO_FREEZE_TIME).astimezone().isoformat()}"
+        f"resumed from checkpoint at {datetime.fromisoformat(ISO_FREEZE_TIME).astimezone().strftime('%Y-%m-%d %H:%M:%S')}"
         in result.output
     ), result.output
-    assert f"FINISHED TRACKING Job: Mock Job ({MOCK_JOB_ID})" in result.output, result.output
+    assert "RETIRED   Mock Job" in result.output, result.output
     assert (
-        "Job is not a download candidate anymore (likely suspended, canceled or failed)"
-        in result.output
+        "no longer a download candidate (likely suspended, canceled or failed)" in result.output
     ), result.output
-    assert "inactive: 1" in result.output, result.output
+    assert "1 retired" in result.output, result.output
 
 
 @pytest.mark.skipif(
@@ -974,6 +1154,7 @@ def test_incremental_output_download_job_completed_then_requeued(
             [
                 "queue",
                 "sync-output",
+                "--verbose",
                 "--ignore-storage-profiles",
                 "--farm-id",
                 MOCK_FARM_ID,
@@ -990,20 +1171,20 @@ def test_incremental_output_download_job_completed_then_requeued(
     assert result.exit_code == 0, result.output
 
     # Assert that the output contained information about the bootstrapping and the mocked resources
-    assert "Started incremental download for queue: Mock Queue" in result.output, result.output
+    assert "Queue sync: Mock Queue" in result.output, result.output
     assert (
-        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_ignore-storage-profiles_download_checkpoint.json')}"
+        f"checkpoint  {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_ignore-storage-profiles_download_checkpoint.json')}"
         in result.output
     ), result.output
-    assert "Checkpoint not found, lookback is 4.5 minutes" in result.output, result.output
+    assert "(4.5 minute lookback, no checkpoint found)" in result.output, result.output
     # Need to convert the freeze time to the local time zone for this print assertion
     assert (
-        f"Initializing from: {(iso_freeze_time - timedelta(minutes=4.5)).astimezone().isoformat()}"
+        f"bootstrapping from {(iso_freeze_time - timedelta(minutes=4.5)).astimezone().strftime('%Y-%m-%d %H:%M:%S')}"
         in result.output
     ), result.output
-    assert f"NEW Job: Mock Job ({MOCK_JOB_ID})" in result.output, result.output
-    assert "Succeeded tasks: 2 / 2" in result.output, result.output
-    assert "completed: 1" in result.output, result.output
+    assert "NEW       Mock Job" in result.output, result.output
+    assert "(2/2 tasks succeeded)" in result.output, result.output
+    assert "jobs        1 downloaded" in result.output, result.output
 
     # RUN 2: Run the CLI command again to see that the job becomes inactive
     with freeze_time(ISO_FREEZE_TIME_PLUS_5MIN):
@@ -1012,6 +1193,7 @@ def test_incremental_output_download_job_completed_then_requeued(
             [
                 "queue",
                 "sync-output",
+                "--verbose",
                 "--ignore-storage-profiles",
                 "--farm-id",
                 MOCK_FARM_ID,
@@ -1026,18 +1208,18 @@ def test_incremental_output_download_job_completed_then_requeued(
     assert result.exit_code == 0, result.output
 
     # Assert that the output contained information about loading the checkpoint and the mocked resources
-    assert "Started incremental download for queue: Mock Queue" in result.output, result.output
+    assert "Queue sync: Mock Queue" in result.output, result.output
     assert (
-        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_ignore-storage-profiles_download_checkpoint.json')}"
+        f"checkpoint  {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_ignore-storage-profiles_download_checkpoint.json')}"
         in result.output
     ), result.output
-    assert "Checkpoint found" in result.output, result.output
+    assert "resumed from checkpoint" in result.output, result.output
     # Need to convert the freeze time to the local time zone for this print assertion
     assert (
-        f"Continuing from: {(iso_freeze_time - timedelta(seconds=EVENTUAL_CONSISTENCY_MAX_SECONDS)).astimezone().isoformat()}"
+        f"resumed from checkpoint at {(iso_freeze_time - timedelta(seconds=EVENTUAL_CONSISTENCY_MAX_SECONDS)).astimezone().strftime('%Y-%m-%d %H:%M:%S')}"
         in result.output
     ), result.output
-    assert "inactive: 1" in result.output, result.output
+    assert "1 retired" in result.output, result.output
 
     # RUN 3: Run the CLI command again after requeuing tasks
     mock_jobs[0]["taskRunStatus"] = "READY"
@@ -1052,6 +1234,7 @@ def test_incremental_output_download_job_completed_then_requeued(
             [
                 "queue",
                 "sync-output",
+                "--verbose",
                 "--ignore-storage-profiles",
                 "--farm-id",
                 MOCK_FARM_ID,
@@ -1066,20 +1249,20 @@ def test_incremental_output_download_job_completed_then_requeued(
     assert result.exit_code == 0, result.output
 
     # Assert that the output contained information about loading the checkpoint and the mocked resources
-    assert "Started incremental download for queue: Mock Queue" in result.output, result.output
+    assert "Queue sync: Mock Queue" in result.output, result.output
     assert (
-        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_ignore-storage-profiles_download_checkpoint.json')}"
+        f"checkpoint  {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_ignore-storage-profiles_download_checkpoint.json')}"
         in result.output
     ), result.output
-    assert "Checkpoint found" in result.output, result.output
+    assert "resumed from checkpoint" in result.output, result.output
     # Need to convert the freeze time to the local time zone for this print assertion
     assert (
-        f"Continuing from: {(datetime.fromisoformat(ISO_FREEZE_TIME_PLUS_5MIN) - timedelta(seconds=EVENTUAL_CONSISTENCY_MAX_SECONDS)).astimezone().isoformat()}"
+        f"resumed from checkpoint at {(datetime.fromisoformat(ISO_FREEZE_TIME_PLUS_5MIN) - timedelta(seconds=EVENTUAL_CONSISTENCY_MAX_SECONDS)).astimezone().strftime('%Y-%m-%d %H:%M:%S')}"
         in result.output
     ), result.output
-    assert f"NEW Job: Mock Job ({MOCK_JOB_ID})" in result.output, result.output
-    assert "Succeeded tasks: 1 / 2" in result.output, result.output
-    assert "added: 1" in result.output, result.output
+    assert "NEW       Mock Job" in result.output, result.output
+    assert "(1/2 tasks succeeded)" in result.output, result.output
+    assert "jobs        0 downloaded, 1 in progress" in result.output, result.output
 
 
 @pytest.mark.skipif(
@@ -1113,6 +1296,7 @@ def test_incremental_output_download_dry_run(fresh_deadline_config, deadline_moc
             [
                 "queue",
                 "sync-output",
+                "--verbose",
                 "--ignore-storage-profiles",
                 "--farm-id",
                 MOCK_FARM_ID,
@@ -1128,24 +1312,23 @@ def test_incremental_output_download_dry_run(fresh_deadline_config, deadline_moc
     assert result.exit_code == 0, result.output
 
     # Assert that the output contained information about the bootstrapping and the mocked resources
-    assert "Started incremental download for queue: Mock Queue" in result.output, result.output
+    assert "Queue sync: Mock Queue" in result.output, result.output
     assert (
-        f"Checkpoint: {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_ignore-storage-profiles_download_checkpoint.json')}"
+        f"checkpoint  {os.path.join(checkpoint_dir, MOCK_QUEUE_ID + '_ignore-storage-profiles_download_checkpoint.json')}"
         in result.output
     ), result.output
-    assert "Checkpoint not found, lookback is 0.0 minutes" in result.output, result.output
+    assert "(0.0 minute lookback, no checkpoint found)" in result.output, result.output
     # Need to convert the freeze time to the local time zone for this print assertion
     assert (
-        f"Initializing from: {datetime.fromisoformat(ISO_FREEZE_TIME).astimezone().isoformat()}"
+        f"bootstrapping from {datetime.fromisoformat(ISO_FREEZE_TIME).astimezone().strftime('%Y-%m-%d %H:%M:%S')}"
         in result.output
     ), result.output
-    assert f"NEW Job: Mock Job ({MOCK_JOB_ID})" in result.output, result.output
-    assert "Skipping downloads due to DRY RUN" in result.output, result.output
-    assert (
-        "Summary of DRY RUN for incremental output download (no files were downloaded to the file system):"
-        in result.output
-    ), result.output
-    assert "This is a DRY RUN so the checkpoint was not saved" in result.output, result.output
+    assert "NEW       Mock Job" in result.output, result.output
+    # This run has nothing to download, so the per-download dry-run notice is never reached.
+    # The summary heading and the unsaved checkpoint still mark the run as a dry run.
+    assert "nothing new to download" in result.output, result.output
+    assert "Summary (dry run, nothing written to disk)" in result.output, result.output
+    assert "checkpoint  not saved (dry run)" in result.output, result.output
 
 
 @pytest.mark.skipif(
@@ -1183,6 +1366,7 @@ def test_incremental_output_download_stats_telemetry(
             [
                 "queue",
                 "sync-output",
+                "--verbose",
                 "--farm-id",
                 MOCK_FARM_ID,
                 "--queue-id",
@@ -1307,6 +1491,7 @@ def test_incremental_output_download_unmapped_paths_without_storage_profile(
             [
                 "queue",
                 "sync-output",
+                "--verbose",
                 "--ignore-storage-profiles",
                 "--force-bootstrap",
                 "--bootstrap-lookback-minutes",
@@ -1322,7 +1507,9 @@ def test_incremental_output_download_unmapped_paths_without_storage_profile(
 
     # Must not crash (previously raised UnboundLocalError on 'storage_profiles').
     assert result.exit_code == 0, result.output
-    assert "WARNING: THE FOLLOWING FILES WILL NOT BE DOWNLOADED" in result.output, result.output
+    assert "unmapped output paths, these files will not be downloaded" in result.output, (
+        result.output
+    )
     assert "/etc/cron.d/evil" in result.output, result.output
 
 
@@ -1453,6 +1640,7 @@ def test_incremental_output_download_manifest_mismatch_still_downloads(
             [
                 "queue",
                 "sync-output",
+                "--verbose",
                 "--ignore-storage-profiles",
                 "--force-bootstrap",
                 "--bootstrap-lookback-minutes",
@@ -1468,14 +1656,14 @@ def test_incremental_output_download_manifest_mismatch_still_downloads(
 
     assert result.exit_code == 0, result.output
     # The mismatch warning fired, but the file was STILL downloaded (via the fallback bucket).
-    assert "Manifest list length mismatch" in result.output, result.output
+    assert "manifest list length mismatch" in result.output, result.output
     assert downloaded_file in downloaded_files_seen, (
         f"Expected {downloaded_file} to be downloaded despite skip_attribution; "
         f"got {downloaded_files_seen}"
     )
     # A successful fallback run must still report what it downloaded — the retained "" bucket
     # feeds the run-level stats, so a real download never reports "0 files downloaded".
-    assert "Downloaded files: 1" in result.output, result.output
+    assert "files       1 downloaded" in result.output, result.output
     # ...and the run is reported successful, with no synthetic "" job leaking into the entries.
     status_path = os.path.join(
         checkpoint_dir, f"{MOCK_QUEUE_ID}_ignore-storage-profiles_download_status.json"
@@ -1598,6 +1786,7 @@ def test_incremental_output_download_fallback_failure_marks_run_failed(
             [
                 "queue",
                 "sync-output",
+                "--verbose",
                 "--ignore-storage-profiles",
                 "--force-bootstrap",
                 "--bootstrap-lookback-minutes",
@@ -1778,6 +1967,7 @@ def test_incremental_output_download_per_task_error_isolation(
             [
                 "queue",
                 "sync-output",
+                "--verbose",
                 "--ignore-storage-profiles",
                 "--force-bootstrap",
                 "--bootstrap-lookback-minutes",
@@ -1795,7 +1985,15 @@ def test_incremental_output_download_per_task_error_isolation(
 
     # The run summary counts the succeeded tasks even though the job carries an error_code:
     # task-0 and task-2 landed their files, so 2 (not 0) files are reported downloaded.
-    assert "Downloaded files: 2" in result.output, result.output
+    assert "files       2 downloaded" in result.output, result.output
+
+    # The failure is repeated in the summary so an unattended run does not bury it, and the
+    # closing line reports the failure without needing to scroll back.
+    assert "problems    1 job failed" in result.output, result.output
+    assert "PERMISSION_DENIED" in result.output.split("problems")[1], result.output
+    assert "jobs        0 downloaded, 1 in progress, 1 failed" in result.output, result.output
+    result_line = click.unstyle(result.output.strip().splitlines()[-1])
+    assert result_line.startswith("FAILED  1 of 1 jobs failed after "), result_line
 
     # The status file records per-task isolation: task-1 failed, task-0 and task-2 succeeded.
     status_file_path = os.path.join(
@@ -2240,6 +2438,7 @@ def test_incremental_output_download_leftover_non_task_paths_are_downloaded(
             [
                 "queue",
                 "sync-output",
+                "--verbose",
                 "--ignore-storage-profiles",
                 "--force-bootstrap",
                 "--bootstrap-lookback-minutes",
@@ -2258,7 +2457,7 @@ def test_incremental_output_download_leftover_non_task_paths_are_downloaded(
     assert task_file_path in downloaded_paths, downloaded_paths
     assert leftover_file_path in downloaded_paths, downloaded_paths
     assert os.path.exists(leftover_file_path), "leftover non-task path was silently dropped"
-    assert "Downloaded files: 2" in result.output, result.output
+    assert "files       2 downloaded" in result.output, result.output
 
 
 @pytest.mark.skipif(
@@ -2390,6 +2589,7 @@ def test_incremental_output_download_same_path_across_tasks_downloaded_once(
             [
                 "queue",
                 "sync-output",
+                "--verbose",
                 "--ignore-storage-profiles",
                 "--force-bootstrap",
                 "--bootstrap-lookback-minutes",
@@ -2406,7 +2606,7 @@ def test_incremental_output_download_same_path_across_tasks_downloaded_once(
     assert result.exit_code == 0, result.output
     # The shared path is downloaded once, not once per task.
     assert downloaded_paths.count(shared_file_path) == 1, downloaded_paths
-    assert "Downloaded files: 1" in result.output, result.output
+    assert "files       1 downloaded" in result.output, result.output
 
     # It is attributed to the newer task only; the older task no longer owns it.
     status_file_path = os.path.join(
@@ -2559,6 +2759,7 @@ def test_incremental_output_download_shared_path_newest_wins_regardless_of_order
             [
                 "queue",
                 "sync-output",
+                "--verbose",
                 "--ignore-storage-profiles",
                 "--force-bootstrap",
                 "--bootstrap-lookback-minutes",
@@ -2577,8 +2778,8 @@ def test_incremental_output_download_shared_path_newest_wins_regardless_of_order
     # The newer job owns the shared path and performs the actual download; the older job
     # is deduped out and downloads nothing. With list-order attribution (the bug), the
     # older job — appearing later in the list — would incorrectly claim the path.
-    assert "for job: New Job" in result.output, result.output
-    assert "for job: Old Job" not in result.output, result.output
+    assert "New Job: downloading" in result.output, result.output
+    assert "Old Job: downloading" not in result.output, result.output
 
     # The deduped (losing) job must still report filesystem-based status, not total=0/downloaded=0.
     # Its paths were claimed by the winning job and pruned from the download lists, so its status
@@ -3257,7 +3458,7 @@ def test_incremental_output_download_retries_failed_job_via_get_job(
     # --force-bootstrap is intentionally omitted: it clears the failed-jobs tracker for a
     # fresh start. Without it (and with no checkpoint file) the run still bootstraps but
     # preserves the tracker, so the previously-failed jobs are retried.
-    assert "Retrying 2 previously failed job(s)" in result.output, result.output
+    assert "retrying 2 previously failed jobs" in result.output, result.output
     # The re-fetched job was pulled in via GetJob.
     assert retried_job_id in [c.kwargs.get("jobId") for c in deadline_mock.get_job.call_args_list]
 
@@ -3511,7 +3712,7 @@ def test_incremental_output_download_shared_path_across_three_jobs_newest_wins(
 
     assert result.exit_code == 0, result.output
     assert downloaded_paths.count(shared_path) == 1, downloaded_paths
-    assert "Downloaded files: 1" in result.output, result.output
+    assert "files       1 downloaded" in result.output, result.output
 
     with open(_ignore_profiles_status_file(checkpoint_dir)) as f:
         status = json.load(f)
@@ -3556,7 +3757,7 @@ def test_incremental_output_download_cross_job_then_within_job_overwrite(
 
     assert result.exit_code == 0, result.output
     assert downloaded_paths.count(shared_path) == 1, downloaded_paths
-    assert "Downloaded files: 1" in result.output, result.output
+    assert "files       1 downloaded" in result.output, result.output
 
     with open(_ignore_profiles_status_file(checkpoint_dir)) as f:
         status = json.load(f)
@@ -3603,7 +3804,7 @@ def test_incremental_output_download_case_differing_paths_treated_as_one(
     # One download total — the two spellings are one file, so only the newest owner fetches it.
     assert len(downloaded_paths) == 1, downloaded_paths
     assert downloaded_paths[0] == lower_path, downloaded_paths
-    assert "Downloaded files: 1" in result.output, result.output
+    assert "files       1 downloaded" in result.output, result.output
 
     with open(_ignore_profiles_status_file(checkpoint_dir)) as f:
         status = json.load(f)
@@ -3659,7 +3860,7 @@ def test_incremental_output_download_every_path_downloaded_exactly_once(
     # Every distinct path fetched exactly once — none skipped, none fetched twice.
     assert sorted(downloaded_paths) == sorted(all_paths), downloaded_paths
     assert len(downloaded_paths) == len(set(downloaded_paths)), downloaded_paths
-    assert "Downloaded files: 5" in result.output, result.output
+    assert "files       5 downloaded" in result.output, result.output
     for path in all_paths:
         assert os.path.exists(path), path
 
@@ -3865,7 +4066,7 @@ def test_incremental_output_download_transient_getjob_error_keeps_job_in_tracker
     # A control-plane error on the retry path must not fail the whole sync — the other jobs in
     # the run still have output to fetch.
     assert result.exit_code == 0, result.output
-    assert "Retrying 2 previously failed job(s)" in result.output, result.output
+    assert "retrying 2 previously failed jobs" in result.output, result.output
 
     with open(failed_jobs_file) as f:
         tracker_after = json.load(f)
@@ -3998,8 +4199,8 @@ def test_incremental_output_download_succeeded_task_with_no_output_is_not_a_fail
         )
 
     assert result.exit_code == 0, result.output
-    assert "ran 1 / 1 session actions with no output" in result.output, result.output
-    assert "Downloaded files: 0" in result.output, result.output
+    assert "ran 1/1 task runs with no output" in result.output, result.output
+    assert "files       0 downloaded" in result.output, result.output
 
     with open(_ignore_profiles_status_file(checkpoint_dir)) as f:
         status = json.load(f)
@@ -4157,7 +4358,7 @@ def test_incremental_output_download_mixed_output_and_no_output_steps(
     assert result.exit_code == 0, result.output
     assert downloaded_paths == [output_path], downloaded_paths
     # The output-free session action is filtered, not downloaded, and the run says so.
-    assert "ran 1 / 2 session actions with no output" in result.output, result.output
+    assert "ran 1/2 task runs with no output" in result.output, result.output
 
     with open(_ignore_profiles_status_file(checkpoint_dir)) as f:
         status = json.load(f)

--- a/test/unit/deadline_client/cli/test_cli_queue_incremental_download.py
+++ b/test/unit/deadline_client/cli/test_cli_queue_incremental_download.py
@@ -278,8 +278,11 @@ def test_incremental_output_download_quiet_when_nothing_new(
         second = runner.invoke(main, _sync_output_args(checkpoint_dir))
 
     assert second.exit_code == 0, second.output
+    checked_at = (
+        datetime.fromisoformat(ISO_FREEZE_TIME_PLUS_3MIN).astimezone().strftime("%Y-%m-%d %H:%M:%S")
+    )
     assert second.output.splitlines() == [
-        "OK  Mock Queue: nothing new (window 3m, checked 2025-05-26 05:03:00)"
+        f"OK  Mock Queue: nothing new (window 3m, checked {checked_at})"
     ], second.output
 
 

--- a/test/unit/deadline_client/cli/test_cli_queue_incremental_download.py
+++ b/test/unit/deadline_client/cli/test_cli_queue_incremental_download.py
@@ -16,6 +16,7 @@ from freezegun import freeze_time
 import click
 from click.testing import CliRunner
 from deadline.client.cli import main
+from deadline.client.cli._groups import queue_group
 import psutil
 
 from ..shared_constants import (
@@ -284,6 +285,59 @@ def test_incremental_output_download_quiet_when_nothing_new(
     assert second.output.splitlines() == [
         f"OK  Mock Queue: nothing new (window 3m, checked {checked_at})"
     ], second.output
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
+)
+def test_incremental_output_download_failure_releases_the_held_back_report(
+    fresh_deadline_config,
+    deadline_mock,
+    checkpoint_dir,
+):
+    """A quiet run holds its report back. On failure that report is the only record of what
+    the run had done, so it must be released rather than dropped for the traceback alone."""
+    _mock_unchanged_job(deadline_mock)
+    runner = CliRunner()
+
+    with patch.object(
+        queue_group, "_incremental_output_download", side_effect=RuntimeError("boom")
+    ):
+        with freeze_time(ISO_FREEZE_TIME):
+            result = runner.invoke(main, _sync_output_args(checkpoint_dir))
+
+    assert result.exit_code != 0, result.output
+    # The header was buffered before the failure and has to survive it.
+    assert "Queue sync: Mock Queue" in result.output, result.output
+    assert "checkpoint" in result.output, result.output
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="Incremental output download requires Python >= 3.9"
+)
+def test_incremental_output_download_quiet_result_line_comes_last(
+    fresh_deadline_config,
+    deadline_mock,
+    checkpoint_dir,
+):
+    """The one-line result has to be the last line, so a warning raised while writing the
+    checkpoint or status file cannot appear below a line already claiming success."""
+    _mock_unchanged_job(deadline_mock)
+    runner = CliRunner()
+    with freeze_time(ISO_FREEZE_TIME):
+        runner.invoke(main, _sync_output_args(checkpoint_dir))
+
+    def _warn(*args, **kwargs):
+        kwargs["print_function_callback"]("  WARNING: status file trouble")
+
+    with patch.object(queue_group, "write_download_status_file", side_effect=_warn):
+        with freeze_time(ISO_FREEZE_TIME_PLUS_3MIN):
+            result = runner.invoke(main, _sync_output_args(checkpoint_dir))
+
+    assert result.exit_code == 0, result.output
+    lines = [click.unstyle(line) for line in result.output.strip().splitlines()]
+    assert any("status file trouble" in line for line in lines), lines
+    assert lines[-1].startswith("OK  Mock Queue: nothing new"), lines
 
 
 @pytest.mark.skipif(
@@ -1812,6 +1866,13 @@ def test_incremental_output_download_fallback_failure_marks_run_failed(
     with open(status_path) as f:
         status = json.load(f)
     assert status["sync_metadata"]["last_run_status"] == "failed", status
+
+    # The failure is recorded only under the synthetic "" bucket, which is not a job. The
+    # closing line still has to report the run as failed: it is the sole record that the whole
+    # window was lost, and a green line is what a scheduled job's log gets grepped for.
+    result_line = click.unstyle(result.output.strip().splitlines()[-1])
+    assert result_line.startswith("FAILED  "), result_line
+    assert "no job could be identified" in result_line, result_line
     # The synthetic "" bucket never leaks into the per-job entries.
     assert "" not in status["jobs"], status["jobs"]
 

--- a/test/unit/deadline_client/cli/test_cli_region_per_command.py
+++ b/test/unit/deadline_client/cli/test_cli_region_per_command.py
@@ -521,7 +521,27 @@ def test_cli_queue_sync_output_region(fresh_deadline_config, tmp_path):
         patch.object(
             queue_group,
             "_incremental_output_download",
-            return_value=(MagicMock(), MagicMock(), {}, {}, {}, {}),
+            return_value=(
+                MagicMock(),
+                MagicMock(),
+                {},
+                {},
+                {},
+                {},
+                {
+                    "downloaded_files": 0,
+                    "downloaded_bytes": 0,
+                    "downloaded_session_actions": 0,
+                    "jobs_with_downloads": {"completed": 0, "added": 0, "updated": 0},
+                    "jobs_without_downloads": {
+                        "not_using_job_attachments": 0,
+                        "missing_storage_profile": 0,
+                        "unchanged": 0,
+                        "inactive": 0,
+                    },
+                    "unmapped_paths": 0,
+                },
+            ),
         ),
     ):
         runner = CliRunner()

--- a/test/unit/deadline_client/cli/test_sync_output_format.py
+++ b/test/unit/deadline_client/cli/test_sync_output_format.py
@@ -1,0 +1,267 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Tests for the terminal formatting helpers behind `deadline queue sync-output`.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta, timezone
+import click
+import pytest
+
+from deadline.client.cli import _sync_output_format
+from deadline.client.cli._sync_output_format import (
+    _MIN_REPORTED_SECONDS,
+    _SyncOutputFormatter,
+    _SyncOutputWriter,
+    _format_duration,
+    _format_interval,
+    _format_path,
+    _format_timestamp,
+    _plural,
+)
+
+
+@pytest.mark.parametrize(
+    "seconds,expected",
+    [
+        (0.0, "<0.1s"),
+        (0.000032, "<0.1s"),
+        (0.099, "<0.1s"),
+        (0.1, "0.1s"),
+        (0.606954, "0.6s"),
+        (9.94, "9.9s"),
+        (10.0, "10s"),
+        (42.4, "42s"),
+        (59.6, "60s"),
+        (60.0, "1m"),
+        (120.0, "2m"),
+        (655.04, "10m55s"),
+        (3600.0, "1h"),
+        (7500.0, "2h05m"),
+    ],
+)
+def test_format_duration(seconds, expected):
+    assert _format_duration(seconds) == expected
+    assert _format_duration(timedelta(seconds=seconds)) == expected
+
+
+def test_format_duration_clamps_negative():
+    """A clock adjustment can produce a negative delta; it must not render as garbage."""
+    assert _format_duration(timedelta(seconds=-5)) == "<0.1s"
+
+
+def test_format_timestamp_drops_microseconds():
+    when = datetime(2026, 8, 21, 17, 16, 59, 319524, tzinfo=timezone.utc)
+    formatted = _format_timestamp(when)
+
+    assert formatted == when.astimezone().strftime("%Y-%m-%d %H:%M:%S")
+    assert "." not in formatted
+
+
+def test_format_interval_collapses_the_date_within_one_day():
+    start = datetime(2026, 8, 21, 12, 0, 0, tzinfo=timezone.utc)
+    end = start + timedelta(minutes=13)
+
+    interval = _format_interval(start, end)
+
+    assert interval.startswith(_format_timestamp(start))
+    assert interval.endswith(end.astimezone().strftime("%H:%M:%S"))
+    # The end has no date of its own when both ends land on the same local day.
+    assert interval.count("-") == 2
+    assert " to " in interval
+
+
+def test_format_interval_keeps_both_dates_across_days():
+    start = datetime(2026, 8, 21, 12, 0, 0, tzinfo=timezone.utc)
+    end = start + timedelta(days=3)
+
+    interval = _format_interval(start, end)
+
+    assert _format_timestamp(start) in interval
+    assert _format_timestamp(end) in interval
+
+
+def test_format_path_collapses_home():
+    path = os.path.join(os.path.expanduser("~"), ".deadline", "checkpoint.json")
+
+    assert _format_path(path) == os.path.join("~", ".deadline", "checkpoint.json")
+
+
+def test_format_path_leaves_other_paths_intact():
+    """A long path is never truncated: it is printed so the operator can copy it."""
+    path = os.path.join(os.sep, "mnt", "renders", "a" * 200, "checkpoint.json")
+
+    assert _format_path(path) == path
+
+
+def test_format_path_does_not_match_a_home_prefixed_sibling():
+    home = os.path.expanduser("~")
+
+    assert _format_path(home + "-backup") == home + "-backup"
+
+
+@pytest.mark.parametrize(
+    "count,expected",
+    [(0, "0 jobs"), (1, "1 job"), (2, "2 jobs")],
+)
+def test_plural(count, expected):
+    assert _plural(count, "job") == expected
+
+
+def test_plural_with_an_irregular_plural():
+    assert _plural(2, "entry", "entries") == "2 entries"
+
+
+def _render(build) -> list[str]:
+    """Runs `build` against a capturing formatter and returns the lines with styling removed.
+
+    click.style always emits escape codes; click.echo is what strips them when stdout is not
+    a terminal. Capturing the raw calls bypasses that, so unstyle here to assert on columns.
+    """
+    lines: list[str] = []
+    build(_SyncOutputFormatter(lines.append))
+    return [click.unstyle(line) for line in lines]
+
+
+def test_section_is_preceded_by_a_blank_line():
+    lines = _render(lambda fmt: fmt.section("Download"))
+
+    assert lines[0] == ""
+    assert "Download" in lines[1]
+
+
+def test_section_heading_is_unindented():
+    """Unindented headings over indented bodies is what carries structure without color."""
+    lines = _render(lambda fmt: (fmt.section("Download"), fmt.line("4 files")))
+
+    assert lines[1] == "Download"
+    assert lines[2].startswith("  ")
+
+
+def test_line_flushes_the_duration_to_a_fixed_column():
+    lines = _render(lambda fmt: fmt.line("4 files", timedelta(seconds=1.08)))
+
+    assert lines[0].endswith("1.1s")
+    assert lines[0].index("1.1s") == _sync_output_format._TIMING_COLUMN
+
+
+def test_line_keeps_one_space_when_the_text_overruns_the_timing_column():
+    lines = _render(lambda fmt: fmt.line("x" * 90, timedelta(seconds=1)))
+
+    assert lines[0].endswith("x 1.0s")
+
+
+def test_line_hides_a_duration_that_is_too_short_to_be_informative():
+    """Six steps each reporting <0.1s is noise that hides the one slow step."""
+    lines = _render(lambda fmt: fmt.line("manifest S3 keys populated", timedelta(seconds=0.00003)))
+
+    assert lines[0] == "  manifest S3 keys populated"
+
+
+def test_line_shows_a_duration_at_the_reporting_threshold():
+    lines = _render(lambda fmt: fmt.line("slow step", timedelta(seconds=_MIN_REPORTED_SECONDS)))
+
+    assert lines[0].endswith("1.0s")
+
+
+def test_line_without_a_duration_prints_no_timing():
+    lines = _render(lambda fmt: fmt.line("checkpoint saved"))
+
+    assert lines[0] == "  checkpoint saved"
+
+
+def test_field_and_continuation_align():
+    lines = _render(
+        lambda fmt: (fmt.field("checkpoint", "/tmp/a.json"), fmt.field_continuation("/tmp/b.json"))
+    )
+
+    assert lines[0].index("/tmp/a.json") == lines[1].index("/tmp/b.json")
+
+
+def test_entry_details_align_under_the_entry_title():
+    lines = _render(
+        lambda fmt: (
+            fmt.entry("NEW", "my-job", "(4/4 tasks succeeded)"),
+            fmt.entry_detail("job-1234"),
+        )
+    )
+
+    assert lines[0].index("my-job") == lines[1].index("job-1234")
+    assert "(4/4 tasks succeeded)" in lines[0]
+
+
+def test_entry_detail_aligns_under_the_longest_tag():
+    """UNCHANGED is the longest tag; it must not run into the job name."""
+    lines = _render(lambda fmt: (fmt.entry("UNCHANGED", "my-job"), fmt.entry_detail("job-1234")))
+
+    assert "UNCHANGED my-job" in lines[0]
+    assert lines[0].index("my-job") == lines[1].index("job-1234")
+
+
+def test_warning_and_error_use_text_prefixes():
+    """The prefix, not a glyph, is what marks a problem, so it survives any encoding."""
+    lines = _render(lambda fmt: (fmt.warning("careful"), fmt.error("broken")))
+
+    assert lines[0] == "  WARNING: careful"
+    assert lines[1] == "  ERROR: broken"
+
+
+def test_output_is_pure_ascii():
+    """No unicode anywhere: redirecting under a legacy Windows codepage must not fail."""
+    lines = _render(
+        lambda fmt: (
+            fmt.section("Download"),
+            fmt.field("checkpoint", "/tmp/a.json"),
+            fmt.line("4 files", timedelta(seconds=2)),
+            fmt.entry("RETIRED", "my-job", "(4/4 tasks succeeded)"),
+            fmt.entry_detail("job-1234"),
+            fmt.warning("careful"),
+            fmt.error("broken"),
+            fmt.summary_row("files", "4"),
+            fmt.result("4 files in 2.0s"),
+        )
+    )
+
+    joined = "\n".join(lines)
+    assert joined.isascii(), [line for line in lines if not line.isascii()]
+    joined.encode("cp1252")
+
+
+def test_warning_and_error_record_a_problem_on_the_shared_writer():
+    """The flag lives on the writer so warnings raised in any module reach one place."""
+    lines: list[str] = []
+    writer = _SyncOutputWriter(lines.append)
+    fmt = _SyncOutputFormatter(writer)
+
+    assert not fmt.had_problem
+    fmt.warning("careful")
+
+    assert fmt.had_problem
+    assert writer.had_problem
+    # A second formatter over the same writer sees the problem the first one reported.
+    assert _SyncOutputFormatter(writer).had_problem
+
+
+def test_had_problem_is_false_without_a_writer():
+    """A plain callback sink has nowhere to record a problem, and must not crash."""
+    fmt = _SyncOutputFormatter([].append)
+    fmt.warning("careful")
+
+    assert not fmt.had_problem
+    assert not fmt.suppressed
+
+
+def test_result_marks_success_and_failure_distinctly():
+    lines = _render(lambda fmt: (fmt.result("4 files in 2s"), fmt.result("2 failed", failed=True)))
+
+    assert lines[0] == "OK  4 files in 2s"
+    assert lines[1] == "FAILED  2 failed"
+
+
+def test_summary_row_pads_the_label():
+    lines = _render(lambda fmt: (fmt.summary_row("files", "4"), fmt.summary_row("jobs", "1")))
+
+    assert lines[0].index("4") == lines[1].index("1")


### PR DESCRIPTION
## What changed

`deadline queue sync-output` prints a multi-section progress report. This restructures it as indented plain-ASCII sections with a closing summary and a single greppable result line, and adds `--verbose`.

Before:

```
Ignoring all storage profiles.
Started incremental download for queue: Test queue
Checkpoint: /Users/me/.deadline/incremental_download/queue-d8bb..._download_checkpoint.json

Checkpoint found
Continuing from: 2026-08-21T10:16:59.319524-07:00

Updating download state across time interval:
    From: 2026-08-21T10:16:59.319524-07:00
      To: 2026-08-21T10:29:54.361383-07:00
  Length: 0:10:55.041859 + 0:02:00 (eventual consistency allowance)

Retrieving updated data from Deadline Cloud...
DEBUG: Got 0 active jobs
DEBUG: Filtered down to 0 active jobs based on SUCCEEDED task filter
...retrieval completed in 0:00:00.606954
Retrieving sessions for 1 jobs...
Using 3 threads
...retrieval completed in 0:00:00.264083
```

After:

```
Queue sync: Test queue
  checkpoint  ~/.deadline/incremental_download/queue-d8bb..._download_checkpoint.json
  storage     ignoring all storage profiles
  state       resumed from checkpoint at 2026-08-21 10:16:59
  window      2026-08-21 10:16:59 to 10:29:54 (10m55s + 2m eventual consistency allowance)

Deadline Cloud
  1 candidate job (0 active, 1 recently ended)
  categorized 1 job (0 in checkpoint)
    NEW       my_render_job (4/4 tasks succeeded)
              job-ec1bc8ac3b14409d8ed010262c7b8b32
              output root: / (posix)
  3 sessions across 1 job
  4 succeeded task runs

Download
  4 asset manifests                                     5.3s
  4 files, 4.58 MB to download
    /tmp/ViewLayer_Camera_output_%04d.png (4 files, 4.58 MB, sequence 1-4)
  downloaded 4 files                                    1.1s

Summary
  files       4 downloaded, 4.58 MB
  jobs        1 downloaded
  task runs   4
  skipped     none
  status file ~/.deadline/.../queue-d8bb..._download_status.json
  checkpoint  saved
  elapsed     7.6s
OK  4 files, 4.58 MB, 1 job in 7.6s
```

## Details

**Plain ASCII only.** Color now marks a problem and nothing else: yellow on `WARNING`, red on `ERROR` and `FAILED`. This matches the three places the CLI already uses color (`job_group.py`, `manifest_group.py`, `bundle_group.py`), all of which are warnings. No other CLI source emitted non-ASCII, so structure is carried by indentation rather than box-drawing characters, which would raise `UnicodeEncodeError` when output is redirected to a file under a legacy Windows codepage.

**A run that finds nothing new prints one line.** This command is built to be polled on a schedule, and most polls find nothing:

```
OK  Test queue: nothing new (window 10m55s, checked 2026-08-21 10:29:54)
```

The new `--verbose` flag forces the full report. A run that finds work, retries a previously failed job, or hits a warning always prints the full report regardless. This changes the default output of a no-op run.

**Failures are repeated in the summary**, so an unattended run does not bury them part-way up a download log:

```
  problems    2 jobs failed
              PERMISSION_DENIED  shot_041_comp (job-abc123def456)
              DISK_FULL          shot_042_comp (job-789abc012def)
  elapsed     41s
FAILED  2 of 7 jobs failed after 41s (12 files, 31.2 MB downloaded)
```

**Durations** render as `0.6s` or `10m55s` instead of `0:00:00.606954`, and are omitted below one second so a genuinely slow step stands out.

**Job wording follows the download status file's vocabulary** (`downloaded`, `in_progress`, `skipped`, `failed`) so the terminal and the JSON report describe a job the same way. The `DONE` tag, which meant "no longer tracked" rather than "downloaded", is now `RETIRED`.

## Bug fixed along the way

Four `DEBUG:` lines used bare `print()` rather than the logger, so they reached stdout even under `--json` and corrupted the JSON output. They are gone, and a regression test asserts `--json` writes nothing to stdout.

## Note for reviewers

Two `job_attachments` helpers are now passed a no-op print callback. Their only output was a thread count, and this command reports those phases in its own format.

Tagged `feat:` rather than `feat!:`. The default output of a no-op run changed, which `AGENTS.md` arguably covers under "default values and behaviors", but `--json` (the documented machine-readable path) is unchanged. Happy to relabel if the team reads that differently.

## Testing

`hatch run lint` (ruff + mypy) clean. `hatch run test`: 3859 passed, 22 skipped, coverage 77.78%. New tests cover the formatter (durations, alignment, ASCII-only output that encodes to cp1252), quiet-by-default, `--verbose`, the problems block, the result line, and the `--json` regression.

`hatch run integ:test` has **not** been run; it needs AWS resources I do not have set up.